### PR TITLE
fix: persist versioned OAuth ingestion tokens

### DIFF
--- a/packages/calendar/src/providers/google/source/fetch-adapter.ts
+++ b/packages/calendar/src/providers/google/source/fetch-adapter.ts
@@ -1,6 +1,6 @@
 import type { FetchEventsResult } from "../../../core/sync-engine/ingest";
 import type { RedisRateLimiter } from "../../../core/utils/redis-rate-limiter";
-import { resolveSyncTokenForWindow } from "../../../core/oauth/sync-token";
+import { encodeStoredSyncToken, resolveSyncTokenForWindow } from "../../../core/oauth/sync-token";
 import { getOAuthSyncWindow, OAUTH_SYNC_WINDOW_VERSION } from "../../../core/oauth/sync-window";
 import { fetchCalendarEvents, parseGoogleEvents } from "./utils/fetch-events";
 
@@ -46,12 +46,19 @@ const createGoogleSourceFetcher = (config: GoogleSourceFetcherConfig): GoogleSou
 
     const events = parseGoogleEvents(result.events);
 
-    return {
+    const fetchResult: FetchEventsResult = {
       events,
-      nextSyncToken: result.nextSyncToken,
       cancelledEventUids: result.cancelledEventUids,
       isDeltaSync: result.isDeltaSync,
     };
+    if (result.nextSyncToken) {
+      fetchResult.nextSyncToken = encodeStoredSyncToken(
+        result.nextSyncToken,
+        OAUTH_SYNC_WINDOW_VERSION,
+      );
+    }
+
+    return fetchResult;
   };
 
   return { fetchEvents };

--- a/packages/calendar/src/providers/outlook/source/fetch-adapter.ts
+++ b/packages/calendar/src/providers/outlook/source/fetch-adapter.ts
@@ -1,5 +1,5 @@
 import type { FetchEventsResult } from "../../../core/sync-engine/ingest";
-import { resolveSyncTokenForWindow } from "../../../core/oauth/sync-token";
+import { encodeStoredSyncToken, resolveSyncTokenForWindow } from "../../../core/oauth/sync-token";
 import { getOAuthSyncWindow, OAUTH_SYNC_WINDOW_VERSION } from "../../../core/oauth/sync-window";
 import { fetchCalendarEvents, parseOutlookEvents } from "./utils/fetch-events";
 
@@ -44,12 +44,19 @@ const createOutlookSourceFetcher = (config: OutlookSourceFetcherConfig): Outlook
 
     const events = parseOutlookEvents(result.events);
 
-    return {
+    const fetchResult: FetchEventsResult = {
       events,
-      nextSyncToken: result.nextDeltaLink,
       cancelledEventUids: result.cancelledEventUids,
       isDeltaSync: result.isDeltaSync,
     };
+    if (result.nextDeltaLink) {
+      fetchResult.nextSyncToken = encodeStoredSyncToken(
+        result.nextDeltaLink,
+        OUTLOOK_SYNC_TOKEN_VERSION,
+      );
+    }
+
+    return fetchResult;
   };
 
   return { fetchEvents };

--- a/packages/calendar/tests/providers/google/source/fetch-adapter.test.ts
+++ b/packages/calendar/tests/providers/google/source/fetch-adapter.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { OAUTH_SYNC_WINDOW_VERSION } from "../../../../src/core/oauth/sync-window";
+import { resolveSyncTokenForWindow } from "../../../../src/core/oauth/sync-token";
+import { createGoogleSourceFetcher } from "../../../../src/providers/google/source/fetch-adapter";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
 
 describe("createGoogleSourceFetcher", () => {
-  it("returns a fetchEvents function that retrieves and parses Google Calendar events", async () => {
-    const { createGoogleSourceFetcher } = await import("../../../../src/providers/google/source/fetch-adapter");
-
+  it("returns a fetchEvents function that retrieves and parses Google Calendar events", () => {
     const fetcher = createGoogleSourceFetcher({
       accessToken: "test-token",
       externalCalendarId: "primary",
@@ -11,5 +18,31 @@ describe("createGoogleSourceFetcher", () => {
     });
 
     expect(typeof fetcher.fetchEvents).toBe("function");
+  });
+
+  it("returns a versioned token that the next cron run accepts", async () => {
+    const rawSyncToken = "google-sync-token";
+    const queuedFetch = (): Promise<Response> => Promise.resolve(Response.json({
+      items: [],
+      nextSyncToken: rawSyncToken,
+    }));
+    queuedFetch.preconnect = originalFetch.preconnect;
+    globalThis.fetch = queuedFetch;
+    const fetcher = createGoogleSourceFetcher({
+      accessToken: "test-token",
+      externalCalendarId: "primary",
+      syncToken: null,
+    });
+
+    const result = await fetcher.fetchEvents();
+
+    expect(result.nextSyncToken).not.toBe(rawSyncToken);
+    expect(resolveSyncTokenForWindow(
+      result.nextSyncToken ?? null,
+      OAUTH_SYNC_WINDOW_VERSION,
+    )).toEqual({
+      requiresBackfill: false,
+      syncToken: rawSyncToken,
+    });
   });
 });

--- a/packages/calendar/tests/providers/outlook/source/fetch-adapter.test.ts
+++ b/packages/calendar/tests/providers/outlook/source/fetch-adapter.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { OAUTH_SYNC_WINDOW_VERSION } from "../../../../src/core/oauth/sync-window";
+import { resolveSyncTokenForWindow } from "../../../../src/core/oauth/sync-token";
+import { createOutlookSourceFetcher } from "../../../../src/providers/outlook/source/fetch-adapter";
+
+const OUTLOOK_SYNC_TOKEN_VERSION = OAUTH_SYNC_WINDOW_VERSION + 1;
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
 
 describe("createOutlookSourceFetcher", () => {
-  it("returns a fetchEvents function", async () => {
-    const { createOutlookSourceFetcher } = await import("../../../../src/providers/outlook/source/fetch-adapter");
-
+  it("returns a fetchEvents function", () => {
     const fetcher = createOutlookSourceFetcher({
       accessToken: "test-token",
       externalCalendarId: "calendar-id",
@@ -11,5 +19,31 @@ describe("createOutlookSourceFetcher", () => {
     });
 
     expect(typeof fetcher.fetchEvents).toBe("function");
+  });
+
+  it("returns a versioned delta link that the next cron run accepts", async () => {
+    const rawDeltaLink = "https://graph.microsoft.com/delta?$deltatoken=next";
+    const queuedFetch = (): Promise<Response> => Promise.resolve(Response.json({
+      "@odata.deltaLink": rawDeltaLink,
+      value: [],
+    }));
+    queuedFetch.preconnect = originalFetch.preconnect;
+    globalThis.fetch = queuedFetch;
+    const fetcher = createOutlookSourceFetcher({
+      accessToken: "test-token",
+      externalCalendarId: "calendar-id",
+      syncToken: null,
+    });
+
+    const result = await fetcher.fetchEvents();
+
+    expect(result.nextSyncToken).not.toBe(rawDeltaLink);
+    expect(resolveSyncTokenForWindow(
+      result.nextSyncToken ?? null,
+      OUTLOOK_SYNC_TOKEN_VERSION,
+    )).toEqual({
+      requiresBackfill: false,
+      syncToken: rawDeltaLink,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- encode Google next-sync tokens at the cron fetch-adapter boundary
- encode Outlook delta links with the Outlook-specific sync-window version
- verify persisted adapter tokens are accepted by the next run without a backfill

## Validation
- calendar type check
- focused lint
- 8 targeted adapter/sync-token tests