### PR TITLE
fix(api): validate ICS sources before transaction

### DIFF
--- a/services/api/src/utils/source-lifecycle.ts
+++ b/services/api/src/utils/source-lifecycle.ts
@@ -10,11 +10,16 @@ interface CreateSourceInput {
   url: string;
 }
 
+interface SourceCreationPreflightDependencies {
+  countExistingAccounts: (userId: string) => Promise<number>;
+  canAddAccount: (userId: string, existingAccountCount: number) => Promise<boolean>;
+  validateSourceUrl: (url: string) => Promise<void>;
+}
+
 interface CreateSourceDependencies<TSource extends SourceReference> {
   acquireAccountLock: (userId: string) => Promise<void>;
   countExistingAccounts: (userId: string) => Promise<number>;
   canAddAccount: (userId: string, existingAccountCount: number) => Promise<boolean>;
-  validateSourceUrl: (url: string) => Promise<void>;
   createCalendarAccount: (payload: {
     userId: string;
     displayName: string;
@@ -35,42 +40,74 @@ interface CreateSourceDependencies<TSource extends SourceReference> {
 }
 
 class SourceLimitError extends Error {
-  constructor() {
+  public constructor() {
     super("Account limit reached. Upgrade to Pro for unlimited accounts.");
+    this.name = "SourceLimitError";
   }
 }
+
+const getInvalidSourceUrlDetails = (cause: unknown): {
+  authRequired: boolean;
+  message: string;
+} => {
+  if (cause instanceof CalendarFetchError) {
+    return {
+      authRequired: cause.authRequired,
+      message: cause.message,
+    };
+  }
+
+  return {
+    authRequired: false,
+    message: "Invalid calendar URL",
+  };
+};
 
 class InvalidSourceUrlError extends Error {
   public readonly authRequired: boolean;
 
-  constructor(cause?: unknown) {
-    if (cause instanceof CalendarFetchError) {
-      super(cause.message);
-      this.authRequired = cause.authRequired;
-    } else {
-      super("Invalid calendar URL");
-      this.authRequired = false;
-    }
+  public constructor(cause?: unknown) {
+    const details = getInvalidSourceUrlDetails(cause);
+    super(details.message);
+    this.name = "InvalidSourceUrlError";
+    this.authRequired = details.authRequired;
     this.cause = cause;
   }
 }
 
-const runCreateSource = async <TSource extends SourceReference>(
-  input: CreateSourceInput,
-  dependencies: CreateSourceDependencies<TSource>,
-): Promise<TSource> => {
-  await dependencies.acquireAccountLock(input.userId);
-  const existingAccountCount = await dependencies.countExistingAccounts(input.userId);
-  const allowed = await dependencies.canAddAccount(input.userId, existingAccountCount);
+const assertAccountCanBeAdded = async (
+  userId: string,
+  dependencies: Pick<
+    SourceCreationPreflightDependencies,
+    "canAddAccount" | "countExistingAccounts"
+  >,
+): Promise<void> => {
+  const existingAccountCount = await dependencies.countExistingAccounts(userId);
+  const allowed = await dependencies.canAddAccount(userId, existingAccountCount);
   if (!allowed) {
     throw new SourceLimitError();
   }
+};
+
+const runSourceCreationPreflight = async (
+  input: CreateSourceInput,
+  dependencies: SourceCreationPreflightDependencies,
+): Promise<void> => {
+  await assertAccountCanBeAdded(input.userId, dependencies);
 
   try {
     await dependencies.validateSourceUrl(input.url);
   } catch (error) {
     throw new InvalidSourceUrlError(error);
   }
+};
+
+const runCreateSource = async <TSource extends SourceReference>(
+  input: CreateSourceInput,
+  dependencies: CreateSourceDependencies<TSource>,
+): Promise<TSource> => {
+  await dependencies.acquireAccountLock(input.userId);
+  await assertAccountCanBeAdded(input.userId, dependencies);
 
   const accountId = await dependencies.createCalendarAccount({
     displayName: input.url,
@@ -101,10 +138,12 @@ const runCreateSource = async <TSource extends SourceReference>(
 export {
   SourceLimitError,
   InvalidSourceUrlError,
+  runSourceCreationPreflight,
   runCreateSource,
 };
 export type {
   SourceReference,
   CreateSourceInput,
+  SourceCreationPreflightDependencies,
   CreateSourceDependencies,
 };

--- a/services/api/src/utils/sources.ts
+++ b/services/api/src/utils/sources.ts
@@ -11,6 +11,7 @@ import { enqueuePushSync } from "./enqueue-push-sync";
 import {
   SourceLimitError,
   InvalidSourceUrlError,
+  runSourceCreationPreflight,
   runCreateSource,
 } from "./source-lifecycle";
 import { applySourceSyncDefaults } from "./source-sync-defaults";
@@ -145,10 +146,27 @@ const validateSourceUrl = async (url: string): Promise<void> => {
   await pullRemoteCalendar("json", url, safeFetchOptions);
 };
 
-const createSource = (userId: string, name: string, url: string): Promise<Source> =>
-  database.transaction((tx) =>
+const countExistingAccounts = async (userId: string): Promise<number> => {
+  const [result] = await database
+    .select({ value: count() })
+    .from(calendarAccountsTable)
+    .where(eq(calendarAccountsTable.userId, userId));
+  return result?.value ?? 0;
+};
+
+const createSource = async (userId: string, name: string, url: string): Promise<Source> => {
+  const input = { userId, name, url };
+
+  await runSourceCreationPreflight(input, {
+    canAddAccount: (userIdToCheck, existingAccountCount) =>
+      premiumService.canAddAccount(userIdToCheck, existingAccountCount),
+    countExistingAccounts,
+    validateSourceUrl,
+  });
+
+  return database.transaction((tx) =>
     runCreateSource(
-      { userId, name, url },
+      input,
       {
         acquireAccountLock: async (userIdToLock) => {
           await tx.execute(
@@ -200,10 +218,10 @@ const createSource = (userId: string, name: string, url: string): Promise<Source
           }
           await enqueuePushSync(enqueuedUserId, plan);
         },
-        validateSourceUrl,
       },
     ),
   );
+};
 
 export {
   SourceLimitError,

--- a/services/api/tests/utils/source-lifecycle.test.ts
+++ b/services/api/tests/utils/source-lifecycle.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import { CalendarFetchError } from "@keeper.sh/calendar/ics";
 import {
   SourceLimitError,
+  runSourceCreationPreflight,
   runCreateSource,
 } from "../../src/utils/source-lifecycle";
+import type { InvalidSourceUrlError } from "../../src/utils/source-lifecycle";
 
 interface TestSource {
   id: string;
@@ -27,6 +29,74 @@ const createSourceRecord = (overrides: Partial<TestSource> = {}): TestSource => 
 const missingSourceLifecycleCallback = (): Promise<void> =>
   Promise.reject(new Error("Expected background callback"));
 
+describe("runSourceCreationPreflight", () => {
+  it("rejects source creation before validation when the plan limit is exceeded", async () => {
+    let validationCalls = 0;
+
+    await expect(
+      runSourceCreationPreflight(
+        {
+          name: "Team Feed",
+          url: "https://example.com/team.ics",
+          userId: "user-1",
+        },
+        {
+          canAddAccount: () => Promise.resolve(false),
+          countExistingAccounts: () => Promise.resolve(3),
+          validateSourceUrl: () => {
+            validationCalls += 1;
+            return Promise.resolve();
+          },
+        },
+      ),
+    ).rejects.toBeInstanceOf(SourceLimitError);
+
+    expect(validationCalls).toBe(0);
+  });
+
+  it("wraps CalendarFetchError details in InvalidSourceUrlError", async () => {
+    const rejection = new CalendarFetchError("auth needed", 401);
+
+    await expect(
+      runSourceCreationPreflight(
+        {
+          name: "Team Feed",
+          url: "https://example.com/private.ics",
+          userId: "user-1",
+        },
+        {
+          canAddAccount: () => Promise.resolve(true),
+          countExistingAccounts: () => Promise.resolve(0),
+          validateSourceUrl: () => Promise.reject(rejection),
+        },
+      ),
+    ).rejects.toMatchObject({
+      authRequired: true,
+      message: "auth needed",
+    });
+  });
+
+  it("wraps unknown validation failures without exposing their details", async () => {
+    await expect(
+      runSourceCreationPreflight(
+        {
+          name: "Team Feed",
+          url: "https://example.com/broken.ics",
+          userId: "user-1",
+        },
+        {
+          canAddAccount: () => Promise.resolve(true),
+          countExistingAccounts: () => Promise.resolve(0),
+          validateSourceUrl: () => Promise.reject(new Error("internal detail")),
+        },
+      ),
+    ).rejects.toEqual(expect.objectContaining<Partial<InvalidSourceUrlError>>({
+      authRequired: false,
+      message: "Invalid calendar URL",
+    }));
+  });
+});
+
 describe("runCreateSource", () => {
   it("rejects source creation when plan limit is exceeded", async () => {
     await expect(
@@ -45,38 +115,9 @@ describe("runCreateSource", () => {
           fetchAndSyncSource: () => Promise.resolve(),
           spawnBackgroundJob: Boolean,
           enqueuePushSync: () => Promise.resolve(),
-          validateSourceUrl: () => Promise.resolve(),
         },
       ),
     ).rejects.toBeInstanceOf(SourceLimitError);
-  });
-
-  it("wraps CalendarFetchError details in InvalidSourceUrlError", async () => {
-    const rejection = new CalendarFetchError("auth needed", 401);
-
-    await expect(
-      runCreateSource(
-        {
-          name: "Team Feed",
-          url: "https://example.com/private.ics",
-          userId: "user-1",
-        },
-        {
-          acquireAccountLock: () => Promise.resolve(),
-          canAddAccount: () => Promise.resolve(true),
-          countExistingAccounts: () => Promise.resolve(0),
-          createCalendarAccount: () => Promise.resolve("account-1"),
-          createSourceCalendar: () => Promise.resolve(createSourceRecord()),
-          fetchAndSyncSource: () => Promise.resolve(),
-          spawnBackgroundJob: Boolean,
-          enqueuePushSync: () => Promise.resolve(),
-          validateSourceUrl: () => Promise.reject(rejection),
-        },
-      ),
-    ).rejects.toMatchObject({
-      authRequired: true,
-      message: "auth needed",
-    });
   });
 
   it("creates source and schedules background fetch-sync callback", async () => {
@@ -122,7 +163,6 @@ describe("runCreateSource", () => {
           syncedUserIds.push(userId);
           return Promise.resolve();
         },
-        validateSourceUrl: () => Promise.resolve(),
       },
     );
 
@@ -152,7 +192,6 @@ describe("runCreateSource", () => {
           fetchAndSyncSource: () => Promise.resolve(),
           spawnBackgroundJob: Boolean,
           enqueuePushSync: () => Promise.resolve(),
-          validateSourceUrl: () => Promise.resolve(),
         },
       ),
     ).rejects.toThrow("Failed to create calendar account");
@@ -176,7 +215,6 @@ describe("runCreateSource", () => {
           fetchAndSyncSource: () => Promise.resolve(),
           spawnBackgroundJob: Boolean,
           enqueuePushSync: () => Promise.resolve(),
-          validateSourceUrl: () => Promise.resolve(),
         },
       ),
     ).rejects.toThrow("Failed to create source");


### PR DESCRIPTION
## Summary
- run the account-limit preflight and remote ICS validation before opening a database transaction
- retain a second account-limit check under the per-user advisory lock before creating records
- preserve structured validation errors and cover both preflight and transactional lifecycle behavior

## Validation
- `bun run test` in `services/api` (185 tests)
- `bun run types` in `services/api`
- `bun x oxlint src/utils/source-lifecycle.ts tests/utils/source-lifecycle.test.ts`

The repository-wide API lint command still reports pre-existing violations in unrelated files.