### PR TITLE
fix: compute and store content hash on event mapping creation

### DIFF
--- a/packages/calendar/src/core/sync-engine/index.ts
+++ b/packages/calendar/src/core/sync-engine/index.ts
@@ -1,6 +1,7 @@
 import type { SyncResult, SyncOperation, SyncableEvent, RemoteEvent, PushResult, DeleteResult } from "../types";
 import type { EventMapping } from "../events/mappings";
 import type { SyncProgressUpdate } from "../sync/types";
+import { createSyncEventContentHash } from "../events/content-hash";
 import { computeSyncOperations } from "../sync/operations";
 import type { CalendarSyncProvider, PendingChanges } from "./types";
 
@@ -39,7 +40,7 @@ const processAddResults = (
       calendarId,
       destinationEventUid: pushResult.remoteId,
       deleteIdentifier: pushResult.deleteId ?? pushResult.remoteId,
-      syncEventHash: null,
+      syncEventHash: createSyncEventContentHash(operation.event),
       startTime: operation.event.startTime,
       endTime: operation.event.endTime,
     });


### PR DESCRIPTION
syncEventHash was always set to null when creating mappings, causing identifyStaleMappings to mark every mapping as stale on every run (null !== actualHash). This triggered a delete-and-re-add cycle for every mapped event on every sync, creating duplicates indefinitely.