### PR TITLE
test: avoid mutable call counters

### DIFF
--- a/packages/calendar/tests/core/oauth/create-source-provider.test.ts
+++ b/packages/calendar/tests/core/oauth/create-source-provider.test.ts
@@ -45,16 +45,16 @@ describe("createOAuthSourceProvider", () => {
   });
 
   it("keeps an explicit unscoped method for intentional global syncs", async () => {
-    let globalQueries = 0;
+    const globalQueries: string[] = [];
     const provider = createTestProvider({
       getAllSources: () => {
-        globalQueries += 1;
+        globalQueries.push("queried");
         return Promise.resolve([]);
       },
     });
 
     await provider.syncAllSources();
 
-    expect(globalQueries).toBe(1);
+    expect(globalQueries).toEqual(["queried"]);
   });
 });

--- a/services/api/tests/utils/source-lifecycle.test.ts
+++ b/services/api/tests/utils/source-lifecycle.test.ts
@@ -31,7 +31,7 @@ const missingSourceLifecycleCallback = (): Promise<void> =>
 
 describe("runSourceCreationPreflight", () => {
   it("rejects source creation before validation when the plan limit is exceeded", async () => {
-    let validationCalls = 0;
+    const validationCalls: string[] = [];
 
     await expect(
       runSourceCreationPreflight(
@@ -44,14 +44,14 @@ describe("runSourceCreationPreflight", () => {
           canAddAccount: () => Promise.resolve(false),
           countExistingAccounts: () => Promise.resolve(3),
           validateSourceUrl: () => {
-            validationCalls += 1;
+            validationCalls.push("validated");
             return Promise.resolve();
           },
         },
       ),
     ).rejects.toBeInstanceOf(SourceLimitError);
 
-    expect(validationCalls).toBe(0);
+    expect(validationCalls).toEqual([]);
   });
 
   it("wraps CalendarFetchError details in InvalidSourceUrlError", async () => {


### PR DESCRIPTION
## Summary
- replace mutable numeric call counters introduced by #430 and #438 with captured call arrays
- keep the tests declarative and consistent with the repository style

## Validation
- focused calendar OAuth source-provider tests
- focused API source-lifecycle tests
- changed-file lint