### PR TITLE
fix: scope user-triggered Outlook source syncs

### DIFF
--- a/packages/calendar/src/core/oauth/create-source-provider.ts
+++ b/packages/calendar/src/core/oauth/create-source-provider.ts
@@ -37,6 +37,7 @@ interface OAuthSourceAccount {
 
 interface SourceProvider {
   syncAllSources(): Promise<SourceSyncResult>;
+  syncSourcesForUser(userId: string): Promise<SourceSyncResult>;
 }
 
 interface CreateOAuthSourceProviderOptions<
@@ -47,6 +48,7 @@ interface CreateOAuthSourceProviderOptions<
   oauthProvider: OAuthTokenProvider;
   refreshLockStore?: RefreshLockStore | null;
   getAllSources: (database: BunSQLDatabase) => Promise<TAccount[]>;
+  getSourcesForUser?: (database: BunSQLDatabase, userId: string) => Promise<TAccount[]>;
   createProviderInstance: (
     config: TConfig,
     oauthProvider: OAuthTokenProvider,
@@ -60,11 +62,17 @@ const createOAuthSourceProvider = <
 >(
   options: CreateOAuthSourceProviderOptions<TAccount, TConfig>,
 ): SourceProvider => {
-  const { database, oauthProvider, refreshLockStore, getAllSources, createProviderInstance, buildConfig } = options;
+  const {
+    database,
+    oauthProvider,
+    refreshLockStore,
+    getAllSources,
+    getSourcesForUser,
+    createProviderInstance,
+    buildConfig,
+  } = options;
 
-  const syncAllSources = async (): Promise<SourceSyncResult> => {
-    const sources = await getAllSources(database);
-
+  const syncSources = async (sources: TAccount[]): Promise<SourceSyncResult> => {
     if (sources.length === EMPTY_SOURCES_COUNT) {
       return { eventsAdded: INITIAL_ADDED_COUNT, eventsRemoved: INITIAL_REMOVED_COUNT };
     }
@@ -123,7 +131,12 @@ const createOAuthSourceProvider = <
     return combined;
   };
 
-  return { syncAllSources };
+  const syncAllSources = async (): Promise<SourceSyncResult> =>
+    syncSources(await getAllSources(database));
+  const syncSourcesForUser = async (userId: string): Promise<SourceSyncResult> =>
+    syncSources(await (getSourcesForUser?.(database, userId) ?? getAllSources(database)));
+
+  return { syncAllSources, syncSourcesForUser };
 };
 
 export { createOAuthSourceProvider };

--- a/packages/calendar/src/providers/outlook/source/provider.ts
+++ b/packages/calendar/src/providers/outlook/source/provider.ts
@@ -261,7 +261,16 @@ interface CreateOutlookSourceProviderConfig {
 
 const getOutlookSourcesWithCredentials = async (
   database: BunSQLDatabase,
+  userId?: string,
 ): Promise<OutlookSourceAccount[]> => {
+  const sourceConditions = [
+    eq(calendarsTable.calendarType, "oauth"),
+    arrayContains(calendarsTable.capabilities, ["pull"]),
+    eq(calendarAccountsTable.provider, OUTLOOK_PROVIDER_ID),
+  ];
+  if (userId) {
+    sourceConditions.push(eq(calendarsTable.userId, userId));
+  }
   const sources = await database
     .select({
       accessToken: oauthCredentialsTable.accessToken,
@@ -284,13 +293,7 @@ const getOutlookSourcesWithCredentials = async (
       oauthCredentialsTable,
       eq(calendarAccountsTable.oauthCredentialId, oauthCredentialsTable.id),
     )
-    .where(
-      and(
-        eq(calendarsTable.calendarType, "oauth"),
-        arrayContains(calendarsTable.capabilities, ["pull"]),
-        eq(calendarAccountsTable.provider, OUTLOOK_PROVIDER_ID),
-      ),
-    );
+    .where(and(...sourceConditions));
 
   return sources.flatMap((source) => {
     if (!source.externalCalendarId) {return [];}
@@ -324,7 +327,8 @@ const createOutlookSourceProvider = (config: CreateOutlookSourceProviderConfig):
     createProviderInstance: (providerConfig, oauth) =>
       new OutlookSourceProvider(providerConfig, oauth),
     database,
-    getAllSources: getOutlookSourcesWithCredentials,
+    getAllSources: (db) => getOutlookSourcesWithCredentials(db),
+    getSourcesForUser: getOutlookSourcesWithCredentials,
     oauthProvider,
     refreshLockStore,
   });

--- a/packages/calendar/tests/core/oauth/create-source-provider.test.ts
+++ b/packages/calendar/tests/core/oauth/create-source-provider.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { BunSQLDatabase } from "drizzle-orm/bun-sql";
+import {
+  createOAuthSourceProvider,
+  type OAuthSourceAccount,
+} from "../../../src/core/oauth/create-source-provider";
+import type { OAuthSourceConfig } from "../../../src/core/types";
+
+const database = {} as BunSQLDatabase;
+
+const createTestProvider = (
+  options: {
+    getAllSources: (database: BunSQLDatabase) => Promise<OAuthSourceAccount[]>;
+    getSourcesForUser?: (database: BunSQLDatabase, userId: string) => Promise<OAuthSourceAccount[]>;
+  },
+) =>
+  createOAuthSourceProvider<OAuthSourceAccount, OAuthSourceConfig>({
+    buildConfig: (): never => {
+      throw new Error("No sources should be built in this test");
+    },
+    createProviderInstance: (): never => {
+      throw new Error("No provider should be created in this test");
+    },
+    database,
+    ...options,
+    oauthProvider: {
+      refreshAccessToken: () => Promise.reject(new Error("Token refresh should not run")),
+    },
+  });
+
+describe("createOAuthSourceProvider", () => {
+  it("passes the user ID to user-scoped source queries", async () => {
+    const requestedUserIds: string[] = [];
+    const provider = createTestProvider({
+      getAllSources: () => Promise.reject(new Error("Global query should not run")),
+      getSourcesForUser: (_database, userId) => {
+        requestedUserIds.push(userId);
+        return Promise.resolve([]);
+      },
+    });
+
+    await provider.syncSourcesForUser("user-1");
+
+    expect(requestedUserIds).toEqual(["user-1"]);
+  });
+
+  it("keeps an explicit unscoped method for intentional global syncs", async () => {
+    let globalQueries = 0;
+    const provider = createTestProvider({
+      getAllSources: () => {
+        globalQueries += 1;
+        return Promise.resolve([]);
+      },
+    });
+
+    await provider.syncAllSources();
+
+    expect(globalQueries).toBe(1);
+  });
+});

--- a/packages/calendar/tests/core/oauth/create-source-provider.test.ts
+++ b/packages/calendar/tests/core/oauth/create-source-provider.test.ts
@@ -45,16 +45,16 @@ describe("createOAuthSourceProvider", () => {
   });
 
   it("keeps an explicit unscoped method for intentional global syncs", async () => {
-    let globalQueries = 0;
+    const globalQueries: string[] = [];
     const provider = createTestProvider({
       getAllSources: () => {
-        globalQueries += 1;
+        globalQueries.push("queried");
         return Promise.resolve([]);
       },
     });
 
     await provider.syncAllSources();
 
-    expect(globalQueries).toBe(1);
+    expect(globalQueries).toEqual(["queried"]);
   });
 });

--- a/packages/calendar/tests/providers/outlook/source/provider.test.ts
+++ b/packages/calendar/tests/providers/outlook/source/provider.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { BunSQLDatabase } from "drizzle-orm/bun-sql";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import type { ProcessEventsOptions } from "../../../../src/core/oauth/source-provider";
 import type { SourceEvent, SourceSyncResult } from "../../../../src/core/types";
-import { OutlookSourceProvider } from "../../../../src/providers/outlook/source/provider";
+import {
+  createOutlookSourceProvider,
+  OutlookSourceProvider,
+} from "../../../../src/providers/outlook/source/provider";
 
 class TestableOutlookSourceProvider extends OutlookSourceProvider {
   runProcessEvents(events: SourceEvent[], options: ProcessEventsOptions): Promise<SourceSyncResult> {
@@ -11,6 +16,33 @@ class TestableOutlookSourceProvider extends OutlookSourceProvider {
 }
 
 describe("OutlookSourceProvider", () => {
+  it("scopes user-triggered source queries to the requested user", async () => {
+    const captured: { query: { sql: string; params: unknown[] } | null } = { query: null };
+    const selectBuilder = {
+      innerJoin: () => selectBuilder,
+      where: (condition: SQL) => {
+        captured.query = new PgDialect().sqlToQuery(condition);
+        return Promise.resolve([]);
+      },
+    };
+    const mockDatabase = {
+      select: () => ({
+        from: () => selectBuilder,
+      }),
+    } as unknown as BunSQLDatabase;
+    const provider = createOutlookSourceProvider({
+      database: mockDatabase,
+      oauthProvider: {
+        refreshAccessToken: () => Promise.reject(new Error("No sources should be synced")),
+      },
+    });
+
+    await provider.syncSourcesForUser("user-1");
+
+    expect(captured.query?.sql).toContain('"calendars"."userId" =');
+    expect(captured.query?.params).toContain("user-1");
+  });
+
   it("removes out-of-range events directly without triggering full resync", async () => {
     let outOfRangeDeleteCalled = false;
     const mockDatabase = {

--- a/services/api/src/utils/oauth-sources.ts
+++ b/services/api/src/utils/oauth-sources.ts
@@ -363,7 +363,7 @@ const hasExistingOAuthCalendar = async (
   return hasExistingOAuthCalendarWithDatabase(database, options);
 };
 
-const syncOAuthSourcesByProvider = async (providerId: string): Promise<void> => {
+const syncOAuthSourcesByProvider = async (userId: string, providerId: string): Promise<void> => {
   const { database, oauthProviders, refreshLockStore } = await import("@/context");
   const sourceProvider = getSourceProvider(providerId, {
     database,
@@ -373,7 +373,7 @@ const syncOAuthSourcesByProvider = async (providerId: string): Promise<void> => 
   if (!sourceProvider) {
     return;
   }
-  await sourceProvider.syncAllSources();
+  await sourceProvider.syncSourcesForUser(userId);
 };
 
 const createOAuthSourceRecordWithDatabase = async (
@@ -461,7 +461,7 @@ const createDefaultCreateOAuthSourceDependencies = (): CreateOAuthSourceDependen
   hasExistingCalendar: hasExistingOAuthCalendar,
   triggerSync: (userId, provider) => {
     spawnBackgroundJob("oauth-source-sync", { userId, provider }, async () => {
-      await syncOAuthSourcesByProvider(provider);
+      await syncOAuthSourcesByProvider(userId, provider);
       const { premiumService } = await import("@/context");
       const plan = await premiumService.getUserPlan(userId);
       if (!plan) {
@@ -707,7 +707,7 @@ const createDefaultImportOAuthAccountDependencies = (): ImportOAuthAccountDepend
   },
   triggerSync: (userId, provider) => {
     spawnBackgroundJob("oauth-account-import", { userId, provider }, async () => {
-      await syncOAuthSourcesByProvider(provider);
+      await syncOAuthSourcesByProvider(userId, provider);
       const { premiumService } = await import("@/context");
       const plan = await premiumService.getUserPlan(userId);
       if (!plan) {


### PR DESCRIPTION
## Summary
- add an explicit user-scoped OAuth source sync method while preserving intentional global syncs
- filter user-triggered Outlook source ingestion by calendar owner
- pass the initiating user through OAuth source creation/import background jobs
- add regression coverage for scoped and global source selection

## Validation
- calendar type check
- API type check
- 16 targeted calendar/API tests