### PR TITLE
fix(ical): emit feed EXDATE and RRULE UNTIL in UTC to match DTSTART

### DIFF
--- a/services/api/src/utils/ical-format.ts
+++ b/services/api/src/utils/ical-format.ts
@@ -26,6 +26,26 @@ interface CalendarEvent {
   sourceEventUid: string | null;
 }
 
+// The feed emits DTSTART/DTEND as bare UTC ("...Z"). Per RFC 5545, EXDATE and
+// RRULE UNTIL must use the same value type as DTSTART, so they must be UTC too.
+// Source-parsed dates can carry a TZID (the `local` block); strict clients like
+// Apple Calendar drop the whole recurring event when EXDATE has an IANA TZID but
+// DTSTART is UTC. Strip `local` so these serialize as UTC, preserving the instant.
+// All-day exceptions (VALUE=DATE) keep their date-only type.
+const toUtcDateObject = (value: IcsDateObject): IcsDateObject => {
+  if (value.type === "DATE") {
+    return { date: value.date, type: "DATE" };
+  }
+  return { date: value.date };
+};
+
+const normalizeRecurrenceRuleToUtc = (rule: IcsRecurrenceRule): IcsRecurrenceRule => {
+  if (!rule.until) {
+    return rule;
+  }
+  return { ...rule, until: toUtcDateObject(rule.until) };
+};
+
 const toAllDayShape = (event: CalendarEvent) => ({
   startTime: event.startTime,
   endTime: event.endTime,
@@ -95,8 +115,8 @@ const buildBaseIcsEvent = (event: CalendarEvent, uid: string, settings: FeedSett
 
 const buildMasterIcsEvent = (master: CalendarEvent, uid: string, settings: FeedSettings): IcsEvent => ({
   ...buildBaseIcsEvent(master, uid, settings),
-  ...(master.recurrenceRule && { recurrenceRule: master.recurrenceRule }),
-  ...(master.exceptionDates?.length && { exceptionDates: master.exceptionDates }),
+  ...(master.recurrenceRule && { recurrenceRule: normalizeRecurrenceRuleToUtc(master.recurrenceRule) }),
+  ...(master.exceptionDates?.length && { exceptionDates: master.exceptionDates.map(toUtcDateObject) }),
 });
 
 const buildOverrideIcsEvent = (override: CalendarEvent, uid: string, settings: FeedSettings): IcsEvent => ({

--- a/services/api/tests/utils/ical.test.ts
+++ b/services/api/tests/utils/ical.test.ts
@@ -205,10 +205,12 @@ describe("recurring events", () => {
     expect(ics).toContain("20260402T180000Z");
   });
 
-  // Regression: the feed emits DTSTART as bare UTC, but source-parsed
-  // exceptions carry a TZID (the `local` block). Emitting EXDATE with an IANA
-  // TZID against a UTC DTSTART is an RFC 5545 value-type mismatch that makes
-  // Apple Calendar drop the whole recurring event. EXDATE must be UTC too.
+  /*
+   * Regression: the feed emits DTSTART as bare UTC, but source-parsed
+   * exceptions carry a TZID (the `local` block). Emitting EXDATE with an IANA
+   * TZID against a UTC DTSTART is an RFC 5545 value-type mismatch that makes
+   * Apple Calendar drop the whole recurring event. EXDATE must be UTC too.
+   */
   it("emits EXDATE in UTC even when the source exception carries a TZID", () => {
     const ics = formatEventsAsIcal(
       [makeEvent({

--- a/services/api/tests/utils/ical.test.ts
+++ b/services/api/tests/utils/ical.test.ts
@@ -205,6 +205,63 @@ describe("recurring events", () => {
     expect(ics).toContain("20260402T180000Z");
   });
 
+  // Regression: the feed emits DTSTART as bare UTC, but source-parsed
+  // exceptions carry a TZID (the `local` block). Emitting EXDATE with an IANA
+  // TZID against a UTC DTSTART is an RFC 5545 value-type mismatch that makes
+  // Apple Calendar drop the whole recurring event. EXDATE must be UTC too.
+  it("emits EXDATE in UTC even when the source exception carries a TZID", () => {
+    const ics = formatEventsAsIcal(
+      [makeEvent({
+        isAllDay: false,
+        startTime: new Date("2025-09-24T23:00:00Z"),
+        endTime: new Date("2025-09-25T02:00:00Z"),
+        recurrenceRule: { frequency: "WEEKLY", byDay: [{ day: "WE" }] } as never,
+        exceptionDates: [{
+          date: new Date("2025-11-19T23:00:00Z"),
+          type: "DATE-TIME",
+          local: {
+            date: new Date("2025-11-19T20:00:00Z"),
+            timezone: "America/Montevideo",
+            tzoffset: "-03:00",
+          },
+        }] as never,
+      })],
+      DEFAULT_SETTINGS,
+    );
+
+    expect(ics).toContain("DTSTART:20250924T230000Z");
+    expect(ics).toContain("EXDATE");
+    // Instant preserved, emitted as UTC, with no TZID parameter.
+    expect(ics).toContain("20251119T230000Z");
+    expect(ics).not.toContain("TZID=America/Montevideo");
+  });
+
+  it("emits RRULE UNTIL in UTC even when the source rule carries a TZID", () => {
+    const ics = formatEventsAsIcal(
+      [makeEvent({
+        isAllDay: false,
+        startTime: new Date("2025-06-02T14:00:00Z"),
+        endTime: new Date("2025-06-02T16:00:00Z"),
+        recurrenceRule: {
+          frequency: "WEEKLY",
+          until: {
+            date: new Date("2027-05-24T14:00:00Z"),
+            type: "DATE-TIME",
+            local: {
+              date: new Date("2027-05-24T11:00:00Z"),
+              timezone: "America/Montevideo",
+              tzoffset: "-03:00",
+            },
+          },
+        } as never,
+      })],
+      DEFAULT_SETTINGS,
+    );
+
+    expect(ics).toContain("UNTIL=20270524T140000Z");
+    expect(ics).not.toContain("UNTIL=20270524T110000");
+  });
+
   it("does not emit RRULE for one-off events", () => {
     const ics = formatEventsAsIcal([makeEvent()], DEFAULT_SETTINGS);
     expect(ics).not.toContain("RRULE:");


### PR DESCRIPTION
## Summary

The public ICS feed serializes `DTSTART`/`DTEND` as bare UTC (`...Z`), but source-parsed `exceptionDates` and `RRULE UNTIL` carry the source's TZID (the ts-ics `local` block). Emitting `EXDATE;TZID=America/Montevideo:...` against a UTC `DTSTART` is an RFC 5545 value-type mismatch — the value type of EXDATE/UNTIL must match `DTSTART`.

Apple Calendar drops the entire recurring event when it can't reconcile an IANA-TZID EXDATE against a UTC `DTSTART`. Events whose EXDATE used an unrecognized Windows zone name survived because Apple silently ignored it — hence the inconsistency where some recurring events render and others vanish from the subscribed feed.

## Fix

Normalize `exceptionDates` and `recurrenceRule.until` to bare UTC (strip the `local` block) before serializing, so they match the feed's UTC `DTSTART`. The underlying instant is preserved, and all-day exceptions keep `VALUE=DATE`.

## Tests

Regression tests assert EXDATE and `RRULE UNTIL` are emitted in UTC (no `TZID`) when the source date carries an IANA timezone, with the instant preserved.
