### PR TITLE
fix(ical): emit Outlook-compatible timezone observances

### DIFF
--- a/packages/calendar/src/ics/utils/build-vtimezone.ts
+++ b/packages/calendar/src/ics/utils/build-vtimezone.ts
@@ -6,6 +6,7 @@ const MINUTES_PER_HOUR = 60;
 const HOURS_IN_DAY = 24;
 const MS_PER_DAY = HOURS_IN_DAY * MINUTES_PER_HOUR * MS_PER_MINUTE;
 const DAYS_OF_WEEK = ["SU", "MO", "TU", "WE", "TH", "FR", "SA"] as const;
+const OBSERVANCE_ANCHOR_YEAR = 1970;
 
 interface Transition {
   instant: number;
@@ -86,17 +87,60 @@ const formatOffset = (minutes: number): string => {
   return `${sign}${padTwo(Math.floor(absolute / MINUTES_PER_HOUR))}${padTwo(absolute % MINUTES_PER_HOUR)}`;
 };
 
+const minutesToMs = (minutes: number): number => minutes * MS_PER_MINUTE;
+
+const getDaysInMonth = (year: number, month: number): number =>
+  new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+
+const getFirstWeekdayOfMonth = (year: number, month: number): number =>
+  new Date(Date.UTC(year, month, 1)).getUTCDay();
+
+const getLastWeekdayOfMonth = (year: number, month: number): number =>
+  new Date(Date.UTC(year, month + 1, 0)).getUTCDay();
+
+const wrapWeekdayDistance = (distance: number): number =>
+  (distance + DAYS_OF_WEEK.length) % DAYS_OF_WEEK.length;
+
+const getWeekdayOccurrence = (dayOfMonth: number): number =>
+  Math.floor((dayOfMonth - 1) / DAYS_OF_WEEK.length) + 1;
+
+const isFinalWeekdayOccurrence = (dayOfMonth: number, daysInMonth: number): boolean =>
+  dayOfMonth + DAYS_OF_WEEK.length > daysInMonth;
+
+const resolveOccurrence = (dayOfMonth: number, daysInMonth: number): number => {
+  if (isFinalWeekdayOccurrence(dayOfMonth, daysInMonth)) {
+    return -1;
+  }
+  return getWeekdayOccurrence(dayOfMonth);
+};
+
+const resolveNthWeekdayDayOfMonth = (year: number, month: number, weekday: number, occurrence: number): number => {
+  const firstWeekday = getFirstWeekdayOfMonth(year, month);
+  const offsetToWeekday = wrapWeekdayDistance(weekday - firstWeekday);
+  const offsetToOccurrence = (occurrence - 1) * DAYS_OF_WEEK.length;
+  return 1 + offsetToWeekday + offsetToOccurrence;
+};
+
+const resolveLastWeekdayDayOfMonth = (year: number, month: number, weekday: number): number => {
+  const daysInMonth = getDaysInMonth(year, month);
+  const lastWeekday = getLastWeekdayOfMonth(year, month);
+  const offsetFromLastDay = wrapWeekdayDistance(lastWeekday - weekday);
+  return daysInMonth - offsetFromLastDay;
+};
+
+const resolveDayOfMonthForOccurrence = (year: number, month: number, weekday: number, occurrence: number): number => {
+  if (occurrence === -1) {
+    return resolveLastWeekdayDayOfMonth(year, month, weekday);
+  }
+  return resolveNthWeekdayDayOfMonth(year, month, weekday, occurrence);
+};
+
 const buildRecurrenceRule = (localOnset: Date): IcsRecurrenceRule => {
   const month = localOnset.getUTCMonth();
   const dayOfMonth = localOnset.getUTCDate();
   const weekday = DAYS_OF_WEEK[localOnset.getUTCDay()];
-  const daysInMonth = new Date(Date.UTC(localOnset.getUTCFullYear(), month + 1, 0)).getUTCDate();
-  const isLastWeekday = dayOfMonth + DAYS_OF_WEEK.length > daysInMonth;
-
-  let occurrence = Math.floor((dayOfMonth - 1) / DAYS_OF_WEEK.length) + 1;
-  if (isLastWeekday) {
-    occurrence = -1;
-  }
+  const daysInMonth = getDaysInMonth(localOnset.getUTCFullYear(), month);
+  const occurrence = resolveOccurrence(dayOfMonth, daysInMonth);
 
   return {
     frequency: "YEARLY",
@@ -105,9 +149,29 @@ const buildRecurrenceRule = (localOnset: Date): IcsRecurrenceRule => {
   } as IcsRecurrenceRule;
 };
 
+const buildAnchoredLocalOnset = (localOnset: Date): Date => {
+  const month = localOnset.getUTCMonth();
+  const weekday = localOnset.getUTCDay();
+  const dayOfMonth = localOnset.getUTCDate();
+  const daysInMonth = getDaysInMonth(localOnset.getUTCFullYear(), month);
+  const occurrence = resolveOccurrence(dayOfMonth, daysInMonth);
+  const anchoredDay = resolveDayOfMonthForOccurrence(OBSERVANCE_ANCHOR_YEAR, month, weekday, occurrence);
+
+  return new Date(Date.UTC(
+    OBSERVANCE_ANCHOR_YEAR,
+    month,
+    anchoredDay,
+    localOnset.getUTCHours(),
+    localOnset.getUTCMinutes(),
+    localOnset.getUTCSeconds(),
+  ));
+};
+
 const buildObservance = (transition: Transition): IcsTimezoneProp => {
-  const localOnsetMs = transition.instant + transition.offsetFrom * MS_PER_MINUTE;
-  const start = new Date(localOnsetMs - transition.offsetTo * MS_PER_MINUTE);
+  const localOnsetMs = transition.instant + minutesToMs(transition.offsetFrom);
+  const localOnset = new Date(localOnsetMs);
+  const anchoredLocalOnset = buildAnchoredLocalOnset(localOnset);
+  const start = new Date(anchoredLocalOnset.getTime() - minutesToMs(transition.offsetTo));
 
   let type: IcsTimezoneProp["type"] = "STANDARD";
   if (transition.offsetTo > transition.offsetFrom) {
@@ -119,7 +183,7 @@ const buildObservance = (transition: Transition): IcsTimezoneProp => {
     start,
     offsetFrom: formatOffset(transition.offsetFrom),
     offsetTo: formatOffset(transition.offsetTo),
-    recurrenceRule: buildRecurrenceRule(new Date(localOnsetMs)),
+    recurrenceRule: buildRecurrenceRule(localOnset),
   };
 };
 
@@ -150,11 +214,7 @@ const buildVtimezone = (timezone: string | undefined, referenceInstant: Date): I
 
   const transitions = findTransitions(resolved, referenceInstant);
   if (transitions.length === 2) {
-    const recurringObservances = transitions.map((transition) => buildObservance(transition));
-    // Ts-ics can expand both recurrence rules to an empty list.
-    // Keep a baseline offset available for dates before the first matching onset.
-    const baselineObservance = buildFixedObservance(transitions[0]?.offsetFrom ?? 0);
-    return { id: resolved, props: [...recurringObservances, baselineObservance] };
+    return { id: resolved, props: transitions.map((transition) => buildObservance(transition)) };
   }
 
   const offset = offsetMinutesAt(referenceInstant.getTime(), resolved);

--- a/packages/calendar/tests/ics/utils/build-vtimezone.test.ts
+++ b/packages/calendar/tests/ics/utils/build-vtimezone.test.ts
@@ -35,14 +35,15 @@ describe("buildVtimezone", () => {
     expect(ics).toContain("TZOFFSETFROM:+0100");
     expect(ics).toContain("TZOFFSETTO:+0200");
     expect(ics).toContain("RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3");
-    expect(ics).toContain("DTSTART:20260329T020000");
+    expect(ics).toContain("DTSTART:19700329T020000");
 
     // Standard onset: last Sunday of October, +02:00 -> +01:00.
     expect(ics).toContain("BEGIN:STANDARD");
     expect(ics).toContain("TZOFFSETFROM:+0200");
     expect(ics).toContain("TZOFFSETTO:+0100");
     expect(ics).toContain("RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10");
-    expect(ics).toContain("DTSTART:20261025T030000");
+    expect(ics).toContain("DTSTART:19701025T030000");
+    expect(ics.match(/BEGIN:STANDARD/g)).toHaveLength(1);
   });
 
   it("emits nth-Sunday rules for America/New_York", () => {
@@ -53,10 +54,17 @@ describe("buildVtimezone", () => {
     expect(ics).toContain("TZOFFSETFROM:-0500");
     expect(ics).toContain("TZOFFSETTO:-0400");
     expect(ics).toContain("RRULE:FREQ=YEARLY;BYDAY=2SU;BYMONTH=3");
-    expect(ics).toContain("DTSTART:20260308T020000");
+    expect(ics).toContain("DTSTART:19700308T020000");
     // Standard: 1st Sunday of November, -04:00 -> -05:00.
     expect(ics).toContain("RRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=11");
-    expect(ics).toContain("DTSTART:20261101T020000");
+    expect(ics).toContain("DTSTART:19701101T020000");
+  });
+
+  it("recomputes the anchored onset date from the recurrence rule", () => {
+    const ics = renderVtimezone("Europe/Berlin", new Date("2025-06-17T12:00:00.000Z"));
+
+    expect(ics).toContain("DTSTART:19700329T020000");
+    expect(ics).not.toContain("DTSTART:19700330T020000");
   });
 
   it("classifies southern-hemisphere transitions by offset direction, not calendar order (Australia/Sydney)", () => {

--- a/services/api/tests/utils/ical.test.ts
+++ b/services/api/tests/utils/ical.test.ts
@@ -453,6 +453,41 @@ describe("timezone-aware feed (Outlook)", () => {
     expect(ics).toContain("RECURRENCE-ID;TZID=Europe/Berlin:20260624T124500");
   });
 
+  it("preserves Apple recurrence invariants with the Outlook-compatible VTIMEZONE", () => {
+    const sourceUid = "cross-client-recurring-event";
+    const ics = formatEventsAsIcal(
+      [
+        makeEvent({
+          id: "master-id",
+          sourceEventUid: sourceUid,
+          startTime: new Date("2026-06-17T10:45:00Z"),
+          endTime: new Date("2026-06-17T11:45:00Z"),
+          startTimeZone: "Europe/Berlin",
+          recurrenceRule: {
+            frequency: "WEEKLY",
+            until: { date: new Date("2026-12-30T10:45:00Z"), type: "DATE-TIME" },
+          } as never,
+          exceptionDates: [{ date: new Date("2026-07-01T10:45:00Z"), type: "DATE-TIME" }] as never,
+        }),
+        makeEvent({
+          id: "override-id",
+          sourceEventUid: sourceUid,
+          startTime: new Date("2026-06-24T12:45:00Z"),
+          endTime: new Date("2026-06-24T13:45:00Z"),
+          startTimeZone: "Europe/Berlin",
+          recurrenceId: new Date("2026-06-24T10:45:00Z"),
+        }),
+      ],
+      DEFAULT_SETTINGS,
+    );
+
+    expect(occurrences(ics, "BEGIN:STANDARD")).toBe(1);
+    expect(ics).toContain("DTSTART;TZID=Europe/Berlin:20260617T124500");
+    expect(ics).toContain("EXDATE;TZID=Europe/Berlin:20260701T124500");
+    expect(ics).toContain("RECURRENCE-ID;TZID=Europe/Berlin:20260624T124500");
+    expect(ics).toMatch(/RRULE:FREQ=WEEKLY;UNTIL=20261230T104500Z/);
+  });
+
   it("emits a single VTIMEZONE per distinct zone", () => {
     const ics = formatEventsAsIcal(
       [


### PR DESCRIPTION
Follow-up to #413 and #420.

## Problem

The original timezone fix emitted a matching `TZID`/`VTIMEZONE`, but #420 prevented `ts-ics` from throwing by appending a second fixed `STANDARD` observance. Microsoft's Outlook/Exchange iCalendar behavior expects a `VTIMEZONE` to contain exactly one `STANDARD`; clients may reject the whole timezone definition when multiple are present. Outlook Classic then falls back to UTC in the event inspector, matching the user report.

## Fix

- Anchor recurring `STANDARD`/`DAYLIGHT` onsets in 1970 so `ts-ics` can resolve dates before and after the reference year.
- Remove the extra fixed `STANDARD` fallback.
- Recompute the anchor date from the nth/last-weekday recurrence rule instead of merely replacing the year.
- Keep the anchoring math in small named helpers rather than inline calendar arithmetic.

The generated timezone now has one recurring `STANDARD` and one recurring `DAYLIGHT`, while retaining the no-500 behavior from #420.

## iCloud / Apple compatibility

Checked against the earlier Apple/iCloud recurrence fixes (#397/#398). This change only alters the `VTIMEZONE` observance anchors; it does not reintroduce the Apple-breaking mismatches. Added an end-to-end regression proving a timezone-aware recurring feed still emits:

- one Outlook-compatible `STANDARD` observance
- `DTSTART`, `EXDATE`, and `RECURRENCE-ID` with matching `TZID`
- `RRULE` with `FREQ` first
- `UNTIL` in UTC

## TDD

The Outlook regression test was changed first and failed against the existing 2026 anchors plus duplicate `STANDARD`. Coverage now asserts:

- Outlook-compatible single-`STANDARD` shape
- 1970 recurring observance anchors
- Correct recalculation of last-weekday dates across years
- Existing January-before-first-transition and following-year feed cases remain green
- Cross-client Apple recurrence invariants remain intact

## Verification

- `bun run types`
- `bun run lint`
- `bun run test` (all packages)
- `bun run --cwd packages/calendar test -- tests/ics/utils/build-vtimezone.test.ts`
- `bun run --cwd services/api test -- tests/utils/ical.test.ts`

Microsoft behavior reference: https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcical/25619839-5b3a-402e-865a-f4fa511db4b2