### PR TITLE
fix(ical): keep baseline timezone observance

### DIFF
--- a/packages/calendar/src/ics/utils/build-vtimezone.ts
+++ b/packages/calendar/src/ics/utils/build-vtimezone.ts
@@ -150,7 +150,11 @@ const buildVtimezone = (timezone: string | undefined, referenceInstant: Date): I
 
   const transitions = findTransitions(resolved, referenceInstant);
   if (transitions.length === 2) {
-    return { id: resolved, props: transitions.map((transition) => buildObservance(transition)) };
+    const recurringObservances = transitions.map((transition) => buildObservance(transition));
+    // Ts-ics can expand both recurrence rules to an empty list.
+    // Keep a baseline offset available for dates before the first matching onset.
+    const baselineObservance = buildFixedObservance(transitions[0]?.offsetFrom ?? 0);
+    return { id: resolved, props: [...recurringObservances, baselineObservance] };
   }
 
   const offset = offsetMinutesAt(referenceInstant.getTime(), resolved);

--- a/services/api/tests/utils/ical.test.ts
+++ b/services/api/tests/utils/ical.test.ts
@@ -468,6 +468,41 @@ describe("timezone-aware feed (Outlook)", () => {
     expect(ics).toContain("TZID:America/New_York");
   });
 
+  it("renders a January event before the year's first New York DST transition", () => {
+    const ics = formatEventsAsIcal(
+      [makeEvent({
+        startTime: new Date("2026-01-15T15:00:00Z"),
+        endTime: new Date("2026-01-15T16:00:00Z"),
+        startTimeZone: "America/New_York",
+      })],
+      DEFAULT_SETTINGS,
+    );
+
+    expect(ics).toContain("DTSTART;TZID=America/New_York:20260115T100000");
+  });
+
+  it("renders events after the VTIMEZONE reference year without empty observances", () => {
+    const ics = formatEventsAsIcal(
+      [
+        makeEvent({
+          id: "reference-year",
+          startTime: new Date("2026-06-17T10:45:00Z"),
+          endTime: new Date("2026-06-17T11:45:00Z"),
+          startTimeZone: "Europe/Berlin",
+        }),
+        makeEvent({
+          id: "following-year",
+          startTime: new Date("2027-01-15T10:45:00Z"),
+          endTime: new Date("2027-01-15T11:45:00Z"),
+          startTimeZone: "Europe/Berlin",
+        }),
+      ],
+      DEFAULT_SETTINGS,
+    );
+
+    expect(ics).toContain("DTSTART;TZID=Europe/Berlin:20270115T114500");
+  });
+
   it("falls back to bare UTC for an unresolvable timezone", () => {
     const ics = formatEventsAsIcal(
       [makeEvent({


### PR DESCRIPTION
## Problem

The timezone-aware feed added in #417 can throw while rendering some events:

```
TypeError: undefined is not an object (evaluating props[props.length - 1].offsetTo)
```

Keeper generated only recurring DAYLIGHT/STANDARD observances. For dates before the first matching onset—or dates beyond the VTIMEZONE reference year—`ts-ics` can expand both recurrence rules to an empty list and then dereference its final entry. This makes `/api/cal/[identifier]` return 500 for affected feeds.

## Fix

Add a non-recurring baseline STANDARD observance using the offset active before the first transition, while retaining the recurring DST observances. `ts-ics` therefore always has an offset to resolve, including gaps before the first recurrence.

## TDD

Added feed-level regressions first and confirmed both failed with the production exception:

- January 2026 in `America/New_York`, before the first DST transition
- January 2027 in `Europe/Berlin`, after a feed timezone anchored by a 2026 event

Both now render the expected local DTSTART values.

## Verification

- `bun run types`
- `bun run lint`
- `bun run test` (696 tests)
- Calendar: 385 tests
- API: 179 tests