### PR TITLE
Set ENV variable to production in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ services:
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
       MICROSOFT_CLIENT_ID: ${MICROSOFT_CLIENT_ID:-}
       MICROSOFT_CLIENT_SECRET: ${MICROSOFT_CLIENT_SECRET:-}
+      ENV: production
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
thanks for a great project! lack of this env variable was breaking the pino logger based on your recent PR 