### PR TITLE
fix: verify account ownership before sync invalidation

### DIFF
--- a/services/api/src/routes/api/accounts/[id].ts
+++ b/services/api/src/routes/api/accounts/[id].ts
@@ -52,7 +52,10 @@ const DELETE = withWideEvent(
     }
     const { id } = params;
 
-    await invalidateCalendarsForAccount(database, redis, id);
+    const owned = await invalidateCalendarsForAccount(database, redis, userId, id);
+    if (!owned) {
+      return ErrorResponse.notFound("Account not found").toResponse();
+    }
 
     const [deleted] = await database
       .delete(calendarAccountsTable)

--- a/services/api/src/utils/destinations.ts
+++ b/services/api/src/utils/destinations.ts
@@ -321,7 +321,10 @@ const deleteCalendarDestination = async (
   userId: string,
   accountId: string,
 ): Promise<boolean> => {
-  await invalidateCalendarsForAccount(database, redis, accountId);
+  const owned = await invalidateCalendarsForAccount(database, redis, userId, accountId);
+  if (!owned) {
+    return false;
+  }
 
   const result = await database
     .delete(calendarAccountsTable)

--- a/services/api/src/utils/invalidate-calendars.ts
+++ b/services/api/src/utils/invalidate-calendars.ts
@@ -1,5 +1,5 @@
-import { calendarsTable } from "@keeper.sh/database/schema";
-import { eq } from "drizzle-orm";
+import { calendarAccountsTable, calendarsTable } from "@keeper.sh/database/schema";
+import { and, eq } from "drizzle-orm";
 import type { BunSQLDatabase } from "drizzle-orm/bun-sql";
 import type Redis from "ioredis";
 
@@ -9,23 +9,38 @@ const INVALIDATION_TTL_SECONDS = 300;
 const invalidateCalendarsForAccount = async (
   database: BunSQLDatabase,
   redis: Redis,
+  userId: string,
   accountId: string,
-): Promise<void> => {
-  const calendars = await database
-    .select({ id: calendarsTable.id })
-    .from(calendarsTable)
-    .where(eq(calendarsTable.accountId, accountId));
+): Promise<boolean> => {
+  const ownedCalendars = await database
+    .select({ calendarId: calendarsTable.id })
+    .from(calendarAccountsTable)
+    .leftJoin(calendarsTable, eq(calendarsTable.accountId, calendarAccountsTable.id))
+    .where(
+      and(
+        eq(calendarAccountsTable.id, accountId),
+        eq(calendarAccountsTable.userId, userId),
+      ),
+    );
 
-  if (calendars.length === 0) {
-    return;
+  if (ownedCalendars.length === 0) {
+    return false;
+  }
+
+  const calendarIds = ownedCalendars
+    .map(({ calendarId }) => calendarId)
+    .filter((calendarId): calendarId is string => calendarId !== null);
+  if (calendarIds.length === 0) {
+    return true;
   }
 
   const pipeline = redis.pipeline();
-  for (const calendar of calendars) {
-    const key = `${INVALIDATION_PREFIX}${calendar.id}`;
+  for (const calendarId of calendarIds) {
+    const key = `${INVALIDATION_PREFIX}${calendarId}`;
     pipeline.set(key, "1", "EX", INVALIDATION_TTL_SECONDS);
   }
   await pipeline.exec();
+  return true;
 };
 
 export { invalidateCalendarsForAccount };

--- a/services/api/tests/utils/invalidate-calendars.test.ts
+++ b/services/api/tests/utils/invalidate-calendars.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { BunSQLDatabase } from "drizzle-orm/bun-sql";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import type Redis from "ioredis";
+import { invalidateCalendarsForAccount } from "../../src/utils/invalidate-calendars";
+
+interface CalendarRow {
+  calendarId: string | null;
+}
+
+type SelectBuilder = Promise<CalendarRow[]> & {
+  from: () => SelectBuilder;
+  leftJoin: () => SelectBuilder;
+  where: (condition: SQL) => SelectBuilder;
+};
+
+const createDatabase = (
+  rows: CalendarRow[],
+  capture?: { query: { sql: string; params: unknown[] } | null },
+): BunSQLDatabase => {
+  const builder = Promise.resolve(rows) as SelectBuilder;
+  builder.from = () => builder;
+  builder.leftJoin = () => builder;
+  builder.where = (condition) => {
+    if (capture) {
+      capture.query = new PgDialect().sqlToQuery(condition);
+    }
+    return builder;
+  };
+
+  return {
+    select: () => builder,
+  } as unknown as BunSQLDatabase;
+};
+
+const createRedis = () => {
+  const writes: [string, string, string, number][] = [];
+  let execCalls = 0;
+  const pipeline = {
+    exec: () => {
+      execCalls += 1;
+      return Promise.resolve([]);
+    },
+    set: (...args: [string, string, string, number]) => {
+      writes.push(args);
+      return pipeline;
+    },
+  };
+
+  return {
+    execCalls: () => execCalls,
+    redis: { pipeline: () => pipeline } as unknown as Redis,
+    writes,
+  };
+};
+
+describe("invalidateCalendarsForAccount", () => {
+  it("does not write invalidation keys when the account is not owned", async () => {
+    const { redis, writes, execCalls } = createRedis();
+    const captured: { query: { sql: string; params: unknown[] } | null } = { query: null };
+
+    const owned = await invalidateCalendarsForAccount(
+      createDatabase([], captured),
+      redis,
+      "attacker-user",
+      "victim-account",
+    );
+
+    expect(owned).toBe(false);
+    expect(writes).toEqual([]);
+    expect(execCalls()).toBe(0);
+    expect(captured.query?.sql).toContain('"calendar_accounts"."userId" =');
+    expect(captured.query?.params).toEqual(["victim-account", "attacker-user"]);
+  });
+
+  it("invalidates every calendar after ownership is established", async () => {
+    const { redis, writes, execCalls } = createRedis();
+
+    const owned = await invalidateCalendarsForAccount(
+      createDatabase([{ calendarId: "calendar-1" }, { calendarId: "calendar-2" }]),
+      redis,
+      "owner-user",
+      "owned-account",
+    );
+
+    expect(owned).toBe(true);
+    expect(writes).toEqual([
+      ["sync:invalidated:calendar-1", "1", "EX", 300],
+      ["sync:invalidated:calendar-2", "1", "EX", 300],
+    ]);
+    expect(execCalls()).toBe(1);
+  });
+
+  it("allows deleting an owned account that has no calendars", async () => {
+    const { redis, writes, execCalls } = createRedis();
+
+    const owned = await invalidateCalendarsForAccount(
+      createDatabase([{ calendarId: null }]),
+      redis,
+      "owner-user",
+      "empty-account",
+    );
+
+    expect(owned).toBe(true);
+    expect(writes).toEqual([]);
+    expect(execCalls()).toBe(0);
+  });
+});

--- a/services/api/tests/utils/invalidate-calendars.test.ts
+++ b/services/api/tests/utils/invalidate-calendars.test.ts
@@ -36,10 +36,10 @@ const createDatabase = (
 
 const createRedis = () => {
   const writes: [string, string, string, number][] = [];
-  let execCalls = 0;
+  const execCalls: string[] = [];
   const pipeline = {
     exec: () => {
-      execCalls += 1;
+      execCalls.push("executed");
       return Promise.resolve([]);
     },
     set: (...args: [string, string, string, number]) => {
@@ -49,7 +49,7 @@ const createRedis = () => {
   };
 
   return {
-    execCalls: () => execCalls,
+    execCalls,
     redis: { pipeline: () => pipeline } as unknown as Redis,
     writes,
   };
@@ -69,7 +69,7 @@ describe("invalidateCalendarsForAccount", () => {
 
     expect(owned).toBe(false);
     expect(writes).toEqual([]);
-    expect(execCalls()).toBe(0);
+    expect(execCalls).toEqual([]);
     expect(captured.query?.sql).toContain('"calendar_accounts"."userId" =');
     expect(captured.query?.params).toEqual(["victim-account", "attacker-user"]);
   });
@@ -89,7 +89,7 @@ describe("invalidateCalendarsForAccount", () => {
       ["sync:invalidated:calendar-1", "1", "EX", 300],
       ["sync:invalidated:calendar-2", "1", "EX", 300],
     ]);
-    expect(execCalls()).toBe(1);
+    expect(execCalls).toEqual(["executed"]);
   });
 
   it("allows deleting an owned account that has no calendars", async () => {
@@ -104,6 +104,6 @@ describe("invalidateCalendarsForAccount", () => {
 
     expect(owned).toBe(true);
     expect(writes).toEqual([]);
-    expect(execCalls()).toBe(0);
+    expect(execCalls).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- scope account calendar lookup by both account ID and user ID before writing invalidation keys
- return not found without Redis side effects for unowned accounts
- apply the ownership-safe path to both destination and account DELETE routes
- cover unauthorized, multi-calendar, and empty-account cases

## Validation
- API type check
- focused lint
- 3 regression tests