### PR TITLE
fix: always flush stale mapping deletes even when superseded

### DIFF
--- a/packages/calendar/src/core/sync-engine/index.ts
+++ b/packages/calendar/src/core/sync-engine/index.ts
@@ -374,9 +374,7 @@ const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncResult> =
     wideEvent["events.remove_failed"] = outcome.result.removeFailed;
     wideEvent["superseded"] = outcome.superseded;
 
-    if (!outcome.superseded) {
-      outcome.changes.deletes.push(...staleMappingIds);
-    }
+    outcome.changes.deletes.push(...staleMappingIds);
 
     await flush(outcome.changes);
     flushed = true;


### PR DESCRIPTION
When a sync is superseded mid-run, stale mapping IDs were not included in the flush. This meant the old mapping survived in the database while a new remote event was already pushed. The next run would push another new event (old mapping still exists so onConflictDoNothing skips the new mapping insert), creating duplicates on every cycle. Always flushing stale mapping deletes ensures the old mapping is removed so the new mapping can be inserted on the next flush.