### PR TITLE
fix(caldav): include recurring events with master before sync window

### DIFF
--- a/packages/calendar/src/providers/caldav/source/fetch-adapter.ts
+++ b/packages/calendar/src/providers/caldav/source/fetch-adapter.ts
@@ -48,7 +48,14 @@ const createCalDAVSourceFetcher = (config: CalDAVSourceFetcherConfig): CalDAVSou
       }
 
       for (const parsed of parseICalToRemoteEvents(data)) {
-        if (isKeeperEvent(parsed.uid) || parsed.endTime < syncWindow.start) {
+        if (isKeeperEvent(parsed.uid)) {
+          continue;
+        }
+        // Non-recurring events that ended before the sync window are out of scope.
+        // Recurring events with a master DTSTART before the window are kept: their
+        // occurrences within the window were already returned by the CalDAV
+        // time-range filter, and downstream RRULE expansion handles the rest.
+        if (!parsed.recurrenceRule && parsed.endTime < syncWindow.start) {
           continue;
         }
 

--- a/packages/calendar/src/providers/caldav/source/fetch-adapter.ts
+++ b/packages/calendar/src/providers/caldav/source/fetch-adapter.ts
@@ -51,10 +51,12 @@ const createCalDAVSourceFetcher = (config: CalDAVSourceFetcherConfig): CalDAVSou
         if (isKeeperEvent(parsed.uid)) {
           continue;
         }
-        // Non-recurring events that ended before the sync window are out of scope.
-        // Recurring events with a master DTSTART before the window are kept: their
-        // occurrences within the window were already returned by the CalDAV
-        // time-range filter, and downstream RRULE expansion handles the rest.
+        /*
+         * Non-recurring events that ended before the sync window are out of scope.
+         * Recurring events with a master DTSTART before the window are kept: their
+         * occurrences within the window were already returned by the CalDAV time-range
+         * filter, and downstream RRULE expansion handles the rest.
+         */
         if (!parsed.recurrenceRule && parsed.endTime < syncWindow.start) {
           continue;
         }


### PR DESCRIPTION
## Summary

The CalDAV source fetcher post-filters events with `parsed.endTime < syncWindow.start`. For recurring events whose master `DTSTART` is older than the sync window (a common case: a weekly meeting set up years ago, with an open-ended `RRULE`), this incorrectly discards the entire event — even though the CalDAV server already returned only the occurrences that fall inside the time-range filter.

Net effect on real calendars: most older recurring events disappear from the feed.

## Repro

Against a CalDAV calendar with a `RRULE:FREQ=WEEKLY` master whose `DTSTART` is e.g. 2025 and a `YEARS_UNTIL_FUTURE = 2` sync window:

1. CalDAV `REPORT` with `time-range` returns the master + its in-window occurrences.
2. `parseICalToRemoteEvents` resolves `parsed.endTime` to the master's end (2025).
3. `parsed.endTime < syncWindow.start` is `true` → the event is dropped before reaching the DB.
4. All recurring events with old masters end up missing.

In one real calendar I tested against, an iCloud `Personal` collection with 1357 total VEVENTs had 65 fall inside the 2-year window, 34 of those were recurring with masters before the window, and all 34 were being dropped — only 17 one-off events made it through.

## Fix

Keep recurring events regardless of master `endTime`; only apply the `endTime < syncWindow.start` filter to non-recurring events. Their in-window occurrences were already filtered server-side by the CalDAV `time-range` query, and downstream RRULE expansion handles the rest.

```ts
if (isKeeperEvent(parsed.uid)) {
  continue;
}
if (!parsed.recurrenceRule && parsed.endTime < syncWindow.start) {
  continue;
}
```

## Notes

- One-off events that ended before the window are still skipped — same behavior as before.
- No schema or migration changes.
- Existing `tests/providers/caldav/source/fetch-adapter.test.ts` only smoke-tests `createCalDAVSourceFetcher`; adding a behavioral test that exercises this filter would be a useful follow-up (would need to mock the CalDAV client).
