### PR TITLE
fix(api): expand recurring events when serving range queries

### DIFF
--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -62,6 +62,10 @@ export { allSettledWithConcurrency, type AllSettledWithConcurrencyOptions } from
 export { getErrorMessage } from "./core/utils/error";
 export { getEventsForDestination } from "./core/events/events";
 export {
+  parseExceptionDatesFromJson,
+  parseRecurrenceRuleFromJson,
+} from "./core/events/recurrence";
+export {
   buildSourceEventIdentityKey,
   buildSourceEventsToAdd,
   buildSourceEventStateIdsToRemove,

--- a/services/api/src/queries/expand-recurring-event.ts
+++ b/services/api/src/queries/expand-recurring-event.ts
@@ -1,0 +1,106 @@
+import { extendByRecurrenceRule } from "ts-ics";
+
+import {
+  parseExceptionDatesFromJson,
+  parseRecurrenceRuleFromJson,
+} from "@keeper.sh/calendar";
+
+interface RecurringEventRow {
+  id: string;
+  calendarId: string;
+  startTime: Date;
+  endTime: Date;
+  recurrenceRule: string | null;
+  exceptionDates: string | null;
+  title: string | null;
+  description: string | null;
+  location: string | null;
+}
+
+interface RecurringOccurrence {
+  id: string;
+  calendarId: string;
+  startTime: Date;
+  endTime: Date;
+  title: string | null;
+  description: string | null;
+  location: string | null;
+}
+
+const MS_OFFSET_NONE = 0;
+
+const buildOccurrenceId = (masterId: string, occurrenceStart: Date): string =>
+  `${masterId}_${occurrenceStart.toISOString()}`;
+
+const isWithinInclusive = (date: Date, start: Date, end: Date): boolean =>
+  date >= start && date <= end;
+
+/**
+ * Materialise recurring-event occurrences that fall inside [windowStart,
+ * windowEnd]. The master row stores the first occurrence's start/end plus the
+ * serialised RRULE / EXDATE; we use `ts-ics`'s `extendByRecurrenceRule` to
+ * generate every concrete occurrence within the window, honouring exception
+ * dates and the rule's `until` / `count` terminators.
+ *
+ * Each occurrence inherits the master's duration. RECURRENCE-ID overrides
+ * (per-instance edits/cancellations beyond plain EXDATE) are not yet
+ * persisted by the ingest path and are therefore not honoured here.
+ *
+ * When the RRULE is missing or unparseable, only the master row is returned,
+ * and only if it lies within the window.
+ */
+const expandRecurringEvent = (
+  row: RecurringEventRow,
+  windowStart: Date,
+  windowEnd: Date,
+): RecurringOccurrence[] => {
+  const rule = parseRecurrenceRuleFromJson(row.recurrenceRule);
+  if (!rule) {
+    if (isWithinInclusive(row.startTime, windowStart, windowEnd)) {
+      return [
+        {
+          id: row.id,
+          calendarId: row.calendarId,
+          startTime: row.startTime,
+          endTime: row.endTime,
+          title: row.title,
+          description: row.description,
+          location: row.location,
+        },
+      ];
+    }
+    return [];
+  }
+
+  const exceptions = parseExceptionDatesFromJson(row.exceptionDates);
+  const durationMs = Math.max(
+    row.endTime.getTime() - row.startTime.getTime(),
+    MS_OFFSET_NONE,
+  );
+
+  const dates = extendByRecurrenceRule(rule, {
+    start: row.startTime,
+    end: windowEnd,
+    exceptions,
+  });
+
+  const occurrences: RecurringOccurrence[] = [];
+  for (const occurrenceStart of dates) {
+    if (!isWithinInclusive(occurrenceStart, windowStart, windowEnd)) {
+      continue;
+    }
+    occurrences.push({
+      id: buildOccurrenceId(row.id, occurrenceStart),
+      calendarId: row.calendarId,
+      startTime: occurrenceStart,
+      endTime: new Date(occurrenceStart.getTime() + durationMs),
+      title: row.title,
+      description: row.description,
+      location: row.location,
+    });
+  }
+  return occurrences;
+};
+
+export { expandRecurringEvent };
+export type { RecurringEventRow, RecurringOccurrence };

--- a/services/api/src/queries/get-events-in-range.ts
+++ b/services/api/src/queries/get-events-in-range.ts
@@ -5,19 +5,21 @@ import {
   userEventsTable,
 } from "@keeper.sh/database/schema";
 import { normalizeDateRange } from "@/utils/date-range";
-import { and, arrayContains, asc, eq, gte, inArray, lte } from "drizzle-orm";
+import { and, arrayContains, asc, eq, gte, inArray, isNotNull, isNull, lte, or } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
+
+import { expandRecurringEvent } from "./expand-recurring-event";
+import type { RecurringOccurrence } from "./expand-recurring-event";
+
 import type { KeeperDatabase, KeeperEvent, KeeperEventFilters, KeeperEventRangeInput } from "@/types";
 
 const EMPTY_RESULT_COUNT = 0;
 
 const toRequiredDate = (value: Date | string, label: "from" | "to"): Date => {
   const parsedDate = new Date(value);
-
   if (Number.isNaN(parsedDate.getTime())) {
     throw new TypeError(`Invalid ${label} date`);
   }
-
   return parsedDate;
 };
 
@@ -75,6 +77,84 @@ const getSourcesForUser = async (
   return { calendarIds, sourceMap };
 };
 
+interface SyncedEventRow {
+  calendarId: string;
+  description: string | null;
+  endTime: Date;
+  exceptionDates: string | null;
+  id: string;
+  location: string | null;
+  recurrenceRule: string | null;
+  startTime: Date;
+  title: string | null;
+}
+
+interface UserEventRow {
+  calendarId: string;
+  description: string | null;
+  endTime: Date;
+  id: string;
+  location: string | null;
+  startTime: Date;
+  title: string | null;
+}
+
+type FlattenedEvent = UserEventRow;
+
+const flattenSyncedEvent = (
+  row: SyncedEventRow,
+  windowStart: Date,
+  windowEnd: Date,
+): FlattenedEvent[] => {
+  if (!row.recurrenceRule) {
+    return [
+      {
+        calendarId: row.calendarId,
+        description: row.description,
+        endTime: row.endTime,
+        id: row.id,
+        location: row.location,
+        startTime: row.startTime,
+        title: row.title,
+      },
+    ];
+  }
+  const occurrences: RecurringOccurrence[] = expandRecurringEvent(
+    row,
+    windowStart,
+    windowEnd,
+  );
+  return occurrences.map((occurrence) => ({
+    calendarId: occurrence.calendarId,
+    description: occurrence.description,
+    endTime: occurrence.endTime,
+    id: occurrence.id,
+    location: occurrence.location,
+    startTime: occurrence.startTime,
+    title: occurrence.title,
+  }));
+};
+
+/**
+ * Build the WHERE clause for fetching synced rows that may contribute events
+ * to [start, end]: one-offs whose startTime is in-window, plus recurring
+ * masters whose first occurrence is at-or-before the window end (later
+ * occurrences may still land inside the window even if the master is far in
+ * the past).
+ */
+const buildSyncedRangeCondition = (start: Date, end: Date): SQL | undefined =>
+  or(
+    and(
+      isNull(eventStatesTable.recurrenceRule),
+      gte(eventStatesTable.startTime, start),
+      lte(eventStatesTable.startTime, end),
+    ),
+    and(
+      isNotNull(eventStatesTable.recurrenceRule),
+      lte(eventStatesTable.startTime, end),
+    ),
+  );
+
 const getEventsInRange = async (
   database: KeeperDatabase,
   userId: string,
@@ -90,31 +170,38 @@ const getEventsInRange = async (
 
   const syncedConditions: SQL[] = [
     inArray(eventStatesTable.calendarId, calendarIds),
-    gte(eventStatesTable.startTime, start),
-    lte(eventStatesTable.startTime, end),
   ];
+  const syncedRangeCondition = buildSyncedRangeCondition(start, end);
+  if (syncedRangeCondition) {
+    syncedConditions.push(syncedRangeCondition);
+  }
 
   if (filters?.availability && filters.availability.length > 0) {
     syncedConditions.push(inArray(eventStatesTable.availability, filters.availability));
   }
-
   if (filters && "isAllDay" in filters && typeof filters.isAllDay === "boolean") {
     syncedConditions.push(eq(eventStatesTable.isAllDay, filters.isAllDay));
   }
 
-  const syncedEvents = await database
+  const syncedRows: SyncedEventRow[] = await database
     .select({
       calendarId: eventStatesTable.calendarId,
       description: eventStatesTable.description,
       endTime: eventStatesTable.endTime,
+      exceptionDates: eventStatesTable.exceptionDates,
       id: eventStatesTable.id,
       location: eventStatesTable.location,
+      recurrenceRule: eventStatesTable.recurrenceRule,
       startTime: eventStatesTable.startTime,
       title: eventStatesTable.title,
     })
     .from(eventStatesTable)
     .where(and(...syncedConditions))
     .orderBy(asc(eventStatesTable.startTime));
+
+  const syncedEvents: FlattenedEvent[] = syncedRows.flatMap((row) =>
+    flattenSyncedEvent(row, start, end),
+  );
 
   const userConditions: SQL[] = [
     inArray(userEventsTable.calendarId, calendarIds),
@@ -126,12 +213,11 @@ const getEventsInRange = async (
   if (filters?.availability && filters.availability.length > 0) {
     userConditions.push(inArray(userEventsTable.availability, filters.availability));
   }
-
   if (filters && "isAllDay" in filters && typeof filters.isAllDay === "boolean") {
     userConditions.push(eq(userEventsTable.isAllDay, filters.isAllDay));
   }
 
-  const userEvents = await database
+  const userEvents: UserEventRow[] = await database
     .select({
       calendarId: userEventsTable.calendarId,
       description: userEventsTable.description,
@@ -145,16 +231,14 @@ const getEventsInRange = async (
     .where(and(...userConditions))
     .orderBy(asc(userEventsTable.startTime));
 
-  const allEvents = [...syncedEvents, ...userEvents];
+  const allEvents: FlattenedEvent[] = [...syncedEvents, ...userEvents];
   allEvents.sort((left, right) => left.startTime.getTime() - right.startTime.getTime());
 
   return allEvents.map((event) => {
     const source = sourceMap.get(event.calendarId);
-
     if (!source) {
       throw new Error(`No source calendar found for event calendar ID: ${event.calendarId}`);
     }
-
     return {
       calendarId: event.calendarId,
       calendarName: source.name,

--- a/services/api/tests/queries/expand-recurring-event.test.ts
+++ b/services/api/tests/queries/expand-recurring-event.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  expandRecurringEvent,
+  type RecurringEventRow,
+} from "@/queries/expand-recurring-event";
+
+const MINUTES_PER_HOUR = 60;
+const MS_PER_SECOND = 1000;
+const MS_PER_MINUTE = MINUTES_PER_HOUR * MS_PER_SECOND;
+const NINETY_MINUTES_MS = 90 * MS_PER_MINUTE;
+const SIXTY_MINUTES_MS = MINUTES_PER_HOUR * MS_PER_MINUTE;
+
+const buildRow = (overrides: Partial<RecurringEventRow> = {}): RecurringEventRow => ({
+  id: "master-id",
+  calendarId: "calendar-id",
+  startTime: new Date("2026-05-04T14:00:00.000Z"),
+  endTime: new Date("2026-05-04T15:00:00.000Z"),
+  recurrenceRule: null,
+  exceptionDates: null,
+  title: "Ops Daily",
+  description: null,
+  location: null,
+  ...overrides,
+});
+
+const ruleJson = (rule: Record<string, unknown>): string => JSON.stringify(rule);
+
+const exceptionDatesJson = (dates: string[]): string =>
+  JSON.stringify(dates.map((date) => ({ date })));
+
+const startsIso = (occurrences: { startTime: Date }[]): string[] =>
+  occurrences.map((occurrence) => occurrence.startTime.toISOString());
+
+const durationMs = (occurrence: { startTime: Date; endTime: Date }): number =>
+  occurrence.endTime.getTime() - occurrence.startTime.getTime();
+
+describe("expandRecurringEvent", () => {
+  it("emits one occurrence per day for a DAILY rule within the window", () => {
+    const row = buildRow({
+      recurrenceRule: ruleJson({ frequency: "DAILY" }),
+    });
+
+    const occurrences = expandRecurringEvent(
+      row,
+      new Date("2026-05-04T00:00:00.000Z"),
+      new Date("2026-05-07T23:59:59.999Z"),
+    );
+
+    expect(startsIso(occurrences)).toEqual([
+      "2026-05-04T14:00:00.000Z",
+      "2026-05-05T14:00:00.000Z",
+      "2026-05-06T14:00:00.000Z",
+      "2026-05-07T14:00:00.000Z",
+    ]);
+  });
+
+  it("preserves the master duration on each occurrence", () => {
+    const row = buildRow({
+      startTime: new Date("2026-05-04T14:00:00.000Z"),
+      endTime: new Date("2026-05-04T15:30:00.000Z"),
+      recurrenceRule: ruleJson({ frequency: "DAILY" }),
+    });
+
+    const occurrences = expandRecurringEvent(
+      row,
+      new Date("2026-05-04T00:00:00.000Z"),
+      new Date("2026-05-05T23:59:59.999Z"),
+    );
+
+    expect(occurrences.map((occurrence) => durationMs(occurrence))).toEqual([
+      NINETY_MINUTES_MS,
+      NINETY_MINUTES_MS,
+    ]);
+  });
+
+  it("skips occurrences listed in EXDATE", () => {
+    const row = buildRow({
+      recurrenceRule: ruleJson({ frequency: "DAILY" }),
+      exceptionDates: exceptionDatesJson(["2026-05-06T14:00:00.000Z"]),
+    });
+
+    const occurrences = expandRecurringEvent(
+      row,
+      new Date("2026-05-04T00:00:00.000Z"),
+      new Date("2026-05-07T23:59:59.999Z"),
+    );
+
+    expect(startsIso(occurrences)).toEqual([
+      "2026-05-04T14:00:00.000Z",
+      "2026-05-05T14:00:00.000Z",
+      "2026-05-07T14:00:00.000Z",
+    ]);
+  });
+
+  it("returns occurrences inside the window when the master started before it", () => {
+    const row = buildRow({
+      startTime: new Date("2026-01-01T14:00:00.000Z"),
+      endTime: new Date("2026-01-01T15:00:00.000Z"),
+      recurrenceRule: ruleJson({ frequency: "WEEKLY" }),
+    });
+    const windowStart = new Date("2026-05-04T00:00:00.000Z");
+    const windowEnd = new Date("2026-05-31T23:59:59.999Z");
+
+    const occurrences = expandRecurringEvent(row, windowStart, windowEnd);
+
+    expect(occurrences.length).toBeGreaterThan(0);
+    for (const occurrence of occurrences) {
+      expect(occurrence.startTime.getTime()).toBeGreaterThanOrEqual(windowStart.getTime());
+      expect(occurrence.startTime.getTime()).toBeLessThanOrEqual(windowEnd.getTime());
+      expect(durationMs(occurrence)).toBe(SIXTY_MINUTES_MS);
+    }
+  });
+
+  it("honours the rule's UNTIL terminator", () => {
+    const row = buildRow({
+      recurrenceRule: ruleJson({
+        frequency: "DAILY",
+        until: { date: "2026-05-06T23:59:59.000Z" },
+      }),
+    });
+
+    const occurrences = expandRecurringEvent(
+      row,
+      new Date("2026-05-04T00:00:00.000Z"),
+      new Date("2026-05-10T23:59:59.999Z"),
+    );
+
+    expect(startsIso(occurrences)).toEqual([
+      "2026-05-04T14:00:00.000Z",
+      "2026-05-05T14:00:00.000Z",
+      "2026-05-06T14:00:00.000Z",
+    ]);
+  });
+
+  it("honours the rule's COUNT terminator", () => {
+    const row = buildRow({
+      recurrenceRule: ruleJson({ frequency: "DAILY", count: 2 }),
+    });
+
+    const occurrences = expandRecurringEvent(
+      row,
+      new Date("2026-05-04T00:00:00.000Z"),
+      new Date("2026-05-10T23:59:59.999Z"),
+    );
+
+    expect(occurrences).toHaveLength(2);
+  });
+
+  it("emits the master alone when the RRULE is missing and the master is in-window", () => {
+    const row = buildRow({ recurrenceRule: null });
+
+    const occurrences = expandRecurringEvent(
+      row,
+      new Date("2026-05-04T00:00:00.000Z"),
+      new Date("2026-05-04T23:59:59.999Z"),
+    );
+
+    expect(occurrences).toHaveLength(1);
+    expect(occurrences[0]?.id).toBe("master-id");
+  });
+
+  it("emits nothing when the RRULE is missing and the master is out of window", () => {
+    const row = buildRow({ recurrenceRule: null });
+
+    const occurrences = expandRecurringEvent(
+      row,
+      new Date("2026-06-01T00:00:00.000Z"),
+      new Date("2026-06-30T23:59:59.999Z"),
+    );
+
+    expect(occurrences).toEqual([]);
+  });
+
+  it("assigns synthetic ids that are stable per occurrence", () => {
+    const row = buildRow({
+      recurrenceRule: ruleJson({ frequency: "DAILY" }),
+    });
+
+    const occurrences = expandRecurringEvent(
+      row,
+      new Date("2026-05-04T00:00:00.000Z"),
+      new Date("2026-05-05T23:59:59.999Z"),
+    );
+
+    expect(occurrences[0]?.id).toBe("master-id_2026-05-04T14:00:00.000Z");
+    expect(occurrences[1]?.id).toBe("master-id_2026-05-05T14:00:00.000Z");
+  });
+});


### PR DESCRIPTION
## Summary

`getEventsInRange` matches event rows with a flat `eventStatesTable.startTime BETWEEN start AND end` filter. For recurring events the master row's `startTime` holds only the first occurrence, so DAILY / WEEKLY / etc. masters whose first occurrence falls outside the queried window are dropped entirely — every later occurrence is lost. This makes the ICS provider effectively unusable as a source of truth for any feed with recurring events (Bankingly feed in my case, but the same applies to anything pulled from Outlook / Exchange / Google ICS exports).

Repro against a fresh keeper instance synced with an ICS feed that has a DAILY event:

```
GET /api/events?from=2026-05-18T00:00:00Z&to=2026-05-18T23:59:59Z
```

returns only the one-off VEVENTs scheduled that day. The daily recurring meeting that should land at 10:00 is missing because its master `startTime` is two months earlier.

## Why

ICS ingest in `packages/calendar/src/ics/utils/parse-ics-events.ts` correctly reads `recurrenceRule` and `exceptionDates` and stores them on the master row in `event_states`. The destination/write path consumes them via `extendByRecurrenceRule` in `hasActiveFutureOccurrence` to decide whether a recurring master is still active.

The **read path** never materialises occurrences. `getEventsInRange` only queries `eventStatesTable.startTime BETWEEN start AND end`, so the master row is included iff its first occurrence is in-window. If the rule has run for months, every subsequent occurrence is missing from the response.

This is symmetric with what the destination path already does (it knows recurring masters are special) — the read path just hadn't caught up.

## Changes

Two source files + one new test file.

### `services/api/src/queries/expand-recurring-event.ts` (new)

Pure function that takes a stored master row and the `[windowStart, windowEnd]` instants and returns the occurrences that fall in the window:

```ts
const expandRecurringEvent = (
  row: RecurringEventRow,
  windowStart: Date,
  windowEnd: Date,
): RecurringOccurrence[] => {
  const rule = parseRecurrenceRuleFromJson(row.recurrenceRule);
  if (!rule) {
    if (isWithinInclusive(row.startTime, windowStart, windowEnd)) {
      return [/* master as-is */];
    }
    return [];
  }
  const exceptions = parseExceptionDatesFromJson(row.exceptionDates);
  const durationMs = Math.max(
    row.endTime.getTime() - row.startTime.getTime(),
    0,
  );
  const dates = extendByRecurrenceRule(rule, {
    start: row.startTime,
    end: windowEnd,
    exceptions,
  });
  // Filter to [windowStart, windowEnd] and emit one occurrence per date,
  // inheriting the master duration.
};
```

Each occurrence gets a synthetic id of the form `${masterId}_${occurrenceISO}` so downstream consumers can distinguish instances. The master's duration is carried onto each occurrence.

### `services/api/src/queries/get-events-in-range.ts`

The synced-events query now considers two row classes:

```ts
or(
  and(
    isNull(eventStatesTable.recurrenceRule),
    gte(eventStatesTable.startTime, start),
    lte(eventStatesTable.startTime, end),
  ),
  and(
    isNotNull(eventStatesTable.recurrenceRule),
    lte(eventStatesTable.startTime, end),
  ),
)
```

Non-recurring rows still match by `startTime` in-range. Recurring masters match when their **first** occurrence is at-or-before the window end (later occurrences may still land inside the window even if the master is far in the past); the in-app expansion step then filters each materialised occurrence to `[start, end]`.

### `packages/calendar/src/index.ts`

Exports `parseRecurrenceRuleFromJson` and `parseExceptionDatesFromJson` so the API service can reuse them without reaching into internal paths.

`userEventsTable` doesn't have `recurrenceRule` / `exceptionDates` columns, so the user-events query is unchanged.

## Testing

Added `services/api/tests/queries/expand-recurring-event.test.ts` covering:

- DAILY rule emits one occurrence per day in the window
- master duration preserved on each occurrence
- EXDATE removes the matching occurrence
- WEEKLY master whose first occurrence is months before the window still emits the in-window occurrences
- `until` terminator caps the expansion
- `count` terminator caps the expansion
- missing/unparseable RRULE falls back to the master row when in-window, drops it when out
- synthetic ids are stable per occurrence

`bun run types` clean across `services/api` and `packages/calendar`.

Manual verification against a Bankingly ICS feed: the previously-missing `Daily HN` recurring event now shows up in `get_events` responses for every day in the queried window; EXDATE'd days are correctly skipped.

## Compatibility

- `KeeperEvent.id` is typed as `string`, which the synthetic id format respects. Web clients that store ids as React keys / map entries keep working — keys are stable per occurrence.
- The new branch keeps backwards-compatible behavior for events without a `recurrenceRule` (the existing `startTime BETWEEN start AND end` filter).
- No schema changes.

## Out of scope

- **RECURRENCE-ID overrides.** The ingest path doesn't persist per-instance overrides (edited single occurrence, single-occurrence cancellation beyond plain EXDATE) yet, so the read path can't surface them either. That's a separate change — likely a `recurrence_overrides` table keyed by `(master_id, occurrenceISO)` — and worth its own PR once the storage shape is decided. For the common case of plain RRULE + EXDATE, the current PR is sufficient.
- **`get_event(synthetic_id)`.** The MCP `get_event` tool still expects a real master UUID and won't dereference a synthetic occurrence id. The expansion only affects `get_events` (list); fetching a recurring instance by its synthetic id would require a separate routing change. Mentioned for completeness but I don't see a current consumer that needs it.
- **Pagination.** `getEventsInRange` doesn't paginate today; expanding recurring events makes large windows (e.g. a year of dailies) potentially noisy. The expansion is bounded by `windowEnd`, so as long as callers use reasonable windows (the web frontend uses 7-day pages) this is fine. If pagination is added later, the expansion will need to be re-considered to keep page boundaries deterministic.
