### PR TITLE
fix(calendar): require explicit OAuth source scope

### DIFF
--- a/packages/calendar/src/providers/google/source/provider.ts
+++ b/packages/calendar/src/providers/google/source/provider.ts
@@ -239,14 +239,14 @@ interface CreateGoogleSourceProviderConfig {
 
 const getGoogleSourcesWithCredentials = async (
   database: BunSQLDatabase,
-  userId?: string,
+  userId: string | null,
 ): Promise<GoogleSourceAccount[]> => {
   const sourceConditions = [
     eq(calendarsTable.calendarType, "oauth"),
     arrayContains(calendarsTable.capabilities, ["pull"]),
     eq(calendarAccountsTable.provider, GOOGLE_PROVIDER_ID),
   ];
-  if (userId) {
+  if (userId !== null) {
     sourceConditions.push(eq(calendarsTable.userId, userId));
   }
   const sources = await database
@@ -310,7 +310,7 @@ const createGoogleCalendarSourceProvider = (
     createProviderInstance: (providerConfig, oauth) =>
       new GoogleCalendarSourceProvider(providerConfig, oauth),
     database,
-    getAllSources: (db) => getGoogleSourcesWithCredentials(db),
+    getAllSources: (db) => getGoogleSourcesWithCredentials(db, null),
     getSourcesForUser: getGoogleSourcesWithCredentials,
     oauthProvider,
     refreshLockStore,

--- a/packages/calendar/src/providers/outlook/source/provider.ts
+++ b/packages/calendar/src/providers/outlook/source/provider.ts
@@ -261,14 +261,14 @@ interface CreateOutlookSourceProviderConfig {
 
 const getOutlookSourcesWithCredentials = async (
   database: BunSQLDatabase,
-  userId?: string,
+  userId: string | null,
 ): Promise<OutlookSourceAccount[]> => {
   const sourceConditions = [
     eq(calendarsTable.calendarType, "oauth"),
     arrayContains(calendarsTable.capabilities, ["pull"]),
     eq(calendarAccountsTable.provider, OUTLOOK_PROVIDER_ID),
   ];
-  if (userId) {
+  if (userId !== null) {
     sourceConditions.push(eq(calendarsTable.userId, userId));
   }
   const sources = await database
@@ -327,7 +327,7 @@ const createOutlookSourceProvider = (config: CreateOutlookSourceProviderConfig):
     createProviderInstance: (providerConfig, oauth) =>
       new OutlookSourceProvider(providerConfig, oauth),
     database,
-    getAllSources: (db) => getOutlookSourcesWithCredentials(db),
+    getAllSources: (db) => getOutlookSourcesWithCredentials(db, null),
     getSourcesForUser: getOutlookSourcesWithCredentials,
     oauthProvider,
     refreshLockStore,


### PR DESCRIPTION
## Summary
- require Google and Outlook source queries to receive an explicit scope argument
- use a user ID for user-triggered ingestion and explicit `null` only for intentional global ingestion
- prevent an omitted query argument from silently broadening a sync to every tenant

## Validation
- focused OAuth provider and factory tests: 9 tests
- calendar type check
- changed-file lint