### PR TITLE
fix: renew and verify destination sync locks

### DIFF
--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -1,5 +1,5 @@
 export { syncDestinationsForUser } from "./sync-user";
-export { invalidateCalendar, isCalendarInvalidated } from "./sync-lock";
+export { invalidateCalendar, isCalendarInvalidated, SyncLockRenewalError } from "./sync-lock";
 export type { InvalidationRedis } from "./sync-lock";
 export type { SyncConfig, SyncDestinationsResult } from "./sync-user";
 export type { OAuthConfig } from "./resolve-provider";

--- a/packages/sync/src/sync-lock.ts
+++ b/packages/sync/src/sync-lock.ts
@@ -21,6 +21,16 @@ interface SyncLockHandle {
   release: () => Promise<void>;
 }
 
+class SyncLockRenewalError extends Error {
+  public readonly calendarId: string;
+
+  public constructor(calendarId: string, cause: unknown) {
+    super(`Failed to renew sync lock for calendar ${calendarId}`, { cause });
+    this.name = "SyncLockRenewalError";
+    this.calendarId = calendarId;
+  }
+}
+
 interface AcquireSyncLockResult {
   acquired: true;
   handle: SyncLockHandle;
@@ -86,18 +96,26 @@ const RENEW_SCRIPT = `
 
 const createLockHandle = (
   redis: SyncLockRedis,
+  calendarId: string,
   lockKey: string,
   signalKey: string,
   invalidationKey: string,
   holderId: string,
 ): SyncLockHandle => {
-  const renewalTimer = setInterval(() => {
-    redis
-      .eval(RENEW_SCRIPT, 1, lockKey, holderId, String(LOCK_TTL_SECONDS))
-      .catch(() => false);
+  const renewalState: { error?: unknown } = {};
+  const renewalTimer = setInterval(async () => {
+    try {
+      await redis.eval(RENEW_SCRIPT, 1, lockKey, holderId, String(LOCK_TTL_SECONDS));
+    } catch (error) {
+      renewalState.error = error;
+    }
   }, LOCK_RENEW_INTERVAL_MS);
 
   const isCurrent = async (): Promise<boolean> => {
+    if ("error" in renewalState) {
+      throw new SyncLockRenewalError(calendarId, renewalState.error);
+    }
+
     const [lockHolder, pendingWaiter, invalidated] = await Promise.all([
       redis.get(lockKey),
       redis.get(signalKey),
@@ -139,7 +157,14 @@ const createSyncLock = (redis: SyncLockRedis) => {
     );
 
     if (result === "acquired") {
-      const handle = createLockHandle(redis, lockKey, signalKey, invalidationKey, holderId);
+      const handle = createLockHandle(
+        redis,
+        calendarId,
+        lockKey,
+        signalKey,
+        invalidationKey,
+        holderId,
+      );
       return { acquired: true, handle };
     }
 
@@ -167,7 +192,14 @@ const createSyncLock = (redis: SyncLockRedis) => {
         );
 
         if (retryResult === "acquired") {
-          const handle = createLockHandle(redis, lockKey, signalKey, invalidationKey, holderId);
+          const handle = createLockHandle(
+            redis,
+            calendarId,
+            lockKey,
+            signalKey,
+            invalidationKey,
+            holderId,
+          );
           return { acquired: true, handle };
         }
       }
@@ -192,5 +224,5 @@ const isCalendarInvalidated = async (redis: SyncLockRedis, calendarId: string): 
   return value !== null;
 };
 
-export { createSyncLock, invalidateCalendar, isCalendarInvalidated, LOCK_PREFIX, SIGNAL_PREFIX, INVALIDATION_PREFIX, LOCK_TTL_SECONDS, LOCK_RENEW_INTERVAL_MS, INVALIDATION_TTL_SECONDS, POLL_INTERVAL_MS };
+export { createSyncLock, invalidateCalendar, isCalendarInvalidated, SyncLockRenewalError, LOCK_PREFIX, SIGNAL_PREFIX, INVALIDATION_PREFIX, LOCK_TTL_SECONDS, LOCK_RENEW_INTERVAL_MS, INVALIDATION_TTL_SECONDS, POLL_INTERVAL_MS };
 export type { SyncLockHandle, SyncLockRedis, InvalidationRedis, AcquireSyncLockResult, SyncLockSkippedResult };

--- a/packages/sync/src/sync-lock.ts
+++ b/packages/sync/src/sync-lock.ts
@@ -2,6 +2,7 @@ const LOCK_PREFIX = "sync:lock:";
 const SIGNAL_PREFIX = "sync:signal:";
 const INVALIDATION_PREFIX = "sync:invalidated:";
 const LOCK_TTL_SECONDS = 120;
+const LOCK_RENEW_INTERVAL_MS = (LOCK_TTL_SECONDS * 1000) / 3;
 const INVALIDATION_TTL_SECONDS = 300;
 const POLL_INTERVAL_MS = 250;
 const POLL_TIMEOUT_MS = (LOCK_TTL_SECONDS * 1000) + 10_000;
@@ -74,6 +75,15 @@ const RELEASE_SCRIPT = `
   return 0
 `;
 
+const RENEW_SCRIPT = `
+  local holder = redis.call('GET', KEYS[1])
+  if holder == ARGV[1] then
+    redis.call('EXPIRE', KEYS[1], ARGV[2])
+    return 1
+  end
+  return 0
+`;
+
 const createLockHandle = (
   redis: SyncLockRedis,
   lockKey: string,
@@ -81,13 +91,20 @@ const createLockHandle = (
   invalidationKey: string,
   holderId: string,
 ): SyncLockHandle => {
+  const renewalTimer = setInterval(() => {
+    redis
+      .eval(RENEW_SCRIPT, 1, lockKey, holderId, String(LOCK_TTL_SECONDS))
+      .catch(() => false);
+  }, LOCK_RENEW_INTERVAL_MS);
+
   const isCurrent = async (): Promise<boolean> => {
-    const [pendingWaiter, invalidated] = await Promise.all([
+    const [lockHolder, pendingWaiter, invalidated] = await Promise.all([
+      redis.get(lockKey),
       redis.get(signalKey),
       redis.get(invalidationKey),
     ]);
 
-    if (invalidated !== null) {
+    if (lockHolder !== holderId || invalidated !== null) {
       return false;
     }
 
@@ -95,6 +112,7 @@ const createLockHandle = (
   };
 
   const release = async (): Promise<void> => {
+    clearInterval(renewalTimer);
     await redis.eval(RELEASE_SCRIPT, 1, lockKey, holderId);
   };
 
@@ -174,5 +192,5 @@ const isCalendarInvalidated = async (redis: SyncLockRedis, calendarId: string): 
   return value !== null;
 };
 
-export { createSyncLock, invalidateCalendar, isCalendarInvalidated, LOCK_PREFIX, SIGNAL_PREFIX, INVALIDATION_PREFIX, LOCK_TTL_SECONDS, INVALIDATION_TTL_SECONDS, POLL_INTERVAL_MS };
+export { createSyncLock, invalidateCalendar, isCalendarInvalidated, LOCK_PREFIX, SIGNAL_PREFIX, INVALIDATION_PREFIX, LOCK_TTL_SECONDS, LOCK_RENEW_INTERVAL_MS, INVALIDATION_TTL_SECONDS, POLL_INTERVAL_MS };
 export type { SyncLockHandle, SyncLockRedis, InvalidationRedis, AcquireSyncLockResult, SyncLockSkippedResult };

--- a/packages/sync/src/sync-user.ts
+++ b/packages/sync/src/sync-user.ts
@@ -219,6 +219,10 @@ const syncDestinationsForUser = async (
         },
       });
 
+      if (!(await handle.isCurrent())) {
+        continue;
+      }
+
       const invalidated = await isCalendarInvalidated(redis, destination.calendarId);
       if (invalidated) {
         continue;

--- a/packages/sync/tests/sync-lock.test.ts
+++ b/packages/sync/tests/sync-lock.test.ts
@@ -4,12 +4,14 @@ import {
   LOCK_PREFIX,
   LOCK_RENEW_INTERVAL_MS,
   LOCK_TTL_SECONDS,
+  SyncLockRenewalError,
   SIGNAL_PREFIX,
   POLL_INTERVAL_MS,
 } from "../src/sync-lock";
 
 const createMockRedis = () => {
   const store = new Map<string, { value: string; expiresAt: number | null }>();
+  const evalFailures: Error[] = [];
 
   const isExpired = (key: string): boolean => {
     const entry = store.get(key);
@@ -55,14 +57,18 @@ const createMockRedis = () => {
   };
 
   const evalImpl = (
-    script: string,
-    _keyCount: number,
+    _script: string,
+    keyCount: number,
     ...args: string[]
   ): Promise<unknown> => {
+    const evalFailure = evalFailures.shift();
+    if (evalFailure) {
+      return Promise.reject(new Error(evalFailure.message, { cause: evalFailure }));
+    }
+
     const lockKey = args[0] ?? "";
 
-    // ACQUIRE_OR_SIGNAL_SCRIPT (has two keys)
-    if (script.includes("KEYS[2]") && script.includes("return 'acquired'")) {
+    if (keyCount === 2 && args.length === 4) {
       const signalKey = args[1] ?? "";
       const holderId = args[2] ?? "";
       const ttlSeconds = Number(args[3]);
@@ -83,7 +89,7 @@ const createMockRedis = () => {
       return Promise.resolve("queued");
     }
 
-    if (script.includes("EXPIRE")) {
+    if (keyCount === 1 && args.length === 3) {
       const holderId = args[1] ?? "";
       const ttlSeconds = Number(args[2]);
       const holder = readValue(lockKey);
@@ -94,17 +100,26 @@ const createMockRedis = () => {
       return Promise.resolve(0);
     }
 
-    // RELEASE_SCRIPT (has one key)
-    const holderId = args[1] ?? "";
-    const holder = readValue(lockKey);
-    if (holder === holderId) {
-      del(lockKey);
-      return Promise.resolve(1);
+    if (keyCount === 1 && args.length === 2) {
+      const holderId = args[1] ?? "";
+      const holder = readValue(lockKey);
+      if (holder === holderId) {
+        del(lockKey);
+        return Promise.resolve(1);
+      }
+      return Promise.resolve(0);
     }
-    return Promise.resolve(0);
+
+    return Promise.reject(
+      new Error(`Unexpected EVAL call with ${keyCount} keys and ${args.length} arguments`),
+    );
   };
 
-  return { get, set, del, eval: evalImpl };
+  const rejectNextEval = (error: Error): void => {
+    evalFailures.push(error);
+  };
+
+  return { get, set, del, eval: evalImpl, rejectNextEval };
 };
 
 const flushAsync = async (): Promise<void> => {
@@ -225,6 +240,31 @@ describe("createSyncLock", () => {
 
       expect(await redis.get(`${LOCK_PREFIX}cal-1`)).not.toBeNull();
       expect(await result.handle.isCurrent()).toBe(true);
+      await result.handle.release();
+    });
+
+    it("surfaces Redis renewal failures through the lock handle", async () => {
+      const redis = createMockRedis();
+      const syncLock = createSyncLock(redis);
+      const result = await syncLock.acquire("cal-1");
+
+      if (!result.acquired) {
+        throw new Error("expected acquired");
+      }
+
+      const renewalFailure = new Error("Redis unavailable");
+      redis.rejectNextEval(renewalFailure);
+      vi.advanceTimersByTime(LOCK_RENEW_INTERVAL_MS);
+      await flushAsync();
+
+      await expect(result.handle.isCurrent()).rejects.toBeInstanceOf(SyncLockRenewalError);
+      await expect(result.handle.isCurrent()).rejects.toEqual(
+        expect.objectContaining({
+          calendarId: "cal-1",
+          cause: expect.objectContaining({ cause: renewalFailure }),
+          name: "SyncLockRenewalError",
+        }),
+      );
       await result.handle.release();
     });
   });
@@ -422,8 +462,7 @@ describe("createSyncLock", () => {
 
       // First detects supersession, does its work, flushes, releases
       expect(await first.handle.isCurrent()).toBe(false);
-      executionOrder.push("first:superseded");
-      executionOrder.push("first:flushed");
+      executionOrder.push("first:superseded", "first:flushed");
       await first.handle.release();
       executionOrder.push("first:released");
 

--- a/packages/sync/tests/sync-lock.test.ts
+++ b/packages/sync/tests/sync-lock.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createSyncLock, LOCK_PREFIX, SIGNAL_PREFIX, POLL_INTERVAL_MS } from "../src/sync-lock";
+import {
+  createSyncLock,
+  LOCK_PREFIX,
+  LOCK_RENEW_INTERVAL_MS,
+  LOCK_TTL_SECONDS,
+  SIGNAL_PREFIX,
+  POLL_INTERVAL_MS,
+} from "../src/sync-lock";
 
 const createMockRedis = () => {
   const store = new Map<string, { value: string; expiresAt: number | null }>();
@@ -74,6 +81,17 @@ const createMockRedis = () => {
         return Promise.resolve("replaced");
       }
       return Promise.resolve("queued");
+    }
+
+    if (script.includes("EXPIRE")) {
+      const holderId = args[1] ?? "";
+      const ttlSeconds = Number(args[2]);
+      const holder = readValue(lockKey);
+      if (holder === holderId) {
+        set(lockKey, holderId, "EX", ttlSeconds);
+        return Promise.resolve(1);
+      }
+      return Promise.resolve(0);
     }
 
     // RELEASE_SCRIPT (has one key)
@@ -164,6 +182,50 @@ describe("createSyncLock", () => {
 
       const current = await firstResult.handle.isCurrent();
       expect(current).toBe(false);
+    });
+
+    it("returns false when the holder no longer owns the lock key", async () => {
+      const { redis, syncLock } = makeSyncLock();
+      const result = await syncLock.acquire("cal-1");
+
+      if (!result.acquired) {
+        throw new Error("expected acquired");
+      }
+
+      redis.del(`${LOCK_PREFIX}cal-1`);
+
+      expect(await result.handle.isCurrent()).toBe(false);
+    });
+
+    it("returns false when another holder owns the lock key", async () => {
+      const { redis, syncLock } = makeSyncLock();
+      const result = await syncLock.acquire("cal-1");
+
+      if (!result.acquired) {
+        throw new Error("expected acquired");
+      }
+
+      redis.set(`${LOCK_PREFIX}cal-1`, "replacement-holder");
+
+      expect(await result.handle.isCurrent()).toBe(false);
+    });
+  });
+
+  describe("renewal", () => {
+    it("renews the lock before its original TTL expires", async () => {
+      const { redis, syncLock } = makeSyncLock();
+      const result = await syncLock.acquire("cal-1");
+
+      if (!result.acquired) {
+        throw new Error("expected acquired");
+      }
+
+      vi.advanceTimersByTime((LOCK_TTL_SECONDS * 1000) + LOCK_RENEW_INTERVAL_MS);
+      await flushAsync();
+
+      expect(await redis.get(`${LOCK_PREFIX}cal-1`)).not.toBeNull();
+      expect(await result.handle.isCurrent()).toBe(true);
+      await result.handle.release();
     });
   });
 

--- a/services/worker/src/processor.ts
+++ b/services/worker/src/processor.ts
@@ -3,7 +3,7 @@ import type { PushSyncJobPayload, PushSyncJobResult } from "@keeper.sh/queue";
 import { USER_TIMEOUT_MS } from "@keeper.sh/queue";
 import type { DestinationSyncResult } from "@keeper.sh/calendar";
 import { createSyncAggregateRuntime, mergeAbortSignals } from "@keeper.sh/calendar";
-import { syncDestinationsForUser } from "@keeper.sh/sync";
+import { syncDestinationsForUser, SyncLockRenewalError } from "@keeper.sh/sync";
 import { createBroadcastService } from "@keeper.sh/broadcast";
 import { syncStatusTable } from "@keeper.sh/database/schema";
 import { database, refreshLockRedis, refreshLockStore } from "./context";
@@ -25,6 +25,9 @@ const toError = (value: unknown): Error => {
 };
 
 const classifySyncError = (error: unknown): string => {
+  if (error instanceof SyncLockRenewalError) {
+    return "sync-lock-renewal-failed";
+  }
   if (typeof error === "string") {
     if (error.includes("conflict") || error.includes("409")) {
       return "sync-push-conflict";
@@ -197,7 +200,7 @@ const processJob = (
       };
     } catch (error) {
       widelog.set("outcome", "error");
-      widelog.errorFields(error, { slug: "push-sync-failed" });
+      widelog.errorFields(error, { slug: classifySyncError(error) });
       throw error;
     } finally {
       await Promise.all(pendingDestinationSyncs);


### PR DESCRIPTION
## Summary
- require the Redis lock value to match the current holder in `isCurrent`
- renew held locks with an ownership-checked Lua heartbeat
- retain heartbeat failures and surface a typed error through the normal sync checkpoint
- classify renewal failures in the worker existing Widelogger job context
- model Redis `EVAL` calls in tests by key/argument contract instead of inspecting Lua source text

## Validation
- sync package type check
- worker type check
- changed-file lint
- full sync suite: 24 tests