### PR TITLE
fix: add onConflictDoNothing to flush mapping inserts to prevent transaction rollbacks

### DIFF
--- a/packages/calendar/src/core/sync-engine/flush.ts
+++ b/packages/calendar/src/core/sync-engine/flush.ts
@@ -42,7 +42,7 @@ const createDatabaseFlush = (database: BunSQLDatabase): (changes: PendingChanges
               startTime: insert.startTime,
               endTime: insert.endTime,
             })),
-          );
+          ).onConflictDoNothing();
         }
       }
     });

--- a/packages/calendar/src/core/sync-engine/index.test.ts
+++ b/packages/calendar/src/core/sync-engine/index.test.ts
@@ -450,7 +450,7 @@ describe("createDatabaseFlush", () => {
     const fakeDatabase = {
       transaction: (callback: (tx: unknown) => Promise<void>) => {
         const tx = {
-          insert: () => { executedOperations.push("insert"); return { values: () => Promise.resolve() }; },
+          insert: () => { executedOperations.push("insert"); return { values: () => ({ onConflictDoNothing: () => Promise.resolve() }) }; },
           delete: () => { executedOperations.push("delete"); return { where: () => Promise.resolve() }; },
         };
         return callback(tx);
@@ -476,7 +476,7 @@ describe("createDatabaseFlush", () => {
     const fakeDatabase = {
       transaction: (callback: (tx: unknown) => Promise<void>) => {
         const tx = {
-          insert: () => { executedOperations.push("insert"); return { values: () => Promise.resolve() }; },
+          insert: () => { executedOperations.push("insert"); return { values: () => ({ onConflictDoNothing: () => Promise.resolve() }) }; },
           delete: () => { executedOperations.push("delete"); return { where: () => Promise.resolve() }; },
         };
         return callback(tx);
@@ -502,7 +502,7 @@ describe("createDatabaseFlush", () => {
     const fakeDatabase = {
       transaction: (callback: (tx: unknown) => Promise<void>) => {
         const tx = {
-          insert: () => { executedOperations.push("insert"); return { values: () => Promise.resolve() }; },
+          insert: () => { executedOperations.push("insert"); return { values: () => ({ onConflictDoNothing: () => Promise.resolve() }) }; },
           delete: () => { executedOperations.push("delete"); return { where: () => Promise.resolve() }; },
         };
         return callback(tx);
@@ -559,7 +559,7 @@ describe("createDatabaseFlush", () => {
         const tx = {
           insert: () => {
             insertCallCount += 1;
-            return { values: () => Promise.resolve() };
+            return { values: () => ({ onConflictDoNothing: () => Promise.resolve() }) };
           },
           delete: () => ({ where: () => Promise.resolve() }),
         };
@@ -590,7 +590,7 @@ describe("createDatabaseFlush", () => {
           insert: () => {
             insertCallCount += 1;
             return {
-              values: (rows: unknown[]) => { valuesReceived = rows; return Promise.resolve(); },
+              values: (rows: unknown[]) => { valuesReceived = rows; return { onConflictDoNothing: () => Promise.resolve() }; },
             };
           },
           delete: () => ({ where: () => Promise.resolve() }),


### PR DESCRIPTION
The unique constraint on (eventStateId, calendarId) caused the entire flush transaction to roll back when inserting a mapping that already existed. This lost all mappings from the run, causing the next sync to re-add all events as if they were new — creating duplicates on every cycle. onConflictDoNothing silently skips duplicate inserts.