### PR TITLE
Sync full-day ICS events as all-day

### DIFF
--- a/applications/web/src/routes/(dashboard)/dashboard/accounts/$accountId.$calendarId.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/accounts/$accountId.$calendarId.tsx
@@ -49,6 +49,7 @@ import {
   customEventNameAtom,
   excludeEventNameAtom,
   excludeFieldAtoms,
+  treatFullDayTimedEventsAsAllDayAtom,
 } from "@/state/calendar-detail";
 import type { ExcludeField } from "@/state/calendar-detail";
 import {
@@ -405,7 +406,8 @@ function DestinationCheckboxIndicator({ destinationId }: { destinationId: string
 
 function SyncSettingsSection({ calendarId }: { calendarId: string }) {
   const { data: entitlements } = useEntitlements();
-  const locked = entitlements ? !entitlements.canUseEventFilters : false;
+  const locked = Boolean(entitlements && !entitlements.canUseEventFilters);
+  const calendarType = useAtomValue(calendarTypeAtom);
 
   return (
     <>
@@ -413,10 +415,11 @@ function SyncSettingsSection({ calendarId }: { calendarId: string }) {
         title="Sync Settings"
         description={<>Choose which event details are synced to destination calendars. Use <Text as="span" size="sm" className="text-template inline">{"{{calendar_name}}"}</Text> or <Text as="span" size="sm" className="text-template inline">{"{{event_name}}"}</Text> in text fields for dynamic values.</>}
       />
-      <PremiumFeatureGate locked={locked} hint="Event filters are a Pro feature.">
+      <PremiumFeatureGate locked={locked} hint="Advanced sync settings are a Pro feature.">
         <NavigationMenu>
           <SyncEventNameTemplateItem calendarId={calendarId} locked={locked} />
           <SyncEventNameToggle calendarId={calendarId} locked={locked} />
+          <ProviderSyncSettings calendarId={calendarId} calendarType={calendarType} locked={locked} />
           {SYNC_SETTINGS.map((setting) => (
             <ExcludeFieldToggle
               key={setting.field}
@@ -430,6 +433,75 @@ function SyncSettingsSection({ calendarId }: { calendarId: string }) {
         </NavigationMenu>
       </PremiumFeatureGate>
     </>
+  );
+}
+
+function ProviderSyncSettings({
+  calendarId,
+  calendarType,
+  locked,
+}: {
+  calendarId: string;
+  calendarType: string;
+  locked: boolean;
+}) {
+  switch (calendarType) {
+    case "ical":
+      return <TreatFullDayTimedEventsToggle calendarId={calendarId} locked={locked} />;
+    default:
+      return null;
+  }
+}
+
+function TreatFullDayTimedEventsToggle({ calendarId, locked }: { calendarId: string; locked: boolean }) {
+  const store = useStore();
+  const variant = use(MenuVariantContext);
+
+  const handleClick = () => {
+    if (locked) return;
+    const current = store.get(calendarDetailAtom);
+    if (!current) return;
+
+    const treatFullDayTimedEventsAsAllDay = !current.treatFullDayTimedEventsAsAllDay;
+    track(ANALYTICS_EVENTS.calendar_setting_toggled, {
+      field: "treatFullDayTimedEventsAsAllDay",
+      enabled: treatFullDayTimedEventsAsAllDay,
+    });
+    store.set(calendarDetailAtom, (prev) => {
+      if (!prev) {
+        return prev;
+      }
+      return { ...prev, treatFullDayTimedEventsAsAllDay };
+    });
+    patchSource(store, calendarId, { treatFullDayTimedEventsAsAllDay });
+  };
+
+  return (
+    <li>
+      <ItemDisabledContext value={locked}>
+        <button
+          type="button"
+          role="switch"
+          disabled={locked}
+          onClick={handleClick}
+          className={navigationMenuItemStyle({ variant, interactive: !locked })}
+        >
+          <NavigationMenuItemLabel>Sync Full-Day Events as All-Day</NavigationMenuItemLabel>
+          <TreatFullDayTimedEventsToggleIndicator disabled={locked} />
+        </button>
+      </ItemDisabledContext>
+    </li>
+  );
+}
+
+function TreatFullDayTimedEventsToggleIndicator({ disabled }: { disabled: boolean }) {
+  const checked = useAtomValue(treatFullDayTimedEventsAsAllDayAtom);
+  const variant = use(MenuVariantContext);
+
+  return (
+    <div className={navigationMenuToggleTrack({ variant, checked, disabled, className: "ml-auto" })}>
+      <div className={navigationMenuToggleThumb({ variant, checked })} />
+    </div>
   );
 }
 

--- a/applications/web/src/state/calendar-detail.ts
+++ b/applications/web/src/state/calendar-detail.ts
@@ -17,6 +17,7 @@ export const excludeEventLocationAtom = selectAtom(calendarDetailAtom, (detail) 
 export const excludeAllDayEventsAtom = selectAtom(calendarDetailAtom, (detail) => detail?.excludeAllDayEvents ?? false);
 export const excludeFocusTimeAtom = selectAtom(calendarDetailAtom, (detail) => detail?.excludeFocusTime ?? false);
 export const excludeOutOfOfficeAtom = selectAtom(calendarDetailAtom, (detail) => detail?.excludeOutOfOffice ?? false);
+export const treatFullDayTimedEventsAsAllDayAtom = selectAtom(calendarDetailAtom, (detail) => detail?.treatFullDayTimedEventsAsAllDay ?? false);
 export type ExcludeField = keyof Pick<
   CalendarDetail,
   | "excludeAllDayEvents"

--- a/applications/web/src/types/api.ts
+++ b/applications/web/src/types/api.ts
@@ -48,6 +48,7 @@ export interface CalendarDetail {
   excludeEventName: boolean;
   excludeFocusTime: boolean;
   excludeOutOfOffice: boolean;
+  treatFullDayTimedEventsAsAllDay: boolean;
   destinationIds: string[];
   sourceIds: string[];
   createdAt: string;

--- a/packages/calendar/src/ics/index.ts
+++ b/packages/calendar/src/ics/index.ts
@@ -5,7 +5,13 @@ export { parseIcsCalendar } from "./utils/parse-ics-calendar";
 export { diffEvents } from "./utils/diff-events";
 export { createSnapshot } from "./utils/create-snapshot";
 export { createIcsSourceFetcher } from "./utils/fetch-adapter";
-export type { IcsSourceFetcherConfig, IcsSourceFetcher } from "./utils/fetch-adapter";
+export type {
+  FetchIcsSourceEventsOptions,
+  IcsSourceEventContext,
+  IcsSourceFetcher,
+  IcsSourceFetcherConfig,
+} from "./utils/fetch-adapter";
+export { interpretFullDayTimedEventsAsAllDay } from "./utils/interpret-full-day-timed-events";
 export { buildZonedIcsDate, formatTzOffset } from "./utils/build-zoned-date";
 export { buildVtimezone } from "./utils/build-vtimezone";
 export { normalizeTimezone } from "./utils/normalize-timezone";

--- a/packages/calendar/src/ics/utils/fetch-adapter.ts
+++ b/packages/calendar/src/ics/utils/fetch-adapter.ts
@@ -15,8 +15,16 @@ interface IcsSourceFetcherConfig {
   safeFetchOptions?: SafeFetchOptions;
 }
 
+interface IcsSourceEventContext {
+  calendarTimeZone?: string;
+}
+
+interface FetchIcsSourceEventsOptions {
+  interpretEvents?: (events: SourceEvent[], context: IcsSourceEventContext) => SourceEvent[];
+}
+
 interface IcsSourceFetcher {
-  fetchEvents: () => Promise<FetchEventsResult>;
+  fetchEvents: (options?: FetchIcsSourceEventsOptions) => Promise<FetchEventsResult>;
 }
 
 const createIcsSourceFetcher = (config: IcsSourceFetcherConfig): IcsSourceFetcher => {
@@ -32,7 +40,7 @@ const createIcsSourceFetcher = (config: IcsSourceFetcherConfig): IcsSourceFetche
     return ical;
   };
 
-  const fetchEvents = async (): Promise<FetchEventsResult> => {
+  const fetchEvents = async (options: FetchIcsSourceEventsOptions = {}): Promise<FetchEventsResult> => {
     const ical = await fetchRemoteIcal();
     if (!ical) {
       /*
@@ -65,6 +73,13 @@ const createIcsSourceFetcher = (config: IcsSourceFetcherConfig): IcsSourceFetche
       title: event.title,
       uid: event.uid,
     }));
+    if (options.interpretEvents) {
+      return {
+        events: options.interpretEvents(events, {
+          calendarTimeZone: calendar.nonStandard?.wrTimezone,
+        }),
+      };
+    }
     return { events };
   };
 
@@ -72,4 +87,9 @@ const createIcsSourceFetcher = (config: IcsSourceFetcherConfig): IcsSourceFetche
 };
 
 export { createIcsSourceFetcher };
-export type { IcsSourceFetcherConfig, IcsSourceFetcher };
+export type {
+  FetchIcsSourceEventsOptions,
+  IcsSourceEventContext,
+  IcsSourceFetcher,
+  IcsSourceFetcherConfig,
+};

--- a/packages/calendar/src/ics/utils/interpret-full-day-timed-events.ts
+++ b/packages/calendar/src/ics/utils/interpret-full-day-timed-events.ts
@@ -1,0 +1,103 @@
+import type { SourceEvent } from "../../core/types";
+import { normalizeTimezone } from "./normalize-timezone";
+
+interface InterpretFullDayTimedEventsOptions {
+  calendarTimeZone?: string;
+  enabled: boolean;
+}
+
+interface WallClockParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+}
+
+const HOURS_IN_DAY = 24;
+
+const partsInTimeZone = (instant: Date, timeZone: string): WallClockParts => {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+
+  const lookup = new Map<string, string>();
+  for (const part of formatter.formatToParts(instant)) {
+    lookup.set(part.type, part.value);
+  }
+
+  const read = (type: string): number => Number.parseInt(lookup.get(type) ?? "0", 10);
+  let hour = read("hour");
+  if (hour === HOURS_IN_DAY) {
+    hour = 0;
+  }
+
+  return {
+    year: read("year"),
+    month: read("month"),
+    day: read("day"),
+    hour,
+    minute: read("minute"),
+    second: read("second"),
+  };
+};
+
+const isMidnight = (parts: WallClockParts): boolean =>
+  parts.hour === 0 && parts.minute === 0 && parts.second === 0;
+
+const localDateKey = (parts: WallClockParts): string =>
+  `${parts.year}-${parts.month.toString().padStart(2, "0")}-${parts.day.toString().padStart(2, "0")}`;
+
+const isLocalMidnightSpan = (
+  event: SourceEvent,
+  calendarTimeZone: string | undefined,
+): boolean => {
+  if (event.isAllDay || event.endTime <= event.startTime) {
+    return false;
+  }
+
+  const timezone = event.startTimeZone ?? normalizeTimezone(calendarTimeZone);
+  if (!timezone) {
+    return false;
+  }
+
+  try {
+    const startParts = partsInTimeZone(event.startTime, timezone);
+    const endParts = partsInTimeZone(event.endTime, timezone);
+    return (
+      isMidnight(startParts)
+      && isMidnight(endParts)
+      && localDateKey(startParts) !== localDateKey(endParts)
+    );
+  } catch {
+    return false;
+  }
+};
+
+const interpretFullDayTimedEventsAsAllDay = (
+  events: SourceEvent[],
+  options: InterpretFullDayTimedEventsOptions,
+): SourceEvent[] => {
+  if (!options.enabled) {
+    return events;
+  }
+
+  return events.map((event) => {
+    if (!isLocalMidnightSpan(event, options.calendarTimeZone)) {
+      return event;
+    }
+
+    return { ...event, isAllDay: true };
+  });
+};
+
+export { interpretFullDayTimedEventsAsAllDay };
+export type { InterpretFullDayTimedEventsOptions };

--- a/packages/calendar/src/ics/utils/parse-ics-calendar.ts
+++ b/packages/calendar/src/ics/utils/parse-ics-calendar.ts
@@ -1,10 +1,27 @@
 import { convertIcsCalendar } from "ts-ics";
+import type { Line, ParseNonStandardValues } from "ts-ics";
+
+interface CalendarNonStandardValues {
+  wrTimezone?: string;
+}
 
 interface ParseIcsCalendarOptions {
   icsString: string;
 }
 
+const parseTextLine = (line: Line): string => line.value;
+
+const CALENDAR_NON_STANDARD_VALUES: ParseNonStandardValues<CalendarNonStandardValues> = {
+  wrTimezone: {
+    name: "X-WR-TIMEZONE",
+    convert: parseTextLine,
+  },
+};
+
 const parseIcsCalendar = (options: ParseIcsCalendarOptions) =>
-  convertIcsCalendar(globalThis.undefined, options.icsString);
+  convertIcsCalendar<CalendarNonStandardValues>(globalThis.undefined, options.icsString, {
+    nonStandard: CALENDAR_NON_STANDARD_VALUES,
+  });
 
 export { parseIcsCalendar };
+export type { CalendarNonStandardValues };

--- a/packages/calendar/tests/ics/utils/fetch-adapter.test.ts
+++ b/packages/calendar/tests/ics/utils/fetch-adapter.test.ts
@@ -67,6 +67,39 @@ describe("createIcsSourceFetcher", () => {
     expect(result.unchanged).toBeUndefined();
   });
 
+  it("passes calendar timezone metadata to event interpretation", async () => {
+    const { createIcsSourceFetcher } = await import("../../../src/ics/utils/fetch-adapter");
+    mockPullRemoteCalendar.mockResolvedValueOnce({
+      ical: [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//test//test//EN",
+        "X-WR-TIMEZONE:America/Toronto",
+        "BEGIN:VEVENT",
+        "UID:event-1@test",
+        "DTSTAMP:20260630T000000Z",
+        "DTSTART:20260630T040000Z",
+        "DTEND:20260701T040000Z",
+        "SUMMARY:Busy",
+        "END:VEVENT",
+        "END:VCALENDAR",
+      ].join("\r\n"),
+    });
+    mockCreateSnapshot.mockResolvedValueOnce({ changed: true });
+
+    const fetcher = createIcsSourceFetcher(buildConfig());
+    let calendarTimeZone: string | null = null;
+    const result = await fetcher.fetchEvents({
+      interpretEvents: (events, { calendarTimeZone: parsedCalendarTimeZone }) => {
+        calendarTimeZone = parsedCalendarTimeZone ?? null;
+        return events;
+      },
+    });
+
+    expect(result.events).toHaveLength(1);
+    expect(calendarTimeZone).toBe("America/Toronto");
+  });
+
   it("returns unchanged when snapshot content has not changed", async () => {
     const { createIcsSourceFetcher } = await import("../../../src/ics/utils/fetch-adapter");
     mockPullRemoteCalendar.mockResolvedValueOnce({ ical: MINIMAL_ICS });

--- a/packages/calendar/tests/ics/utils/interpret-full-day-timed-events.test.ts
+++ b/packages/calendar/tests/ics/utils/interpret-full-day-timed-events.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { interpretFullDayTimedEventsAsAllDay } from "../../../src/ics/utils/interpret-full-day-timed-events";
+import type { SourceEvent } from "../../../src/core/types";
+
+const buildEvent = (overrides: Partial<SourceEvent> = {}): SourceEvent => ({
+  endTime: new Date("2026-07-01T04:00:00.000Z"),
+  startTime: new Date("2026-06-30T04:00:00.000Z"),
+  title: "Busy",
+  uid: "source-event-1",
+  ...overrides,
+});
+
+describe("interpretFullDayTimedEventsAsAllDay", () => {
+  it("keeps full-day timed events as timed when disabled", () => {
+    const [event] = interpretFullDayTimedEventsAsAllDay(
+      [buildEvent()],
+      { calendarTimeZone: "America/Toronto", enabled: false },
+    );
+
+    expect(event?.isAllDay).toBeUndefined();
+  });
+
+  it("treats local-midnight full-day timed events as all-day when enabled", () => {
+    const [event] = interpretFullDayTimedEventsAsAllDay(
+      [buildEvent()],
+      { calendarTimeZone: "America/Toronto", enabled: true },
+    );
+
+    expect(event?.isAllDay).toBe(true);
+  });
+
+  it("does not treat non-midnight 24-hour timed events as all-day", () => {
+    const [event] = interpretFullDayTimedEventsAsAllDay(
+      [
+        buildEvent({
+          startTime: new Date("2026-06-30T17:00:00.000Z"),
+          endTime: new Date("2026-07-01T17:00:00.000Z"),
+        }),
+      ],
+      { calendarTimeZone: "America/Toronto", enabled: true },
+    );
+
+    expect(event?.isAllDay).toBeUndefined();
+  });
+
+  it("uses the event timezone before the calendar timezone", () => {
+    const [event] = interpretFullDayTimedEventsAsAllDay(
+      [
+        buildEvent({
+          startTime: new Date("2026-06-30T07:00:00.000Z"),
+          endTime: new Date("2026-07-01T07:00:00.000Z"),
+          startTimeZone: "America/Los_Angeles",
+        }),
+      ],
+      { calendarTimeZone: "America/Toronto", enabled: true },
+    );
+
+    expect(event?.isAllDay).toBe(true);
+  });
+});

--- a/packages/calendar/tests/ics/utils/parse-ics-calendar.test.ts
+++ b/packages/calendar/tests/ics/utils/parse-ics-calendar.test.ts
@@ -48,4 +48,24 @@ describe("parseIcsCalendar", () => {
       }))
       .toThrow();
   });
+
+  it("parses Google calendar timezone metadata", () => {
+    const parsedCalendar = parseIcsCalendar({
+      icsString: [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Keeper Test//EN",
+        "X-WR-TIMEZONE:America/Toronto",
+        "BEGIN:VEVENT",
+        "UID:event-1",
+        "DTSTART:20260630T040000Z",
+        "DTEND:20260701T040000Z",
+        "SUMMARY:Busy",
+        "END:VEVENT",
+        "END:VCALENDAR",
+      ].join("\r\n"),
+    });
+
+    expect(parsedCalendar.nonStandard?.wrTimezone).toBe("America/Toronto");
+  });
 });

--- a/packages/database/drizzle/0073_treat_full_day_timed_events.sql
+++ b/packages/database/drizzle/0073_treat_full_day_timed_events.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "calendars" ADD COLUMN "treatFullDayTimedEventsAsAllDay" boolean DEFAULT false NOT NULL;

--- a/packages/database/drizzle/meta/0073_snapshot.json
+++ b/packages/database/drizzle/meta/0073_snapshot.json
@@ -1,0 +1,3021 @@
+{
+  "id": "f1a9d9eb-54b1-4a6d-a82c-3ebd7aaddfed",
+  "prevId": "b4dcacf6-fefd-4e0b-8ea6-db52fc688534",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_tokens_user_idx": {
+          "name": "api_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_hash_idx": {
+          "name": "api_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_userId_user_id_fk": {
+          "name": "api_tokens_userId_user_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_tokenHash_unique": {
+          "name": "api_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caldav_credentials": {
+      "name": "caldav_credentials",
+      "schema": "",
+      "columns": {
+        "authMethod": {
+          "name": "authMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'basic'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "encryptedPassword": {
+          "name": "encryptedPassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "serverUrl": {
+          "name": "serverUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_accounts": {
+      "name": "calendar_accounts",
+      "schema": "",
+      "columns": {
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authType": {
+          "name": "authType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caldavCredentialId": {
+          "name": "caldavCredentialId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "needsReauthentication": {
+          "name": "needsReauthentication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "oauthCredentialId": {
+          "name": "oauthCredentialId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_accounts_user_idx": {
+          "name": "calendar_accounts_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_accounts_provider_idx": {
+          "name": "calendar_accounts_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_accounts_needs_reauth_idx": {
+          "name": "calendar_accounts_needs_reauth_idx",
+          "columns": [
+            {
+              "expression": "needsReauthentication",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_accounts_caldavCredentialId_caldav_credentials_id_fk": {
+          "name": "calendar_accounts_caldavCredentialId_caldav_credentials_id_fk",
+          "tableFrom": "calendar_accounts",
+          "tableTo": "caldav_credentials",
+          "columnsFrom": [
+            "caldavCredentialId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_accounts_oauthCredentialId_oauth_credentials_id_fk": {
+          "name": "calendar_accounts_oauthCredentialId_oauth_credentials_id_fk",
+          "tableFrom": "calendar_accounts",
+          "tableTo": "oauth_credentials",
+          "columnsFrom": [
+            "oauthCredentialId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_accounts_userId_user_id_fk": {
+          "name": "calendar_accounts_userId_user_id_fk",
+          "tableFrom": "calendar_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_snapshots": {
+      "name": "calendar_snapshots",
+      "schema": "",
+      "columns": {
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ical": {
+          "name": "ical",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "calendar_snapshots_calendarId_calendars_id_fk": {
+          "name": "calendar_snapshots_calendarId_calendars_id_fk",
+          "tableFrom": "calendar_snapshots",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_snapshots_calendarId_unique": {
+          "name": "calendar_snapshots_calendarId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendarId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendars": {
+      "name": "calendars",
+      "schema": "",
+      "columns": {
+        "accountId": {
+          "name": "accountId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarType": {
+          "name": "calendarType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarUrl": {
+          "name": "calendarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "excludeAllDayEvents": {
+          "name": "excludeAllDayEvents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeEventDescription": {
+          "name": "excludeEventDescription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeEventLocation": {
+          "name": "excludeEventLocation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeEventName": {
+          "name": "excludeEventName",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeFocusTime": {
+          "name": "excludeFocusTime",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeOutOfOffice": {
+          "name": "excludeOutOfOffice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeInIcalFeed": {
+          "name": "includeInIcalFeed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "treatFullDayTimedEventsAsAllDay": {
+          "name": "treatFullDayTimedEventsAsAllDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customEventName": {
+          "name": "customEventName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "failureCount": {
+          "name": "failureCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastFailureAt": {
+          "name": "lastFailureAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextAttemptAt": {
+          "name": "nextAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestFailureCount": {
+          "name": "ingestFailureCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ingestLastFailureAt": {
+          "name": "ingestLastFailureAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestNextAttemptAt": {
+          "name": "ingestNextAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalCalendarId": {
+          "name": "externalCalendarId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"pull\"}'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalName": {
+          "name": "originalName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncToken": {
+          "name": "syncToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendars_user_idx": {
+          "name": "calendars_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_account_idx": {
+          "name": "calendars_account_idx",
+          "columns": [
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_capabilities_idx": {
+          "name": "calendars_capabilities_idx",
+          "columns": [
+            {
+              "expression": "capabilities",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_type_idx": {
+          "name": "calendars_type_idx",
+          "columns": [
+            {
+              "expression": "calendarType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendars_accountId_calendar_accounts_id_fk": {
+          "name": "calendars_accountId_calendar_accounts_id_fk",
+          "tableFrom": "calendars",
+          "tableTo": "calendar_accounts",
+          "columnsFrom": [
+            "accountId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendars_userId_user_id_fk": {
+          "name": "calendars_userId_user_id_fk",
+          "tableFrom": "calendars",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_mappings": {
+      "name": "event_mappings",
+      "schema": "",
+      "columns": {
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleteIdentifier": {
+          "name": "deleteIdentifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destinationEventUid": {
+          "name": "destinationEventUid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventStateId": {
+          "name": "eventStateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "syncEventHash": {
+          "name": "syncEventHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "event_mappings_event_cal_idx": {
+          "name": "event_mappings_event_cal_idx",
+          "columns": [
+            {
+              "expression": "eventStateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_mappings_calendar_idx": {
+          "name": "event_mappings_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_mappings_sync_hash_idx": {
+          "name": "event_mappings_sync_hash_idx",
+          "columns": [
+            {
+              "expression": "syncEventHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_mappings_calendarId_calendars_id_fk": {
+          "name": "event_mappings_calendarId_calendars_id_fk",
+          "tableFrom": "event_mappings",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_mappings_eventStateId_event_states_id_fk": {
+          "name": "event_mappings_eventStateId_event_states_id_fk",
+          "tableFrom": "event_mappings",
+          "tableTo": "event_states",
+          "columnsFrom": [
+            "eventStateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_states": {
+      "name": "event_states",
+      "schema": "",
+      "columns": {
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrenceRule": {
+          "name": "recurrenceRule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exceptionDates": {
+          "name": "exceptionDates",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrenceId": {
+          "name": "recurrenceId",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAllDay": {
+          "name": "isAllDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceEventType": {
+          "name": "sourceEventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceEventUid": {
+          "name": "sourceEventUid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startTimeZone": {
+          "name": "startTimeZone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_states_start_time_idx": {
+          "name": "event_states_start_time_idx",
+          "columns": [
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_states_end_time_idx": {
+          "name": "event_states_end_time_idx",
+          "columns": [
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_states_calendar_idx": {
+          "name": "event_states_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_states_identity_idx": {
+          "name": "event_states_identity_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceEventUid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_states_calendarId_calendars_id_fk": {
+          "name": "event_states_calendarId_calendars_id_fk",
+          "tableFrom": "event_states",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wantsFollowUp": {
+          "name": "wantsFollowUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "feedback_user_idx": {
+          "name": "feedback_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_userId_user_id_fk": {
+          "name": "feedback_userId_user_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ical_feed_settings": {
+      "name": "ical_feed_settings",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "includeEventName": {
+          "name": "includeEventName",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeEventDescription": {
+          "name": "includeEventDescription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeEventLocation": {
+          "name": "includeEventLocation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeAllDayEvents": {
+          "name": "excludeAllDayEvents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customEventName": {
+          "name": "customEventName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Busy'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ical_feed_settings_userId_user_id_fk": {
+          "name": "ical_feed_settings_userId_user_id_fk",
+          "tableFrom": "ical_feed_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_credentials": {
+      "name": "oauth_credentials",
+      "schema": "",
+      "columns": {
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "needsReauthentication": {
+          "name": "needsReauthentication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_credentials_user_idx": {
+          "name": "oauth_credentials_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_credentials_provider_idx": {
+          "name": "oauth_credentials_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_credentials_expires_at_idx": {
+          "name": "oauth_credentials_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_credentials_userId_user_id_fk": {
+          "name": "oauth_credentials_userId_user_id_fk",
+          "tableFrom": "oauth_credentials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_destination_mappings": {
+      "name": "source_destination_mappings",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "destinationCalendarId": {
+          "name": "destinationCalendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sourceCalendarId": {
+          "name": "sourceCalendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "source_destination_mapping_idx": {
+          "name": "source_destination_mapping_idx",
+          "columns": [
+            {
+              "expression": "sourceCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destinationCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_destination_mappings_source_idx": {
+          "name": "source_destination_mappings_source_idx",
+          "columns": [
+            {
+              "expression": "sourceCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_destination_mappings_destination_idx": {
+          "name": "source_destination_mappings_destination_idx",
+          "columns": [
+            {
+              "expression": "destinationCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_destination_mappings_destinationCalendarId_calendars_id_fk": {
+          "name": "source_destination_mappings_destinationCalendarId_calendars_id_fk",
+          "tableFrom": "source_destination_mappings",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "destinationCalendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_destination_mappings_sourceCalendarId_calendars_id_fk": {
+          "name": "source_destination_mappings_sourceCalendarId_calendars_id_fk",
+          "tableFrom": "source_destination_mappings",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "sourceCalendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "",
+      "columns": {
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "localEventCount": {
+          "name": "localEventCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remoteEventCount": {
+          "name": "remoteEventCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_status_calendar_idx": {
+          "name": "sync_status_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_status_calendarId_calendars_id_fk": {
+          "name": "sync_status_calendarId_calendars_id_fk",
+          "tableFrom": "sync_status",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_events": {
+      "name": "user_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceEventUid": {
+          "name": "sourceEventUid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAllDay": {
+          "name": "isAllDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startTimeZone": {
+          "name": "startTimeZone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_events_user_idx": {
+          "name": "user_events_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_events_calendar_idx": {
+          "name": "user_events_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_events_start_time_idx": {
+          "name": "user_events_start_time_idx",
+          "columns": [
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_events_end_time_idx": {
+          "name": "user_events_end_time_idx",
+          "columns": [
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_events_calendarId_calendars_id_fk": {
+          "name": "user_events_calendarId_calendars_id_fk",
+          "tableFrom": "user_events",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_events_userId_user_id_fk": {
+          "name": "user_events_userId_user_id_fk",
+          "tableFrom": "user_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscriptions": {
+      "name": "user_subscriptions",
+      "schema": "",
+      "columns": {
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "polarSubscriptionId": {
+          "name": "polarSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_subscriptions_userId_user_id_fk": {
+          "name": "user_subscriptions_userId_user_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshId": {
+          "name": "refreshId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_idx": {
+          "name": "oauth_access_token_client_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_session_idx": {
+          "name": "oauth_access_token_session_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_idx": {
+          "name": "oauth_access_token_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_refresh_idx": {
+          "name": "oauth_access_token_refresh_idx",
+          "columns": [
+            {
+              "expression": "refreshId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_clientId_oauth_application_clientId_fk": {
+          "name": "oauth_access_token_clientId_oauth_application_clientId_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_sessionId_session_id_fk": {
+          "name": "oauth_access_token_sessionId_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_userId_user_id_fk": {
+          "name": "oauth_access_token_userId_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refreshId_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refreshId_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refreshId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientSecret": {
+          "name": "clientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "skipConsent": {
+          "name": "skipConsent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enableEndSession": {
+          "name": "enableEndSession",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjectType": {
+          "name": "subjectType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "softwareId": {
+          "name": "softwareId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "softwareVersion": {
+          "name": "softwareVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "softwareStatement": {
+          "name": "softwareStatement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirectUris": {
+          "name": "redirectUris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postLogoutRedirectUris": {
+          "name": "postLogoutRedirectUris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenEndpointAuthMethod": {
+          "name": "tokenEndpointAuthMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grantTypes": {
+          "name": "grantTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTypes": {
+          "name": "responseTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirePKCE": {
+          "name": "requirePKCE",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_application_user_idx": {
+          "name": "oauth_application_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_application_userId_user_id_fk": {
+          "name": "oauth_application_userId_user_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_clientId_unique": {
+          "name": "oauth_application_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clientId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_idx": {
+          "name": "oauth_consent_client_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_idx": {
+          "name": "oauth_consent_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_reference_idx": {
+          "name": "oauth_consent_reference_idx",
+          "columns": [
+            {
+              "expression": "referenceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_clientId_oauth_application_clientId_fk": {
+          "name": "oauth_consent_clientId_oauth_application_clientId_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_userId_user_id_fk": {
+          "name": "oauth_consent_userId_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authTime": {
+          "name": "authTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_client_idx": {
+          "name": "oauth_refresh_token_client_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_session_idx": {
+          "name": "oauth_refresh_token_session_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_user_idx": {
+          "name": "oauth_refresh_token_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_clientId_oauth_application_clientId_fk": {
+          "name": "oauth_refresh_token_clientId_oauth_application_clientId_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_sessionId_session_id_fk": {
+          "name": "oauth_refresh_token_sessionId_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_userId_user_id_fk": {
+          "name": "oauth_refresh_token_userId_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passkey_userId_user_id_fk": {
+          "name": "passkey_userId_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -512,6 +512,13 @@
       "when": 1782843765741,
       "tag": "0072_directional_calendar_health",
       "breakpoints": true
+    },
+    {
+      "idx": 73,
+      "version": "7",
+      "when": 1782849346106,
+      "tag": "0073_treat_full_day_timed_events",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/database/schema.ts
+++ b/packages/database/src/database/schema.ts
@@ -99,6 +99,7 @@ const calendarsTable = pgTable(
     excludeFocusTime: boolean().notNull().default(false),
     excludeOutOfOffice: boolean().notNull().default(false),
     includeInIcalFeed: boolean().notNull().default(false),
+    treatFullDayTimedEventsAsAllDay: boolean().notNull().default(false),
     customEventName: text().notNull().default(""),
     disabled: boolean().notNull().default(false),
     failureCount: integer().notNull().default(0),

--- a/services/api/src/routes/api/sources/[id].ts
+++ b/services/api/src/routes/api/sources/[id].ts
@@ -35,6 +35,7 @@ const GET = withWideEvent(
         excludeEventName: calendarsTable.excludeEventName,
         excludeFocusTime: calendarsTable.excludeFocusTime,
         excludeOutOfOffice: calendarsTable.excludeOutOfOffice,
+        treatFullDayTimedEventsAsAllDay: calendarsTable.treatFullDayTimedEventsAsAllDay,
         createdAt: calendarsTable.createdAt,
         updatedAt: calendarsTable.updatedAt,
       })

--- a/services/api/src/routes/api/sources/[id]/source-item-routes.ts
+++ b/services/api/src/routes/api/sources/[id]/source-item-routes.ts
@@ -15,6 +15,13 @@ const EVENT_FILTER_FIELDS = [
 const SOURCE_BOOLEAN_UPDATE_FIELDS = [
   ...EVENT_FILTER_FIELDS,
   "includeInIcalFeed",
+  "treatFullDayTimedEventsAsAllDay",
+] as const;
+
+const PRO_GATED_SOURCE_FIELDS = [
+  ...EVENT_FILTER_FIELDS,
+  "customEventName",
+  "treatFullDayTimedEventsAsAllDay",
 ] as const;
 
 interface SourceRouteContext {
@@ -79,14 +86,14 @@ const handlePatchSourceRoute = async (
     parsedBody = context.body;
   }
 
-  const hasEventFilterUpdates = EVENT_FILTER_FIELDS.some(
-    (field) => typeof parsedBody[field] === "boolean",
-  );
-  const isUpdatingEventNameTemplate = typeof parsedBody.customEventName === "string";
-  if (hasEventFilterUpdates || isUpdatingEventNameTemplate) {
+  const hasProGatedUpdates = PRO_GATED_SOURCE_FIELDS.some((field) => {
+    const value = parsedBody[field];
+    return typeof value === "boolean" || typeof value === "string";
+  });
+  if (hasProGatedUpdates) {
     const allowed = await dependencies.canUseEventFilters(context.userId);
     if (!allowed) {
-      return ErrorResponse.forbidden("Event filters require a Pro plan.").toResponse();
+      return ErrorResponse.forbidden("This setting requires a Pro plan.").toResponse();
     }
   }
 

--- a/services/api/src/utils/request-body.ts
+++ b/services/api/src/utils/request-body.ts
@@ -16,6 +16,7 @@ const sourcePatchBodySchema = type({
   "excludeFocusTime?": "boolean",
   "excludeOutOfOffice?": "boolean",
   "includeInIcalFeed?": "boolean",
+  "treatFullDayTimedEventsAsAllDay?": "boolean",
   "+": "reject",
 });
 type SourcePatchBody = typeof sourcePatchBodySchema.infer;

--- a/services/api/src/utils/sources.ts
+++ b/services/api/src/utils/sources.ts
@@ -1,5 +1,9 @@
 import { calendarAccountsTable, calendarsTable, eventStatesTable } from "@keeper.sh/database/schema";
-import { pullRemoteCalendar, createIcsSourceFetcher } from "@keeper.sh/calendar/ics";
+import {
+  pullRemoteCalendar,
+  createIcsSourceFetcher,
+  interpretFullDayTimedEventsAsAllDay,
+} from "@keeper.sh/calendar/ics";
 import { ingestSource, insertEventStatesWithConflictResolution } from "@keeper.sh/calendar";
 import type { IngestionChanges } from "@keeper.sh/calendar";
 import { and, count, eq, inArray, sql } from "drizzle-orm";
@@ -79,7 +83,14 @@ const ingestIcsSource = async (source: Source): Promise<void> => {
 
   await ingestSource({
     calendarId: source.id,
-    fetchEvents: () => fetcher.fetchEvents(),
+    fetchEvents: () =>
+      fetcher.fetchEvents({
+        interpretEvents: (events, context) =>
+          interpretFullDayTimedEventsAsAllDay(events, {
+            calendarTimeZone: context.calendarTimeZone,
+            enabled: source.treatFullDayTimedEventsAsAllDay,
+          }),
+      }),
     readExistingEvents: () =>
       database
         .select({

--- a/services/api/tests/routes/api/sources/[id]/source-item-routes.test.ts
+++ b/services/api/tests/routes/api/sources/[id]/source-item-routes.test.ts
@@ -59,7 +59,7 @@ describe("handlePatchSourceRoute", () => {
 
     expect(response.status).toBe(403);
     expect(await readJson(response)).toEqual({
-      error: "Event filters require a Pro plan.",
+      error: "This setting requires a Pro plan.",
     });
   });
 
@@ -99,5 +99,27 @@ describe("handlePatchSourceRoute", () => {
     );
 
     expect(response.status).toBe(200);
+  });
+
+  it("returns 403 when free users update full-day timed event interpretation", async () => {
+    const response = await handlePatchSourceRoute(
+      {
+        body: { treatFullDayTimedEventsAsAllDay: true },
+        params: { id: "source-1" },
+        userId: "user-1",
+      },
+      {
+        canUseEventFilters: () => Promise.resolve(false),
+        updateSource: (_userId, _sourceId, updates) => Promise.resolve({
+          id: "source-1",
+          ...updates,
+        }),
+      },
+    );
+
+    expect(response.status).toBe(403);
+    expect(await readJson(response)).toEqual({
+      error: "This setting requires a Pro plan.",
+    });
   });
 });

--- a/services/api/tests/utils/request-body.test.ts
+++ b/services/api/tests/utils/request-body.test.ts
@@ -46,6 +46,7 @@ describe("sourcePatchBodySchema", () => {
     const result = sourcePatchBodySchema({
       excludeAllDayEvents: true,
       excludeEventDescription: false,
+      treatFullDayTimedEventsAsAllDay: true,
     });
     expect(result instanceof type.errors).toBe(false);
   });
@@ -182,4 +183,3 @@ describe("tokenCreateBodySchema", () => {
     expect(result instanceof type.errors).toBe(true);
   });
 });
-

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -13,7 +13,10 @@ import {
 } from "@keeper.sh/calendar";
 import { INGEST_SOURCE_TIMEOUT_MS, PROVIDER_INGEST_REQUEST_TIMEOUT_MS } from "@keeper.sh/constants";
 import type { CalendarBackoffState, IngestionChanges, IngestionFetchEventsResult, RedisRateLimiter, TokenState } from "@keeper.sh/calendar";
-import { createIcsSourceFetcher } from "@keeper.sh/calendar/ics";
+import {
+  createIcsSourceFetcher,
+  interpretFullDayTimedEventsAsAllDay,
+} from "@keeper.sh/calendar/ics";
 import { createGoogleSourceFetcher } from "@keeper.sh/calendar/google";
 import { createOutlookSourceFetcher } from "@keeper.sh/calendar/outlook";
 import { createCalDAVSourceFetcher, isCalDAVAuthenticationError } from "@keeper.sh/calendar/caldav";
@@ -548,6 +551,7 @@ const ingestIcsSources = async (): Promise<{ added: number; removed: number; err
     .select({
       calendarId: calendarsTable.id,
       url: calendarsTable.url,
+      treatFullDayTimedEventsAsAllDay: calendarsTable.treatFullDayTimedEventsAsAllDay,
       userId: calendarsTable.userId,
       ingestFailureCount: calendarsTable.ingestFailureCount,
     })
@@ -600,7 +604,14 @@ const ingestIcsSources = async (): Promise<{ added: number; removed: number; err
             const result = await widelog.time.measure("duration_ms", () =>
               ingestSource({
                 calendarId: source.calendarId,
-                fetchEvents: () => fetcher.fetchEvents(),
+                fetchEvents: () =>
+                  fetcher.fetchEvents({
+                    interpretEvents: (events, fetchContext) =>
+                      interpretFullDayTimedEventsAsAllDay(events, {
+                        calendarTimeZone: fetchContext.calendarTimeZone,
+                        enabled: source.treatFullDayTimedEventsAsAllDay,
+                      }),
+                  }),
                 readExistingEvents: () => readExistingEvents(source.calendarId),
                 flush: createIngestionFlush(source.calendarId),
                 onIngestEvent: (event) => {


### PR DESCRIPTION
## Summary
- add an iCal sync setting, "Sync Full-Day Events as All-Day", gated behind Pro in UI and API
- interpret local-midnight timed ICS events as all-day after fetch/parse using parsed X-WR-TIMEZONE metadata
- add database column and migration for the source setting

## Verification
- `bun run test tests/ics/utils/parse-ics-calendar.test.ts tests/ics/utils/parse-ics-events.test.ts tests/ics/utils/interpret-full-day-timed-events.test.ts tests/ics/utils/fetch-adapter.test.ts` in `packages/calendar`
- `bun run test tests/utils/request-body.test.ts tests/routes/api/sources/[id]/source-item-routes.test.ts` in `services/api`
- `bun run types` in `packages/calendar`, `services/api`, `services/cron`, `applications/web`
- `bun run lint` in `packages/calendar`, `services/api`, `services/cron`, `applications/web`