### PR TITLE
Improve logging context and normalize web operation routes

### DIFF
--- a/applications/canary-web/src/server/logging.test.ts
+++ b/applications/canary-web/src/server/logging.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeOperationPath } from "./logging";
+
+describe("normalizeOperationPath", () => {
+  it("normalizes UUID path segments", () => {
+    expect(normalizeOperationPath("/api/accounts/24750098-9575-4bc8-8830-5d1b3adb2240")).toBe(
+      "/api/accounts/:id",
+    );
+  });
+
+  it("normalizes numeric path segments", () => {
+    expect(normalizeOperationPath("/api/accounts/12345")).toBe("/api/accounts/:id");
+  });
+
+  it("normalizes /api/cal identifier segments", () => {
+    expect(normalizeOperationPath("/api/cal/my-calendar-id")).toBe("/api/cal/:id");
+  });
+
+  it("collapses all assets paths to /assets/:asset", () => {
+    expect(normalizeOperationPath("/assets/auth-switch-pro-A1B2C3.js")).toBe("/assets/:asset");
+    expect(normalizeOperationPath("/assets/chunks/runtime/main.js")).toBe("/assets/:asset");
+  });
+
+  it("keeps static routes unchanged", () => {
+    expect(normalizeOperationPath("/api/socket/url")).toBe("/api/socket/url");
+    expect(normalizeOperationPath("/dashboard")).toBe("/dashboard");
+  });
+});

--- a/applications/canary-web/src/server/logging.ts
+++ b/applications/canary-web/src/server/logging.ts
@@ -2,6 +2,11 @@ import { widelogger } from "widelogger";
 import type { ServerConfig } from "./types";
 
 const loggerServiceName = "@keeper.sh/canary-web";
+const UUID_SEGMENT_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const NUMERIC_ID_SEGMENT_PATTERN = /^\d{2,}$/;
+const NORMALIZED_PATH_CACHE_MAX_SIZE = 1024;
+const normalizedPathCache = new Map<string, string>();
 
 const { destroy: destroyWideLogger, widelog } = widelogger({
   defaultEventName: "wide_event",
@@ -20,6 +25,61 @@ function isAbortError(error: unknown): boolean {
 
   const name = Reflect.get(error, "name");
   return name === "AbortError";
+}
+
+function normalizeOperationPath(pathname: string): string {
+  const cachedPath = normalizedPathCache.get(pathname);
+  if (cachedPath !== undefined) {
+    normalizedPathCache.delete(pathname);
+    normalizedPathCache.set(pathname, cachedPath);
+    return cachedPath;
+  }
+
+  const segments = pathname.split("/").filter((segment) => segment.length > 0);
+  const isAssetsPath = segments[0] === "assets";
+
+  if (isAssetsPath) {
+    const normalizedAssetsPath = "/assets/:asset";
+    setNormalizedPathCache(pathname, normalizedAssetsPath);
+    return normalizedAssetsPath;
+  }
+
+  const normalizedSegments: string[] = [];
+
+  for (const [index, segment] of segments.entries()) {
+    const previousSegments = normalizedSegments.slice(Math.max(0, index - 2), index);
+    const [firstPreviousSegment, secondPreviousSegment] = previousSegments;
+    const isApiCalIdentifierSegment =
+      previousSegments.length === 2 &&
+      firstPreviousSegment === "api" &&
+      secondPreviousSegment === "cal";
+
+    if (
+      isApiCalIdentifierSegment ||
+      UUID_SEGMENT_PATTERN.test(segment) ||
+      NUMERIC_ID_SEGMENT_PATTERN.test(segment)
+    ) {
+      normalizedSegments.push(":id");
+      continue;
+    }
+
+    normalizedSegments.push(segment);
+  }
+
+  const normalizedPath = `/${normalizedSegments.join("/")}`;
+  setNormalizedPathCache(pathname, normalizedPath);
+  return normalizedPath;
+}
+
+function setNormalizedPathCache(pathname: string, normalizedPath: string): void {
+  if (normalizedPathCache.size >= NORMALIZED_PATH_CACHE_MAX_SIZE) {
+    const oldestPath = normalizedPathCache.keys().next().value;
+    if (oldestPath !== undefined) {
+      normalizedPathCache.delete(oldestPath);
+    }
+  }
+
+  normalizedPathCache.set(pathname, normalizedPath);
 }
 
 export async function emitLifecycleWideEvent(
@@ -51,7 +111,9 @@ export async function handleWithWideLogging(
     const requestStart = Date.now();
     const requestId = request.headers.get("x-request-id") ?? crypto.randomUUID();
 
-    widelog.set("operation.name", `${request.method} ${requestUrl.pathname}`);
+    const normalizedOperationPath = normalizeOperationPath(requestUrl.pathname);
+
+    widelog.set("operation.name", `${request.method} ${normalizedOperationPath}`);
     widelog.set("operation.type", "http");
     widelog.set("request.id", requestId);
     widelog.set("request.timing.start", requestStart);
@@ -94,4 +156,4 @@ export async function handleWithWideLogging(
   });
 }
 
-export { destroyWideLogger };
+export { destroyWideLogger, normalizeOperationPath };

--- a/applications/cron/src/utils/sync-calendar-events.ts
+++ b/applications/cron/src/utils/sync-calendar-events.ts
@@ -17,7 +17,9 @@ interface SyncUserSourcesDependencies<TSource> {
   syncDestinationsForUser: (userId: string) => Promise<SyncResult>;
 }
 
-const createSyncUserSourcesDependencies = async (): Promise<{
+const createSyncUserSourcesDependencies = async (
+  jobName: string,
+): Promise<{
   dependencies: SyncUserSourcesDependencies<Source>;
   close: () => void;
 }> => {
@@ -34,6 +36,7 @@ const createSyncUserSourcesDependencies = async (): Promise<{
           userId,
           syncContext.destinationProviders,
           syncContext.syncCoordinator,
+          { jobName, jobType: "sync-calendar-events" },
         ),
     },
     close: syncContext.close,
@@ -141,8 +144,9 @@ const runSyncJob = async <TSource extends SourceOwner>(
 const createSyncJob = (plan: Plan, cron: string): CronOptions =>
   withCronWideEvent({
     async callback(): Promise<void> {
+      const jobName = `sync-calendar-events-${plan}`;
       const { dependencies: syncUserSourcesDependencies, close } =
-        await createSyncUserSourcesDependencies();
+        await createSyncUserSourcesDependencies(jobName);
       try {
         const { getSourcesByPlan, getUsersWithDestinationsByPlan } = await import("./get-sources");
         await runSyncJob(plan, {

--- a/packages/provider-core/src/oauth/create-provider.ts
+++ b/packages/provider-core/src/oauth/create-provider.ts
@@ -84,6 +84,12 @@ const createOAuthDestinationProvider = <
           widelog.set("operation.type", "sync");
           widelog.set("destination.calendar_id", account.calendarId);
           widelog.set("user.id", userId);
+          if (context.jobName) {
+            widelog.set("job.name", context.jobName);
+          }
+          if (context.jobType) {
+            widelog.set("job.type", context.jobType);
+          }
           widelog.time.start("duration_ms");
 
           const localEvents = await getEventsForDestination(database, account.calendarId);

--- a/packages/provider-core/src/sync/coordinator.ts
+++ b/packages/provider-core/src/sync/coordinator.ts
@@ -31,6 +31,8 @@ interface SyncProgressUpdate {
 interface SyncContext {
   userId: string;
   generation: number;
+  jobName?: string;
+  jobType?: string;
   isCurrent: () => Promise<boolean>;
   onDestinationSync?: (result: DestinationSyncResult) => Promise<void>;
   onSyncProgress?: (update: SyncProgressUpdate) => void;

--- a/packages/provider-core/src/sync/destinations.ts
+++ b/packages/provider-core/src/sync/destinations.ts
@@ -19,19 +19,33 @@ interface DestinationProvider {
   syncForUser(userId: string, context: SyncContext): Promise<SyncResult | null>;
 }
 
+interface SyncDestinationsOptions {
+  jobName?: string;
+  jobType?: string;
+}
+
 const syncDestinationsForUser = (
   userId: string,
   providers: DestinationProvider[],
   syncCoordinator: SyncCoordinator,
+  options: SyncDestinationsOptions = {},
 ): Promise<SyncResult> =>
   widelog.context(async () => {
     widelog.set("operation.name", "sync:destinations");
     widelog.set("operation.type", "sync");
     widelog.set("user.id", userId);
     widelog.set("provider.count", providers.length);
+    if (options.jobName) {
+      widelog.set("job.name", options.jobName);
+    }
+    if (options.jobType) {
+      widelog.set("job.type", options.jobType);
+    }
     widelog.time.start("duration_ms");
 
     const context = await syncCoordinator.startSync(userId);
+    context.jobName = options.jobName;
+    context.jobType = options.jobType;
 
     const settledResults = await Promise.allSettled(
       providers.map((provider) =>

--- a/packages/provider-core/src/sync/provider.ts
+++ b/packages/provider-core/src/sync/provider.ts
@@ -60,6 +60,12 @@ abstract class CalendarProvider<TConfig extends ProviderConfig = ProviderConfig>
       widelog.set("destination.provider", this.id);
       widelog.set("user.id", userId);
       widelog.set("local_events.count", localEvents.length);
+      if (context.jobName) {
+        widelog.set("job.name", context.jobName);
+      }
+      if (context.jobType) {
+        widelog.set("job.type", context.jobType);
+      }
       widelog.time.start("duration_ms");
 
       try {


### PR DESCRIPTION
## Summary
- normalize  operation routes app-side for stable observability labels
- collapse asset paths and normalize UUID/numeric/API-cal identifiers
- add bounded memoization for normalization to keep runtime overhead low
- propagate cron job context (/) into sync provider logs
- restore logger environment fallback to 
- add focused unit tests for route normalization

## Validation
- bun test v1.3.10 (30e609e0)
- bun test v1.3.10 (30e609e0)
- vite v7.3.1 building client environment for production...
transforming...
✓ 1274 modules transformed.
rendering chunks...
computing gzip size...
dist/client/index.html                                      0.33 kB │ gzip:   0.21 kB
dist/client/sitemap.xml                                     0.60 kB │ gzip:   0.24 kB
dist/client/.vite/manifest.json                            41.90 kB │ gzip:   4.01 kB
dist/client/assets/index-BMj7ajFz.css                      52.92 kB │ gzip:   9.29 kB
dist/client/assets/cn-M6QGW1UD.js                           0.12 kB │ gzip:   0.14 kB │ map:     0.32 kB
dist/client/assets/popover-overlay-xxt3AHKW.js              0.13 kB │ gzip:   0.14 kB │ map:     0.29 kB
dist/client/assets/commercial-Mz7h0HxS.js                   0.14 kB │ gzip:   0.14 kB │ map:     0.36 kB
dist/client/assets/pluralize-kQf4VLF3.js                    0.14 kB │ gzip:   0.15 kB │ map:     0.52 kB
dist/client/assets/swr-vAQuxXKS.js                          0.15 kB │ gzip:   0.15 kB │ map:     0.78 kB
dist/client/assets/check-yKt2GXGy.js                        0.17 kB │ gzip:   0.18 kB │ map:     0.84 kB
dist/client/assets/route-BgNApU53.js                        0.19 kB │ gzip:   0.18 kB │ map:     0.78 kB
dist/client/assets/route-nywBIcoJ.js                        0.19 kB │ gzip:   0.17 kB │ map:     0.74 kB
dist/client/assets/route-CE-5ZPKz.js                        0.19 kB │ gzip:   0.17 kB │ map:     0.47 kB
dist/client/assets/route-B3v31Iyg.js                        0.19 kB │ gzip:   0.18 kB │ map:     0.49 kB
dist/client/assets/route-CVxqqbHj.js                        0.19 kB │ gzip:   0.17 kB │ map:     0.49 kB
dist/client/assets/route-LADTTQYK.js                        0.19 kB │ gzip:   0.18 kB │ map:     0.49 kB
dist/client/assets/calendars-C7mfseEf.js                    0.19 kB │ gzip:   0.16 kB │ map:     0.80 kB
dist/client/assets/loader-circle-B2UFOuKX.js                0.20 kB │ gzip:   0.20 kB │ map:     0.91 kB
dist/client/assets/arrow-left-B-o-Qo4q.js                   0.23 kB │ gzip:   0.21 kB │ map:     0.98 kB
dist/client/assets/arrow-right-BdRwWcbF.js                  0.23 kB │ gzip:   0.20 kB │ map:     0.98 kB
dist/client/assets/auth-switch-prompt-Ct7aSXh8.js           0.25 kB │ gzip:   0.22 kB │ map:     0.62 kB
dist/client/assets/mail-g0BfYoqg.js                         0.27 kB │ gzip:   0.24 kB │ map:     1.05 kB
dist/client/assets/page-metadata-BKRMaMh6.js                0.27 kB │ gzip:   0.23 kB │ map:     1.00 kB
dist/client/assets/route-DqncnaF6.js                        0.27 kB │ gzip:   0.23 kB │ map:     0.63 kB
dist/client/assets/link-DPZe3QQx.js                         0.31 kB │ gzip:   0.24 kB │ map:     1.04 kB
dist/client/assets/calendar-Bu2rjNJ_.js                     0.32 kB │ gzip:   0.25 kB │ map:     1.24 kB
dist/client/assets/route-IaH7p4CS.js                        0.35 kB │ gzip:   0.26 kB │ map:     0.83 kB
dist/client/assets/route-CG-BILD2.js                        0.35 kB │ gzip:   0.26 kB │ map:     1.25 kB
dist/client/assets/providers-CPDVJkdo.js                    0.39 kB │ gzip:   0.20 kB │ map:     0.68 kB
dist/client/assets/clsx-B-dksMZM.js                         0.42 kB │ gzip:   0.28 kB │ map:     1.18 kB
dist/client/assets/use-start-of-today-BAKNT_ci.js           0.43 kB │ gzip:   0.28 kB │ map:     1.56 kB
dist/client/assets/verify-authentication-B8JxrmvF.js        0.45 kB │ gzip:   0.35 kB │ map:     1.28 kB
dist/client/assets/error-state-CmQbBbz0.js                  0.47 kB │ gzip:   0.35 kB │ map:     1.15 kB
dist/client/assets/google-B171xOV0.js                       0.49 kB │ gzip:   0.33 kB │ map:     0.59 kB
dist/client/assets/outlook-BloHXsAr.js                      0.49 kB │ gzip:   0.33 kB │ map:     0.59 kB
dist/client/assets/microsoft-Dnfh6qJ2.js                    0.50 kB │ gzip:   0.33 kB │ map:     0.61 kB
dist/client/assets/sync-Dkgdll9U.js                         0.51 kB │ gzip:   0.32 kB │ map:     1.99 kB
dist/client/assets/provider-icon-CLsrthmA.js                0.52 kB │ gzip:   0.33 kB │ map:     1.60 kB
dist/client/assets/divider-Cv0boJjt.js                      0.53 kB │ gzip:   0.33 kB │ map:     1.11 kB
dist/client/assets/use-session-CtSTjb1T.js                  0.54 kB │ gzip:   0.35 kB │ map:     1.55 kB
dist/client/assets/google-DiQcWoD7.js                       0.57 kB │ gzip:   0.38 kB │ map:     1.37 kB
dist/client/assets/outlook-BKcH1jor.js                      0.58 kB │ gzip:   0.38 kB │ map:     1.38 kB
dist/client/assets/highlighted-body-TPN3WLV5-C0TcucAp.js    0.59 kB │ gzip:   0.41 kB │ map:     1.40 kB
dist/client/assets/back-button-DPwCLAQE.js                  0.59 kB │ gzip:   0.41 kB │ map:     2.27 kB
dist/client/assets/index-DCy9hU8p.js                        0.60 kB │ gzip:   0.38 kB │ map:     1.89 kB
dist/client/assets/keeper-BEfDmY8E.js                       0.66 kB │ gzip:   0.37 kB │ map:     1.02 kB
dist/client/assets/route-shell-DC3q3sip.js                  0.67 kB │ gzip:   0.38 kB │ map:     1.67 kB
dist/client/assets/input-colOpxKI.js                        0.70 kB │ gzip:   0.42 kB │ map:     1.45 kB
dist/client/assets/use-passkeys-Bzpj1Phq.js                 0.73 kB │ gzip:   0.46 kB │ map:     2.31 kB
dist/client/assets/text-link-ByoauMhV.js                    0.77 kB │ gzip:   0.38 kB │ map:     2.45 kB
dist/client/assets/template-text-CCLt2FDe.js                0.88 kB │ gzip:   0.49 kB │ map:     3.23 kB
dist/client/assets/login-DcuDyOy0.js                        0.89 kB │ gzip:   0.55 kB │ map:     1.81 kB
dist/client/assets/register-6tchV7Zi.js                     0.90 kB │ gzip:   0.55 kB │ map:     1.83 kB
dist/client/assets/checkout-CTPqZtsc.js                     0.95 kB │ gzip:   0.53 kB │ map:     2.80 kB
dist/client/assets/ics-file-BVAA2Zg7.js                     0.99 kB │ gzip:   0.60 kB │ map:     1.86 kB
dist/client/assets/dashboard-heading-Cropw-8R.js            1.01 kB │ gzip:   0.48 kB │ map:     3.43 kB
dist/client/assets/time-Du-1y1S0.js                         1.11 kB │ gzip:   0.55 kB │ map:     4.28 kB
dist/client/assets/caldav-Bf0iIIZ5.js                       1.15 kB │ gzip:   0.67 kB │ map:     1.67 kB
dist/client/assets/createLucideIcon-B9domUdS.js             1.26 kB │ gzip:   0.74 kB │ map:     7.95 kB
dist/client/assets/apple-Cej-mASp.js                        1.38 kB │ gzip:   0.79 kB │ map:     1.91 kB
dist/client/assets/checkbox-D5y5DUon.js                     1.40 kB │ gzip:   0.64 kB │ map:     3.61 kB
dist/client/assets/modal-BlI4L1lY.js                        1.47 kB │ gzip:   0.80 kB │ map:     4.87 kB
dist/client/assets/fastmail-CrO7Krte.js                     1.47 kB │ gzip:   0.80 kB │ map:     2.07 kB
dist/client/assets/index-nhHjMWeb.js                        1.56 kB │ gzip:   0.78 kB │ map:     4.27 kB
dist/client/assets/metadata-row-D8hU_G0b.js                 1.68 kB │ gzip:   0.68 kB │ map:     6.09 kB
dist/client/assets/change-password-181kxegC.js              1.72 kB │ gzip:   0.88 kB │ map:     5.41 kB
dist/client/assets/verify-email-C3OAi2-N.js                 1.73 kB │ gzip:   0.78 kB │ map:     4.74 kB
dist/client/assets/use-entitlements-BwF_mkRO.js             1.74 kB │ gzip:   0.89 kB │ map:     5.91 kB
dist/client/assets/feedback-Czh-uFtX.js                     1.82 kB │ gzip:   0.95 kB │ map:     4.82 kB
dist/client/assets/auth-BxkyNR6t.js                         1.88 kB │ gzip:   0.81 kB │ map:     5.69 kB
dist/client/assets/report-N9pYZH8n.js                       2.07 kB │ gzip:   1.07 kB │ map:     5.28 kB
dist/client/assets/forgot-password-UzC3nU8D.js              2.11 kB │ gzip:   0.98 kB │ map:     5.65 kB
dist/client/assets/index-uOEPyEBT.js                        2.34 kB │ gzip:   0.80 kB │ map:     6.57 kB
dist/client/assets/passkeys-DDX9dMy6.js                     2.58 kB │ gzip:   1.29 kB │ map:     9.26 kB
dist/client/assets/consent-BtKctS-2.js                      2.78 kB │ gzip:   1.37 kB │ map:     9.31 kB
dist/client/assets/reset-password-DNgg9A1L.js               2.80 kB │ gzip:   1.16 kB │ map:     8.61 kB
dist/client/assets/ical-link-BwPVp_dD.js                    2.96 kB │ gzip:   1.45 kB │ map:     8.45 kB
dist/client/assets/oauth-preamble-CYCCxkiT.js               2.98 kB │ gzip:   1.34 kB │ map:     8.72 kB
dist/client/assets/caldav-connect-page-D4MTaakR.js          3.80 kB │ gzip:   1.65 kB │ map:    12.82 kB
dist/client/assets/embed-C95HVHgc.js                        4.18 kB │ gzip:   1.61 kB │ map:     7.82 kB
dist/client/assets/navigation-menu-editable-C3Q4pV4U.js     4.21 kB │ gzip:   1.62 kB │ map:    16.22 kB
dist/client/assets/_accountId.index-6tGgh3er.js             4.27 kB │ gzip:   1.92 kB │ map:    13.83 kB
dist/client/assets/route-BgNTPidK.js                        4.48 kB │ gzip:   1.84 kB │ map:    19.34 kB
dist/client/assets/index-BhYZSj3n.js                        4.55 kB │ gzip:   1.99 kB │ map:    16.68 kB
dist/client/assets/index-DE3avfe1.js                        4.88 kB │ gzip:   2.05 kB │ map:    15.80 kB
dist/client/assets/navigation-menu-items-sIVav3mG.js        5.90 kB │ gzip:   1.74 kB │ map:    19.60 kB
dist/client/assets/ical-C8CcnV0N.js                         6.62 kB │ gzip:   2.53 kB │ map:    25.01 kB
dist/client/assets/index-CmKey_ac.js                        6.77 kB │ gzip:   3.03 kB │ map:    34.60 kB
dist/client/assets/privacy-mUpICAsA.js                      7.16 kB │ gzip:   2.64 kB │ map:    12.86 kB
dist/client/assets/auth-form-Bwqs4K8h.js                    7.94 kB │ gzip:   2.99 kB │ map:    29.07 kB
dist/client/assets/_accountId.setup-BqBb7ZlQ.js             8.06 kB │ gzip:   2.78 kB │ map:    30.79 kB
dist/client/assets/route-DTG85Sbb.js                        8.17 kB │ gzip:   3.01 kB │ map:    28.30 kB
dist/client/assets/terms-pvhvwU1l.js                        8.77 kB │ gzip:   3.37 kB │ map:    15.12 kB
dist/client/assets/_accountId._calendarId-CYdtnMSY.js      11.30 kB │ gzip:   3.88 kB │ map:    43.18 kB
dist/client/assets/auth-client-Dq1VvO8X.js                 11.40 kB │ gzip:   3.84 kB │ map:    46.30 kB
dist/client/assets/index-B11_hKAV.js                       17.13 kB │ gzip:   6.11 kB │ map:    66.54 kB
dist/client/assets/index-adkNAMu4.js                       28.21 kB │ gzip:   8.56 kB │ map:    84.28 kB
dist/client/assets/elements-DX7iWffZ.js                    44.48 kB │ gzip:  16.32 kB │ map:   270.42 kB
dist/client/assets/react-BO6ouHwi.js                      132.00 kB │ gzip:  44.99 kB │ map:   725.84 kB
dist/client/assets/react-vendor-CVkWrbk8.js               232.50 kB │ gzip:  75.23 kB │ map: 1,112.41 kB
dist/client/assets/index-CFdwMzZj.js                      315.49 kB │ gzip: 100.73 kB │ map: 1,497.70 kB
dist/client/assets/mermaid-O7DHMXV3-B1UZMiy-.js           484.00 kB │ gzip: 147.75 kB │ map: 2,013.65 kB
✓ built in 2.97s
vite v7.3.1 building ssr environment for production...
transforming...
✓ 209 modules transformed.
rendering chunks...
dist/server/assets/cn-CYy_d8Mw.js                         0.14 kB │ map:   0.30 kB
dist/server/assets/popover-overlay-DEajiT8y.js            0.16 kB │ map:   0.26 kB
dist/server/assets/motion-features-B9chbyKl.js            0.17 kB │ map:   0.31 kB
dist/server/assets/commercial-CYHQTyhK.js                 0.22 kB │ map:   0.32 kB
dist/server/assets/pluralize-BgmSVc79.js                  0.24 kB │ map:   0.48 kB
dist/server/assets/route-4ry9o4rS.js                      0.25 kB │ map:   0.48 kB
dist/server/assets/route-CiaIqzM7.js                      0.25 kB │ map:   0.49 kB
dist/server/assets/route-BM8oE7Br.js                      0.25 kB │ map:   0.49 kB
dist/server/assets/route-n1yh18-V.js                      0.25 kB │ map:   0.73 kB
dist/server/assets/route-DbVCd73P.js                      0.25 kB │ map:   0.46 kB
dist/server/assets/route-Cuf12_xJ.js                      0.26 kB │ map:   0.77 kB
dist/server/assets/auth-client-BCSp-vsg.js                0.31 kB │ map:   0.49 kB
dist/server/assets/auth-switch-prompt-BCqXo0xo.js         0.31 kB │ map:   0.56 kB
dist/server/assets/swr-CiMBabXR.js                        0.32 kB │ map:   0.73 kB
dist/server/assets/calendars-DIfFmR7k.js                  0.34 kB │ map:   0.76 kB
dist/server/assets/route-DurDg4D2.js                      0.36 kB │ map:   0.62 kB
dist/server/assets/route-CDEB7vdT.js                      0.44 kB │ map:   1.22 kB
dist/server/assets/route-FMDCGqk0.js                      0.45 kB │ map:   0.80 kB
dist/server/assets/providers-ady8cDEk.js                  0.45 kB │ map:   0.69 kB
dist/server/assets/page-metadata-Cq8pk5rS.js              0.47 kB │ map:   0.94 kB
dist/server/assets/use-passkeys-DpXeCPd8.js               0.61 kB │ map:   1.09 kB
dist/server/assets/error-state-kmIReNXW.js                0.65 kB │ map:   1.07 kB
dist/server/assets/use-session-Ba9rhFE8.js                0.71 kB │ map:   1.38 kB
dist/server/assets/divider-B6jzPa-T.js                    0.73 kB │ map:   1.07 kB
dist/server/assets/keeper-D6pTaYRB.js                     0.74 kB │ map:   0.99 kB
dist/server/assets/input-BfsFdO9b.js                      0.81 kB │ map:   1.40 kB
dist/server/assets/use-start-of-today-BrRZGO63.js         0.83 kB │ map:   1.40 kB
dist/server/assets/google-D3jibRZx.js                     0.86 kB │ map:   0.57 kB
dist/server/assets/outlook-BVBW3FNd.js                    0.87 kB │ map:   0.58 kB
dist/server/assets/provider-icon-CJOIj_qj.js              0.87 kB │ map:   1.48 kB
dist/server/assets/microsoft-WwDWL-rt.js                  0.87 kB │ map:   0.60 kB
dist/server/assets/verify-authentication-B1eeBb3Z.js      0.92 kB │ map:   1.30 kB
dist/server/assets/back-button-CCw_gpUs.js                0.93 kB │ map:   1.61 kB
dist/server/assets/sync-DzsDkffq.js                       0.97 kB │ map:   2.08 kB
dist/server/assets/index-Bl_hncSG.js                      1.00 kB │ map:   1.87 kB
dist/server/assets/google-rVyOv9tk.js                     1.03 kB │ map:   1.35 kB
dist/server/assets/outlook-CQe0rJHR.js                    1.03 kB │ map:   1.36 kB
dist/server/assets/route-shell-YS8nITm9.js                1.04 kB │ map:   1.63 kB
dist/server/assets/text-link-6L1ZUYNM.js                  1.08 kB │ map:   2.33 kB
dist/server/assets/login-BeGLHoWK.js                      1.40 kB │ map:   1.84 kB
dist/server/assets/register-BLthHm1Y.js                   1.41 kB │ map:   1.86 kB
dist/server/assets/template-text-DV8CQSfz.js              1.48 kB │ map:   3.06 kB
dist/server/assets/checkout-DtGrAjLD.js                   1.49 kB │ map:   2.80 kB
dist/server/assets/dashboard-heading-oEnFTLaj.js          1.59 kB │ map:   3.05 kB
dist/server/assets/ics-file-beaI5sTT.js                   1.62 kB │ map:   1.76 kB
dist/server/assets/caldav-CKC7d7ki.js                     1.68 kB │ map:   1.61 kB
dist/server/assets/apple-B3-g9Wog.js                      1.93 kB │ map:   1.87 kB
dist/server/assets/checkbox-Crf3j_QK.js                   2.06 kB │ map:   3.55 kB
dist/server/assets/fastmail-DM5tHbNG.js                   2.06 kB │ map:   2.02 kB
dist/server/assets/time-C3dj2SIE.js                       2.32 kB │ map:   4.29 kB
dist/server/assets/index-VwXQqGTA.js                      2.34 kB │ map:   4.27 kB
dist/server/assets/metadata-row-DWV9848N.js               2.63 kB │ map:   4.21 kB
dist/server/assets/modal-CBkqj8i2.js                      2.70 kB │ map:   4.48 kB
dist/server/assets/verify-email-CnD4EgkV.js               2.76 kB │ map:   4.73 kB
dist/server/assets/feedback-Cf5hNM_B.js                   3.03 kB │ map:   4.82 kB
dist/server/assets/auth-DqyLxk7y.js                       3.03 kB │ map:   5.44 kB
dist/server/assets/change-password-Dvnw1mng.js            3.19 kB │ map:   5.43 kB
dist/server/assets/use-entitlements-Hi_5CNIN.js           3.29 kB │ map:   5.72 kB
dist/server/assets/report-Bro5TUMX.js                     3.41 kB │ map:   5.27 kB
dist/server/assets/forgot-password-B5Kkcsh4.js            3.46 kB │ map:   5.57 kB
dist/server/assets/oauth-preamble-zPPsexwc.js             4.47 kB │ map:   7.22 kB
dist/server/assets/reset-password-PNkTOjPb.js             4.53 kB │ map:   7.65 kB
dist/server/assets/index-23X1RvN6.js                      4.73 kB │ map:   6.46 kB
dist/server/assets/consent-CQrKVLKd.js                    4.90 kB │ map:   8.71 kB
dist/server/assets/passkeys-DxDC_4Bv.js                   5.11 kB │ map:   8.32 kB
dist/server/assets/ical-link-CGy67R89.js                  5.59 kB │ map:   8.24 kB
dist/server/assets/index-CGnPSkr0.js                      7.10 kB │ map:  13.38 kB
dist/server/assets/caldav-connect-page-BbjpSbIn.js        7.18 kB │ map:  12.46 kB
dist/server/assets/index-CX3-jMz6.js                      7.53 kB │ map:  12.14 kB
dist/server/assets/_slug-RF7c1yci.js                      7.71 kB │ map:  15.69 kB
dist/server/assets/navigation-menu-editable-Dejkq4aA.js   8.18 kB │ map:  14.62 kB
dist/server/assets/index-uCa35l6X.js                      8.19 kB │ map:  15.73 kB
dist/server/assets/_accountId.index-BtxU2ULT.js           8.40 kB │ map:  13.53 kB
dist/server/assets/privacy-BMY0Lb2q.js                    9.37 kB │ map:  12.86 kB
dist/server/assets/route-CN2h4vgU.js                      9.70 kB │ map:  19.46 kB
dist/server/assets/navigation-menu-items-jPtQKy5s.js     10.78 kB │ map:  19.21 kB
dist/server/assets/terms-BMfhOYmW.js                     11.04 kB │ map:  15.13 kB
dist/server/assets/route-CG89Uesw.js                     12.61 kB │ map:  23.54 kB
dist/server/assets/ical-Rdh_vnMl.js                      13.14 kB │ map:  24.44 kB
dist/server/assets/auth-form-dmhB8LXF.js                 15.86 kB │ map:  27.84 kB
dist/server/assets/_accountId.setup-CjG7Rh82.js          16.07 kB │ map:  31.34 kB
dist/server/assets/_accountId._calendarId-B4Jb0Qpe.js    23.72 kB │ map:  43.65 kB
dist/server/assets/index-Dr0gdzXG.js                     31.57 kB │ map:  54.38 kB
dist/server/assets/index-IKgR_Rk4.js                     46.60 kB │ map:  80.38 kB
dist/server/server.js                                    74.50 kB │ map: 342.34 kB
✓ built in 881ms
- 