### PR TITLE
fix: stop holding DB transactions open across non-DB work (idle-in-transaction pool leak)

### DIFF
--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -1,3 +1,5 @@
 export { createDatabase, closeDatabase } from "./utils/database";
+export { classifyDatabaseError } from "./utils/errors";
+export type { DatabaseErrorClassification } from "./utils/errors";
 export { account, user } from "./database/auth-schema";
 export { encryptPassword, decryptPassword } from "./encryption";

--- a/packages/database/src/utils/database.ts
+++ b/packages/database/src/utils/database.ts
@@ -4,13 +4,25 @@ import type { BunSQLDatabase } from "drizzle-orm/bun-sql";
 
 interface DatabasePoolOptions {
   statementTimeoutMs?: number;
+  idleInTransactionTimeoutMs?: number;
 }
 
 const DEFAULT_STATEMENT_TIMEOUT_MS = 30_000;
+const DEFAULT_IDLE_IN_TRANSACTION_TIMEOUT_MS = 30_000;
+const POOL_MAX_CONNECTIONS = 10;
+const POOL_IDLE_TIMEOUT_SECONDS = 30;
+const POOL_MAX_LIFETIME_SECONDS = 1800;
 
-const appendStatementTimeout = (url: string, timeoutMs: number): string => {
+const appendServerSettings = (
+  url: string,
+  statementTimeoutMs: number,
+  idleInTransactionTimeoutMs: number,
+): string => {
   const parsed = new URL(url);
-  parsed.searchParams.set("options", `-c statement_timeout=${timeoutMs}`);
+  parsed.searchParams.set(
+    "options",
+    `-c statement_timeout=${statementTimeoutMs} -c idle_in_transaction_session_timeout=${idleInTransactionTimeoutMs}`,
+  );
   return parsed.toString();
 };
 
@@ -37,8 +49,17 @@ const waitForConnection = async (database: DatabaseInstance): Promise<void> => {
 
 const createDatabase = async (url: string, options?: DatabasePoolOptions): Promise<DatabaseInstance> => {
   const statementTimeoutMs = options?.statementTimeoutMs ?? DEFAULT_STATEMENT_TIMEOUT_MS;
-  const connectionUrl = appendStatementTimeout(url, statementTimeoutMs);
-  const database = drizzle(connectionUrl);
+  const idleInTransactionTimeoutMs =
+    options?.idleInTransactionTimeoutMs ?? DEFAULT_IDLE_IN_TRANSACTION_TIMEOUT_MS;
+  const connectionUrl = appendServerSettings(url, statementTimeoutMs, idleInTransactionTimeoutMs);
+  const database = drizzle({
+    connection: {
+      url: connectionUrl,
+      max: POOL_MAX_CONNECTIONS,
+      idleTimeout: POOL_IDLE_TIMEOUT_SECONDS,
+      maxLifetime: POOL_MAX_LIFETIME_SECONDS,
+    },
+  });
   await waitForConnection(database);
   return database;
 };

--- a/packages/database/src/utils/errors.ts
+++ b/packages/database/src/utils/errors.ts
@@ -1,0 +1,35 @@
+// SQLSTATE 57014 (query_canceled) — Postgres raises this when statement_timeout fires.
+const STATEMENT_TIMEOUT_SQLSTATE = "57014";
+// Bun's code for a backend terminated mid-flight (idle-in-transaction timeout, shutdown, drop).
+const CONNECTION_TERMINATED_CODE = "ERR_POSTGRES_EXPECTED_REQUEST";
+
+interface DatabaseErrorClassification {
+  slug: string;
+  sqlState: string | null;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const readCause = (error: unknown): Record<string, unknown> | null => {
+  if (isRecord(error) && isRecord(error.cause)) {
+    return error.cause;
+  }
+  return null;
+};
+
+const classifyDatabaseError = (error: unknown): DatabaseErrorClassification | null => {
+  const cause = readCause(error);
+  if (cause && String(cause.errno) === STATEMENT_TIMEOUT_SQLSTATE) {
+    return { slug: "db-statement-timeout", sqlState: STATEMENT_TIMEOUT_SQLSTATE };
+  }
+
+  if (isRecord(error) && error.code === CONNECTION_TERMINATED_CODE) {
+    return { slug: "db-connection-terminated", sqlState: null };
+  }
+
+  return null;
+};
+
+export { classifyDatabaseError };
+export type { DatabaseErrorClassification };

--- a/services/api/src/utils/caldav-sources.ts
+++ b/services/api/src/utils/caldav-sources.ts
@@ -190,6 +190,11 @@ const createCalDAVSource = async (
 
   const resolvedEncryptionKey = encryptionKey;
 
+  const plan = await premiumService.getUserPlan(userId);
+  if (!plan) {
+    throw new Error("Unable to resolve user plan for sync enqueue");
+  }
+
   const result = await database.transaction(async (tx) => {
     await tx.execute(
       sql`select pg_advisory_xact_lock(${USER_ACCOUNT_LOCK_NAMESPACE}, hashtext(${userId}))`,
@@ -221,7 +226,7 @@ const createCalDAVSource = async (
 
     if (!existingAccount) {
       const existingAccountCount = await countUserAccountsWithDatabase(tx, userId);
-      const allowed = await premiumService.canAddAccount(userId, existingAccountCount);
+      const allowed = existingAccountCount < premiumService.getAccountLimit(plan);
 
       if (!allowed) {
         throw new CalDAVSourceLimitError();
@@ -261,10 +266,6 @@ const createCalDAVSource = async (
     };
   });
 
-  const plan = await premiumService.getUserPlan(userId);
-  if (!plan) {
-    throw new Error("Unable to resolve user plan for sync enqueue");
-  }
   await enqueuePushSync(userId, plan);
 
   return result;

--- a/services/api/src/utils/caldav.ts
+++ b/services/api/src/utils/caldav.ts
@@ -98,6 +98,11 @@ const createCalDAVDestination = async (
   const serverHost = new URL(serverUrl).host;
   const accountId = `${credentials.username}@${serverHost}`;
 
+  const plan = await premiumService.getUserPlan(userId);
+  if (!plan) {
+    throw new Error("Unable to resolve user plan for sync enqueue");
+  }
+
   await database.transaction(async (tx) => {
     await tx.execute(
       sql`select pg_advisory_xact_lock(${USER_ACCOUNT_LOCK_NAMESPACE}, hashtext(${userId}))`,
@@ -121,7 +126,7 @@ const createCalDAVDestination = async (
         .from(calendarAccountsTable)
         .where(eq(calendarAccountsTable.userId, userId));
 
-      const allowed = await premiumService.canAddAccount(userId, existingAccounts.length);
+      const allowed = existingAccounts.length < premiumService.getAccountLimit(plan);
       if (!allowed) {
         throw new DestinationLimitError();
       }
@@ -141,10 +146,6 @@ const createCalDAVDestination = async (
     );
   });
 
-  const plan = await premiumService.getUserPlan(userId);
-  if (!plan) {
-    throw new Error("Unable to resolve user plan for sync enqueue");
-  }
   await enqueuePushSync(userId, plan);
 };
 

--- a/services/api/src/utils/middleware.ts
+++ b/services/api/src/utils/middleware.ts
@@ -2,6 +2,7 @@ import type { MaybePromise } from "bun";
 import { isKeeperMcpEnabledAuth } from "@keeper.sh/auth";
 import { ErrorResponse } from "./responses";
 import { apiTokensTable } from "@keeper.sh/database/schema";
+import { classifyDatabaseError } from "@keeper.sh/database";
 import { isApiToken, hashApiToken } from "./api-tokens";
 import { user as userTable } from "@keeper.sh/database/auth-schema";
 import { eq } from "drizzle-orm";
@@ -117,7 +118,11 @@ const withWideEvent =
       } catch (error) {
         widelog.set("status_code", 500);
         widelog.set("outcome", "error");
-        widelog.errorFields(error, { slug: "unclassified" });
+        const databaseError = classifyDatabaseError(error);
+        if (databaseError?.sqlState) {
+          widelog.set("db.error_sqlstate", databaseError.sqlState);
+        }
+        widelog.errorFields(error, { slug: databaseError?.slug ?? "unclassified" });
         throw error;
       } finally {
         widelog.flush();

--- a/services/api/src/utils/oauth-sources.ts
+++ b/services/api/src/utils/oauth-sources.ts
@@ -854,17 +854,23 @@ const insertOAuthCalendarsWithDatabase = async (
 const importOAuthAccountCalendars = async (
   options: ImportOAuthAccountOptions,
 ): Promise<string> => {
-  const { database } = await import("@/context");
+  const { database, premiumService } = await import("@/context");
+
+  const dependencies = createDefaultImportOAuthAccountDependencies();
+
+  const plan = await premiumService.getUserPlan(options.userId);
+  const externalCalendars = await dependencies.listCalendars(options.provider, options.accessToken);
 
   return database.transaction(async (tx) => {
     await tx.execute(
       sql`select pg_advisory_xact_lock(${USER_ACCOUNT_LOCK_NAMESPACE}, hashtext(${options.userId}))`,
     );
 
-    const dependencies = createDefaultImportOAuthAccountDependencies();
-
     return importOAuthAccountCalendarsWithDependencies(options, {
       ...dependencies,
+      canAddAccount: (_userId, currentCount) =>
+        Promise.resolve(currentCount < premiumService.getAccountLimit(plan)),
+      listCalendars: () => Promise.resolve(externalCalendars),
       countUserAccounts: (userId) => countUserAccountsWithDatabase(tx, userId),
       createAccountId: (accountOptions) => createOAuthAccountIdWithDatabase(tx, accountOptions),
       findExistingAccountId: (accountOptions) => findOAuthAccountIdWithDatabase(tx, accountOptions),

--- a/services/api/src/utils/oauth.ts
+++ b/services/api/src/utils/oauth.ts
@@ -214,6 +214,7 @@ const handleOAuthCallback = async (
     refreshToken: string;
     userId: string;
   }): Promise<void> => {
+    const plan = await premiumService.getUserPlan(payload.userId);
     await database.transaction(async (tx) => {
       await tx.execute(
         sql`select pg_advisory_xact_lock(${USER_ACCOUNT_LOCK_NAMESPACE}, hashtext(${payload.userId}))`,
@@ -227,7 +228,7 @@ const handleOAuthCallback = async (
             .from(calendarAccountsTable)
             .where(eq(calendarAccountsTable.userId, payload.userId));
 
-          const allowed = await premiumService.canAddAccount(payload.userId, accountCount?.value ?? 0);
+          const allowed = (accountCount?.value ?? 0) < premiumService.getAccountLimit(plan);
           if (!allowed) {
             throw new OAuthError(
               "Account limit reached",

--- a/services/api/src/utils/source-destination-mappings.ts
+++ b/services/api/src/utils/source-destination-mappings.ts
@@ -37,11 +37,13 @@ interface SetDestinationsTransaction {
   ensureDestinationSyncStatuses: (destinationCalendarIds: string[]) => Promise<void>;
 }
 
+type ResolveMappingLimit = (userId: string) => Promise<number>;
+
 interface SetDestinationsDependencies {
   withTransaction: <TResult>(
     callback: (transaction: SetDestinationsTransaction) => Promise<TResult>,
   ) => Promise<TResult>;
-  isMappingCountAllowed?: (userId: string, nextMappingCount: number) => Promise<boolean>;
+  resolveMappingLimit?: ResolveMappingLimit;
 }
 
 interface SetSourcesTransaction {
@@ -61,7 +63,7 @@ interface SetSourcesDependencies {
   withTransaction: <TResult>(
     callback: (transaction: SetSourcesTransaction) => Promise<TResult>,
   ) => Promise<TResult>;
-  isMappingCountAllowed?: (userId: string, nextMappingCount: number) => Promise<boolean>;
+  resolveMappingLimit?: ResolveMappingLimit;
 }
 
 const assertAllIdsOwned = (
@@ -258,10 +260,9 @@ const createSetDestinationsDependencies = async (): Promise<SetDestinationsDepen
   const { database, premiumService } = await import("@/context");
 
   return {
-    isMappingCountAllowed: async (userId, nextMappingCount) => {
+    resolveMappingLimit: async (userId) => {
       const userPlan = await premiumService.getUserPlan(userId);
-      const mappingLimit = premiumService.getMappingLimit(userPlan);
-      return nextMappingCount <= mappingLimit;
+      return premiumService.getMappingLimit(userPlan);
     },
     withTransaction: (callback) =>
       database.transaction((transactionClient) =>
@@ -273,15 +274,24 @@ const createSetSourcesDependencies = async (): Promise<SetSourcesDependencies> =
   const { database, premiumService } = await import("@/context");
 
   return {
-    isMappingCountAllowed: async (userId, nextMappingCount) => {
+    resolveMappingLimit: async (userId) => {
       const userPlan = await premiumService.getUserPlan(userId);
-      const mappingLimit = premiumService.getMappingLimit(userPlan);
-      return nextMappingCount <= mappingLimit;
+      return premiumService.getMappingLimit(userPlan);
     },
     withTransaction: (callback) =>
       database.transaction((transactionClient) =>
         callback(createSetSourcesTransaction(transactionClient))),
   };
+};
+
+const resolveMappingLimitOrNull = (
+  userId: string,
+  resolve?: ResolveMappingLimit,
+): Promise<number | null> => {
+  if (!resolve) {
+    return Promise.resolve(null);
+  }
+  return resolve(userId);
 };
 
 const runSetDestinationsForSource = async (
@@ -291,6 +301,8 @@ const runSetDestinationsForSource = async (
   dependencies: SetDestinationsDependencies,
 ): Promise<void> => {
   const uniqueDestinationCalendarIds = [...new Set(destinationCalendarIds)];
+
+  const mappingLimit = await resolveMappingLimitOrNull(userId, dependencies.resolveMappingLimit);
 
   await dependencies.withTransaction(async (transaction) => {
     await transaction.acquireUserLock(userId);
@@ -313,7 +325,7 @@ const runSetDestinationsForSource = async (
     }
 
     if (
-      dependencies.isMappingCountAllowed
+      mappingLimit !== null
       && transaction.countUserMappings
       && transaction.countMappingsForSource
     ) {
@@ -325,8 +337,7 @@ const runSetDestinationsForSource = async (
         - currentSourceMappingCount
         + uniqueDestinationCalendarIds.length;
 
-      const allowed = await dependencies.isMappingCountAllowed(userId, nextMappingCount);
-      if (!allowed) {
+      if (nextMappingCount > mappingLimit) {
         throw new Error(MAPPING_LIMIT_ERROR_MESSAGE);
       }
     }
@@ -347,6 +358,8 @@ const runSetSourcesForDestination = async (
 ): Promise<void> => {
   const uniqueSourceCalendarIds = [...new Set(sourceCalendarIds)];
 
+  const mappingLimit = await resolveMappingLimitOrNull(userId, dependencies.resolveMappingLimit);
+
   await dependencies.withTransaction(async (transaction) => {
     await transaction.acquireUserLock(userId);
 
@@ -364,7 +377,7 @@ const runSetSourcesForDestination = async (
     }
 
     if (
-      dependencies.isMappingCountAllowed
+      mappingLimit !== null
       && transaction.countUserMappings
       && transaction.countMappingsForDestination
     ) {
@@ -376,8 +389,7 @@ const runSetSourcesForDestination = async (
         - currentDestinationMappingCount
         + uniqueSourceCalendarIds.length;
 
-      const allowed = await dependencies.isMappingCountAllowed(userId, nextMappingCount);
-      if (!allowed) {
+      if (nextMappingCount > mappingLimit) {
         throw new Error(MAPPING_LIMIT_ERROR_MESSAGE);
       }
     }

--- a/services/api/tests/utils/account-locks.test.ts
+++ b/services/api/tests/utils/account-locks.test.ts
@@ -107,6 +107,18 @@ beforeAll(async () => {
     premiumService: {
       canAddAccount: () => Promise.resolve(canAddAccountResult),
       getUserPlan: () => Promise.resolve("free"),
+      getAccountLimit: () => {
+        if (canAddAccountResult) {
+          return Number.MAX_SAFE_INTEGER;
+        }
+        return 0;
+      },
+      getMappingLimit: () => {
+        if (canAddAccountResult) {
+          return Number.MAX_SAFE_INTEGER;
+        }
+        return 0;
+      },
     },
   }));
 

--- a/services/api/tests/utils/source-destination-mappings.test.ts
+++ b/services/api/tests/utils/source-destination-mappings.test.ts
@@ -143,7 +143,7 @@ describe("runSetDestinationsForSource", () => {
     let replaceCalled = false;
     expect(
       runSetDestinationsForSource("user-1", "source-1", ["dest-1", "dest-2", "dest-3"], {
-        isMappingCountAllowed: () => Promise.resolve(false),
+        resolveMappingLimit: () => Promise.resolve(0),
         withTransaction: (transactionCallback) =>
           transactionCallback({
             acquireUserLock: () => Promise.resolve(),
@@ -510,7 +510,7 @@ describe("runSetSourcesForDestination", () => {
     let replaceCalled = false;
     expect(
       runSetSourcesForDestination("user-1", "dest-1", ["source-1", "source-2"], {
-        isMappingCountAllowed: () => Promise.resolve(false),
+        resolveMappingLimit: () => Promise.resolve(0),
         withTransaction: (transactionCallback) =>
           transactionCallback({
             acquireUserLock: () => Promise.resolve(),


### PR DESCRIPTION
## Problem

Production accumulates a backlog of unsynced calendars over days and only recovers after a manual restart. RDS Performance Insights flags `keepersql` for **long-running `idle in transaction` connections**, and `pg_stat_activity` shows connection usage (~79/189) well above the ~40 expected for the four `max:10` pools.

## Root cause

Several API write paths open a transaction (taking a per-user `pg_advisory_xact_lock`) and then `await` work that runs on a **different** pooled connection or over the network, leaving the transaction's own connection `idle in transaction` for the whole duration:

- **OAuth account import** (`oauth-sources.ts`) — ran the provider `listCalendars()` **HTTP call** *and* the premium check inside `BEGIN`. An idle-in-transaction session for the length of a provider round-trip.
- **OAuth/CalDAV destination + CalDAV source creation** (`oauth.ts`, `caldav.ts`, `caldav-sources.ts`) — called `premiumService.canAddAccount` (a query on a separate pooled connection) inside the transaction.
- **Source/destination mappings** (`source-destination-mappings.ts`) — resolved the plan-based mapping limit via `premiumService` inside the transaction.

`statement_timeout` (30s) does not cover idle-in-transaction time, so these sat open until something else freed them. Under concurrency they also risk pool-exhaustion deadlock (every pooled connection held by a transaction waiting on yet another connection), which a restart clears — matching the observed symptom.

## Changes (by commit)

1. **`fix(database)`** — add `idle_in_transaction_session_timeout=30s` (alongside the existing `statement_timeout`) as a backstop that auto-terminates any leaked transaction, and configure the bun:sql pool explicitly (`max:10`, `idleTimeout:30s`, `maxLifetime:30m`) instead of the defaults (`maxLifetime:0` = connections never recycled).
2. **`fix(api)` account paths** — resolve the user plan (and, for the import flow, fetch the provider calendar list) **before** opening the transaction; compare the account count against the pure entitlement limit inside it. No network or second-connection work happens inside `BEGIN`.
3. **`fix(api)` mappings** — resolve the mapping entitlement limit before the transaction and compare the projected count in place.
4. **`feat(api)` observability** — `classifyDatabaseError` maps `statement_timeout` (SQLSTATE 57014) and bun:sql backend-termination errors (raised when the idle-in-transaction backstop fires, on admin shutdown, or on a dropped connection) to stable slugs, wired into the API request error handler. Timeouts now surface in wide events as `db-statement-timeout` / `db-connection-terminated` (with `db.error_sqlstate`) instead of `unclassified`, so we can watch in Grafana whether the new backstop ever fires (i.e. whether a leak source remains).

No behavioural change to the limits/locking — only *where* the plan read and HTTP happen relative to `BEGIN`.

## Verification

- `bun run types` 17/17, `bun run lint` 17/17
- `services/api` 160/160 tests, `packages/database` 6/6
- Validated against a local Postgres 17: connection succeeds with the combined `options=-c ...` startup param, `statement_timeout` and `idle_in_transaction_session_timeout` both read back as `30s`, the idle backstop actually terminates a deliberately-idle transaction, and `classifyDatabaseError` returns the expected slugs for both timeout types. The `options=-c` mechanism is the same one already used in prod for `statement_timeout`, so it is proven on Aurora; the pool options are client-side and never reach the server.

## Follow-ups (not in this PR)

- Confirm the before/after on the RDS `DatabaseConnections` CloudWatch graph (sawtooth resetting at restarts should flatten).
- Container `mem_limit`s were intentionally **not** added — OOM was ruled out (`oomkilled=false`, no dmesg OOM, swap unused).
- `classifyDatabaseError` is exported from `@keeper.sh/database` and can be adopted by the cron/worker wide-event error paths too.