### PR TITLE
fix(mcp): emit valid ISO 8601 offsets in localized event times

### DIFF
--- a/services/mcp/src/toolset.ts
+++ b/services/mcp/src/toolset.ts
@@ -103,14 +103,25 @@ const isEventRangeInput = (
 ): input is Record<string, unknown> & { from: string; to: string; timezone: string } =>
   typeof input.from === "string" && typeof input.to === "string" && typeof input.timezone === "string";
 
+const TIMEZONE_OFFSET_PATTERN = /^([+-]?)(\d{1,2})(?::?(\d{2}))?$/;
+const UTC_OFFSET = "+00:00";
+const DEFAULT_MINUTES = "00";
+
 const normalizeTimezoneOffset = (raw: string): string => {
   if (raw === "") {
-    return "+00:00";
+    return UTC_OFFSET;
   }
-  if (raw.includes(":")) {
-    return raw.padStart(6, "+0");
+  const match = TIMEZONE_OFFSET_PATTERN.exec(raw);
+  if (!match) {
+    return raw;
   }
-  return `${raw.padStart(3, "+0")}:00`;
+  let sign: "+" | "-" = "+";
+  if (match[1] === "-") {
+    sign = "-";
+  }
+  const hours = (match[2] ?? "00").padStart(2, "0");
+  const minutes = (match[3] ?? DEFAULT_MINUTES).padStart(2, "0");
+  return `${sign}${hours}:${minutes}`;
 };
 
 const toLocalizedTime = (utcIso: string, timeZone: string): string => {
@@ -324,5 +335,5 @@ const createKeeperMcpToolset = (): KeeperMcpToolset => ({
   },
 });
 
-export { createKeeperMcpToolset };
+export { createKeeperMcpToolset, normalizeTimezoneOffset, toLocalizedTime };
 export type { KeeperCalendar, KeeperMcpToolDefinition, KeeperMcpToolset, KeeperToolContext };

--- a/services/mcp/tests/normalize-timezone-offset.test.ts
+++ b/services/mcp/tests/normalize-timezone-offset.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeTimezoneOffset, toLocalizedTime } from "../src/toolset";
+
+describe("normalizeTimezoneOffset", () => {
+  it("returns +00:00 for an empty offset (UTC)", () => {
+    expect(normalizeTimezoneOffset("")).toBe("+00:00");
+  });
+
+  it("pads negative single-digit offsets correctly", () => {
+    // Regression: padStart(3, "+0") on "-3" used to yield "+-3:00".
+    expect(normalizeTimezoneOffset("-3")).toBe("-03:00");
+  });
+
+  it("pads positive single-digit offsets correctly", () => {
+    expect(normalizeTimezoneOffset("+5")).toBe("+05:00");
+  });
+
+  it("defaults to + when no sign is present", () => {
+    expect(normalizeTimezoneOffset("5")).toBe("+05:00");
+  });
+
+  it("normalizes short colon-separated offsets", () => {
+    expect(normalizeTimezoneOffset("-3:00")).toBe("-03:00");
+    expect(normalizeTimezoneOffset("+5:30")).toBe("+05:30");
+  });
+
+  it("passes canonical offsets through unchanged", () => {
+    expect(normalizeTimezoneOffset("-10:00")).toBe("-10:00");
+    expect(normalizeTimezoneOffset("+05:30")).toBe("+05:30");
+  });
+
+  it("handles compact (colon-less) offsets", () => {
+    expect(normalizeTimezoneOffset("-1030")).toBe("-10:30");
+    expect(normalizeTimezoneOffset("+0530")).toBe("+05:30");
+  });
+
+  it("returns the raw input when it does not match a known offset shape", () => {
+    expect(normalizeTimezoneOffset("not-an-offset")).toBe("not-an-offset");
+  });
+});
+
+describe("toLocalizedTime", () => {
+  it("serializes Montevideo time with a valid ISO 8601 offset", () => {
+    const localized = toLocalizedTime("2026-05-18T14:00:00.000Z", "America/Montevideo");
+    expect(localized).toBe("2026-05-18T11:00:00-03:00");
+  });
+
+  it("serializes UTC times with a +00:00 offset", () => {
+    const localized = toLocalizedTime("2026-05-18T14:00:00.000Z", "UTC");
+    expect(localized).toBe("2026-05-18T14:00:00+00:00");
+  });
+
+  it("serializes a half-hour offset zone (Kolkata) correctly", () => {
+    const localized = toLocalizedTime("2026-05-18T14:00:00.000Z", "Asia/Kolkata");
+    expect(localized).toBe("2026-05-18T19:30:00+05:30");
+  });
+});


### PR DESCRIPTION
## Summary

`normalizeTimezoneOffset` in `services/mcp/src/toolset.ts` mis-pads sign-prefixed offset strings, so localized `startTime` / `endTime` values come back with malformed offsets like `"+-3:00"` for any zone whose `Intl.DateTimeFormat` `shortOffset` representation is shorter than `±HH:MM`. Strict ISO 8601 parsers (and the `Temporal` polyfill on modern clients) reject those.

## Why

When a caller hits `get_events` for `timezone: "America/Montevideo"`, the MCP serialises each event's instant via:

```ts
const offset = getPartValue("timeZoneName").replace("GMT", "");
const normalizedOffset = normalizeTimezoneOffset(offset);
// → `${YYYY-MM-DD}T${HH:mm:ss}${normalizedOffset}`
```

`Intl.DateTimeFormat({ timeZoneName: "shortOffset" })` returns `"GMT-3"` for Montevideo, so `offset === "-3"`. The current normalizer hits the third branch:

```ts
return `${raw.padStart(3, "+0")}:00`;
```

`String.prototype.padStart` with a multi-char filler takes characters from the **start** of the filler string. `"-3".padStart(3, "+0")` yields `"+-3"`, not `"0-3"`, so the final output is `"+-3:00"`.

The same kind of issue exists for the colon branch: `"-3:00".padStart(6, "+0")` yields `"+-3:00"` rather than `"-03:00"`.

This affects every zone where the short offset is single-digit (`-1` through `-9`, `+0` through `+9`) and any non-padded colon form. Concrete zones I hit in production:

- `America/Montevideo`, `America/Argentina/Buenos_Aires`, `America/Sao_Paulo` (UTC-3)
- `Europe/Paris`, `Africa/Lagos` (UTC+1)
- `Asia/Tehran` (UTC+3:30 — also currently broken in the colon branch)

## Changes

Single file: `services/mcp/src/toolset.ts`.

Rewrites `normalizeTimezoneOffset` around a regex that splits sign, hours, and optional minutes, then formats canonical `±HH:MM`:

```ts
const TIMEZONE_OFFSET_PATTERN = /^([+-]?)(\d{1,2})(?::?(\d{2}))?$/;
const UTC_OFFSET = "+00:00";
const DEFAULT_MINUTES = "00";

const normalizeTimezoneOffset = (raw: string): string => {
  if (raw === "") {
    return UTC_OFFSET;
  }
  const match = TIMEZONE_OFFSET_PATTERN.exec(raw);
  if (!match) {
    return raw;
  }
  let sign: "+" | "-" = "+";
  if (match[1] === "-") {
    sign = "-";
  }
  const hours = (match[2] ?? "00").padStart(2, "0");
  const minutes = (match[3] ?? DEFAULT_MINUTES).padStart(2, "0");
  return `${sign}${hours}:${minutes}`;
};
```

Also exports `normalizeTimezoneOffset` and `toLocalizedTime` so they can be unit-tested.

## Testing

Added `services/mcp/tests/normalize-timezone-offset.test.ts` covering:

- empty input → `"+00:00"`
- single-digit negative (regression) → `"-3" → "-03:00"`
- single-digit positive → `"+5" → "+05:00"`
- no-sign defaults to `+` → `"5" → "+05:00"`
- short colon shapes → `"-3:00" → "-03:00"`, `"+5:30" → "+05:30"`
- canonical pass-through → `"-10:00"`, `"+05:30"`
- compact colon-less shapes → `"-1030" → "-10:30"`
- garbage input → unchanged

Plus an end-to-end check on `toLocalizedTime` for Montevideo (negative offset), UTC (`+00:00`), and Asia/Kolkata (half-hour offset).

All tests pass under `bun run test` in `services/mcp`.

## Compatibility

- No schema, API, or wire-format change. The output is **more** standards-compliant, not less.
- Behavior is unchanged for inputs that were already canonical (`±HH:MM` strings of length 6).
- The two new named exports are additive.

## Out of scope

- Reviewing other places where `Intl.DateTimeFormat({ timeZoneName })` output is consumed. I only touched the MCP serialiser since that's where I hit the issue, but a quick grep didn't surface other call sites.
