### PR TITLE
fix(ics): strip stale VTIMEZONE blocks for IANA zones

### DIFF
--- a/packages/calendar/src/ics/utils/parse-ics-calendar.ts
+++ b/packages/calendar/src/ics/utils/parse-ics-calendar.ts
@@ -4,7 +4,46 @@ interface ParseIcsCalendarOptions {
   icsString: string;
 }
 
-const parseIcsCalendar = (options: ParseIcsCalendarOptions) =>
-  convertIcsCalendar(globalThis.undefined, options.icsString);
+const VTIMEZONE_BLOCK_PATTERN = /BEGIN:VTIMEZONE\r?\n([\s\S]*?)END:VTIMEZONE\r?\n?/g;
+const TZID_LINE_PATTERN = /(?:^|\r?\n)TZID:(.+?)(?:\r?\n|$)/;
 
-export { parseIcsCalendar };
+const isIanaTimezone = (tzid: string): boolean => {
+  try {
+    // Throws RangeError for non-IANA values (including Windows zone names like
+    // "Eastern Standard Time"). The runtime falls back to a static lookup, so
+    // this is O(1) — no need to memoize.
+    new Intl.DateTimeFormat("en", { timeZone: tzid });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * iCloud (and some other CalDAV servers) embed a VTIMEZONE block that lists
+ * historical DST transitions but truncates future rules at the year the zone
+ * was last updated. For zones like America/Montevideo — which abolished DST in
+ * 2015 — the embedded VTIMEZONE has no rules after 2015, and ts-ics extrapolates
+ * the last DAYLIGHT rule forward indefinitely, producing UTC offsets that are
+ * off by one hour for any date after the last rule.
+ *
+ * When the TZID matches a runtime-recognized IANA zone, we strip the VTIMEZONE
+ * block so ts-ics falls back to the platform's IANA tzdata (Node/Bun's ICU),
+ * which has correct post-2015 rules. Non-IANA TZIDs (Microsoft Windows zone
+ * names like "Eastern Standard Time", custom zones, etc.) are left untouched
+ * because the embedded VTIMEZONE is the only way to resolve them.
+ */
+const stripIanaVTimezones = (icsString: string): string =>
+  icsString.replace(VTIMEZONE_BLOCK_PATTERN, (match, body: string) => {
+    const tzidMatch = body.match(TZID_LINE_PATTERN);
+    const tzid = tzidMatch?.[1]?.trim();
+    if (tzid && isIanaTimezone(tzid)) {
+      return "";
+    }
+    return match;
+  });
+
+const parseIcsCalendar = (options: ParseIcsCalendarOptions) =>
+  convertIcsCalendar(globalThis.undefined, stripIanaVTimezones(options.icsString));
+
+export { parseIcsCalendar, stripIanaVTimezones };

--- a/packages/calendar/tests/ics/utils/parse-ics-calendar.test.ts
+++ b/packages/calendar/tests/ics/utils/parse-ics-calendar.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseIcsCalendar } from "../../../src/ics/utils/parse-ics-calendar";
+import { parseIcsCalendar, stripIanaVTimezones } from "../../../src/ics/utils/parse-ics-calendar";
 
 describe("parseIcsCalendar", () => {
   it("parses calendar data with malformed recurrence rules", () => {
@@ -23,7 +23,7 @@ describe("parseIcsCalendar", () => {
     expect(parsedCalendar.events?.[0]?.uid).toBe("malformed-rrule");
   });
 
-  it("throws on malformed timezone blocks", () => {
+  it("throws on malformed timezone blocks for non-IANA TZIDs (VTIMEZONE is required to resolve them)", () => {
     expect(() =>
       parseIcsCalendar({
         icsString: [
@@ -31,7 +31,7 @@ describe("parseIcsCalendar", () => {
           "VERSION:2.0",
           "PRODID:-//Keeper Test//EN",
           "BEGIN:VTIMEZONE",
-          "TZID:America/New_York",
+          "TZID:Eastern Standard Time",
           "BEGIN:STANDARD",
           "DTSTART:INVALID",
           "RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU",
@@ -39,7 +39,7 @@ describe("parseIcsCalendar", () => {
           "END:VTIMEZONE",
           "BEGIN:VEVENT",
           "UID:event-1",
-          "DTSTART;TZID=America/New_York:20260310T090000",
+          "DTSTART;TZID=Eastern Standard Time:20260310T090000",
           "DURATION:PT30M",
           "SUMMARY:Timezone Event",
           "END:VEVENT",
@@ -47,5 +47,102 @@ describe("parseIcsCalendar", () => {
         ].join("\r\n"),
       }))
       .toThrow();
+  });
+
+  // Regression: iCloud (and other servers) embed historical VTIMEZONE blocks
+  // whose recurrence rules are truncated at the year DST was last applied.
+  // For zones that abolished DST after that year (e.g. America/Montevideo in
+  // 2015), the embedded rules extrapolate DST forward forever, yielding the
+  // wrong UTC offset (-02:00 instead of -03:00).
+  //
+  // We strip VTIMEZONE blocks for IANA zones so ts-ics falls back to the
+  // platform's tzdata, which has accurate post-abolition rules.
+  it("uses platform tzdata for IANA zones with stale VTIMEZONE (America/Montevideo)", () => {
+    const ics = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//Apple Inc.//macOS//EN",
+      "BEGIN:VEVENT",
+      "UID:maciel",
+      "DTSTAMP:20260518T215405Z",
+      "DTSTART;TZID=America/Montevideo:20260519T080000",
+      "DTEND;TZID=America/Montevideo:20260519T110000",
+      "SUMMARY:Maciel",
+      "END:VEVENT",
+      "BEGIN:VTIMEZONE",
+      "TZID:America/Montevideo",
+      "X-LIC-LOCATION:America/Montevideo",
+      "BEGIN:DAYLIGHT",
+      "DTSTART:20061001T020000",
+      "RRULE:FREQ=YEARLY;UNTIL=20141005T050000Z;BYMONTH=10;BYDAY=1SU",
+      "TZNAME:-02",
+      "TZOFFSETFROM:-0300",
+      "TZOFFSETTO:-0200",
+      "END:DAYLIGHT",
+      "BEGIN:STANDARD",
+      "DTSTART:20060312T020000",
+      "RRULE:FREQ=YEARLY;UNTIL=20150308T040000Z;BYMONTH=3;BYDAY=2SU",
+      "TZNAME:-03",
+      "TZOFFSETFROM:-0200",
+      "TZOFFSETTO:-0300",
+      "END:STANDARD",
+      "END:VTIMEZONE",
+      "END:VCALENDAR",
+    ].join("\r\n");
+
+    const parsed = parseIcsCalendar({ icsString: ics });
+    const event = parsed.events?.[0];
+    expect(event?.uid).toBe("maciel");
+    // 2026-05-19 08:00 in America/Montevideo (UTC-3, no DST since 2015) is 11:00 UTC.
+    // Without the fix, the stale VTIMEZONE would yield 10:00 UTC (UTC-2, off by one hour).
+    expect(event?.start?.date?.toISOString()).toBe("2026-05-19T11:00:00.000Z");
+    expect(event?.end?.date?.toISOString()).toBe("2026-05-19T14:00:00.000Z");
+    expect(event?.start?.local?.timezone).toBe("America/Montevideo");
+  });
+});
+
+describe("stripIanaVTimezones", () => {
+  const sample = (tzid: string) =>
+    [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "BEGIN:VTIMEZONE",
+      `TZID:${tzid}`,
+      "BEGIN:STANDARD",
+      "DTSTART:20060312T020000",
+      "TZOFFSETFROM:-0200",
+      "TZOFFSETTO:-0300",
+      "END:STANDARD",
+      "END:VTIMEZONE",
+      "END:VCALENDAR",
+    ].join("\r\n");
+
+  it("strips VTIMEZONE blocks for IANA zones", () => {
+    expect(stripIanaVTimezones(sample("America/Montevideo"))).not.toContain("BEGIN:VTIMEZONE");
+    expect(stripIanaVTimezones(sample("Europe/Madrid"))).not.toContain("BEGIN:VTIMEZONE");
+    expect(stripIanaVTimezones(sample("Etc/GMT+3"))).not.toContain("BEGIN:VTIMEZONE");
+  });
+
+  it("keeps VTIMEZONE blocks for non-IANA TZIDs (Windows-style names, custom labels)", () => {
+    expect(stripIanaVTimezones(sample("Eastern Standard Time"))).toContain("BEGIN:VTIMEZONE");
+    expect(stripIanaVTimezones(sample("Pacific Standard Time"))).toContain("BEGIN:VTIMEZONE");
+    expect(stripIanaVTimezones(sample("Custom Bankingly Zone"))).toContain("BEGIN:VTIMEZONE");
+  });
+
+  it("processes multiple VTIMEZONE blocks independently", () => {
+    const ics = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "BEGIN:VTIMEZONE",
+      "TZID:America/Montevideo",
+      "END:VTIMEZONE",
+      "BEGIN:VTIMEZONE",
+      "TZID:Eastern Standard Time",
+      "END:VTIMEZONE",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    const stripped = stripIanaVTimezones(ics);
+    expect(stripped).not.toContain("TZID:America/Montevideo");
+    expect(stripped).toContain("TZID:Eastern Standard Time");
   });
 });


### PR DESCRIPTION
## Summary

Some CalDAV servers — notably iCloud — embed `VTIMEZONE` blocks whose recurrence rules are truncated at the year DST was last applied. For zones that abolished DST after that cutoff, the embedded rules extrapolate DST forward forever, yielding the wrong UTC offset for any date after the cutoff.

Concrete case: Uruguay (`America/Montevideo`) eliminated DST in 2015. iCloud's `VTIMEZONE` for that zone has its last `BEGIN:DAYLIGHT` ending `RRULE...UNTIL=20141005` and last `BEGIN:STANDARD` ending `UNTIL=20150308`. After that, the block defines no rules. `ts-ics` keeps applying the last DAYLIGHT transition (Oct → Mar) forward indefinitely, so an event at `2026-05-19T08:00:00 America/Montevideo` parses as `2026-05-19T10:00:00Z` (UTC-2, applying phantom DST) instead of the correct `2026-05-19T11:00:00Z` (UTC-3).

The same pattern affects any zone that abolished DST after the year iCloud generated its VTIMEZONE truncation — and it's not unique to iCloud; any server that ships a historical VTIMEZONE without future rules has this risk.

## Fix

When the `TZID` matches a runtime-recognized IANA zone (`new Intl.DateTimeFormat({ timeZone: tzid })` doesn't throw), strip the `VTIMEZONE` block so `ts-ics` falls back to the platform's IANA tzdata (Node/Bun's ICU), which has accurate post-abolition rules.

Non-IANA TZIDs are left untouched — the embedded `VTIMEZONE` is the only way to resolve them, so we can't strip it without breaking those events:
- Microsoft Windows zone names like `"Eastern Standard Time"`, `"Pacific Standard Time"`.
- Custom/private labels that some calendar servers emit.
- Anything `Intl.DateTimeFormat` rejects.

The strip happens at the `parseIcsCalendar` wrapper, so both CalDAV and ICS providers benefit.

## Repro

The added regression test exercises iCloud's exact serialization for `America/Montevideo`. Without the fix, `event.start.date.toISOString()` returns `"2026-05-19T10:00:00.000Z"`; with it, the correct `"2026-05-19T11:00:00.000Z"`.

## Notes

- One unit test in `parse-ics-calendar.test.ts` that asserted "throws on malformed VTIMEZONE" had to change its TZID from `America/New_York` (now stripped) to a non-IANA TZID (still parsed). The behavior under test — that malformed VTIMEZONE breaks parsing for non-IANA zones — is preserved.
- No schema, dependency, or runtime changes beyond the strip helper.
