### PR TITLE
fix(worker): accept BullMQ abort signals

### DIFF
--- a/packages/calendar/src/core/utils/fetch-with-timeout.ts
+++ b/packages/calendar/src/core/utils/fetch-with-timeout.ts
@@ -13,15 +13,38 @@ interface TimeoutSignal {
   isTimeout: () => boolean;
 }
 
-const mergeAbortSignals = (...signals: (AbortSignal | null | undefined)[]): AbortSignal =>
-  AbortSignal.any(
-    signals.flatMap((signal) => {
-      if (signal) {
-        return [signal];
-      }
-      return [];
-    }),
+const mergeAbortSignals = (...signals: (AbortSignal | null | undefined)[]): AbortSignal => {
+  const controller = new AbortController();
+  const activeSignals = signals.filter(
+    (signal): signal is AbortSignal => signal !== null && signal !== globalThis.undefined,
   );
+  const listeners = new Map<AbortSignal, () => void>();
+
+  const cleanup = (): void => {
+    for (const [signal, listener] of listeners) {
+      signal.removeEventListener("abort", listener);
+    }
+    listeners.clear();
+  };
+
+  const abortFrom = (signal: AbortSignal): void => {
+    cleanup();
+    controller.abort(signal.reason);
+  };
+
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      abortFrom(signal);
+      break;
+    }
+
+    const listener = (): void => abortFrom(signal);
+    listeners.set(signal, listener);
+    signal.addEventListener("abort", listener, { once: true });
+  }
+
+  return controller.signal;
+};
 
 const buildTimeoutSignal = (timeoutMs: number, externalSignal?: AbortSignal | null): TimeoutSignal => {
   const timeoutSignal = AbortSignal.timeout(timeoutMs);

--- a/packages/calendar/tests/core/utils/fetch-with-timeout.test.ts
+++ b/packages/calendar/tests/core/utils/fetch-with-timeout.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { mergeAbortSignals } from "../../../src/core/utils/fetch-with-timeout";
+
+class PolyfilledAbortSignal extends EventTarget {
+  public aborted = false;
+  public reason: unknown;
+
+  public abort(reason?: unknown): void {
+    this.aborted = true;
+    this.reason = reason;
+    this.dispatchEvent(new Event("abort"));
+  }
+}
+
+describe("mergeAbortSignals", () => {
+  it("merges a structurally compatible signal from a different implementation", () => {
+    const nativeController = new AbortController();
+    const polyfilledSignal = new PolyfilledAbortSignal();
+    const externalSignal = polyfilledSignal as unknown as AbortSignal;
+
+    expect(() => AbortSignal.any([
+      nativeController.signal,
+      externalSignal,
+    ])).toThrow(TypeError);
+
+    const merged = mergeAbortSignals(
+      nativeController.signal,
+      externalSignal,
+    );
+
+    polyfilledSignal.abort("bullmq cancelled the job");
+
+    expect(merged.aborted).toBe(true);
+    expect(merged.reason).toBe("bullmq cancelled the job");
+  });
+
+  it("preserves an already-aborted signal's reason", () => {
+    const signal = new PolyfilledAbortSignal();
+    signal.abort("already cancelled");
+
+    const merged = mergeAbortSignals(signal as unknown as AbortSignal);
+
+    expect(merged.aborted).toBe(true);
+    expect(merged.reason).toBe("already cancelled");
+  });
+});

--- a/services/worker/src/processor.ts
+++ b/services/worker/src/processor.ts
@@ -97,11 +97,10 @@ const processJob = (
 
     const deadlineController = new AbortController();
     const deadlineTimer = setTimeout(() => deadlineController.abort(), USER_TIMEOUT_MS);
-    const abortSignal = mergeAbortSignals(deadlineController.signal, signal);
-
     let flushed = false;
 
     try {
+      const abortSignal = mergeAbortSignals(deadlineController.signal, signal);
       const result = await syncDestinationsForUser(userId, {
         database,
         redis: refreshLockRedis,


### PR DESCRIPTION
## Problem

v2.11.4 combined the worker deadline signal with BullMQ's cancellation signal using native `AbortSignal.any()`. BullMQ supplies its signal through `node-abort-controller`, and Bun rejects that polyfilled object during the native brand check:

```
TypeError: The "signals[1]" argument must be an instance of AbortSignal. Received an instance of AbortSignal
```

The exception happened before the processor error boundary, so every push job failed without emitting a worker wide event. Cron continued enqueueing normally, making production appear ingest-only.

## Fix

- Merge signals by forwarding abort events into a native `AbortController`, avoiding cross-implementation brand checks.
- Preserve the originating abort reason and remove listeners after cancellation.
- Move signal setup inside the worker processor error boundary.
- Add regression coverage with a structurally compatible non-native signal.

## Verification

- `bun run types`
- `bun run lint`
- `bun run test` (694 tests)
- worker production build

`bun run unused` is clean in CI; locally Knip scans the pre-existing untracked `.claude/worktrees/issue-413` directory and reports that external worktree as unused.