### PR TITLE
fix(auth): force public client registration for unauthenticated MCP clients

### DIFF
--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -152,10 +152,6 @@ const defaultUnauthenticatedOAuthClientRegistration = (
     return input.body;
   }
 
-  if ("token_endpoint_auth_method" in input.body) {
-    return input.body;
-  }
-
   if (hasAuthHeader(input.headers) || hasSessionCookie(input.headers)) {
     return input.body;
   }


### PR DESCRIPTION
Claude Desktop MCP OAuth client sends token_endpoint_auth_method in the registration body, causing Better Auth to require authentication. Unauthenticated callers should always be forced to none since they cannot prove ownership of any other auth method.