### PR TITLE
fix(sync): prevent stuck syncing indicator and overreported totals

### DIFF
--- a/applications/web/src/providers/sync-provider-logic.ts
+++ b/applications/web/src/providers/sync-provider-logic.ts
@@ -47,10 +47,6 @@ const isForwardProgress = (
     return true;
   }
 
-  if (current.state === "idle" && next.syncing) {
-    return true;
-  }
-
   if (current.state === "syncing" && !next.syncing && next.syncEventsRemaining === 0) {
     return true;
   }

--- a/applications/web/tests/providers/sync-provider-logic.test.ts
+++ b/applications/web/tests/providers/sync-provider-logic.test.ts
@@ -101,7 +101,7 @@ describe("shouldAcceptAggregatePayload", () => {
     expect(decision.nextSeq).toBe(8);
   });
 
-  it("accepts lower sequence when a new sync cycle starts", () => {
+  it("rejects lower sequence syncing payload after idle completion", () => {
     const current = createCurrentState({
       progressPercent: 100,
       seq: 25,
@@ -116,16 +116,16 @@ describe("shouldAcceptAggregatePayload", () => {
       25,
       createAggregate({
         lastSyncedAt: current.lastSyncedAt,
-        progressPercent: 0,
+        progressPercent: 4.77,
         seq: 1,
         syncing: true,
         syncEventsProcessed: 0,
-        syncEventsRemaining: 12,
-        syncEventsTotal: 12,
+        syncEventsRemaining: 3513,
+        syncEventsTotal: 3689,
       }),
     );
 
-    expect(decision.accepted).toBe(true);
+    expect(decision.accepted).toBe(false);
     expect(decision.nextSeq).toBe(25);
   });
 

--- a/packages/calendar/src/core/sync/aggregate-runtime.ts
+++ b/packages/calendar/src/core/sync/aggregate-runtime.ts
@@ -7,10 +7,32 @@ import type { SyncAggregateMessage, SyncAggregateSnapshot } from "./aggregate-tr
 const SYNC_AGGREGATE_LATEST_KEY_PREFIX = "sync:aggregate:latest:";
 const SYNC_AGGREGATE_SEQUENCE_KEY_PREFIX = "sync:aggregate:seq:";
 
+const MILLISECONDS_PER_MINUTE = 60_000;
+const STALE_SYNCING_THRESHOLD_MINUTES = 10;
+const STALE_SYNCING_THRESHOLD_MS = STALE_SYNCING_THRESHOLD_MINUTES * MILLISECONDS_PER_MINUTE;
+
+const SET_LATEST_IF_NEWER_LUA = `
+local current = redis.call('GET', KEYS[1])
+if current then
+  local ok, decoded = pcall(cjson.decode, current)
+  if ok and type(decoded) == 'table' then
+    local currentSeq = tonumber(decoded.seq)
+    if currentSeq and currentSeq >= tonumber(ARGV[2]) then
+      return 0
+    end
+  end
+end
+redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[3])
+return 1
+`;
+
+type SyncAggregateErrorScope = "emit" | "emit-queue" | "cache-read";
+
 interface SyncAggregateRuntimeConfig {
   redis: Redis;
   broadcast: (userId: string, eventName: string, data: unknown) => void;
   persistSyncStatus: (result: DestinationSyncResult, syncedAt: Date) => Promise<void>;
+  onError: (scope: SyncAggregateErrorScope, error: Error) => void;
   tracker?: SyncAggregateTracker;
 }
 
@@ -18,7 +40,7 @@ interface SyncAggregateRuntime {
   emitSyncAggregate: (userId: string, aggregate: SyncAggregateMessage) => Promise<void>;
   onDestinationSync: (result: DestinationSyncResult) => Promise<void>;
   onSyncProgress: (update: SyncProgressUpdate) => void;
-  holdSyncing: (userId: string) => void;
+  beginSyncRun: (userId: string) => void;
   releaseSyncing: (userId: string) => Promise<void>;
   getCurrentSyncAggregate: (
     userId: string,
@@ -38,6 +60,13 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const isNumberField = (value: unknown): value is number => typeof value === "number";
 
+const toError = (value: unknown): Error => {
+  if (value instanceof Error) {
+    return value;
+  }
+  return new Error(String(value));
+};
+
 const isSyncAggregateMessage = (value: unknown): value is SyncAggregateMessage => {
   if (!isRecord(value)) {
     return false;
@@ -50,6 +79,10 @@ const isSyncAggregateMessage = (value: unknown): value is SyncAggregateMessage =
     }
   }
 
+  if ("emittedAt" in value && typeof value.emittedAt !== "string") {
+    return false;
+  }
+
   return (
     isNumberField(value.progressPercent) &&
     isNumberField(value.seq) &&
@@ -60,10 +93,28 @@ const isSyncAggregateMessage = (value: unknown): value is SyncAggregateMessage =
   );
 };
 
+const isStaleSyncingAggregate = (aggregate: SyncAggregateMessage): boolean => {
+  if (!aggregate.syncing) {
+    return false;
+  }
+
+  if (typeof aggregate.emittedAt !== "string") {
+    return true;
+  }
+
+  const emittedAtMs = Date.parse(aggregate.emittedAt);
+  if (!Number.isFinite(emittedAtMs)) {
+    return true;
+  }
+
+  return Date.now() - emittedAtMs > STALE_SYNCING_THRESHOLD_MS;
+};
+
 const createSyncAggregateRuntime = (config: SyncAggregateRuntimeConfig): SyncAggregateRuntime => {
   const tracker = config.tracker ?? new SyncAggregateTracker();
+  const emitQueueByUser = new Map<string, Promise<void>>();
 
-  const emitSyncAggregate = async (
+  const performEmit = async (
     userId: string,
     aggregate: SyncAggregateMessage,
   ): Promise<void> => {
@@ -72,16 +123,40 @@ const createSyncAggregateRuntime = (config: SyncAggregateRuntimeConfig): SyncAgg
       const sequence = await config.redis.incr(sequenceKey);
       await config.redis.expire(sequenceKey, SYNC_TTL_SECONDS);
 
-      const payload: SyncAggregateMessage = { ...aggregate, seq: sequence };
+      const payload: SyncAggregateMessage = {
+        ...aggregate,
+        emittedAt: new Date().toISOString(),
+        seq: sequence,
+      };
 
-      const latestKey = getSyncAggregateLatestKey(userId);
-      await config.redis.set(latestKey, JSON.stringify(payload));
-      await config.redis.expire(latestKey, SYNC_TTL_SECONDS);
+      await config.redis.eval(
+        SET_LATEST_IF_NEWER_LUA,
+        1,
+        getSyncAggregateLatestKey(userId),
+        JSON.stringify(payload),
+        String(sequence),
+        String(SYNC_TTL_SECONDS),
+      );
 
       config.broadcast(userId, "sync:aggregate", payload);
-    } catch {
+    } catch (error) {
+      config.onError("emit", toError(error));
       config.broadcast(userId, "sync:aggregate", aggregate);
     }
+  };
+
+  const emitSyncAggregate = (
+    userId: string,
+    aggregate: SyncAggregateMessage,
+  ): Promise<void> => {
+    const previous = emitQueueByUser.get(userId) ?? Promise.resolve();
+    const next = previous.then(() => performEmit(userId, aggregate));
+    const settled = next.catch((error: unknown) => {
+      config.onError("emit-queue", toError(error));
+    });
+    emitQueueByUser.set(userId, settled);
+
+    return next;
   };
 
   const onDestinationSync = async (result: DestinationSyncResult): Promise<void> => {
@@ -90,11 +165,14 @@ const createSyncAggregateRuntime = (config: SyncAggregateRuntimeConfig): SyncAgg
     }
 
     const syncedAt = new Date();
-    await config.persistSyncStatus(result, syncedAt);
 
-    const aggregate = tracker.trackDestinationSync(result, syncedAt.toISOString());
-    if (aggregate) {
-      await emitSyncAggregate(result.userId, aggregate);
+    try {
+      await config.persistSyncStatus(result, syncedAt);
+    } finally {
+      const aggregate = tracker.trackDestinationSync(result, syncedAt.toISOString());
+      if (aggregate) {
+        await emitSyncAggregate(result.userId, aggregate);
+      }
     }
   };
 
@@ -121,16 +199,23 @@ const createSyncAggregateRuntime = (config: SyncAggregateRuntimeConfig): SyncAgg
       }
 
       const parsed: unknown = JSON.parse(value);
-      if (isSyncAggregateMessage(parsed)) {
-        return parsed;
+      if (!isSyncAggregateMessage(parsed)) {
+        return null;
       }
-      return null;
-    } catch {
+
+      if (isStaleSyncingAggregate(parsed)) {
+        return null;
+      }
+
+      return parsed;
+    } catch (error) {
+      config.onError("cache-read", toError(error));
       return null;
     }
   };
 
-  const holdSyncing = (userId: string): void => {
+  const beginSyncRun = (userId: string): void => {
+    tracker.resetUser(userId);
     tracker.holdSyncing(userId);
   };
 
@@ -145,7 +230,7 @@ const createSyncAggregateRuntime = (config: SyncAggregateRuntimeConfig): SyncAgg
     emitSyncAggregate,
     onDestinationSync,
     onSyncProgress,
-    holdSyncing,
+    beginSyncRun,
     releaseSyncing,
     getCurrentSyncAggregate,
     getCachedSyncAggregate,

--- a/packages/calendar/src/core/sync/aggregate-tracker.ts
+++ b/packages/calendar/src/core/sync/aggregate-tracker.ts
@@ -17,6 +17,7 @@ interface SyncAggregateSnapshot {
 
 interface SyncAggregateMessage extends SyncAggregateSnapshot {
   seq: number;
+  emittedAt?: string;
 }
 
 interface SyncAggregateTrackerConfig {
@@ -76,8 +77,12 @@ class SyncAggregateTracker {
     current: CalendarOperationProgress | undefined,
     update: SyncProgressUpdate,
   ): CalendarOperationProgress {
-    const currentProcessed = current?.processed ?? INITIAL_COUNT;
-    const currentTotal = current?.total ?? INITIAL_COUNT;
+    let currentProcessed = INITIAL_COUNT;
+    let currentTotal = INITIAL_COUNT;
+    if (current && current.status !== "idle") {
+      currentProcessed = current.processed;
+      currentTotal = current.total;
+    }
 
     const nextTotal = update.progress?.total ?? currentTotal;
     const nextProcessedRaw = update.progress?.current ?? currentProcessed;
@@ -251,6 +256,13 @@ class SyncAggregateTracker {
 
   holdSyncing(userId: string): void {
     this.syncingHeldByUser.add(userId);
+  }
+
+  resetUser(userId: string): void {
+    this.progressByUser.delete(userId);
+    this.highWaterPercentByUser.delete(userId);
+    this.lastPayloadKeyByUser.delete(userId);
+    this.lastProgressEmitAtByUser.delete(userId);
   }
 
   releaseSyncing(userId: string): void {

--- a/packages/calendar/tests/core/sync/aggregate-runtime.test.ts
+++ b/packages/calendar/tests/core/sync/aggregate-runtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createSyncAggregateRuntime } from "../../../src/core/sync/aggregate-runtime";
+import type { SyncAggregateRuntimeConfig } from "../../../src/core/sync/aggregate-runtime";
 import { SyncAggregateTracker } from "../../../src/core/sync/aggregate-tracker";
 import type { DestinationSyncResult, SyncProgressUpdate } from "../../../src/core/sync/types";
 import Redis from "ioredis";
@@ -7,6 +8,18 @@ import Redis from "ioredis";
 const flushAsync = async (): Promise<void> => {
   for (let tick = 0; tick < 10; tick++) {
     await Promise.resolve();
+  }
+};
+
+const parseJsonRecord = (value: string): Record<string, unknown> | null => {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (typeof parsed === "object" && parsed !== null) {
+      return parsed as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
   }
 };
 
@@ -32,6 +45,26 @@ const createMockRedis = (): Redis => {
           return Promise.resolve("OK");
         }
       }
+      case "eval": {
+        return (
+          _script: string,
+          _numberOfKeys: number,
+          key: string,
+          payload: string,
+          sequence: string,
+        ): Promise<number> => {
+          const current = store.get(key);
+          if (current) {
+            const decoded = parseJsonRecord(current);
+            const currentSequence = Number(decoded?.seq);
+            if (Number.isFinite(currentSequence) && currentSequence >= Number(sequence)) {
+              return Promise.resolve(0);
+            }
+          }
+          store.set(key, payload);
+          return Promise.resolve(1);
+        }
+      }
       default: {
         return () => null;
       }
@@ -45,6 +78,10 @@ const createMockRedis = (): Redis => {
 
   const NoopRedis = new Proxy(instance, {
     get(target, property, receiver) {
+      if (Object.hasOwn(target, property)) {
+        return Reflect.get(target, property, receiver);
+      }
+
       if (isRedisMethod(property)) {
         const value = target[property];
         if (typeof value === "function") {
@@ -71,8 +108,23 @@ const ignorePersistSyncStatus = (result: DestinationSyncResult, syncedAt: Date):
   return Promise.resolve();
 };
 
+const ignoreOnError = (scope: string, error: Error): void => {
+  ignoredCallbacks.push({ error, scope });
+};
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
+
+const createRuntimeConfig = (
+  overrides: Partial<SyncAggregateRuntimeConfig> = {},
+): SyncAggregateRuntimeConfig => ({
+  broadcast: ignoreBroadcast,
+  onError: ignoreOnError,
+  persistSyncStatus: ignorePersistSyncStatus,
+  redis: createMockRedis(),
+  tracker: new SyncAggregateTracker({ progressThrottleMs: 0 }),
+  ...overrides,
+});
 
 const createProgressUpdate = (
   overrides: Partial<SyncProgressUpdate> = {},
@@ -100,15 +152,11 @@ const createDestinationResult = (
 describe("createSyncAggregateRuntime", () => {
   describe("onSyncProgress", () => {
     it("broadcasts aggregate when tracker emits a message", async () => {
-      const redis = createMockRedis();
       const broadcasts: { userId: string; event: string; data: unknown }[] = [];
 
-      const runtime = createSyncAggregateRuntime({
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({
         broadcast: (userId, event, data) => broadcasts.push({ data, event, userId }),
-        persistSyncStatus: ignorePersistSyncStatus,
-        redis: redis,
-        tracker: new SyncAggregateTracker({ progressThrottleMs: 0 }),
-      });
+      }));
 
       runtime.onSyncProgress(
         createProgressUpdate({ progress: { current: 0, total: 10 } }),
@@ -129,20 +177,18 @@ describe("createSyncAggregateRuntime", () => {
 
   describe("onDestinationSync", () => {
     it("persists sync status and broadcasts result", async () => {
-      const redis = createMockRedis();
       const broadcasts: { userId: string; event: string; data: unknown }[] = [];
       const persisted: { result: DestinationSyncResult; syncedAt: Date }[] = [];
       const tracker = new SyncAggregateTracker({ progressThrottleMs: 0 });
 
-      const runtime = createSyncAggregateRuntime({
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({
         broadcast: (userId, event, data) => broadcasts.push({ data, event, userId }),
         persistSyncStatus: (result, syncedAt) => {
           persisted.push({ result, syncedAt });
           return Promise.resolve();
         },
-        redis: redis,
         tracker,
-      });
+      }));
 
       tracker.trackProgress(
         createProgressUpdate({ calendarId: "cal-1", progress: { current: 5, total: 10 } }),
@@ -161,11 +207,10 @@ describe("createSyncAggregateRuntime", () => {
     });
 
     it("skips broadcast when result.broadcast is false", async () => {
-      const redis = createMockRedis();
       const broadcasts: unknown[] = [];
       const persisted: unknown[] = [];
 
-      const runtime = createSyncAggregateRuntime({
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({
         broadcast: (userId, eventName, data) => {
           broadcasts.push({ data, eventName, userId });
         },
@@ -173,9 +218,7 @@ describe("createSyncAggregateRuntime", () => {
           persisted.push(true);
           return Promise.resolve();
         },
-        redis: redis,
-        tracker: new SyncAggregateTracker({ progressThrottleMs: 0 }),
-      });
+      }));
 
       await runtime.onDestinationSync(
         createDestinationResult({ broadcast: false }),
@@ -184,19 +227,60 @@ describe("createSyncAggregateRuntime", () => {
       expect(broadcasts).toHaveLength(0);
       expect(persisted).toHaveLength(0);
     });
+
+    it("finalizes and broadcasts completion even when persistence fails", async () => {
+      const broadcasts: { data: unknown }[] = [];
+      const tracker = new SyncAggregateTracker({ progressThrottleMs: 0 });
+
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({
+        broadcast: (_userId, _eventName, data) => {
+          broadcasts.push({ data });
+        },
+        persistSyncStatus: () => Promise.reject(new Error("database down")),
+        tracker,
+      }));
+
+      tracker.trackProgress(
+        createProgressUpdate({ calendarId: "cal-1", progress: { current: 5, total: 10 } }),
+      );
+
+      await expect(
+        runtime.onDestinationSync(createDestinationResult()),
+      ).rejects.toThrow("database down");
+
+      expect(broadcasts.length).toBeGreaterThanOrEqual(1);
+      const lastBroadcast = broadcasts.at(-1);
+      expect(lastBroadcast).toBeDefined();
+      if (!lastBroadcast || !isRecord(lastBroadcast.data)) {
+        throw new TypeError("Expected broadcast data object");
+      }
+      expect(lastBroadcast.data.syncing).toBe(false);
+      expect(lastBroadcast.data.syncEventsRemaining).toBe(0);
+    });
+  });
+
+  describe("beginSyncRun", () => {
+    it("clears accumulated progress from previous runs", () => {
+      const tracker = new SyncAggregateTracker({ progressThrottleMs: 0 });
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({ tracker }));
+
+      tracker.trackProgress(
+        createProgressUpdate({ progress: { current: 176, total: 3689 } }),
+      );
+
+      runtime.beginSyncRun("user-1");
+
+      const aggregate = runtime.getCurrentSyncAggregate("user-1");
+      expect(aggregate.syncEventsTotal).toBe(0);
+      expect(aggregate.syncEventsProcessed).toBe(0);
+      expect(aggregate.syncing).toBe(false);
+      expect(aggregate.progressPercent).toBe(100);
+    });
   });
 
   describe("getCurrentSyncAggregate", () => {
     it("delegates to tracker and returns current state", () => {
-      const redis = createMockRedis();
-      const tracker = new SyncAggregateTracker({ progressThrottleMs: 0 });
-
-      const runtime = createSyncAggregateRuntime({
-        broadcast: ignoreBroadcast,
-        persistSyncStatus: ignorePersistSyncStatus,
-        redis: redis,
-        tracker,
-      });
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig());
 
       const result = runtime.getCurrentSyncAggregate("user-1");
 
@@ -205,15 +289,7 @@ describe("createSyncAggregateRuntime", () => {
     });
 
     it("passes fallback to tracker", () => {
-      const redis = createMockRedis();
-      const tracker = new SyncAggregateTracker({ progressThrottleMs: 0 });
-
-      const runtime = createSyncAggregateRuntime({
-        broadcast: ignoreBroadcast,
-        persistSyncStatus: ignorePersistSyncStatus,
-        redis: redis,
-        tracker,
-      });
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig());
 
       const result = runtime.getCurrentSyncAggregate("user-1", {
         progressPercent: 42,
@@ -228,12 +304,7 @@ describe("createSyncAggregateRuntime", () => {
 
   describe("getCachedSyncAggregate", () => {
     it("returns null when no cached value exists", async () => {
-      const redis = createMockRedis();
-      const runtime = createSyncAggregateRuntime({
-        broadcast: ignoreBroadcast,
-        persistSyncStatus: ignorePersistSyncStatus,
-        redis: redis,
-      });
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig());
 
       const result = await runtime.getCachedSyncAggregate("user-1");
       expect(result).toBeNull();
@@ -251,11 +322,7 @@ describe("createSyncAggregateRuntime", () => {
       };
       redis.set("sync:aggregate:latest:user-1", JSON.stringify(cached));
 
-      const runtime = createSyncAggregateRuntime({
-        broadcast: ignoreBroadcast,
-        persistSyncStatus: ignorePersistSyncStatus,
-        redis: redis,
-      });
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({ redis }));
 
       const result = await runtime.getCachedSyncAggregate("user-1");
       expect(result).toEqual(cached);
@@ -265,11 +332,7 @@ describe("createSyncAggregateRuntime", () => {
       const redis = createMockRedis();
       redis.set("sync:aggregate:latest:user-1", "not-valid-json");
 
-      const runtime = createSyncAggregateRuntime({
-        broadcast: ignoreBroadcast,
-        persistSyncStatus: ignorePersistSyncStatus,
-        redis: redis,
-      });
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({ redis }));
 
       const result = await runtime.getCachedSyncAggregate("user-1");
       expect(result).toBeNull();
@@ -282,11 +345,7 @@ describe("createSyncAggregateRuntime", () => {
         JSON.stringify({ foo: "bar" }),
       );
 
-      const runtime = createSyncAggregateRuntime({
-        broadcast: ignoreBroadcast,
-        persistSyncStatus: ignorePersistSyncStatus,
-        redis: redis,
-      });
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({ redis }));
 
       const result = await runtime.getCachedSyncAggregate("user-1");
       expect(result).toBeNull();
@@ -306,11 +365,84 @@ describe("createSyncAggregateRuntime", () => {
 
       redis.set("sync:aggregate:latest:user-1", JSON.stringify(cached));
 
-      const runtime = createSyncAggregateRuntime({
-        broadcast: ignoreBroadcast,
-        persistSyncStatus: ignorePersistSyncStatus,
-        redis: redis,
-      });
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({ redis }));
+
+      const result = await runtime.getCachedSyncAggregate("user-1");
+      expect(result).toEqual(cached);
+    });
+
+    it("returns fresh syncing aggregate with recent emittedAt", async () => {
+      const redis = createMockRedis();
+      const cached = {
+        emittedAt: new Date().toISOString(),
+        progressPercent: 40,
+        seq: 5,
+        syncEventsProcessed: 4,
+        syncEventsRemaining: 6,
+        syncEventsTotal: 10,
+        syncing: true,
+      };
+      redis.set("sync:aggregate:latest:user-1", JSON.stringify(cached));
+
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({ redis }));
+
+      const result = await runtime.getCachedSyncAggregate("user-1");
+      expect(result).toEqual(cached);
+    });
+
+    it("returns null for a syncing aggregate whose emittedAt is stale", async () => {
+      const redis = createMockRedis();
+      const staleEmittedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const cached = {
+        emittedAt: staleEmittedAt,
+        progressPercent: 4.77,
+        seq: 75_370,
+        syncEventsProcessed: 176,
+        syncEventsRemaining: 3513,
+        syncEventsTotal: 3689,
+        syncing: true,
+      };
+      redis.set("sync:aggregate:latest:user-1", JSON.stringify(cached));
+
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({ redis }));
+
+      const result = await runtime.getCachedSyncAggregate("user-1");
+      expect(result).toBeNull();
+    });
+
+    it("returns null for a syncing aggregate without emittedAt", async () => {
+      const redis = createMockRedis();
+      const cached = {
+        progressPercent: 40,
+        seq: 5,
+        syncEventsProcessed: 4,
+        syncEventsRemaining: 6,
+        syncEventsTotal: 10,
+        syncing: true,
+      };
+      redis.set("sync:aggregate:latest:user-1", JSON.stringify(cached));
+
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({ redis }));
+
+      const result = await runtime.getCachedSyncAggregate("user-1");
+      expect(result).toBeNull();
+    });
+
+    it("returns idle aggregate regardless of age", async () => {
+      const redis = createMockRedis();
+      const staleEmittedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const cached = {
+        emittedAt: staleEmittedAt,
+        progressPercent: 100,
+        seq: 5,
+        syncEventsProcessed: 10,
+        syncEventsRemaining: 0,
+        syncEventsTotal: 10,
+        syncing: false,
+      };
+      redis.set("sync:aggregate:latest:user-1", JSON.stringify(cached));
+
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({ redis }));
 
       const result = await runtime.getCachedSyncAggregate("user-1");
       expect(result).toEqual(cached);
@@ -322,13 +454,12 @@ describe("createSyncAggregateRuntime", () => {
       const redis = createMockRedis();
       const broadcasts: { data: unknown; eventName: string; userId: string }[] = [];
 
-      const runtime = createSyncAggregateRuntime({
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({
         broadcast: (userId, eventName, data) => {
           broadcasts.push({ data, eventName, userId });
         },
-        persistSyncStatus: ignorePersistSyncStatus,
-        redis: redis,
-      });
+        redis,
+      }));
 
       await runtime.emitSyncAggregate("user-1", {
         progressPercent: 50,
@@ -351,22 +482,22 @@ describe("createSyncAggregateRuntime", () => {
         throw new TypeError("Expected broadcast data object");
       }
       expect(broadcastData.seq).toBe(1);
+      expect(typeof broadcastData.emittedAt).toBe("string");
 
-      const stored = redis.get("sync:aggregate:latest:user-1");
-      expect(stored).toBeDefined();
+      const stored = await redis.get("sync:aggregate:latest:user-1");
+      expect(stored).not.toBeNull();
     });
 
     it("stores syncing aggregate in redis latest cache for fresh reconnects", async () => {
       const redis = createMockRedis();
       const broadcasts: { data: unknown; eventName: string; userId: string }[] = [];
 
-      const runtime = createSyncAggregateRuntime({
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({
         broadcast: (userId, eventName, data) => {
           broadcasts.push({ data, eventName, userId });
         },
-        persistSyncStatus: ignorePersistSyncStatus,
-        redis: redis,
-      });
+        redis,
+      }));
 
       await runtime.emitSyncAggregate("user-1", {
         progressPercent: 50,
@@ -378,22 +509,57 @@ describe("createSyncAggregateRuntime", () => {
       });
 
       expect(broadcasts).toHaveLength(1);
-      expect(redis.get("sync:aggregate:latest:user-1")).toBeDefined();
+      expect(redis.get("sync:aggregate:latest:user-1")).resolves.not.toBeNull();
       expect(redis.get("sync:aggregate:seq:user-1")).resolves.toBe("1");
     });
 
-    it("still broadcasts even if redis fails", async () => {
+    it("does not overwrite a cached aggregate with a newer sequence", async () => {
+      const redis = createMockRedis();
+      const newerCached = {
+        emittedAt: new Date().toISOString(),
+        progressPercent: 100,
+        seq: 10,
+        syncEventsProcessed: 10,
+        syncEventsRemaining: 0,
+        syncEventsTotal: 10,
+        syncing: false,
+      };
+      redis.set("sync:aggregate:latest:user-1", JSON.stringify(newerCached));
+
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({ redis }));
+
+      await runtime.emitSyncAggregate("user-1", {
+        progressPercent: 50,
+        seq: 1,
+        syncEventsProcessed: 5,
+        syncEventsRemaining: 5,
+        syncEventsTotal: 10,
+        syncing: true,
+      });
+
+      const stored = await redis.get("sync:aggregate:latest:user-1");
+      expect(stored).not.toBeNull();
+      if (!stored) {
+        throw new TypeError("Expected stored aggregate");
+      }
+      expect(JSON.parse(stored)).toEqual(newerCached);
+    });
+
+    it("still broadcasts and reports the error if redis fails", async () => {
       const broadcasts: { data: unknown; eventName: string; userId: string }[] = [];
+      const reportedErrors: { scope: string; error: Error }[] = [];
       const failingRedis = createMockRedis();
       failingRedis.incr = (() => Promise.reject(new Error("redis down"))) satisfies typeof failingRedis.incr;
 
-      const runtime = createSyncAggregateRuntime({
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({
         broadcast: (userId, eventName, data) => {
           broadcasts.push({ data, eventName, userId });
         },
-        persistSyncStatus: ignorePersistSyncStatus,
+        onError: (scope, error) => {
+          reportedErrors.push({ error, scope });
+        },
         redis: failingRedis,
-      });
+      }));
 
       const aggregate = {
         progressPercent: 50,
@@ -413,6 +579,15 @@ describe("createSyncAggregateRuntime", () => {
         throw new TypeError("Expected first broadcast");
       }
       expect(firstBroadcast.data).toEqual(aggregate);
+
+      expect(reportedErrors).toHaveLength(1);
+      const [firstError] = reportedErrors;
+      expect(firstError).toBeDefined();
+      if (!firstError) {
+        throw new TypeError("Expected reported error");
+      }
+      expect(firstError.scope).toBe("emit");
+      expect(firstError.error.message).toBe("redis down");
     });
   });
 });

--- a/packages/calendar/tests/core/sync/aggregate-tracker.test.ts
+++ b/packages/calendar/tests/core/sync/aggregate-tracker.test.ts
@@ -284,6 +284,59 @@ describe("SyncAggregateTracker", () => {
     });
   });
 
+  describe("resetUser", () => {
+    it("clears accumulated progress so totals do not carry across runs", () => {
+      const tracker = new SyncAggregateTracker({ progressThrottleMs: 0 });
+
+      tracker.trackProgress(
+        createProgressUpdate({ progress: { current: 176, total: 3689 } }),
+      );
+
+      tracker.resetUser("user-1");
+
+      const aggregate = tracker.getCurrentAggregate("user-1");
+      expect(aggregate.syncEventsTotal).toBe(0);
+      expect(aggregate.syncEventsProcessed).toBe(0);
+      expect(aggregate.syncing).toBe(false);
+      expect(aggregate.progressPercent).toBe(100);
+    });
+
+    it("does not affect other users", () => {
+      const tracker = new SyncAggregateTracker({ progressThrottleMs: 0 });
+
+      tracker.trackProgress(
+        createProgressUpdate({ progress: { current: 3, total: 10 }, userId: "user-2" }),
+      );
+
+      tracker.resetUser("user-1");
+
+      const aggregate = tracker.getCurrentAggregate("user-2");
+      expect(aggregate.syncEventsTotal).toBe(10);
+    });
+  });
+
+  describe("stale count resurrection", () => {
+    it("does not revive finalized counts when a new run starts without progress", () => {
+      const tracker = new SyncAggregateTracker({ progressThrottleMs: 0 });
+
+      tracker.trackProgress(
+        createProgressUpdate({ progress: { current: 5, total: 10 } }),
+      );
+      tracker.trackDestinationSync(
+        createDestinationResult(),
+        "2026-03-08T12:00:00.000Z",
+      );
+
+      const result = tracker.trackProgress(
+        createProgressUpdate({ stage: "fetching" }),
+      );
+
+      const aggregateMessage = requireAggregateMessage(result);
+      expect(aggregateMessage.syncEventsTotal).toBe(0);
+      expect(aggregateMessage.syncEventsProcessed).toBe(0);
+    });
+  });
+
   describe("calculatePercent", () => {
     it("returns 100% when not syncing and total is zero", () => {
       const tracker = new SyncAggregateTracker({ progressThrottleMs: 0 });

--- a/packages/data-schemas/src/client.ts
+++ b/packages/data-schemas/src/client.ts
@@ -4,6 +4,7 @@ interface SocketMessage {
 }
 
 interface SyncAggregate {
+  emittedAt?: string;
   progressPercent: number;
   seq: number;
   syncEventsProcessed: number;

--- a/packages/data-schemas/src/index.ts
+++ b/packages/data-schemas/src/index.ts
@@ -218,6 +218,7 @@ const syncStatusSchema = type({
 type SyncStatus = typeof syncStatusSchema.infer;
 
 const syncAggregateSchema = type({
+  "emittedAt?": "string",
   progressPercent: "number",
   seq: "number",
   syncEventsProcessed: "number",

--- a/services/api/src/context.ts
+++ b/services/api/src/context.ts
@@ -11,6 +11,7 @@ import {
   buildOAuthConfigs,
   createSyncAggregateRuntime,
 } from "@keeper.sh/calendar";
+import { context, widelog } from "@/utils/logging";
 import type { OAuthStateStore, RefreshLockStore, DestinationSyncResult } from "@keeper.sh/calendar";
 
 const MIN_TRUSTED_ORIGINS_COUNT = 0;
@@ -112,10 +113,22 @@ const persistSyncStatus = async (
     });
 };
 
+const reportSyncAggregateError = (scope: string, error: Error): void => {
+  context(() => {
+    widelog.set("operation.name", "sync-aggregate");
+    widelog.set("operation.type", "background");
+    widelog.set("aggregate.scope", scope);
+    widelog.set("outcome", "error");
+    widelog.errorFields(error, { slug: "sync-aggregate-failed" });
+    widelog.flush();
+  });
+};
+
 const syncAggregateRuntime = createSyncAggregateRuntime({
   broadcast: (userId, eventName, payload): void => {
     broadcastService.emit(userId, eventName, payload);
   },
+  onError: reportSyncAggregateError,
   persistSyncStatus,
   redis,
 });

--- a/services/api/src/context.ts
+++ b/services/api/src/context.ts
@@ -11,7 +11,7 @@ import {
   buildOAuthConfigs,
   createSyncAggregateRuntime,
 } from "@keeper.sh/calendar";
-import { context, widelog } from "@/utils/logging";
+import { widelog } from "@/utils/logging";
 import type { OAuthStateStore, RefreshLockStore, DestinationSyncResult } from "@keeper.sh/calendar";
 
 const MIN_TRUSTED_ORIGINS_COUNT = 0;
@@ -114,14 +114,7 @@ const persistSyncStatus = async (
 };
 
 const reportSyncAggregateError = (scope: string, error: Error): void => {
-  context(() => {
-    widelog.set("operation.name", "sync-aggregate");
-    widelog.set("operation.type", "background");
-    widelog.set("aggregate.scope", scope);
-    widelog.set("outcome", "error");
-    widelog.errorFields(error, { slug: "sync-aggregate-failed" });
-    widelog.flush();
-  });
+  widelog.error(`sync_aggregate.${scope}`, error);
 };
 
 const syncAggregateRuntime = createSyncAggregateRuntime({

--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -56,7 +56,7 @@ await entry({
       }
 
       activeJobsByUser.set(userId, job.id ?? "");
-      syncAggregateRuntime.holdSyncing(userId);
+      syncAggregateRuntime.beginSyncRun(userId);
     });
 
     worker.on("completed", (job) => {

--- a/services/worker/src/processor.ts
+++ b/services/worker/src/processor.ts
@@ -61,14 +61,7 @@ const persistSyncStatus = async (result: DestinationSyncResult, syncedAt: Date):
 };
 
 const reportAggregateError = (scope: string, error: Error): void => {
-  context(() => {
-    widelog.set("operation.name", "sync-aggregate");
-    widelog.set("operation.type", "background");
-    widelog.set("aggregate.scope", scope);
-    widelog.set("outcome", "error");
-    widelog.errorFields(error, { slug: "sync-aggregate-failed" });
-    widelog.flush();
-  });
+  widelog.error(`sync_aggregate.${scope}`, error);
 };
 
 const syncAggregateRuntime = createSyncAggregateRuntime({

--- a/services/worker/src/processor.ts
+++ b/services/worker/src/processor.ts
@@ -17,6 +17,13 @@ const resolveCount = (value: unknown): number => {
   return 0;
 };
 
+const toError = (value: unknown): Error => {
+  if (value instanceof Error) {
+    return value;
+  }
+  return new Error(String(value));
+};
+
 const classifySyncError = (error: unknown): string => {
   if (typeof error === "string") {
     if (error.includes("conflict") || error.includes("409")) {
@@ -53,10 +60,22 @@ const persistSyncStatus = async (result: DestinationSyncResult, syncedAt: Date):
     });
 };
 
+const reportAggregateError = (scope: string, error: Error): void => {
+  context(() => {
+    widelog.set("operation.name", "sync-aggregate");
+    widelog.set("operation.type", "background");
+    widelog.set("aggregate.scope", scope);
+    widelog.set("outcome", "error");
+    widelog.errorFields(error, { slug: "sync-aggregate-failed" });
+    widelog.flush();
+  });
+};
+
 const syncAggregateRuntime = createSyncAggregateRuntime({
   broadcast: (broadcastUserId, eventName, payload) => {
     broadcastService.emit(broadcastUserId, eventName, payload);
   },
+  onError: reportAggregateError,
   persistSyncStatus,
   redis: refreshLockRedis,
 });
@@ -98,6 +117,7 @@ const processJob = (
     const deadlineController = new AbortController();
     const deadlineTimer = setTimeout(() => deadlineController.abort(), USER_TIMEOUT_MS);
     let flushed = false;
+    const pendingDestinationSyncs: Promise<void>[] = [];
 
     try {
       const abortSignal = mergeAbortSignals(deadlineController.signal, signal);
@@ -132,12 +152,18 @@ const processJob = (
             return;
           }
 
-          syncAggregateRuntime.onDestinationSync({
-            userId,
-            calendarId,
-            localEventCount: resolveCount(localCount),
-            remoteEventCount: resolveCount(remoteCount),
-          });
+          pendingDestinationSyncs.push(
+            syncAggregateRuntime
+              .onDestinationSync({
+                userId,
+                calendarId,
+                localEventCount: resolveCount(localCount),
+                remoteEventCount: resolveCount(remoteCount),
+              })
+              .catch((error: unknown) => {
+                reportAggregateError("destination-sync", toError(error));
+              }),
+          );
         },
         onCalendarComplete: (completion) => {
           widelog.set("provider.name", completion.provider);
@@ -181,6 +207,7 @@ const processJob = (
       widelog.errorFields(error, { slug: "push-sync-failed" });
       throw error;
     } finally {
+      await Promise.all(pendingDestinationSyncs);
       clearTimeout(deadlineTimer);
       if (deadlineController.signal.aborted) {
         widelog.set("timeout.fired", true);


### PR DESCRIPTION
The home page "Syncing" indicator sticks with inflated totals long after syncing finishes. Tracker state was never reset between runs, racing fire-and-forget emits let a stale "syncing" payload win the last write into the Redis cache, and the API replays that cache unconditionally for 24h. A failed status persist also skipped finalization entirely, stranding calendars in "syncing".

- Reset tracker state per run; idle entries no longer leak counts into the next run
- Serialize emits per user + seq-guarded compare-and-set on the cached payload
- Finalize even when persistence fails; worker awaits finalizations before job completion
- Stamp payloads with `emittedAt` and treat syncing payloads older than 10m as stale
- Client rejects lower-seq idle→syncing frames; runtime errors reported via `onError` → widelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)