### PR TITLE
feat(caldav): add direct calendar URL mode

### DIFF
--- a/applications/web/src/features/auth/components/caldav-connect-form.tsx
+++ b/applications/web/src/features/auth/components/caldav-connect-form.tsx
@@ -97,6 +97,12 @@ export function CalDAVConnectForm({ provider }: CalDAVConnectFormProps) {
 
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  const [directMode, setDirectMode] = useState(false);
+
+  // Direct-URL mode is exposed only for the generic CalDAV provider. The
+  // dedicated icloud/fastmail flows already know their server's principal
+  // structure and benefit from discovery.
+  const supportsDirectMode = provider === "caldav";
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -112,60 +118,104 @@ export function CalDAVConnectForm({ provider }: CalDAVConnectFormProps) {
       return;
     }
 
+    const directCalendarUrl = directMode
+      ? readFormFieldValue(formData, "calendarUrl")
+      : "";
+    const directName = directMode ? readFormFieldValue(formData, "name") : "";
+
+    if (directMode && (!directCalendarUrl || !directName)) {
+      setError("Missing required calendar URL or display name");
+      return;
+    }
+
     startTransition(async () => {
-      let discoverResponse: Response;
-      try {
-        discoverResponse = await apiFetch("/api/sources/caldav/discover", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ serverUrl, username, password }),
-        });
-      } catch (err) {
-        setError(resolveErrorMessage(err, "Failed to discover calendars"));
-        return;
-      }
-
-      const discoverPayload = await discoverResponse.json();
-      const calendars = parseCalendarOptions(discoverPayload);
-      const authMethod = parseAuthMethod(discoverPayload);
-      if (!calendars) {
-        setError("Failed to parse discovered calendars");
-        return;
-      }
-
-      if (calendars.length === 0) {
-        setError("No calendars found");
-        return;
-      }
-
       let accountId: string | undefined;
 
-      try {
-        const responses = await Promise.all(
-          calendars.map((calendar) =>
-            apiFetch("/api/sources/caldav", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                authMethod,
-                calendarUrl: calendar.url,
-                name: calendar.displayName,
-                password,
-                provider,
-                serverUrl,
-                username,
-              }),
+      if (directMode) {
+        // Direct-URL mode: skip discovery, create one source pointing to the
+        // user-supplied calendar URL. Useful for servers like Zoho that
+        // surface per-calendar CalDAV URLs but don't expose a walkable
+        // principal/home-set to the CalDAV client.
+        let response: Response;
+        try {
+          response = await apiFetch("/api/sources/caldav", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              authMethod: "basic",
+              calendarUrl: directCalendarUrl,
+              name: directName,
+              password,
+              provider,
+              serverUrl,
+              username,
             }),
-          ),
-        );
-
-        const firstResponse = responses[0];
-        if (firstResponse) {
-          accountId = parseAccountId(await firstResponse.json());
+          });
+        } catch (err) {
+          setError(resolveErrorMessage(err, "Failed to create CalDAV source"));
+          return;
         }
-      } catch {
-        setError("Failed to import calendars");
-        return;
+
+        if (!response.ok) {
+          const message = await response.text().catch(() => "");
+          setError(message || "Failed to create CalDAV source");
+          return;
+        }
+
+        accountId = parseAccountId(await response.json().catch(() => null));
+      } else {
+        let discoverResponse: Response;
+        try {
+          discoverResponse = await apiFetch("/api/sources/caldav/discover", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ serverUrl, username, password }),
+          });
+        } catch (err) {
+          setError(resolveErrorMessage(err, "Failed to discover calendars"));
+          return;
+        }
+
+        const discoverPayload = await discoverResponse.json();
+        const calendars = parseCalendarOptions(discoverPayload);
+        const authMethod = parseAuthMethod(discoverPayload);
+        if (!calendars) {
+          setError("Failed to parse discovered calendars");
+          return;
+        }
+
+        if (calendars.length === 0) {
+          setError("No calendars found");
+          return;
+        }
+
+        try {
+          const responses = await Promise.all(
+            calendars.map((calendar) =>
+              apiFetch("/api/sources/caldav", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  authMethod,
+                  calendarUrl: calendar.url,
+                  name: calendar.displayName,
+                  password,
+                  provider,
+                  serverUrl,
+                  username,
+                }),
+              }),
+            ),
+          );
+
+          const firstResponse = responses[0];
+          if (firstResponse) {
+            accountId = parseAccountId(await firstResponse.json());
+          }
+        } catch {
+          setError("Failed to import calendars");
+          return;
+        }
       }
 
       await invalidateAccountsAndSources(globalMutate);
@@ -192,6 +242,22 @@ export function CalDAVConnectForm({ provider }: CalDAVConnectFormProps) {
         ) : (
           <Input type="hidden" name="serverUrl" defaultValue={config.serverUrl} />
         )}
+        {directMode && (
+          <>
+            <Input
+              name="calendarUrl"
+              type="url"
+              placeholder="Direct CalDAV calendar URL"
+              required
+            />
+            <Input
+              name="name"
+              type="text"
+              placeholder="Display name"
+              required
+            />
+          </>
+        )}
         <Input
           name="username"
           type={config.usernameInputType}
@@ -205,6 +271,19 @@ export function CalDAVConnectForm({ provider }: CalDAVConnectFormProps) {
           required
         />
       </div>
+      {supportsDirectMode && (
+        <label className="flex cursor-pointer select-none items-center gap-2">
+          <input
+            type="checkbox"
+            checked={directMode}
+            onChange={(event) => setDirectMode(event.target.checked)}
+            className="size-4"
+          />
+          <Text size="sm">
+            I have a direct calendar URL (skip discovery)
+          </Text>
+        </label>
+      )}
       {error && <Text size="sm" tone="danger">{error}</Text>}
       <Divider />
       <div className="flex items-stretch gap-2">

--- a/packages/calendar/src/providers/caldav/shared/client.ts
+++ b/packages/calendar/src/providers/caldav/shared/client.ts
@@ -70,7 +70,15 @@ class CalDAVClient {
   }
 
   async fetchCalendarDisplayName(calendarUrl: string): Promise<string | null> {
-    const calendars = await this.discoverCalendars();
+    // Falls back to null when discovery is unsupported by the server (e.g. some
+    // providers expose direct calendar URLs without a walkable principal/home),
+    // letting callers keep the user-supplied name.
+    let calendars: CalendarInfo[];
+    try {
+      calendars = await this.discoverCalendars();
+    } catch {
+      return null;
+    }
     const storedPath = new URL(calendarUrl).pathname;
 
     const matchingCalendar = calendars.find(
@@ -81,7 +89,15 @@ class CalDAVClient {
   }
 
   async resolveCalendarUrl(storedUrl: string): Promise<string> {
-    const calendars = await this.discoverCalendars();
+    // Falls back to the stored URL when discovery fails. This supports sources
+    // added by a direct calendar URL on servers (like Zoho group calendars)
+    // whose principal/home-set walk is not exposed to CalDAV clients.
+    let calendars: CalendarInfo[];
+    try {
+      calendars = await this.discoverCalendars();
+    } catch {
+      return storedUrl;
+    }
     const storedPath = new URL(storedUrl).pathname;
 
     const matchingCalendar = calendars.find(


### PR DESCRIPTION
## Summary

Adds an opt-in "direct calendar URL" mode to the generic CalDAV connect flow, so users can pair a CalDAV calendar by pasting its URL instead of relying on principal/home-set discovery.

## Why

Some hosted CalDAV providers expose per-calendar URLs in their web UI but don't surface a walkable user principal that includes those calendars. The most common case I hit is **Zoho Calendar group calendars**: each one has a stable `https://calendar.zoho.com/caldav/<id>/events/` URL shown in *Settings → Integrate Calendar*, but they live outside the user's personal CalDAV principal and `tsdav.discoverCalendars()` either returns nothing or throws `cannot find homeUrl`. The same pattern shows up with some Nextcloud shared calendars and a few less common providers.

Today the only way through is for the server admin to flip a per-calendar toggle (Zoho's *CalDAV Sync → Group Calendars* tab), which is not always available depending on plan / org policy. Direct-URL mode is a small escape hatch that lets the user bring the URL themselves.

## Changes

Two files. No schema or DB changes.

**`applications/web/src/features/auth/components/caldav-connect-form.tsx`**
- The generic `caldav` provider gets a new checkbox: *"I have a direct calendar URL (skip discovery)"*.
- When enabled, the form reveals `calendarUrl` and `name` inputs. On submit it skips the `POST /api/sources/caldav/discover` call entirely and creates one source via `POST /api/sources/caldav` with the user-supplied values.
- `authMethod` defaults to `basic`; the existing digest-aware fetch wrapper still upgrades automatically at sync time if the server demands digest.
- The toggle is intentionally not shown for `fastmail` / `icloud`, where discovery is well-known and reliable.

**`packages/calendar/src/providers/caldav/shared/client.ts`**
- `resolveCalendarUrl` now falls back to the stored URL when `discoverCalendars()` throws.
- `fetchCalendarDisplayName` now falls back to `null` under the same condition.

This is the minimum needed so sources added by direct URL keep syncing on servers that can't enumerate calendars under the user principal. For sources added via the existing discovery flow, behavior is unchanged — discovery still succeeds, the matching calendar still resolves, etc.

## Testing

Self-hosted `keeper-services:2.9` + locally built `web` and `calendar` packages. Verified:

- Existing discovery flow against Apple iCloud — connects, ingests events, no change in behavior.
- Direct-URL flow against a Zoho group calendar — source created, cron `ingest-source` pulls events successfully (it never needed the discovery walk in the first place).
- Existing discovery flow against a server that fails discovery — used to crash the sync via `resolveCalendarUrl`. Now sync proceeds using the stored URL.

No automated test added for the new path because the change is purely a UI branch + a try/catch in two helpers; existing tests already cover discovery success and `fetchCalendarObjects` behavior, both unchanged. Happy to add one if you think it's worth it.

## Compatibility

- No schema changes.
- Existing sources keep working without any migration.
- New sources created via direct-URL mode are indistinguishable in the DB from those created via discovery — same `calendarUrl`, `serverUrl`, etc. shape.

## Out of scope

- A "direct URL" entry point for the dedicated icloud/fastmail flows. Their discovery is reliable enough that exposing the toggle there feels like noise.
- Validating the direct URL with a probe PROPFIND before creating the source. Easy to add but I wanted to keep this change minimal. Currently the sync engine surfaces the error if the URL is bad.
