### PR TITLE
Fix llms.txt not loading in production

### DIFF
--- a/packages/web/Dockerfile
+++ b/packages/web/Dockerfile
@@ -19,6 +19,7 @@ FROM base AS runtime
 COPY --from=prune /app/out/json/ .
 RUN bun install --frozen-lockfile --production
 COPY --from=build /app/applications/canary-web/dist ./applications/canary-web/dist
+COPY --from=build /app/applications/canary-web/public ./applications/canary-web/public
 
 WORKDIR /app/applications/canary-web
 


### PR DESCRIPTION
The Docker runtime stage only copied dist/ but not public/, so
serveStaticTextFile() could never find llms.txt or llms-full.txt
in production since it reads from public/ relative to cwd.

https://claude.ai/code/session_015NESuvPNJCFGVVgpPLazZH