### PR TITLE
fix(caldav): honor event timezone when serializing ICS

### DIFF
--- a/packages/calendar/src/ics/index.ts
+++ b/packages/calendar/src/ics/index.ts
@@ -6,3 +6,5 @@ export { diffEvents } from "./utils/diff-events";
 export { createSnapshot } from "./utils/create-snapshot";
 export { createIcsSourceFetcher } from "./utils/fetch-adapter";
 export type { IcsSourceFetcherConfig, IcsSourceFetcher } from "./utils/fetch-adapter";
+export { buildZonedIcsDate, formatTzOffset } from "./utils/build-zoned-date";
+export { normalizeTimezone } from "./utils/normalize-timezone";

--- a/packages/calendar/src/ics/utils/build-zoned-date.ts
+++ b/packages/calendar/src/ics/utils/build-zoned-date.ts
@@ -1,0 +1,118 @@
+import type { IcsDateObject } from "ts-ics";
+import { normalizeTimezone } from "./normalize-timezone";
+
+const MINUTES_PER_HOUR = 60;
+const MS_PER_MINUTE = 60 * 1000;
+const HOURS_IN_DAY = 24;
+
+interface WallClockParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+}
+
+const partsInTimeZone = (instant: Date, timeZone: string): WallClockParts => {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+
+  const lookup = new Map<string, string>();
+  for (const part of formatter.formatToParts(instant)) {
+    lookup.set(part.type, part.value);
+  }
+
+  const read = (type: string): number => Number.parseInt(lookup.get(type) ?? "0", 10);
+
+  // Intl can report midnight as hour "24"; normalize it back to 0.
+  let hour = read("hour");
+  if (hour === HOURS_IN_DAY) {
+    hour = 0;
+  }
+
+  return {
+    year: read("year"),
+    month: read("month"),
+    day: read("day"),
+    hour,
+    minute: read("minute"),
+    second: read("second"),
+  };
+};
+
+const padTwo = (value: number): string => value.toString().padStart(2, "0");
+
+/**
+ * Format a millisecond offset (wall-clock minus instant) as an RFC 5545 / ISO
+ * style `±HH:MM` string, e.g. -10800000 → "-03:00".
+ */
+const formatTzOffset = (offsetMs: number): string => {
+  let sign = "+";
+  if (offsetMs < 0) {
+    sign = "-";
+  }
+  const totalMinutes = Math.round(Math.abs(offsetMs) / MS_PER_MINUTE);
+  const hours = Math.floor(totalMinutes / MINUTES_PER_HOUR);
+  const minutes = totalMinutes % MINUTES_PER_HOUR;
+  return `${sign}${padTwo(hours)}:${padTwo(minutes)}`;
+};
+
+/**
+ * Build a ts-ics `IcsDateObject` for a DTSTART/DTEND value, attaching the
+ * calendar-local timezone when one is known.
+ *
+ * - All-day events stay timezone-less (`{ date, type: "DATE" }`).
+ * - Timed events with a known IANA timezone get a `local` block so the
+ *   generator emits `DTSTART;TZID=<tz>:<local-wall-clock>` instead of a bare
+ *   UTC `...Z` value. The read side mirrors this via `event.start.local`.
+ * - Timed events without a timezone (or with an unresolvable one) fall back to
+ *   a bare UTC datetime, preserving the previous behavior.
+ *
+ * The stored instant (`date`) is never shifted; only the emitted representation
+ * changes.
+ */
+const buildZonedIcsDate = (
+  instant: Date,
+  timezone: string | undefined,
+  isAllDay: boolean,
+): IcsDateObject => {
+  if (isAllDay) {
+    return { date: instant, type: "DATE" };
+  }
+
+  const resolved = normalizeTimezone(timezone);
+  if (!resolved) {
+    return { date: instant };
+  }
+
+  try {
+    const parts = partsInTimeZone(instant, resolved);
+    const localDate = new Date(
+      Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second),
+    );
+    const offsetMs = localDate.getTime() - instant.getTime();
+
+    return {
+      date: instant,
+      local: {
+        date: localDate,
+        timezone: resolved,
+        tzoffset: formatTzOffset(offsetMs),
+      },
+    };
+  } catch {
+    // Unknown/invalid timezone — fall back to a bare UTC datetime.
+    return { date: instant };
+  }
+};
+
+export { buildZonedIcsDate, formatTzOffset };

--- a/packages/calendar/src/providers/caldav/shared/ics.ts
+++ b/packages/calendar/src/providers/caldav/shared/ics.ts
@@ -1,5 +1,5 @@
 import { generateIcsCalendar } from "ts-ics";
-import { parseIcsCalendar } from "../../../ics";
+import { parseIcsCalendar, buildZonedIcsDate } from "../../../ics";
 import type { IcsCalendar, IcsDuration, IcsEvent } from "ts-ics";
 import type { SyncableEvent } from "../../../core/types";
 import { isKeeperEvent } from "../../../core/events/identity";
@@ -48,10 +48,10 @@ const eventToICalString = (event: SyncableEvent, uid: string): string => {
   const isAllDay = resolveIsAllDayEvent(event);
   const icsEvent: IcsEvent = {
     description: event.description,
-    end: { date: event.endTime, ...(isAllDay && { type: "DATE" }) },
+    end: buildZonedIcsDate(event.endTime, event.startTimeZone, isAllDay),
     location: event.location,
     stamp: { date: new Date() },
-    start: { date: event.startTime, ...(isAllDay && { type: "DATE" }) },
+    start: buildZonedIcsDate(event.startTime, event.startTimeZone, isAllDay),
     summary: event.summary,
     ...(event.availability === "free" && { timeTransparent: "TRANSPARENT" }),
     uid,

--- a/packages/calendar/tests/ics/utils/build-zoned-date.test.ts
+++ b/packages/calendar/tests/ics/utils/build-zoned-date.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { generateIcsCalendar } from "ts-ics";
+import type { IcsCalendar } from "ts-ics";
+import { buildZonedIcsDate, formatTzOffset } from "../../../src/ics/utils/build-zoned-date";
+
+const renderDtstart = (instant: Date, timezone: string | undefined, isAllDay: boolean): string => {
+  const calendar: IcsCalendar = {
+    events: [
+      {
+        uid: "uid",
+        summary: "Test",
+        stamp: { date: new Date("2026-01-01T00:00:00.000Z") },
+        start: buildZonedIcsDate(instant, timezone, isAllDay),
+        end: buildZonedIcsDate(instant, timezone, isAllDay),
+      },
+    ],
+    prodId: "-//Test//Test//EN",
+    version: "2.0",
+  };
+  const line = generateIcsCalendar(calendar)
+    .split("\r\n")
+    .find((value) => value.startsWith("DTSTART"));
+  return line ?? "";
+};
+
+describe("buildZonedIcsDate", () => {
+  it("attaches the local timezone for a timed event", () => {
+    const result = buildZonedIcsDate(new Date("2026-06-17T10:45:00.000Z"), "America/Montevideo", false);
+
+    expect(result.date.toISOString()).toBe("2026-06-17T10:45:00.000Z");
+    expect(result.local?.timezone).toBe("America/Montevideo");
+    expect(result.local?.tzoffset).toBe("-03:00");
+    // The local wall clock is encoded in the UTC fields of `local.date`.
+    expect(result.local?.date.toISOString()).toBe("2026-06-17T07:45:00.000Z");
+    expect(result.type).toBeUndefined();
+  });
+
+  it("renders a TZID-qualified DTSTART", () => {
+    expect(renderDtstart(new Date("2026-06-17T10:45:00.000Z"), "America/Montevideo", false)).toBe(
+      "DTSTART;TZID=America/Montevideo:20260617T074500",
+    );
+  });
+
+  it("honors daylight-saving offsets via the IANA database", () => {
+    // New York is UTC-4 in July (EDT).
+    const summer = buildZonedIcsDate(new Date("2026-07-01T16:00:00.000Z"), "America/New_York", false);
+    expect(summer.local?.tzoffset).toBe("-04:00");
+    expect(summer.local?.date.toISOString()).toBe("2026-07-01T12:00:00.000Z");
+
+    // New York is UTC-5 in January (EST).
+    const winter = buildZonedIcsDate(new Date("2026-01-01T17:00:00.000Z"), "America/New_York", false);
+    expect(winter.local?.tzoffset).toBe("-05:00");
+    expect(winter.local?.date.toISOString()).toBe("2026-01-01T12:00:00.000Z");
+  });
+
+  it("maps Windows timezone identifiers to IANA before zoning", () => {
+    const result = buildZonedIcsDate(new Date("2026-06-17T10:45:00.000Z"), "Montevideo Standard Time", false);
+    expect(result.local?.timezone).toBe("America/Montevideo");
+  });
+
+  it("keeps all-day events timezone-less", () => {
+    const result = buildZonedIcsDate(new Date("2026-03-08T00:00:00.000Z"), "America/Montevideo", true);
+    expect(result.type).toBe("DATE");
+    expect(result.local).toBeUndefined();
+  });
+
+  it("falls back to a bare UTC datetime without a timezone", () => {
+    const result = buildZonedIcsDate(new Date("2026-06-17T10:45:00.000Z"), undefined, false);
+    expect(result.local).toBeUndefined();
+    expect(result.type).toBeUndefined();
+  });
+
+  it("falls back to a bare UTC datetime for an unresolvable timezone", () => {
+    const result = buildZonedIcsDate(new Date("2026-06-17T10:45:00.000Z"), "Not/AZone", false);
+    expect(result.local).toBeUndefined();
+  });
+});
+
+describe("formatTzOffset", () => {
+  it("formats negative offsets", () => {
+    expect(formatTzOffset(-3 * 60 * 60 * 1000)).toBe("-03:00");
+  });
+
+  it("formats positive offsets with minutes", () => {
+    expect(formatTzOffset(5 * 60 * 60 * 1000 + 30 * 60 * 1000)).toBe("+05:30");
+  });
+
+  it("formats zero as a positive offset", () => {
+    expect(formatTzOffset(0)).toBe("+00:00");
+  });
+});

--- a/packages/calendar/tests/providers/caldav/shared/ics.test.ts
+++ b/packages/calendar/tests/providers/caldav/shared/ics.test.ts
@@ -58,6 +58,91 @@ describe("eventToICalString", () => {
     expect(parsedEvent?.startTime.toISOString()).toBe("2026-03-08T00:00:00.000Z");
     expect(parsedEvent?.endTime.toISOString()).toBe("2026-03-09T00:00:00.000Z");
   });
+
+  it("emits a TZID-qualified local datetime when startTimeZone is set", () => {
+    const icsString = eventToICalString(
+      {
+        calendarId: "calendar-id",
+        calendarName: "Calendar",
+        calendarUrl: null,
+        endTime: new Date("2026-06-17T11:45:00.000Z"),
+        id: "event-id",
+        sourceEventUid: "source-uid",
+        startTime: new Date("2026-06-17T10:45:00.000Z"),
+        startTimeZone: "America/Montevideo",
+        summary: "Appointment",
+      },
+      "destination-uid",
+    );
+
+    // Montevideo is UTC-3 year-round, so 10:45Z renders as 07:45 local.
+    expect(icsString).toContain("DTSTART;TZID=America/Montevideo:20260617T074500");
+    expect(icsString).toContain("DTEND;TZID=America/Montevideo:20260617T084500");
+    expect(icsString).not.toContain("DTSTART:20260617T104500Z");
+  });
+
+  it("round-trips the timezone and the underlying instant", () => {
+    const icsString = eventToICalString(
+      {
+        calendarId: "calendar-id",
+        calendarName: "Calendar",
+        calendarUrl: null,
+        endTime: new Date("2026-06-17T11:45:00.000Z"),
+        id: "event-id",
+        sourceEventUid: "source-uid",
+        startTime: new Date("2026-06-17T10:45:00.000Z"),
+        startTimeZone: "America/Montevideo",
+        summary: "Appointment",
+      },
+      "destination-uid",
+    );
+
+    const parsedEvent = parseICalToRemoteEvent(icsString);
+
+    expect(parsedEvent?.startTimeZone).toBe("America/Montevideo");
+    expect(parsedEvent?.startTime.toISOString()).toBe("2026-06-17T10:45:00.000Z");
+    expect(parsedEvent?.endTime.toISOString()).toBe("2026-06-17T11:45:00.000Z");
+  });
+
+  it("falls back to a bare UTC datetime when no timezone is known", () => {
+    const icsString = eventToICalString(
+      {
+        calendarId: "calendar-id",
+        calendarName: "Calendar",
+        calendarUrl: null,
+        endTime: new Date("2026-06-17T11:45:00.000Z"),
+        id: "event-id",
+        sourceEventUid: "source-uid",
+        startTime: new Date("2026-06-17T10:45:00.000Z"),
+        summary: "Appointment",
+      },
+      "destination-uid",
+    );
+
+    expect(icsString).toContain("DTSTART:20260617T104500Z");
+    expect(icsString).not.toContain("TZID=");
+  });
+
+  it("keeps all-day events timezone-less even when a timezone is supplied", () => {
+    const icsString = eventToICalString(
+      {
+        calendarId: "calendar-id",
+        calendarName: "Calendar",
+        calendarUrl: null,
+        endTime: new Date("2026-03-09T00:00:00.000Z"),
+        id: "event-id",
+        isAllDay: true,
+        sourceEventUid: "source-uid",
+        startTime: new Date("2026-03-08T00:00:00.000Z"),
+        startTimeZone: "America/Montevideo",
+        summary: "Holiday",
+      },
+      "destination-uid",
+    );
+
+    expect(icsString).toContain("DTSTART;VALUE=DATE:20260308");
+    expect(icsString).not.toContain("TZID=");
+  });
 });
 
 describe("parseICalToRemoteEvents", () => {

--- a/services/api/src/mutations/index.ts
+++ b/services/api/src/mutations/index.ts
@@ -201,6 +201,7 @@ const createEventMutation = async (
       location: input.location ?? null,
       startTime: new Date(input.startTime),
       endTime: new Date(input.endTime),
+      startTimeZone: input.startTimeZone ?? null,
       isAllDay: input.isAllDay ?? false,
       availability: input.availability ?? "busy",
     })
@@ -279,6 +280,9 @@ const buildDbUpdates = (updates: EventUpdateInput): Record<string, unknown> => {
   }
   if ("endTime" in updates && updates.endTime) {
     dbUpdates.endTime = new Date(updates.endTime);
+  }
+  if ("startTimeZone" in updates) {
+    dbUpdates.startTimeZone = updates.startTimeZone ?? null;
   }
   if ("isAllDay" in updates) {
     dbUpdates.isAllDay = updates.isAllDay;

--- a/services/api/src/mutations/providers/caldav.ts
+++ b/services/api/src/mutations/providers/caldav.ts
@@ -4,6 +4,7 @@ import { HTTP_STATUS, KEEPER_USER_EVENT_SUFFIX } from "@keeper.sh/constants";
 import { decryptPassword } from "@keeper.sh/database";
 import { createSafeFetch } from "@keeper.sh/calendar/safe-fetch";
 import { createDigestAwareFetch, resolveAuthMethod } from "@keeper.sh/calendar/digest-fetch";
+import { buildZonedIcsDate } from "@keeper.sh/calendar/ics";
 import { createDAVClient } from "tsdav";
 import { safeFetchOptions } from "@/utils/safe-fetch-options";
 import type { EventInput, EventUpdateInput, EventActionResult, RsvpStatus } from "@/types";
@@ -60,14 +61,8 @@ const buildIcsEvent = (uid: string, input: EventInput): IcsEvent => {
     summary: input.title,
     description: input.description,
     location: input.location,
-    start: {
-      date: new Date(input.startTime),
-      ...(isAllDay && { type: "DATE" as const }),
-    },
-    end: {
-      date: new Date(input.endTime),
-      ...(isAllDay && { type: "DATE" as const }),
-    },
+    start: buildZonedIcsDate(new Date(input.startTime), input.startTimeZone, isAllDay),
+    end: buildZonedIcsDate(new Date(input.endTime), input.startTimeZone, isAllDay),
     stamp: { date: new Date() },
   };
 
@@ -161,6 +156,9 @@ const resolveTransparency = (availability: string): "TRANSPARENT" | "OPAQUE" => 
 const applyUpdatesToEvent = (event: IcsEvent, updates: EventUpdateInput): IcsEvent => {
   const updated = { ...event };
 
+  // Preserve the event's existing timezone unless the update overrides it.
+  const timezone = updates.startTimeZone ?? event.start?.local?.timezone;
+
   if ("title" in updates && typeof updates.title === "string") {
     updated.summary = updates.title;
   }
@@ -172,17 +170,11 @@ const applyUpdatesToEvent = (event: IcsEvent, updates: EventUpdateInput): IcsEve
   }
   if ("startTime" in updates && typeof updates.startTime === "string") {
     const isAllDay = resolveEventIsAllDay(updates, event);
-    updated.start = {
-      date: new Date(updates.startTime),
-      ...(isAllDay && { type: "DATE" as const }),
-    };
+    updated.start = buildZonedIcsDate(new Date(updates.startTime), timezone, isAllDay);
   }
   if ("endTime" in updates && typeof updates.endTime === "string") {
     const isAllDay = resolveEventIsAllDay(updates, event);
-    updated.end = {
-      date: new Date(updates.endTime),
-      ...(isAllDay && { type: "DATE" as const }),
-    };
+    updated.end = buildZonedIcsDate(new Date(updates.endTime), timezone, isAllDay);
   }
   if ("availability" in updates && typeof updates.availability === "string") {
     updated.timeTransparent = resolveTransparency(updates.availability);

--- a/services/api/src/routes/api/v1/events/[id].ts
+++ b/services/api/src/routes/api/v1/events/[id].ts
@@ -57,6 +57,7 @@ const PATCH = withWideEvent(
         endTime: validated.endTime,
         isAllDay: validated.isAllDay,
         availability: validated.availability,
+        startTimeZone: validated.timezone,
       });
 
       if (!result.success) {

--- a/services/api/src/routes/api/v1/events/index.ts
+++ b/services/api/src/routes/api/v1/events/index.ts
@@ -63,9 +63,9 @@ const POST = withWideEvent(
     const body = await request.json();
 
     try {
-      const input = eventCreateBodySchema.assert(body);
+      const { timezone, ...input } = eventCreateBodySchema.assert(body);
 
-      const result = await keeperApi.createEvent(userId, input);
+      const result = await keeperApi.createEvent(userId, { ...input, startTimeZone: timezone });
 
       if (!result.success) {
         return ErrorResponse.badRequest(result.error ?? "Failed to create event.").toResponse();

--- a/services/api/src/types.ts
+++ b/services/api/src/types.ts
@@ -75,6 +75,7 @@ interface EventInput {
   endTime: string;
   isAllDay?: boolean;
   availability?: "busy" | "free";
+  startTimeZone?: string;
 }
 
 interface EventUpdateInput {
@@ -85,6 +86,7 @@ interface EventUpdateInput {
   endTime?: string;
   isAllDay?: boolean;
   availability?: "busy" | "free";
+  startTimeZone?: string;
 }
 
 type RsvpStatus = "accepted" | "declined" | "tentative";

--- a/services/api/src/utils/request-body.ts
+++ b/services/api/src/utils/request-body.ts
@@ -39,6 +39,7 @@ const eventCreateBodySchema = type({
   endTime: "string",
   "isAllDay?": "boolean",
   "availability?": "'busy' | 'free'",
+  "timezone?": "string",
   "+": "reject",
 });
 type EventCreateBody = typeof eventCreateBodySchema.infer;
@@ -51,6 +52,7 @@ const eventPatchBodySchema = type({
   "endTime?": "string",
   "isAllDay?": "boolean",
   "availability?": "'busy' | 'free'",
+  "timezone?": "string",
   "rsvpStatus?": "'accepted' | 'declined' | 'tentative'",
   "+": "reject",
 });

--- a/services/api/tests/mutations/providers/caldav.test.ts
+++ b/services/api/tests/mutations/providers/caldav.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createCalDAVEvent, updateCalDAVEvent, deleteCalDAVEvent, rsvpCalDAVEvent, getPendingCalDAVInvites } from "../../../src/mutations/providers/caldav";
+
+const {
+  createCalendarObjectMock,
+  fetchCalendarObjectsMock,
+  updateCalendarObjectMock,
+  deleteCalendarObjectMock,
+} = vi.hoisted(() => ({
+  createCalendarObjectMock: vi.fn(),
+  fetchCalendarObjectsMock: vi.fn(),
+  updateCalendarObjectMock: vi.fn(),
+  deleteCalendarObjectMock: vi.fn(),
+}));
+
+vi.mock("../../../src/env", () => ({
+  default: {
+    ENCRYPTION_KEY: "test-key",
+  },
+}));
+
+vi.mock("tsdav", () => ({
+  createDAVClient: vi.fn(() => ({
+    createCalendarObject: createCalendarObjectMock,
+    fetchCalendarObjects: fetchCalendarObjectsMock,
+    updateCalendarObject: updateCalendarObjectMock,
+    deleteCalendarObject: deleteCalendarObjectMock,
+  })),
+}));
+
+vi.mock("@keeper.sh/database", () => ({
+  decryptPassword: vi.fn(() => "decrypted"),
+}));
+
+vi.mock("@keeper.sh/calendar/safe-fetch", () => ({
+  createSafeFetch: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@keeper.sh/calendar/digest-fetch", () => ({
+  createDigestAwareFetch: vi.fn(() => ({ fetch: vi.fn() })),
+  resolveAuthMethod: vi.fn(),
+}));
+
+describe("caldav provider mutations", () => {
+  const mockCredentials = {
+    serverUrl: "https://dav.com",
+    calendarUrl: "https://dav.com/cal",
+    username: "user",
+    encryptedPassword: "enc",
+    encryptionKey: "key",
+    authMethod: "basic",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createCalendarObjectMock.mockResolvedValue({});
+    fetchCalendarObjectsMock.mockResolvedValue([
+      { url: "url", data: "BEGIN:VCALENDAR\nBEGIN:VEVENT\nUID:uid\nEND:VEVENT\nEND:VCALENDAR" },
+    ]);
+    updateCalendarObjectMock.mockResolvedValue({});
+    deleteCalendarObjectMock.mockResolvedValue({});
+  });
+
+  describe("createCalDAVEvent", () => {
+    it("calls tsdav createCalendarObject and returns UID", async () => {
+      const result = await createCalDAVEvent(mockCredentials, {
+        title: "Test",
+        startTime: "2026-01-01T10:00:00Z",
+        endTime: "2026-01-01T11:00:00Z",
+        calendarId: "cal-1",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.sourceEventUid).toBeDefined();
+    });
+
+    it("emits a TZID-qualified DTSTART when startTimeZone is provided", async () => {
+      const result = await createCalDAVEvent(mockCredentials, {
+        title: "Appointment",
+        startTime: "2026-06-17T10:45:00Z",
+        endTime: "2026-06-17T11:45:00Z",
+        calendarId: "cal-1",
+        startTimeZone: "America/Montevideo",
+      });
+
+      expect(result.success).toBe(true);
+      const icsString = createCalendarObjectMock.mock.calls[0]?.[0]?.iCalString as string;
+      expect(icsString).toContain("DTSTART;TZID=America/Montevideo:20260617T074500");
+      expect(icsString).not.toContain("DTSTART:20260617T104500Z");
+    });
+
+    it("emits a bare UTC DTSTART when no timezone is provided", async () => {
+      await createCalDAVEvent(mockCredentials, {
+        title: "Appointment",
+        startTime: "2026-06-17T10:45:00Z",
+        endTime: "2026-06-17T11:45:00Z",
+        calendarId: "cal-1",
+      });
+
+      const icsString = createCalendarObjectMock.mock.calls[0]?.[0]?.iCalString as string;
+      expect(icsString).toContain("DTSTART:20260617T104500Z");
+      expect(icsString).not.toContain("TZID=");
+    });
+
+    it("keeps all-day events timezone-less even with a timezone", async () => {
+      await createCalDAVEvent(mockCredentials, {
+        title: "Holiday",
+        startTime: "2026-03-08T00:00:00Z",
+        endTime: "2026-03-09T00:00:00Z",
+        calendarId: "cal-1",
+        isAllDay: true,
+        startTimeZone: "America/Montevideo",
+      });
+
+      const icsString = createCalendarObjectMock.mock.calls[0]?.[0]?.iCalString as string;
+      expect(icsString).toContain("DTSTART;VALUE=DATE:20260308");
+      expect(icsString).not.toContain("TZID=");
+    });
+  });
+
+  describe("updateCalDAVEvent", () => {
+    it("finds event and updates it", async () => {
+      const result = await updateCalDAVEvent(mockCredentials, "uid", { title: "New" });
+      expect(result.success).toBe(true);
+    });
+
+    it("emits a TZID-qualified DTSTART when the update carries a timezone", async () => {
+      const result = await updateCalDAVEvent(mockCredentials, "uid", {
+        startTime: "2026-06-17T10:45:00Z",
+        endTime: "2026-06-17T11:45:00Z",
+        startTimeZone: "America/Montevideo",
+      });
+
+      expect(result.success).toBe(true);
+      const icsString = updateCalendarObjectMock.mock.calls[0]?.[0]?.calendarObject?.data as string;
+      expect(icsString).toContain("DTSTART;TZID=America/Montevideo:20260617T074500");
+    });
+
+    it("preserves the event's existing timezone when the update omits one", async () => {
+      fetchCalendarObjectsMock.mockResolvedValueOnce([
+        {
+          url: "url",
+          data: [
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "PRODID:-//Test//Test//EN",
+            "BEGIN:VEVENT",
+            "UID:uid",
+            "SUMMARY:Existing",
+            "DTSTART;TZID=America/Montevideo:20260617T074500",
+            "DTEND;TZID=America/Montevideo:20260617T084500",
+            "END:VEVENT",
+            "END:VCALENDAR",
+          ].join("\r\n"),
+        },
+      ]);
+
+      const result = await updateCalDAVEvent(mockCredentials, "uid", {
+        startTime: "2026-06-18T10:45:00Z",
+        endTime: "2026-06-18T11:45:00Z",
+      });
+
+      expect(result.success).toBe(true);
+      const icsString = updateCalendarObjectMock.mock.calls[0]?.[0]?.calendarObject?.data as string;
+      expect(icsString).toContain("DTSTART;TZID=America/Montevideo:20260618T074500");
+    });
+  });
+
+  describe("deleteCalDAVEvent", () => {
+    it("deletes event", async () => {
+      const result = await deleteCalDAVEvent(mockCredentials, "uid");
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("rsvpCalDAVEvent", () => {
+    it("finds event and updates attendee", async () => {
+      const result = await rsvpCalDAVEvent(mockCredentials, "uid", "accepted", "test@example.com");
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("getPendingCalDAVInvites", () => {
+    it("returns pending invites", async () => {
+      const invites = await getPendingCalDAVInvites(mockCredentials, "2026-01-01", "2026-01-02", "test@example.com");
+      expect(invites).toHaveLength(0); // My mock doesn't have the right data shape for successful parse yet
+    });
+  });
+});

--- a/services/mcp/src/toolset.ts
+++ b/services/mcp/src/toolset.ts
@@ -221,7 +221,7 @@ const createKeeperMcpToolset = (): KeeperMcpToolset => ({
   create_event: {
     title: "Create event",
     description:
-      "Create a new calendar event on a connected calendar. Requires calendarId, title, startTime, and endTime.",
+      "Create a new calendar event on a connected calendar. Requires calendarId, title, startTime, and endTime. Pass an IANA timezone so the event renders in local time on CalDAV calendars (iCloud, Fastmail) instead of GMT.",
     inputSchema: {
       calendarId: z.string().uuid().describe("The calendar to create the event on"),
       title: z.string().describe("Event title"),
@@ -231,6 +231,10 @@ const createKeeperMcpToolset = (): KeeperMcpToolset => ({
       endTime: z.string().datetime().describe("End time in ISO 8601 format"),
       isAllDay: z.boolean().optional().describe("Whether the event is all-day"),
       availability: z.enum(["busy", "free"]).optional().describe("Availability status"),
+      timezone: z
+        .string()
+        .optional()
+        .describe("IANA timezone identifier (e.g. America/New_York) the event's local time is in"),
     },
     execute: (context, input) => {
       if (!input?.calendarId || !input?.title || !input?.startTime || !input?.endTime) {
@@ -255,6 +259,10 @@ const createKeeperMcpToolset = (): KeeperMcpToolset => ({
       endTime: z.string().datetime().optional().describe("Updated end time"),
       isAllDay: z.boolean().optional().describe("Whether the event is all-day"),
       availability: z.enum(["busy", "free"]).optional().describe("Updated availability"),
+      timezone: z
+        .string()
+        .optional()
+        .describe("IANA timezone identifier (e.g. America/New_York) the event's local time is in"),
     },
     execute: (context, input) => {
       if (!input?.eventId || typeof input.eventId !== "string") {


### PR DESCRIPTION
## Summary

Events created or updated on a CalDAV calendar (iCloud, Fastmail, generic CalDAV) are serialized with `DTSTART`/`DTEND` as bare UTC datetimes (`...Z`) and no `TZID`, so calendar clients render them in GMT/UTC. For example, an appointment intended for 07:45 `America/Montevideo` (= 10:45 UTC) shows up as "10:45 (GMT)". The stored instant is correct — the event just carries no timezone.

The Zoho and Google destinations already honor the event's timezone; the CalDAV write path ignores it. It's also an asymmetry within the CalDAV provider itself: the read side (`mapIcsEventToParsedEvent`) already reads `event.start.local?.timezone`, but the write side never sets it.

## Fix

Add a `buildZonedIcsDate` helper that sets the ts-ics `local` block (TZID + local wall clock) for timed events with a known IANA timezone, used at both serialization sites: the sync-engine push (`eventToICalString`) and the live create/update mutation (`buildIcsEvent` / `applyUpdatesToEvent`, which preserves an event's existing TZID on update). With the `local` block set, the generator emits `DTSTART;TZID=America/Montevideo:20260617T074500` instead of `DTSTART:20260617T104500Z`.

Also adds an optional IANA `timezone` parameter to the MCP `create_event`/`update_event` tools, threaded through `POST`/`PUT /api/v1/events` into the event input's `startTimeZone` (previously always undefined for MCP-created events, even though `get_events` already requires a timezone).

## Behavior / edge cases

- All-day events stay timezone-less.
- Recurring events: zoning `DTSTART` doesn't shift the instant, so recurrence instances are unchanged.
- Bare UTC remains the fallback when no timezone is known, so existing behavior is preserved.
- Windows TZIDs are normalized to IANA before zoning.
- No `VTIMEZONE` component is emitted; Apple/Notion accept bare IANA TZIDs and the round-trip parser resolves them via the runtime IANA database. A `VTIMEZONE` could be added later for stricter clients.
- No schema/migration changes — only the emitted representation changes, never the stored instant.

## Tests

ICS serialization (asserts `TZID` in output, bare-UTC fallback, all-day stays timezone-less, DST handling, Windows→IANA mapping, round-trip preserving timezone + instant) and the CalDAV create/update mutation output.
