### PR TITLE
fix(sync): stop gating sync on needsReauthentication

### DIFF
--- a/packages/calendar/src/core/oauth/accounts.ts
+++ b/packages/calendar/src/core/oauth/accounts.ts
@@ -51,7 +51,6 @@ const getOAuthAccountsByPlan = async (
     .where(
       and(
         eq(calendarAccountsTable.provider, provider),
-        eq(calendarAccountsTable.needsReauthentication, false),
         getDestinationScopeFilter(database),
       ),
     );
@@ -103,7 +102,6 @@ const getOAuthAccountsForUser = async (
       and(
         eq(calendarAccountsTable.provider, provider),
         eq(calendarsTable.userId, userId),
-        eq(calendarAccountsTable.needsReauthentication, false),
         getDestinationScopeFilter(database),
       ),
     );

--- a/packages/calendar/src/providers/caldav/source/sync.ts
+++ b/packages/calendar/src/providers/caldav/source/sync.ts
@@ -65,7 +65,6 @@ const createCalDAVSourceService = (config: CalDAVSourceProviderConfig): CalDAVSo
       .where(
         and(
           eq(calendarsTable.calendarType, CALDAV_CALENDAR_TYPE),
-          eq(calendarAccountsTable.needsReauthentication, false),
         ),
       );
 
@@ -98,7 +97,6 @@ const createCalDAVSourceService = (config: CalDAVSourceProviderConfig): CalDAVSo
         and(
           eq(calendarsTable.calendarType, CALDAV_CALENDAR_TYPE),
           eq(calendarAccountsTable.provider, provider),
-          eq(calendarAccountsTable.needsReauthentication, false),
         ),
       );
 
@@ -131,7 +129,6 @@ const createCalDAVSourceService = (config: CalDAVSourceProviderConfig): CalDAVSo
         and(
           eq(calendarsTable.calendarType, CALDAV_CALENDAR_TYPE),
           eq(calendarsTable.userId, userId),
-          eq(calendarAccountsTable.needsReauthentication, false),
         ),
       );
 

--- a/packages/calendar/src/providers/google/source/provider.ts
+++ b/packages/calendar/src/providers/google/source/provider.ts
@@ -269,7 +269,6 @@ const getGoogleSourcesWithCredentials = async (
         eq(calendarsTable.calendarType, "oauth"),
         arrayContains(calendarsTable.capabilities, ["pull"]),
         eq(calendarAccountsTable.provider, GOOGLE_PROVIDER_ID),
-        eq(calendarAccountsTable.needsReauthentication, false),
       ),
     );
 

--- a/packages/calendar/src/providers/outlook/source/provider.ts
+++ b/packages/calendar/src/providers/outlook/source/provider.ts
@@ -289,7 +289,6 @@ const getOutlookSourcesWithCredentials = async (
         eq(calendarsTable.calendarType, "oauth"),
         arrayContains(calendarsTable.capabilities, ["pull"]),
         eq(calendarAccountsTable.provider, OUTLOOK_PROVIDER_ID),
-        eq(calendarAccountsTable.needsReauthentication, false),
       ),
     );
 

--- a/packages/sync/src/sync-user.ts
+++ b/packages/sync/src/sync-user.ts
@@ -125,7 +125,6 @@ const syncDestinationsForUser = async (
         eq(calendarsTable.userId, userId),
         eq(calendarsTable.disabled, false),
         arrayContains(calendarsTable.capabilities, ["push"]),
-        eq(calendarAccountsTable.needsReauthentication, false),
       ),
     );
 

--- a/services/api/src/mutations/resolve-credentials.ts
+++ b/services/api/src/mutations/resolve-credentials.ts
@@ -100,10 +100,6 @@ const resolveCredentialsByCalendarId = async (
     return null;
   }
 
-  if (result.needsReauthentication) {
-    return null;
-  }
-
   return rowToCredentials(result);
 };
 
@@ -204,7 +200,6 @@ const resolveAllSourceCredentials = async (
       and(
         eq(calendarsTable.userId, userId),
         arrayContains(calendarsTable.capabilities, ["pull"]),
-        eq(calendarAccountsTable.needsReauthentication, false),
       ),
     );
 


### PR DESCRIPTION
The needsReauthentication flag is being set on accounts with valid credentials, which silently drops them from every sync/source/credential query. A flagged push destination can never run a push to recover, so it stays stuck in one direction. Removes all needsReauthentication gates from the sync paths; the flag is still written and shown in the UI, just no longer a hard gate.