### PR TITLE
fix(ical): emit feed RRULE with FREQ first (bump ts-ics to 2.4.3)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -253,7 +253,7 @@
         "entrykit": "^0.1.3",
         "ioredis": "^5.10.0",
         "resend": "^6.9.3",
-        "ts-ics": "^2.4.3",
+        "ts-ics": "2.4.3",
         "tsdav": "^2.1.8",
         "widelogger": "^0.7.0",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "keeper.sh",
@@ -254,7 +253,7 @@
         "entrykit": "^0.1.3",
         "ioredis": "^5.10.0",
         "resend": "^6.9.3",
-        "ts-ics": "2.4.0",
+        "ts-ics": "^2.4.3",
         "tsdav": "^2.1.8",
         "widelogger": "^0.7.0",
       },
@@ -1080,7 +1079,7 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
-    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -1246,7 +1245,7 @@
 
     "bullmq": ["bullmq@5.71.0", "", { "dependencies": { "cron-parser": "4.9.0", "ioredis": "5.9.3", "msgpackr": "1.11.5", "node-abort-controller": "3.1.1", "semver": "7.7.4", "tslib": "2.8.1", "uuid": "11.1.0" } }, "sha512-aeNWh4drsafSKnAJeiNH/nZP/5O8ZdtdMbnOPZmpjXj7NZUP5YC901U3bIH41iZValm7d1i3c34ojv7q31m30w=="],
 
-    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -2296,7 +2295,7 @@
 
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 
-    "ts-ics": ["ts-ics@2.4.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0" } }, "sha512-Tguo+7W/swxTw8/Fxv4zPBqiHw/i1ohg0aCWeY50miwdwFGC7TCWcOUuqaeag5EdnaX57zn1qrqERsc4A+4j1A=="],
+    "ts-ics": ["ts-ics@2.4.3", "", { "dependencies": { "@standard-schema/spec": "^1.0.0" } }, "sha512-fHGCXlt7J/pCaokWnmDr8GOh1BgmYMcNuGesJaSv7T0O1hJ4tYYysYn7i7yVJjyTqxDPJjSNFXmSkgxsZP7rQw=="],
 
     "tsdav": ["tsdav@2.1.8", "", { "dependencies": { "base-64": "1.0.0", "cross-fetch": "4.1.0", "debug": "4.4.3", "xml-js": "1.6.11" } }, "sha512-zvQvhZLzTaEmNNgJbBlUYT/JOq9Xpw/xkxCqs7IT2d2/7o7pss0iZOlZXuHJ5VcvSvTny42Vc6+6GyzZcrCJ1g=="],
 
@@ -2468,7 +2467,13 @@
 
     "@humanwhocodes/config-array/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
-    "@keeper.sh/calendar/ts-ics": ["ts-ics@2.4.3", "", { "dependencies": { "@standard-schema/spec": "^1.0.0" } }, "sha512-fHGCXlt7J/pCaokWnmDr8GOh1BgmYMcNuGesJaSv7T0O1hJ4tYYysYn7i7yVJjyTqxDPJjSNFXmSkgxsZP7rQw=="],
+    "@keeper.sh/cron/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@keeper.sh/mcp/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@keeper.sh/sync/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@keeper.sh/worker/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@peculiar/asn1-cms/@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.6.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-uzYbPEpoQiBoTq0/+jZtpM6Gq6zADBx+JNFP3yqRgziWBxQ/Dt/HcuvRfm9zJTPdRcBqPNdaRHTVwpyiq6iNMA=="],
 
@@ -2719,6 +2724,14 @@
     "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "@humanwhocodes/config-array/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "@keeper.sh/cron/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "@keeper.sh/mcp/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "@keeper.sh/sync/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "@keeper.sh/worker/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "@peculiar/asn1-pfx/@peculiar/asn1-rsa/@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.6.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-uzYbPEpoQiBoTq0/+jZtpM6Gq6zADBx+JNFP3yqRgziWBxQ/Dt/HcuvRfm9zJTPdRcBqPNdaRHTVwpyiq6iNMA=="],
 

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -28,7 +28,7 @@
     "entrykit": "^0.1.3",
     "ioredis": "^5.10.0",
     "resend": "^6.9.3",
-    "ts-ics": "2.4.0",
+    "ts-ics": "^2.4.3",
     "tsdav": "^2.1.8",
     "widelogger": "^0.7.0"
   },

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -28,7 +28,7 @@
     "entrykit": "^0.1.3",
     "ioredis": "^5.10.0",
     "resend": "^6.9.3",
-    "ts-ics": "^2.4.3",
+    "ts-ics": "2.4.3",
     "tsdav": "^2.1.8",
     "widelogger": "^0.7.0"
   },

--- a/services/api/tests/utils/ical.test.ts
+++ b/services/api/tests/utils/ical.test.ts
@@ -188,11 +188,13 @@ describe("recurring events", () => {
     expect(ics).toMatch(/BYDAY=MO,TU,WE,TH,FR|BYDAY=MO;BYDAY=TU/);
   });
 
-  // Regression: RFC 5545 §3.3.10 requires FREQ to be the first rule part in an
-  // RRULE. ts-ics < 2.4.3 emitted BY* parts before FREQ (e.g.
-  // RRULE:BYDAY=WE;FREQ=WEEKLY), which Apple Calendar silently fails to expand —
-  // the recurring event then shows only at its master DTSTART and disappears
-  // from current views.
+  /*
+   * Regression: RFC 5545 §3.3.10 requires FREQ to be the first rule part in an
+   * RRULE. ts-ics < 2.4.3 emitted BY* parts before FREQ (e.g.
+   * RRULE:BYDAY=WE;FREQ=WEEKLY), which Apple Calendar silently fails to expand —
+   * the recurring event then shows only at its master DTSTART and disappears
+   * from current views.
+   */
   it("emits RRULE with FREQ as the first rule part (RFC 5545)", () => {
     const ics = formatEventsAsIcal(
       [makeEvent({

--- a/services/api/tests/utils/ical.test.ts
+++ b/services/api/tests/utils/ical.test.ts
@@ -188,6 +188,26 @@ describe("recurring events", () => {
     expect(ics).toMatch(/BYDAY=MO,TU,WE,TH,FR|BYDAY=MO;BYDAY=TU/);
   });
 
+  // Regression: RFC 5545 §3.3.10 requires FREQ to be the first rule part in an
+  // RRULE. ts-ics < 2.4.3 emitted BY* parts before FREQ (e.g.
+  // RRULE:BYDAY=WE;FREQ=WEEKLY), which Apple Calendar silently fails to expand —
+  // the recurring event then shows only at its master DTSTART and disappears
+  // from current views.
+  it("emits RRULE with FREQ as the first rule part (RFC 5545)", () => {
+    const ics = formatEventsAsIcal(
+      [makeEvent({
+        isAllDay: false,
+        startTime: new Date("2025-09-24T23:00:00Z"),
+        endTime: new Date("2025-09-25T02:00:00Z"),
+        recurrenceRule: { frequency: "WEEKLY", byDay: [{ day: "WE" }] } as never,
+      })],
+      DEFAULT_SETTINGS,
+    );
+    const rrule = ics.split(/\r?\n/).find((line) => line.startsWith("RRULE"));
+    expect(rrule).toBeDefined();
+    expect(rrule).toMatch(/^RRULE:FREQ=/);
+  });
+
   it("emits EXDATE for events with exceptionDates", () => {
     const ics = formatEventsAsIcal(
       [makeEvent({


### PR DESCRIPTION
## Summary

The public ICS feed emits recurrence rules with the `BY*` parts before `FREQ` (e.g. `RRULE:BYDAY=WE;FREQ=WEEKLY`). RFC 5545 §3.3.10 requires `FREQ` to be the first rule part, and Apple Calendar (CalendarAgent) silently fails to expand a non-conformant RRULE: the recurring event then renders only at its master `DTSTART` — often months in the past — and disappears from current views entirely.

Recurring events that carry concrete dated override instances (`RECURRENCE-ID`) survive because they don't depend on RRULE expansion, which is why some recurring events render in a subscribed feed and others vanish.

The cause is `ts-ics@2.4.0`, whose RRULE generator orders `BY*` parts before `FREQ`. 2.4.3 emits `FREQ` first:

```
2.4.0 → RRULE:BYDAY=WE;FREQ=WEEKLY
2.4.3 → RRULE:FREQ=WEEKLY;BYDAY=WE
```

## Fix

Bump `services/api` to `ts-ics ^2.4.3` (the version `@keeper.sh/calendar` already uses).

## Tests

Regression test asserts the emitted RRULE leads with `FREQ=`.
