### PR TITLE
fix(caldav): convert HTML descriptions to plain text and stash original under X-ALT-DESC

### DIFF
--- a/packages/calendar/src/providers/caldav/shared/ics.ts
+++ b/packages/calendar/src/providers/caldav/shared/ics.ts
@@ -46,11 +46,67 @@ const resolveEventTimezones = (
   return [timezone];
 };
 
+const HTML_TAG_PATTERN = /<[^>]*>/g;
+const HTML_ENTITIES: Record<string, string> = {
+  "&nbsp;": " ",
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": "\"",
+  "&apos;": "'",
+  "&#39;": "'",
+};
+const ANCHOR_PATTERN = /<a\b[^>]*?href="([^"]*)"[^>]*?>([\s\S]*?)<\/a>/gi;
+const ICS_LINE_MAX_OCTETS = 75;
+
+const isHtmlDescription = (text: string): boolean => /<\/?\w+[^>]*>/.test(text);
+
+const htmlToPlainText = (html: string): string => {
+  const withAnchorsConverted = html.replace(ANCHOR_PATTERN, (_match, href: string, text: string) => {
+    const plainText = text.replaceAll(HTML_TAG_PATTERN, "").replaceAll(/[\r\n\t ]+/g, " ").trim();
+    if (!plainText || plainText === href) {
+      return href;
+    }
+    return `${plainText} (${href})`;
+  });
+  const withoutTags = withAnchorsConverted.replaceAll(HTML_TAG_PATTERN, "");
+  const decoded = withoutTags.replaceAll(
+    /&(?:nbsp|amp|lt|gt|quot|apos|#39);/g,
+    (entity) => HTML_ENTITIES[entity] ?? entity,
+  );
+  return decoded.replaceAll(/[\r\n\t ]+/g, " ").trim();
+};
+
+const foldIcsLine = (line: string): string => {
+  if (Buffer.byteLength(line, "utf8") <= ICS_LINE_MAX_OCTETS) {
+    return line;
+  }
+  const parts: string[] = [];
+  let remaining = line;
+  while (Buffer.byteLength(remaining, "utf8") > ICS_LINE_MAX_OCTETS) {
+    let cut = ICS_LINE_MAX_OCTETS;
+    while (cut > 0 && Buffer.byteLength(remaining.slice(0, cut), "utf8") > ICS_LINE_MAX_OCTETS) {
+      cut--;
+    }
+    parts.push(remaining.slice(0, cut));
+    remaining = remaining.slice(cut);
+  }
+  parts.push(remaining);
+  return parts.join("\r\n ");
+};
+
 const eventToICalString = (event: MaterializedSyncableEvent, uid: string): string => {
   const isAllDay = resolveIsAllDayEvent(event);
   const timezones = resolveEventTimezones(event, isAllDay);
+
+  const rawDescription = event.description;
+  const descriptionIsHtml = Boolean(rawDescription) && isHtmlDescription(rawDescription ?? "");
+  const plainDescription = descriptionIsHtml && rawDescription
+    ? htmlToPlainText(rawDescription)
+    : normalizeIcsText(rawDescription);
+
   const icsEvent: IcsEvent = {
-    description: normalizeIcsText(event.description),
+    description: plainDescription,
     end: buildZonedIcsDate(event.endTime, event.startTimeZone, isAllDay),
     location: normalizeIcsText(event.location),
     stamp: { date: new Date() },
@@ -67,7 +123,21 @@ const eventToICalString = (event: MaterializedSyncableEvent, uid: string): strin
     ...(timezones.length > 0 && { timezones }),
   };
 
-  return generateIcsCalendar(calendar);
+  const baseIcs = generateIcsCalendar(calendar);
+
+  if (!descriptionIsHtml || !rawDescription) {
+    return baseIcs;
+  }
+
+  // Inject X-ALT-DESC with the original HTML before END:VEVENT for clients that support rich descriptions.
+  const escapedHtml = rawDescription
+    .replaceAll("\\", String.raw`\\`)
+    .replaceAll(";", String.raw`\;`)
+    .replaceAll(",", String.raw`\,`)
+    .replaceAll(/\r?\n/g, String.raw`\n`);
+  const altDescLine = `X-ALT-DESC;FMTTYPE=text/html:${escapedHtml}`;
+  const folded = foldIcsLine(altDescLine);
+  return baseIcs.replace(/END:VEVENT\r\n/, `${folded}\r\nEND:VEVENT\r\n`);
 };
 
 interface ParsedCalendarEvent {


### PR DESCRIPTION
## Summary

iCloud (and other strict CalDAV servers) rejects PUTs whose `DESCRIPTION` property carries raw HTML, returning `404 Not Found` for Outlook-style Teams meeting bodies and similar imports. The destination provider was also reading the response body without checking `response.ok`, so those rejections looked like successes and stale mappings persisted.

## Changes

- `eventToICalString`: detect HTML in the source description, convert it to plain text while preserving anchor URLs inline as `Text (URL)`, and emit the original HTML as `X-ALT-DESC;FMTTYPE=text/html` with RFC 5545 line folding (≤75 octets). Plain-text descriptions still pass through unchanged.
- `CalDAVClient.createCalendarObject`: throw with the response status, statusText and URL when iCloud answers with a non-2xx so the sync layer records a real failure instead of optimistically storing a mapping.

## Test plan
- [ ] Push an event with an Outlook Teams meeting description (HTML body, long meetup-join URL): iCloud returns 201 and the event becomes visible in the destination calendar.
- [ ] Push an event with a plain-text description: ICS output is unchanged (no `X-ALT-DESC`).
- [ ] Push an event the server actively rejects: error is propagated up rather than treated as success.
- [ ] Re-sync after the first run: existing mappings remain, no duplicate PUT.