### PR TITLE
fix: make push sync recoverable and observable

### DIFF
--- a/applications/web/src/providers/sync-provider-logic.ts
+++ b/applications/web/src/providers/sync-provider-logic.ts
@@ -12,6 +12,16 @@ interface AggregateDecision {
   nextSeq: number;
 }
 
+const resolveAggregateLastSyncedAt = (
+  currentLastSyncedAt: string | null,
+  nextAggregate: SyncAggregateData,
+): string | null => {
+  if ("lastSyncedAt" in nextAggregate) {
+    return nextAggregate.lastSyncedAt ?? null;
+  }
+  return currentLastSyncedAt;
+};
+
 const parseTimestampMs = (value: string | null | undefined): number | null => {
   if (!value) {
     return null;
@@ -106,5 +116,9 @@ const shouldAcceptAggregatePayload = (
   };
 };
 
-export { parseIncomingSocketAction, shouldAcceptAggregatePayload };
+export {
+  parseIncomingSocketAction,
+  resolveAggregateLastSyncedAt,
+  shouldAcceptAggregatePayload,
+};
 export type { IncomingSocketAction, AggregateDecision };

--- a/applications/web/src/providers/sync-provider.tsx
+++ b/applications/web/src/providers/sync-provider.tsx
@@ -3,6 +3,7 @@ import { useSetAtom } from "jotai";
 import { syncStateAtom, type CompositeSyncState } from "@/state/sync";
 import {
   parseIncomingSocketAction,
+  resolveAggregateLastSyncedAt,
   shouldAcceptAggregatePayload,
 } from "./sync-provider-logic";
 
@@ -145,10 +146,15 @@ const handleMessage = (
   clearInitialAggregateTimer(connectionState);
   connectionState.lastSeq = decision.nextSeq;
 
+  const lastSyncedAt = resolveAggregateLastSyncedAt(
+    connectionState.currentState.lastSyncedAt,
+    action.data,
+  );
+
   applyState(connectionState, setSyncState, {
     connected: true,
     hasReceivedAggregate: true,
-    lastSyncedAt: action.data.lastSyncedAt ?? null,
+    lastSyncedAt,
     progressPercent: resolveProgressPercent(action.data),
     seq: action.data.seq,
     syncEventsProcessed: action.data.syncEventsProcessed,

--- a/applications/web/tests/providers/sync-provider-logic.test.ts
+++ b/applications/web/tests/providers/sync-provider-logic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { CompositeSyncState, SyncAggregateData } from "@/state/sync";
 import {
   parseIncomingSocketAction,
+  resolveAggregateLastSyncedAt,
   shouldAcceptAggregatePayload,
 } from "../../src/providers/sync-provider-logic";
 
@@ -207,5 +208,23 @@ describe("shouldAcceptAggregatePayload", () => {
 
     expect(decision.accepted).toBe(false);
     expect(decision.nextSeq).toBe(50);
+  });
+});
+
+describe("resolveAggregateLastSyncedAt", () => {
+  it("preserves the current timestamp when an aggregate omits it", () => {
+    const next = createAggregate();
+    Reflect.deleteProperty(next, "lastSyncedAt");
+
+    expect(resolveAggregateLastSyncedAt("2026-03-08T12:00:00.000Z", next)).toBe(
+      "2026-03-08T12:00:00.000Z",
+    );
+  });
+
+  it("applies an explicit null timestamp", () => {
+    expect(resolveAggregateLastSyncedAt(
+      "2026-03-08T12:00:00.000Z",
+      createAggregate({ lastSyncedAt: null }),
+    )).toBeNull();
   });
 });

--- a/packages/calendar/src/core/events/content-hash.ts
+++ b/packages/calendar/src/core/events/content-hash.ts
@@ -2,10 +2,13 @@ import type { SyncableEvent } from "../types";
 import { resolveIsAllDayEvent } from "./all-day";
 
 type SyncableEventContent = Pick<SyncableEvent, "summary" | "description" | "location">
-  & Partial<Pick<SyncableEvent, "availability" | "isAllDay" | "startTime" | "endTime">>;
+  & Partial<Pick<
+    SyncableEvent,
+    "availability" | "isAllDay" | "startTime" | "endTime" | "startTimeZone"
+  >>;
 
 const normalizeText = (value?: string): string => value?.trim() ?? "";
-const normalizeAvailability = (value?: SyncableEvent["availability"]): string => value ?? "";
+const normalizeAvailability = (value?: SyncableEvent["availability"]): string => value ?? "busy";
 const resolveHashedAllDay = (event: SyncableEventContent): boolean => {
   if (event.startTime && event.endTime) {
     return resolveIsAllDayEvent({
@@ -25,6 +28,9 @@ const createSyncEventContentHash = (event: SyncableEventContent): string => {
     normalizeText(event.location),
     normalizeAvailability(event.availability),
     resolveHashedAllDay(event),
+    event.startTime?.toISOString() ?? "",
+    event.endTime?.toISOString() ?? "",
+    event.startTimeZone ?? "",
   ]);
 
   return new Bun.CryptoHasher("sha256").update(payload).digest("hex");

--- a/packages/calendar/src/core/sync-engine/index.ts
+++ b/packages/calendar/src/core/sync-engine/index.ts
@@ -18,6 +18,7 @@ const resolveOutcome = (superseded: boolean, invalidated: boolean): string => {
 interface OperationError {
   type: "add" | "remove";
   error: string;
+  errorType?: string;
   statusCode?: number;
 }
 
@@ -39,12 +40,20 @@ const processAddResults = (
     if (!operation || !pushResult?.success) {
       addFailed += 1;
       if (pushResult?.error) {
-        errors.push({ type: "add", error: pushResult.error });
+        errors.push({
+          type: "add",
+          error: pushResult.error,
+          ...(pushResult.errorType && { errorType: pushResult.errorType }),
+          ...(typeof pushResult.statusCode === "number" && { statusCode: pushResult.statusCode }),
+        });
       }
       continue;
     }
 
     if (!pushResult.remoteId) {
+      if (operation.staleMappingId) {
+        changes.deletes.push(operation.staleMappingId);
+      }
       continue;
     }
 
@@ -61,6 +70,9 @@ const processAddResults = (
       startTime: operation.event.startTime,
       endTime: operation.event.endTime,
     });
+    if (operation.staleMappingId) {
+      changes.deletes.push(operation.staleMappingId);
+    }
   }
 
   return { changes, added, addFailed, conflictsResolved, errors };
@@ -83,7 +95,12 @@ const processDeleteResults = (
     if (!operation || !deleteResult?.success) {
       removeFailed += 1;
       if (deleteResult?.error) {
-        errors.push({ type: "remove", error: deleteResult.error });
+        errors.push({
+          type: "remove",
+          error: deleteResult.error,
+          ...(deleteResult.errorType && { errorType: deleteResult.errorType }),
+          ...(typeof deleteResult.statusCode === "number" && { statusCode: deleteResult.statusCode }),
+        });
       }
       continue;
     }
@@ -104,33 +121,8 @@ interface ExecuteRemoteResult {
   conflictsResolved: number;
   errors: OperationError[];
   superseded: boolean;
+  checkpointRejected: boolean;
 }
-
-interface OperationRun {
-  type: "add" | "remove";
-  adds: Extract<SyncOperation, { type: "add" }>[];
-  removes: Extract<SyncOperation, { type: "remove" }>[];
-}
-
-const groupOperationRuns = (operations: SyncOperation[]): OperationRun[] => {
-  const runs: OperationRun[] = [];
-  let currentRun: OperationRun | null = null;
-
-  for (const operation of operations) {
-    if (!currentRun || currentRun.type !== operation.type) {
-      currentRun = { type: operation.type, adds: [], removes: [] };
-      runs.push(currentRun);
-    }
-
-    if (operation.type === "add") {
-      currentRun.adds.push(operation);
-    } else {
-      currentRun.removes.push(operation);
-    }
-  }
-
-  return runs;
-};
 
 interface RunResult {
   changes: PendingChanges;
@@ -171,9 +163,15 @@ const executeRemoveRun = async (
   };
 };
 
-const mergeRunResult = (state: ChunkedExecutionState, runResult: RunResult): void => {
-  state.changes.inserts.push(...runResult.changes.inserts);
-  state.changes.deletes.push(...runResult.changes.deletes);
+const mergeRunResult = (
+  state: ChunkedExecutionState,
+  runResult: RunResult,
+  includeChanges = true,
+): void => {
+  if (includeChanges) {
+    state.changes.inserts.push(...runResult.changes.inserts);
+    state.changes.deletes.push(...runResult.changes.deletes);
+  }
   state.result = {
     added: state.result.added + runResult.result.added,
     addFailed: state.result.addFailed + runResult.result.addFailed,
@@ -182,9 +180,15 @@ const mergeRunResult = (state: ChunkedExecutionState, runResult: RunResult): voi
   };
   state.conflictsResolved += runResult.conflictsResolved;
   state.errors.push(...runResult.errors);
+  if (includeChanges) {
+    for (const insert of runResult.changes.inserts) {
+      state.protectedRemoteUids.add(insert.destinationEventUid);
+    }
+  }
 };
 
 type ProgressCallback = (processed: number, total: number) => void;
+type CheckpointCallback = (changes: PendingChanges) => Promise<boolean>;
 
 const OPERATION_CHUNK_SIZE = 50;
 
@@ -203,7 +207,26 @@ interface ChunkedExecutionState {
   errors: OperationError[];
   processed: number;
   superseded: boolean;
+  checkpointRejected: boolean;
+  protectedRemoteUids: Set<string>;
 }
+
+const checkpointRun = async (
+  state: ChunkedExecutionState,
+  changes: PendingChanges,
+  checkpoint?: CheckpointCallback,
+): Promise<boolean> => {
+  if (!checkpoint || (changes.inserts.length === 0 && changes.deletes.length === 0)) {
+    return true;
+  }
+
+  const accepted = await checkpoint(changes);
+  if (accepted === false) {
+    state.checkpointRejected = true;
+    return false;
+  }
+  return true;
+};
 
 const checkSuperseded = async (
   state: ChunkedExecutionState,
@@ -220,7 +243,7 @@ const checkSuperseded = async (
   return false;
 };
 
-const executeChunkedAdds = async (
+const executeAdds = async (
   adds: Extract<SyncOperation, { type: "add" }>[],
   calendarId: string,
   provider: CalendarSyncProvider,
@@ -228,21 +251,23 @@ const executeChunkedAdds = async (
   totalOperations: number,
   isCurrent?: () => Promise<boolean>,
   onRunComplete?: ProgressCallback,
+  checkpoint?: CheckpointCallback,
 ): Promise<void> => {
-  const chunks = chunkOperations(adds, OPERATION_CHUNK_SIZE);
-  for (const chunk of chunks) {
-    if (state.superseded) {
-      return;
-    }
-    const runResult = await executeAddRun(chunk, calendarId, provider);
-    mergeRunResult(state, runResult);
-    state.processed += chunk.length;
-    onRunComplete?.(state.processed, totalOperations);
-    await checkSuperseded(state, isCurrent);
+  if (adds.length === 0) {
+    return;
   }
+
+  const runResult = await executeAddRun(adds, calendarId, provider);
+  mergeRunResult(state, runResult);
+  if (!(await checkpointRun(state, runResult.changes, checkpoint))) {
+    return;
+  }
+  state.processed += adds.length;
+  onRunComplete?.(state.processed, totalOperations);
+  await checkSuperseded(state, isCurrent);
 };
 
-const executeChunkedRemoves = async (
+const executeRemoves = async (
   removes: Extract<SyncOperation, { type: "remove" }>[],
   provider: CalendarSyncProvider,
   mappingsByDestinationUid: Map<string, EventMapping>,
@@ -250,19 +275,96 @@ const executeChunkedRemoves = async (
   totalOperations: number,
   isCurrent?: () => Promise<boolean>,
   onRunComplete?: ProgressCallback,
+  checkpoint?: CheckpointCallback,
 ): Promise<void> => {
-  const chunks = chunkOperations(removes, OPERATION_CHUNK_SIZE);
-  for (const chunk of chunks) {
-    if (state.superseded) {
+  if (removes.length === 0) {
+    return;
+  }
+
+  const actionable = removes.filter((operation) => !state.protectedRemoteUids.has(operation.uid));
+  if (actionable.length > 0) {
+    const runResult = await executeRemoveRun(actionable, provider, mappingsByDestinationUid);
+    mergeRunResult(state, runResult);
+    if (!(await checkpointRun(state, runResult.changes, checkpoint))) {
       return;
     }
-    const runResult = await executeRemoveRun(chunk, provider, mappingsByDestinationUid);
-    mergeRunResult(state, runResult);
-    state.processed += chunk.length;
-    onRunComplete?.(state.processed, totalOperations);
-    await checkSuperseded(state, isCurrent);
   }
+  state.processed += removes.length;
+  onRunComplete?.(state.processed, totalOperations);
+  await checkSuperseded(state, isCurrent);
 };
+
+const executeReplacements = async (
+  replacements: Extract<SyncOperation, { type: "replace" }>[],
+  calendarId: string,
+  provider: CalendarSyncProvider,
+  mappingsByDestinationUid: Map<string, EventMapping>,
+  state: ChunkedExecutionState,
+  totalOperations: number,
+  isCurrent?: () => Promise<boolean>,
+  onRunComplete?: ProgressCallback,
+  checkpoint?: CheckpointCallback,
+): Promise<void> => {
+  if (replacements.length === 0) {
+    return;
+  }
+
+  const removes: Extract<SyncOperation, { type: "remove" }>[] = replacements.map((operation) => ({
+    deleteId: operation.deleteId,
+    startTime: operation.event.startTime,
+    type: "remove",
+    uid: operation.uid,
+  }));
+  const deleteResults = await provider.deleteEvents(removes.map((operation) => operation.deleteId));
+  const processedRemoves = processDeleteResults(removes, deleteResults, mappingsByDestinationUid);
+  mergeRunResult(state, {
+    changes: { inserts: [], deletes: processedRemoves.deleteIds },
+    result: {
+      added: 0,
+      addFailed: 0,
+      removed: processedRemoves.removed,
+      removeFailed: processedRemoves.removeFailed,
+    },
+    conflictsResolved: 0,
+    errors: processedRemoves.errors,
+  }, false);
+
+  const adds: Extract<SyncOperation, { type: "add" }>[] = [];
+  for (let index = 0; index < replacements.length; index++) {
+    if (deleteResults[index]?.success) {
+      const replacement = replacements[index];
+      if (replacement) {
+        adds.push({
+          event: replacement.event,
+          staleMappingId: replacement.staleMappingId,
+          type: "add",
+        });
+      }
+    }
+  }
+
+  if (adds.length > 0) {
+    const addResult = await executeAddRun(adds, calendarId, provider);
+    mergeRunResult(state, addResult);
+    if (!(await checkpointRun(state, addResult.changes, checkpoint))) {
+      return;
+    }
+  }
+
+  state.processed += replacements.length * 2;
+  onRunComplete?.(state.processed, totalOperations);
+  await checkSuperseded(state, isCurrent);
+};
+
+const getOperationWeight = (operation: SyncOperation): number => {
+  if (operation.type === "replace") {
+    return 2;
+  }
+  return 1;
+};
+
+const getTotalOperationCount = (operations: SyncOperation[]): number =>
+  operations.reduce((total, operation) => total + getOperationWeight(operation), 0);
 
 const executeRemoteOperations = async (
   operations: SyncOperation[],
@@ -271,14 +373,15 @@ const executeRemoteOperations = async (
   provider: CalendarSyncProvider,
   isCurrent?: () => Promise<boolean>,
   onRunComplete?: ProgressCallback,
+  checkpoint?: CheckpointCallback,
 ): Promise<ExecuteRemoteResult> => {
   const mappingsByDestinationUid = new Map<string, EventMapping>();
   for (const mapping of existingMappings) {
     mappingsByDestinationUid.set(mapping.destinationEventUid, mapping);
   }
 
-  const runs = groupOperationRuns(operations);
-  const totalOperations = operations.length;
+  const operationChunks = chunkOperations(operations, OPERATION_CHUNK_SIZE);
+  const totalOperations = getTotalOperationCount(operations);
   const state: ChunkedExecutionState = {
     changes: { inserts: [], deletes: [] },
     result: { added: 0, addFailed: 0, removed: 0, removeFailed: 0 },
@@ -286,23 +389,75 @@ const executeRemoteOperations = async (
     errors: [],
     processed: 0,
     superseded: false,
+    checkpointRejected: false,
+    protectedRemoteUids: new Set<string>(),
   };
 
-  for (const run of runs) {
-    if (state.superseded) {
+  for (const chunk of operationChunks) {
+    if (state.superseded || state.checkpointRejected) {
       break;
     }
 
-    if (run.type === "add" && run.adds.length > 0) {
-      await executeChunkedAdds(run.adds, calendarId, provider, state, totalOperations, isCurrent, onRunComplete);
+    const removes = chunk.filter(
+      (operation): operation is Extract<SyncOperation, { type: "remove" }> => operation.type === "remove",
+    );
+    await executeRemoves(
+      removes,
+      provider,
+      mappingsByDestinationUid,
+      state,
+      totalOperations,
+      isCurrent,
+      onRunComplete,
+      checkpoint,
+    );
+
+    if (state.superseded || state.checkpointRejected) {
+      break;
     }
 
-    if (run.type === "remove" && run.removes.length > 0) {
-      await executeChunkedRemoves(run.removes, provider, mappingsByDestinationUid, state, totalOperations, isCurrent, onRunComplete);
+    const replacements = chunk.filter(
+      (operation): operation is Extract<SyncOperation, { type: "replace" }> => operation.type === "replace",
+    );
+    await executeReplacements(
+      replacements,
+      calendarId,
+      provider,
+      mappingsByDestinationUid,
+      state,
+      totalOperations,
+      isCurrent,
+      onRunComplete,
+      checkpoint,
+    );
+
+    if (state.superseded || state.checkpointRejected) {
+      break;
     }
+
+    const adds = chunk.filter(
+      (operation): operation is Extract<SyncOperation, { type: "add" }> => operation.type === "add",
+    );
+    await executeAdds(
+      adds,
+      calendarId,
+      provider,
+      state,
+      totalOperations,
+      isCurrent,
+      onRunComplete,
+      checkpoint,
+    );
   }
 
-  return { changes: state.changes, result: state.result, conflictsResolved: state.conflictsResolved, errors: state.errors, superseded: state.superseded };
+  return {
+    changes: state.changes,
+    result: state.result,
+    conflictsResolved: state.conflictsResolved,
+    errors: state.errors,
+    superseded: state.superseded,
+    checkpointRejected: state.checkpointRejected,
+  };
 };
 
 interface SyncCalendarOptions {
@@ -339,6 +494,7 @@ const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarR
 
   const startTime = Date.now();
   let flushed = false;
+  let checkpointInvalidated = false;
 
   const emitProgress = (stage: SyncProgressUpdate["stage"], localEventCount: number, remoteEventCount: number, progress?: { current: number; total: number }): void => {
     if (!onProgress) {
@@ -378,12 +534,12 @@ const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarR
       state.remoteEvents,
     );
 
-    const addCount = operations.filter((op) => op.type === "add").length;
-    const removeCount = operations.filter((op) => op.type === "remove").length;
+    const addCount = operations.filter((op) => op.type === "add" || op.type === "replace").length;
+    const removeCount = operations.filter((op) => op.type === "remove" || op.type === "replace").length;
 
     wideEvent["operations.add_count"] = addCount;
     wideEvent["operations.remove_count"] = removeCount;
-    wideEvent["operations.total"] = operations.length;
+    wideEvent["operations.total"] = addCount + removeCount;
     wideEvent["stale_mappings.count"] = staleMappingIds.length;
 
     if (operations.length === 0 && staleMappingIds.length === 0) {
@@ -396,7 +552,10 @@ const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarR
       return EMPTY_RESULT;
     }
 
-    emitProgress("processing", state.localEvents.length, state.remoteEvents.length, { current: 0, total: operations.length });
+    emitProgress("processing", state.localEvents.length, state.remoteEvents.length, {
+      current: 0,
+      total: getTotalOperationCount(operations),
+    });
 
     const outcome = await executeRemoteOperations(
       operations,
@@ -406,6 +565,16 @@ const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarR
       isCurrent,
       (processed, total) => {
         emitProgress("processing", state.localEvents.length, state.remoteEvents.length, { current: processed, total });
+      },
+      async (changes) => {
+        const invalidated = await isInvalidated?.() ?? false;
+        if (invalidated) {
+          checkpointInvalidated = true;
+          return false;
+        }
+        await flush(changes);
+        flushed = true;
+        return true;
       },
     );
 
@@ -420,13 +589,7 @@ const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarR
       wideEvent["operation_errors"] = outcome.errors;
     }
 
-    outcome.changes.deletes.push(...staleMappingIds);
-
-    const invalidated = await isInvalidated?.() ?? false;
-    if (!invalidated) {
-      await flush(outcome.changes);
-      flushed = true;
-    }
+    const invalidated = checkpointInvalidated || outcome.checkpointRejected || (await isInvalidated?.() ?? false);
 
     wideEvent["invalidated"] = invalidated;
     wideEvent["outcome"] = resolveOutcome(outcome.superseded, invalidated);

--- a/packages/calendar/src/core/sync/aggregate-runtime.ts
+++ b/packages/calendar/src/core/sync/aggregate-runtime.ts
@@ -164,12 +164,16 @@ const createSyncAggregateRuntime = (config: SyncAggregateRuntimeConfig): SyncAgg
       return;
     }
 
-    const syncedAt = new Date();
+    let syncedAt: Date | null = null;
 
     try {
-      await config.persistSyncStatus(result, syncedAt);
+      if (result.completedSuccessfully !== false) {
+        const completedAt = new Date();
+        await config.persistSyncStatus(result, completedAt);
+        syncedAt = completedAt;
+      }
     } finally {
-      const aggregate = tracker.trackDestinationSync(result, syncedAt.toISOString());
+      const aggregate = tracker.trackDestinationSync(result, syncedAt?.toISOString());
       if (aggregate) {
         await emitSyncAggregate(result.userId, aggregate);
       }

--- a/packages/calendar/src/core/sync/aggregate-tracker.ts
+++ b/packages/calendar/src/core/sync/aggregate-tracker.ts
@@ -244,13 +244,17 @@ class SyncAggregateTracker {
 
   trackDestinationSync(
     result: DestinationSyncResult,
-    lastSyncedAt: string,
+    lastSyncedAt?: string,
   ): SyncAggregateMessage | null {
     const progress = this.getUserProgress(result.userId);
     const current = progress.get(result.calendarId);
     progress.set(result.calendarId, SyncAggregateTracker.finalizeEntry(current));
 
-    const payload = this.computeSnapshot(result.userId, { lastSyncedAt });
+    const options: { lastSyncedAt?: string } = {};
+    if (lastSyncedAt) {
+      options.lastSyncedAt = lastSyncedAt;
+    }
+    const payload = this.computeSnapshot(result.userId, options);
     return this.maybeEmit(result.userId, payload);
   }
 

--- a/packages/calendar/src/core/sync/operations.ts
+++ b/packages/calendar/src/core/sync/operations.ts
@@ -28,7 +28,7 @@ const identifyStaleMappings = (
   mappings: EventMapping[],
   localEventIds: Set<string>,
   remoteEventUids: Set<string>,
-  localEventHashes: Map<string, string>,
+  localEventsById: Map<string, SyncableEvent>,
 ): StaleMappingResult => {
   const staleMappingIds: string[] = [];
   const staleMappedEventIds = new Set<string>();
@@ -48,13 +48,17 @@ const identifyStaleMappings = (
       continue;
     }
 
-    const localEventHash = localEventHashes.get(mapping.eventStateId);
-    if (!localEventHash) {
+    const localEvent = localEventsById.get(mapping.eventStateId);
+    if (!localEvent) {
       continue;
     }
 
-    if (mapping.syncEventHash !== localEventHash) {
+    const localEventHash = createSyncEventContentHash(localEvent);
+    const eventContentChanged = mapping.syncEventHash !== localEventHash;
+
+    if (eventContentChanged) {
       staleMappingIds.push(mapping.id);
+      staleMappedEventIds.add(mapping.eventStateId);
       staleRemoteMappings.push(mapping);
     }
   }
@@ -70,11 +74,16 @@ const buildAddOperations = (
   const operations: SyncOperation[] = [];
 
   for (const event of localEvents) {
-    const hasMapping = existingMappings.some((mapping) => mapping.eventStateId === event.id);
+    const existingMapping = existingMappings.find((mapping) => mapping.eventStateId === event.id);
+    const hasMapping = Boolean(existingMapping);
     const hasStaleMapping = staleMappedEventIds.has(event.id);
 
     if (!hasMapping || hasStaleMapping) {
-      operations.push({ event, type: "add" });
+      operations.push({
+        event,
+        type: "add",
+        ...(hasStaleMapping && existingMapping && { staleMappingId: existingMapping.id }),
+      });
     }
   }
 
@@ -89,8 +98,29 @@ const buildRemoveOperationsForMappings = (mappings: EventMapping[]): SyncOperati
     uid: mapping.destinationEventUid,
   }));
 
+const buildReplacementOperations = (
+  mappings: EventMapping[],
+  localEventsById: Map<string, SyncableEvent>,
+): SyncOperation[] => {
+  const operations: SyncOperation[] = [];
+  for (const mapping of mappings) {
+    const event = localEventsById.get(mapping.eventStateId);
+    if (!event) {
+      continue;
+    }
+    operations.push({
+      deleteId: mapping.deleteIdentifier,
+      event,
+      staleMappingId: mapping.id,
+      type: "replace",
+      uid: mapping.destinationEventUid,
+    });
+  }
+  return operations;
+};
+
 const getOperationEventTime = (operation: SyncOperation): Date => {
-  if (operation.type === "add") {
+  if (operation.type === "add" || operation.type === "replace") {
     return operation.event.startTime;
   }
   return operation.startTime;
@@ -166,18 +196,19 @@ const computeSyncOperations = (
   timeBoundary: RemoveOperationTimeBoundary = getDefaultTimeBoundary(),
 ): ComputeSyncOperationsResult => {
   const localEventIds = new Set(localEvents.map((event) => event.id));
-  const localEventHashes = new Map(
-    localEvents.map((event) => [event.id, createSyncEventContentHash(event)]),
-  );
+  const localEventsById = new Map(localEvents.map((event) => [event.id, event]));
   const remoteEventUids = new Set(remoteEvents.map((event) => event.uid));
   const mappedDestinationUids = new Set(
     existingMappings.map(({ destinationEventUid }) => destinationEventUid),
   );
 
   const { staleMappingIds, staleMappedEventIds, staleRemoteMappings } =
-    identifyStaleMappings(existingMappings, localEventIds, remoteEventUids, localEventHashes);
+    identifyStaleMappings(existingMappings, localEventIds, remoteEventUids, localEventsById);
 
-  const addOperations = buildAddOperations(localEvents, existingMappings, staleMappedEventIds);
+  const replacedEventIds = new Set(staleRemoteMappings.map((mapping) => mapping.eventStateId));
+  const addOperations = buildAddOperations(localEvents, existingMappings, staleMappedEventIds)
+    .filter((operation) => operation.type !== "add" || !replacedEventIds.has(operation.event.id));
+  const replacementOperations = buildReplacementOperations(staleRemoteMappings, localEventsById);
 
   const removeOperations = buildRemoveOperations(
     existingMappings,
@@ -187,13 +218,11 @@ const computeSyncOperations = (
     timeBoundary,
   );
 
-  const staleMappingRemoveOperations = buildRemoveOperationsForMappings(staleRemoteMappings);
-
   return {
     operations: sortOperationsByTime([
       ...addOperations,
       ...removeOperations,
-      ...staleMappingRemoveOperations,
+      ...replacementOperations,
     ]),
     staleMappingIds,
   };
@@ -203,6 +232,7 @@ export {
   buildAddOperations,
   buildRemoveOperations,
   buildRemoveOperationsForMappings,
+  buildReplacementOperations,
   computeSyncOperations,
   identifyStaleMappings,
 };

--- a/packages/calendar/src/core/sync/types.ts
+++ b/packages/calendar/src/core/sync/types.ts
@@ -4,6 +4,7 @@ interface DestinationSyncResult {
   localEventCount: number;
   remoteEventCount: number;
   broadcast?: boolean;
+  completedSuccessfully?: boolean;
 }
 
 type SyncStage = "fetching" | "comparing" | "processing" | "error";

--- a/packages/calendar/src/core/types.ts
+++ b/packages/calendar/src/core/types.ts
@@ -67,6 +67,8 @@ interface PushResult {
   remoteId?: string;
   deleteId?: string;
   error?: string;
+  errorType?: string;
+  statusCode?: number;
   shouldContinue?: boolean;
   conflictResolved?: boolean;
 }
@@ -74,6 +76,8 @@ interface PushResult {
 interface DeleteResult {
   success: boolean;
   error?: string;
+  errorType?: string;
+  statusCode?: number;
   shouldContinue?: boolean;
 }
 
@@ -93,8 +97,15 @@ interface RemoteEvent {
 }
 
 type SyncOperation =
-  | { type: "add"; event: SyncableEvent }
-  | { type: "remove"; uid: string; deleteId: string; startTime: Date };
+  | { type: "add"; event: SyncableEvent; staleMappingId?: string }
+  | { type: "remove"; uid: string; deleteId: string; startTime: Date }
+  | {
+    type: "replace";
+    event: SyncableEvent;
+    staleMappingId: string;
+    uid: string;
+    deleteId: string;
+  };
 
 interface ListRemoteEventsOptions {
   until: Date;

--- a/packages/calendar/src/core/utils/rate-limiter.ts
+++ b/packages/calendar/src/core/utils/rate-limiter.ts
@@ -1,4 +1,7 @@
-type QueuedTask = () => Promise<void>;
+interface QueuedTask {
+  start: () => Promise<void>;
+  cancel: () => void;
+}
 
 const INITIAL_BACKOFF_MS = 1000;
 const MAX_BACKOFF_MS = 60_000;
@@ -16,6 +19,17 @@ interface RateLimiterConfig {
   concurrency?: number;
   requestsPerMinute?: number;
 }
+
+const createAbortError = (signal: AbortSignal): Error => {
+  let message = "The operation was aborted";
+  const { reason } = signal;
+  if (reason instanceof Error) {
+    ({ message } = reason);
+  }
+  const error = new Error(message);
+  error.name = "AbortError";
+  return error;
+};
 
 class RateLimiter {
   private readonly concurrency: number;
@@ -36,18 +50,61 @@ class RateLimiter {
     this.backoffMs = this.initialBackoffMs;
   }
 
-  execute<TResult>(operation: () => Promise<TResult>): Promise<TResult> {
-    const { promise, resolve, reject } = Promise.withResolvers<TResult>();
+  execute<TResult>(operation: () => Promise<TResult>, signal?: AbortSignal): Promise<TResult> {
+    if (signal?.aborted) {
+      return Promise.reject(createAbortError(signal));
+    }
 
-    const task: QueuedTask = async (): Promise<void> => {
-      try {
-        const result = await operation();
-        this.resetBackoff();
-        resolve(result);
-      } catch (error) {
-        reject(error);
+    const { promise, resolve, reject } = Promise.withResolvers<TResult>();
+    let status: "queued" | "active" | "settled" = "queued";
+    let abortListener: (() => void) | null = null;
+
+    const cleanup = (): void => {
+      if (abortListener) {
+        signal?.removeEventListener("abort", abortListener);
+        abortListener = null;
       }
     };
+
+    const task: QueuedTask = {
+      start: async (): Promise<void> => {
+        if (status !== "queued") {
+          return;
+        }
+        status = "active";
+        cleanup();
+
+        try {
+          const result = await operation();
+          this.resetBackoff();
+          status = "settled";
+          resolve(result);
+        } catch (error) {
+          status = "settled";
+          reject(error);
+        }
+      },
+      cancel: (): void => {
+        if (status !== "queued") {
+          return;
+        }
+        status = "settled";
+        cleanup();
+        const index = this.queue.indexOf(task);
+        if (index !== -1) {
+          this.queue.splice(index, 1);
+        }
+        if (signal) {
+          reject(createAbortError(signal));
+        } else {
+          reject(new Error("The operation was aborted"));
+        }
+        this.processQueue();
+      },
+    };
+
+    abortListener = (): void => task.cancel();
+    signal?.addEventListener("abort", abortListener, { once: true });
 
     this.queue.push(task);
     this.processQueue();
@@ -151,7 +208,7 @@ class RateLimiter {
 
   private async executeTask(task: QueuedTask): Promise<void> {
     try {
-      await task();
+      await task.start();
     } finally {
       this.activeCount--;
       this.processQueue();

--- a/packages/calendar/src/providers/caldav/destination/provider.ts
+++ b/packages/calendar/src/providers/caldav/destination/provider.ts
@@ -1,9 +1,10 @@
 import { RateLimiter } from "../../../core/utils/rate-limiter";
 import { generateDeterministicEventUid, isKeeperEvent } from "../../../core/events/identity";
+import { createSyncEventContentHash } from "../../../core/events/content-hash";
 import { getErrorMessage } from "../../../core/utils/error";
 import type { DeleteResult, PushResult, RemoteEvent, SyncableEvent } from "../../../core/types";
-import { CalDAVClient } from "../shared/client";
-import { eventToICalString, parseICalToRemoteEvents } from "../shared/ics";
+import { CalDAVClient, CalDAVCreateConflictError, CalDAVHttpError } from "../shared/client";
+import { eventToICalString, parseICalToRemoteEvent, parseICalToRemoteEvents } from "../shared/ics";
 import { getCalDAVSyncWindow } from "../shared/sync-window";
 import type { SafeFetchOptions } from "../../../utils/safe-fetch";
 
@@ -18,6 +19,100 @@ interface CalDAVSyncProviderConfig {
   password: string;
   safeFetchOptions?: SafeFetchOptions;
 }
+
+class CalDAVConflictRecoveryError extends Error {
+  constructor(uid: string, cause: unknown) {
+    super(
+      `CalDAV create conflict recovery failed for event ${uid}: ${getErrorMessage(cause)}`,
+      { cause },
+    );
+    this.name = "CalDAVConflictRecoveryError";
+  }
+}
+
+const findCalDAVHttpError = (value: unknown): CalDAVHttpError | null => {
+  let candidate = value;
+  const visited = new Set<unknown>();
+
+  while (candidate instanceof Error && !visited.has(candidate)) {
+    if (candidate instanceof CalDAVHttpError) {
+      return candidate;
+    }
+    visited.add(candidate);
+    candidate = candidate.cause;
+  }
+  return null;
+};
+
+const createFailureResult = (error: unknown): {
+  error: string;
+  errorType: string;
+  statusCode?: number;
+  success: false;
+} => {
+  const httpError = findCalDAVHttpError(error);
+  let errorType = "UnknownError";
+  if (error instanceof Error) {
+    errorType = error.name;
+  }
+  return {
+    error: getErrorMessage(error),
+    errorType,
+    ...(httpError && { statusCode: httpError.status }),
+    success: false,
+  };
+};
+
+const recoverCreateConflict = async (
+  client: CalDAVClient,
+  calendarUrl: string,
+  uid: string,
+  iCalString: string,
+  event: SyncableEvent,
+): Promise<void> => {
+  const existing = await client.fetchCalendarObject({
+    calendarUrl,
+    filename: `${uid}.ics`,
+  });
+
+  if (!existing?.data) {
+    throw new Error(`CalDAV event ${uid} already exists but could not be fetched`);
+  }
+
+  const remoteEvent = parseICalToRemoteEvent(existing.data);
+  let remoteEventHash: string | null = null;
+  if (remoteEvent) {
+    remoteEventHash = createSyncEventContentHash({
+      availability: remoteEvent.availability,
+      description: remoteEvent.description,
+      endTime: remoteEvent.endTime,
+      isAllDay: remoteEvent.isAllDay,
+      location: remoteEvent.location,
+      startTime: remoteEvent.startTime,
+      startTimeZone: remoteEvent.startTimeZone,
+      summary: remoteEvent.title ?? "",
+    });
+  }
+
+  if (remoteEvent?.uid === uid && remoteEventHash === createSyncEventContentHash(event)) {
+    return;
+  }
+
+  if (!existing.etag) {
+    throw new Error(`CalDAV event ${uid} already exists but has no ETag for a safe recreation`);
+  }
+
+  await client.deleteCalendarObject({
+    calendarUrl,
+    filename: `${uid}.ics`,
+    etag: existing.etag,
+  });
+  await client.createCalendarObject({
+    calendarUrl,
+    filename: `${uid}.ics`,
+    iCalString,
+  });
+};
 
 const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
   const client = new CalDAVClient({
@@ -36,17 +131,33 @@ const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
             const uid = generateDeterministicEventUid(event.id);
             const iCalString = eventToICalString(event, uid);
 
-            await client.createCalendarObject({
-              calendarUrl: config.calendarUrl,
-              filename: `${uid}.ics`,
-              iCalString,
-            });
+            try {
+              await client.createCalendarObject({
+                calendarUrl: config.calendarUrl,
+                filename: `${uid}.ics`,
+                iCalString,
+              });
+            } catch (error) {
+              if (!(error instanceof CalDAVCreateConflictError)) {
+                throw error;
+              }
 
-            return { remoteId: uid, success: true };
+              try {
+                await recoverCreateConflict(client, config.calendarUrl, uid, iCalString, event);
+              } catch (recoveryError) {
+                throw new CalDAVConflictRecoveryError(uid, recoveryError);
+              }
+              return { conflictResolved: true, deleteId: uid, remoteId: uid, success: true };
+            }
+
+            return { deleteId: uid, remoteId: uid, success: true };
           } catch (error) {
-            return { error: getErrorMessage(error), success: false };
+            if (config.safeFetchOptions?.signal?.aborted) {
+              throw error;
+            }
+            return createFailureResult(error);
           }
-        }),
+        }, config.safeFetchOptions?.signal),
       ),
     );
 
@@ -61,13 +172,16 @@ const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
             });
             return { success: true };
           } catch (error) {
-            const notFound = error instanceof Error && error.message.includes("404");
+            if (config.safeFetchOptions?.signal?.aborted) {
+              throw error;
+            }
+            const notFound = error instanceof CalDAVHttpError && error.status === 404;
             if (notFound) {
               return { success: true };
             }
-            return { error: getErrorMessage(error), success: false };
+            return createFailureResult(error);
           }
-        }),
+        }, config.safeFetchOptions?.signal),
       ),
     );
 

--- a/packages/calendar/src/providers/caldav/shared/client.ts
+++ b/packages/calendar/src/providers/caldav/shared/client.ts
@@ -11,6 +11,41 @@ interface CalendarObject {
   data?: string;
 }
 
+type CalDAVWriteOperation = "create" | "delete";
+
+class CalDAVHttpError extends Error {
+  readonly operation: CalDAVWriteOperation;
+  readonly status: number;
+
+  constructor(response: Response, operation: CalDAVWriteOperation) {
+    super(`CalDAV ${operation} failed: ${response.status} ${response.statusText}`.trim());
+    this.name = "CalDAVHttpError";
+    this.operation = operation;
+    this.status = response.status;
+  }
+}
+
+class CalDAVCreateConflictError extends CalDAVHttpError {
+  constructor(response: Response) {
+    super(response, "create");
+    this.name = "CalDAVCreateConflictError";
+  }
+}
+
+const releaseResponseBody = async (response: Response): Promise<void> => {
+  await response.body?.cancel();
+};
+
+const assertSuccessfulResponse = async (
+  response: Response,
+  operation: CalDAVWriteOperation,
+): Promise<void> => {
+  await releaseResponseBody(response);
+  if (!response.ok) {
+    throw new CalDAVHttpError(response, operation);
+  }
+};
+
 type DAVClientInstance = Awaited<ReturnType<typeof createDAVClient>>;
 
 const getDisplayName = (name: unknown): string => {
@@ -104,18 +139,40 @@ class CalDAVClient {
       iCalString: params.iCalString,
     });
 
-    await response.body?.cancel?.();
+    if (response.status === 412) {
+      await releaseResponseBody(response);
+      throw new CalDAVCreateConflictError(response);
+    }
+    await assertSuccessfulResponse(response, "create");
   }
 
-  async deleteCalendarObject(params: { calendarUrl: string; filename: string }): Promise<void> {
+  async deleteCalendarObject(params: {
+    calendarUrl: string;
+    filename: string;
+    etag?: string;
+  }): Promise<void> {
     const client = await this.getClient();
     const objectUrl = CalDAVClient.normalizeUrl(params.calendarUrl, params.filename);
 
     const response = await client.deleteCalendarObject({
-      calendarObject: { url: objectUrl },
+      calendarObject: { url: objectUrl, etag: params.etag },
     });
 
-    await response.body?.cancel?.();
+    await assertSuccessfulResponse(response, "delete");
+  }
+
+  async fetchCalendarObject(params: {
+    calendarUrl: string;
+    filename: string;
+  }): Promise<CalendarObject | null> {
+    const client = await this.getClient();
+    const objectUrl = CalDAVClient.normalizeUrl(params.calendarUrl, params.filename);
+    const objects = await client.fetchCalendarObjects({
+      calendar: { url: params.calendarUrl },
+      objectUrls: [objectUrl],
+    });
+
+    return objects[0] ?? null;
   }
 
   async fetchCalendarObjects(params: {
@@ -149,4 +206,4 @@ class CalDAVClient {
 const createCalDAVClient = (config: CalDAVClientConfig, safeFetchOptions?: SafeFetchOptions): CalDAVClient =>
   new CalDAVClient(config, safeFetchOptions);
 
-export { CalDAVClient, createCalDAVClient };
+export { CalDAVClient, CalDAVCreateConflictError, CalDAVHttpError, createCalDAVClient };

--- a/packages/calendar/src/providers/google/destination/provider.ts
+++ b/packages/calendar/src/providers/google/destination/provider.ts
@@ -11,7 +11,7 @@ import { GOOGLE_CALENDAR_API, GOOGLE_CALENDAR_MAX_RESULTS, GONE_STATUS } from ".
 import { withBackoff } from "../shared/backoff";
 import { executeBatchChunked } from "../shared/batch";
 import { isRateLimitApiError, parseGoogleApiError } from "../shared/errors";
-import type { BatchSubRequest } from "../shared/batch";
+import type { BatchSubRequest, BatchSubResponse } from "../shared/batch";
 import { parseEventTime } from "../shared/date-time";
 import { serializeGoogleEvent } from "./serialize-event";
 
@@ -48,15 +48,69 @@ const extractBatchErrorMessage = (body: unknown, fallbackStatus: number): string
   return googleApiErrorSchema.assert(body).error?.message ?? fallback;
 };
 
-const extractEventIdFromLookup = (body: unknown): string | undefined => {
-  if (!googleEventListSchema.allows(body)) {
-    return;
+type DeleteLookupResolution =
+  | { kind: "absent" }
+  | { eventId: string; kind: "found" }
+  | { kind: "failed"; result: DeleteResult };
+
+const resolveDeleteLookup = (response: BatchSubResponse | undefined): DeleteLookupResolution => {
+  if (!response) {
+    return {
+      kind: "failed",
+      result: {
+        error: "Missing batch response for Google event lookup",
+        errorType: "GoogleBatchProtocolError",
+        success: false,
+      },
+    };
   }
-  const firstItem = googleEventListSchema.assert(body).items?.[0];
-  if (!firstItem) {
-    return;
+
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    return {
+      kind: "failed",
+      result: {
+        error: extractBatchErrorMessage(response.body, response.statusCode),
+        errorType: "GoogleCalendarApiError",
+        statusCode: response.statusCode,
+        success: false,
+      },
+    };
   }
-  return firstItem.id;
+
+  if (!googleEventListSchema.allows(response.body)) {
+    return {
+      kind: "failed",
+      result: {
+        error: "Invalid Google event lookup response",
+        errorType: "GoogleBatchProtocolError",
+        statusCode: response.statusCode,
+        success: false,
+      },
+    };
+  }
+
+  const items = googleEventListSchema.assert(response.body).items ?? [];
+  if (items.length === 0) {
+    return { kind: "absent" };
+  }
+
+  if (items.length !== 1 || !items[0]?.id) {
+    let error = `Google event lookup returned ${items.length} matching events`;
+    if (items.length === 1) {
+      error = "Google event lookup response is missing the event ID";
+    }
+    return {
+      kind: "failed",
+      result: {
+        error,
+        errorType: "GoogleBatchProtocolError",
+        statusCode: response.statusCode,
+        success: false,
+      },
+    };
+  }
+
+  return { eventId: items[0].id, kind: "found" };
 };
 
 const createGoogleSyncProvider = (config: GoogleSyncProviderConfig) => {
@@ -190,14 +244,12 @@ const createGoogleSyncProvider = (config: GoogleSyncProviderConfig) => {
         continue;
       }
 
-      const findResponse = findResponses[findIndex];
-      if (!findResponse || findResponse.statusCode !== 200) {
-        results[originalIndex] = { success: true };
+      const resolution = resolveDeleteLookup(findResponses[findIndex]);
+      if (resolution.kind === "failed") {
+        results[originalIndex] = resolution.result;
         continue;
       }
-
-      const eventId = extractEventIdFromLookup(findResponse.body);
-      if (!eventId) {
+      if (resolution.kind === "absent") {
         results[originalIndex] = { success: true };
         continue;
       }
@@ -205,7 +257,7 @@ const createGoogleSyncProvider = (config: GoogleSyncProviderConfig) => {
       directIndexMap.push(originalIndex);
       directSubRequests.push({
         method: "DELETE",
-        path: `${eventsPath}/${encodeURIComponent(eventId)}`,
+        path: `${eventsPath}/${encodeURIComponent(resolution.eventId)}`,
       });
     }
 

--- a/packages/calendar/src/providers/google/destination/provider.ts
+++ b/packages/calendar/src/providers/google/destination/provider.ts
@@ -125,11 +125,20 @@ const createGoogleSyncProvider = (config: GoogleSyncProviderConfig) => {
     for (const entry of pending) {
       const response = responses[entry.batchIndex];
       if (!response) {
-        results[entry.index] = { error: "Missing batch response", success: false };
+        results[entry.index] = {
+          error: "Missing batch response",
+          errorType: "GoogleBatchProtocolError",
+          success: false,
+        };
       } else if (response.statusCode >= 200 && response.statusCode < 300) {
         results[entry.index] = { remoteId: entry.uid, success: true };
       } else {
-        results[entry.index] = { error: extractBatchErrorMessage(response.body, response.statusCode), success: false };
+        results[entry.index] = {
+          error: extractBatchErrorMessage(response.body, response.statusCode),
+          errorType: "GoogleCalendarApiError",
+          statusCode: response.statusCode,
+          success: false,
+        };
       }
     }
 
@@ -227,7 +236,11 @@ const createGoogleSyncProvider = (config: GoogleSyncProviderConfig) => {
 
       const deleteResponse = deleteResponses[deleteIndex];
       if (!deleteResponse) {
-        results[originalIndex] = { error: "Missing batch response", success: false };
+        results[originalIndex] = {
+          error: "Missing batch response",
+          errorType: "GoogleBatchProtocolError",
+          success: false,
+        };
         continue;
       }
 
@@ -238,7 +251,12 @@ const createGoogleSyncProvider = (config: GoogleSyncProviderConfig) => {
         results[originalIndex] = { success: true };
       } else {
         const errorMessage = extractBatchErrorMessage(deleteResponse.body, deleteResponse.statusCode);
-        results[originalIndex] = { error: errorMessage, success: false };
+        results[originalIndex] = {
+          error: errorMessage,
+          errorType: "GoogleCalendarApiError",
+          statusCode: deleteResponse.statusCode,
+          success: false,
+        };
       }
     }
 

--- a/packages/calendar/src/providers/outlook/destination/provider.ts
+++ b/packages/calendar/src/providers/outlook/destination/provider.ts
@@ -23,6 +23,14 @@ interface OutlookSyncProviderConfig {
   refreshAccessToken?: TokenRefresher;
 }
 
+const createCaughtFailure = (error: unknown): PushResult | DeleteResult => {
+  let errorType = "UnknownError";
+  if (error instanceof Error) {
+    errorType = error.name;
+  }
+  return { error: getErrorMessage(error), errorType, success: false };
+};
+
 const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
   const tokenState: TokenState = {
     accessToken: config.accessToken,
@@ -61,7 +69,12 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
         if (!response.ok) {
           const body = await response.json();
           const { error } = microsoftApiErrorSchema.assert(body);
-          results.push({ error: error?.message ?? response.statusText, success: false });
+          results.push({
+            error: error?.message ?? response.statusText,
+            errorType: "MicrosoftGraphHttpError",
+            statusCode: response.status,
+            success: false,
+          });
           continue;
         }
 
@@ -69,7 +82,7 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
         const created = outlookEventSchema.assert(body);
         results.push({ deleteId: created.id, remoteId: created.iCalUId ?? created.id, success: true });
       } catch (error) {
-        results.push({ error: getErrorMessage(error), success: false });
+        results.push(createCaughtFailure(error));
       }
     }
 
@@ -92,14 +105,19 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
         if (!response.ok && response.status !== HTTP_STATUS.NOT_FOUND) {
           const body = await response.json();
           const { error } = microsoftApiErrorSchema.assert(body);
-          results.push({ error: error?.message ?? response.statusText, success: false });
+          results.push({
+            error: error?.message ?? response.statusText,
+            errorType: "MicrosoftGraphHttpError",
+            statusCode: response.status,
+            success: false,
+          });
           continue;
         }
 
         await response.body?.cancel?.();
         results.push({ success: true });
       } catch (error) {
-        results.push({ error: getErrorMessage(error), success: false });
+        results.push(createCaughtFailure(error));
       }
     }
 

--- a/packages/calendar/src/providers/outlook/destination/provider.ts
+++ b/packages/calendar/src/providers/outlook/destination/provider.ts
@@ -1,4 +1,4 @@
-import { HTTP_STATUS, KEEPER_CATEGORY } from "@keeper.sh/constants";
+import { HTTP_STATUS, KEEPER_CATEGORY, PROVIDER_PUSH_REQUEST_TIMEOUT_MS } from "@keeper.sh/constants";
 import {
   microsoftApiErrorSchema,
   outlookEventListSchema,
@@ -12,6 +12,7 @@ import type { TokenState, TokenRefresher } from "../../../core/oauth/ensure-vali
 import { MICROSOFT_GRAPH_API, OUTLOOK_PAGE_SIZE } from "../shared/api";
 import { parseEventTime } from "../shared/date-time";
 import { serializeOutlookEvent } from "./serialize-event";
+import { fetchWithTimeout } from "../../../core/utils/fetch-with-timeout";
 
 interface OutlookSyncProviderConfig {
   accessToken: string;
@@ -21,6 +22,7 @@ interface OutlookSyncProviderConfig {
   calendarId: string;
   userId: string;
   refreshAccessToken?: TokenRefresher;
+  signal?: AbortSignal;
 }
 
 const createCaughtFailure = (error: unknown): PushResult | DeleteResult => {
@@ -60,11 +62,11 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
         const resource = serializeOutlookEvent(event);
         const url = new URL(calendarEventsUrl);
 
-        const response = await fetch(url, {
+        const response = await fetchWithTimeout(url, {
           body: JSON.stringify(resource),
           headers: getHeaders(),
           method: "POST",
-        });
+        }, PROVIDER_PUSH_REQUEST_TIMEOUT_MS, config.signal);
 
         if (!response.ok) {
           const body = await response.json();
@@ -82,6 +84,9 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
         const created = outlookEventSchema.assert(body);
         results.push({ deleteId: created.id, remoteId: created.iCalUId ?? created.id, success: true });
       } catch (error) {
+        if (config.signal?.aborted) {
+          throw error;
+        }
         results.push(createCaughtFailure(error));
       }
     }
@@ -97,10 +102,10 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
       try {
         const url = new URL(`${MICROSOFT_GRAPH_API}/me/events/${eventId}`);
 
-        const response = await fetch(url, {
+        const response = await fetchWithTimeout(url, {
           headers: { Authorization: `Bearer ${tokenState.accessToken}` },
           method: "DELETE",
-        });
+        }, PROVIDER_PUSH_REQUEST_TIMEOUT_MS, config.signal);
 
         if (!response.ok && response.status !== HTTP_STATUS.NOT_FOUND) {
           const body = await response.json();
@@ -117,6 +122,9 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
         await response.body?.cancel?.();
         results.push({ success: true });
       } catch (error) {
+        if (config.signal?.aborted) {
+          throw error;
+        }
         results.push(createCaughtFailure(error));
       }
     }
@@ -153,10 +161,10 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
     do {
       const url = buildOutlookEventsUrl(lookbackStart, futureDate, nextLink);
 
-      const response = await fetch(url, {
+      const response = await fetchWithTimeout(url, {
         headers: { Authorization: `Bearer ${tokenState.accessToken}` },
         method: "GET",
-      });
+      }, PROVIDER_PUSH_REQUEST_TIMEOUT_MS, config.signal);
 
       if (!response.ok) {
         const body = await response.json();

--- a/packages/calendar/src/utils/safe-fetch.ts
+++ b/packages/calendar/src/utils/safe-fetch.ts
@@ -13,6 +13,7 @@ interface SafeFetchOptions {
   blockPrivateResolution?: boolean;
   allowedPrivateHosts?: Set<string>;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }
 
 class UrlSafetyError extends Error {
@@ -245,13 +246,39 @@ const resolveRequestSignal = (
   externalSignal: AbortSignal | null | undefined,
 ): AbortSignal | null | undefined => timeout?.signal ?? externalSignal;
 
+const resolveExternalSignal = (
+  input: string | Request | URL,
+  init: RequestInit | undefined,
+  options: SafeFetchOptions | undefined,
+): AbortSignal | null => {
+  const signals: AbortSignal[] = [];
+  if (options?.signal) {
+    signals.push(options.signal);
+  }
+  if (init?.signal) {
+    signals.push(init.signal);
+  }
+  if (input instanceof Request) {
+    signals.push(input.signal);
+  }
+  const uniqueSignals = [...new Set(signals)];
+
+  if (uniqueSignals.length === 0) {
+    return null;
+  }
+  if (uniqueSignals.length === 1) {
+    return uniqueSignals.at(0) ?? null;
+  }
+  return AbortSignal.any(uniqueSignals);
+};
+
 const createSafeFetch = (options?: SafeFetchOptions): SafeFetch => async (input, init) => {
     const url = extractUrl(input);
     await validateUrlSafety(url, options);
 
     const callerWantsManual = init?.redirect === "manual";
 
-    const externalSignal = init?.signal;
+    const externalSignal = resolveExternalSignal(input, init, options);
     const timeout = resolveTimeoutSignal(options, externalSignal);
     const signal = resolveRequestSignal(timeout, externalSignal);
 

--- a/packages/calendar/tests/core/events/content-hash.test.ts
+++ b/packages/calendar/tests/core/events/content-hash.test.ts
@@ -84,4 +84,32 @@ describe("createSyncEventContentHash", () => {
 
     expect(hash1).not.toBe(hash2);
   });
+
+  it("returns different hashes when event times change", () => {
+    const hash1 = createSyncEventContentHash({
+      endTime: new Date("2026-03-07T10:00:00.000Z"),
+      startTime: new Date("2026-03-07T09:00:00.000Z"),
+      summary: "Meeting",
+    });
+    const hash2 = createSyncEventContentHash({
+      endTime: new Date("2026-03-07T11:00:00.000Z"),
+      startTime: new Date("2026-03-07T10:00:00.000Z"),
+      summary: "Meeting",
+    });
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it("returns different hashes when the serialized timezone changes", () => {
+    const event = {
+      endTime: new Date("2026-03-07T10:00:00.000Z"),
+      startTime: new Date("2026-03-07T09:00:00.000Z"),
+      summary: "Meeting",
+    };
+
+    const hash1 = createSyncEventContentHash({ ...event, startTimeZone: "America/Edmonton" });
+    const hash2 = createSyncEventContentHash({ ...event, startTimeZone: "America/Toronto" });
+
+    expect(hash1).not.toBe(hash2);
+  });
 });

--- a/packages/calendar/tests/core/sync-engine/index.test.ts
+++ b/packages/calendar/tests/core/sync-engine/index.test.ts
@@ -3,6 +3,7 @@ import { executeRemoteOperations } from "../../../src/core/sync-engine/index";
 import type { SyncOperation, PushResult, DeleteResult, SyncableEvent } from "../../../src/core/types";
 import type { EventMapping } from "../../../src/core/events/mappings";
 import type { PendingChanges } from "../../../src/core/sync-engine/types";
+import { createSyncEventContentHash } from "../../../src/core/events/content-hash";
 
 const makeEvent = (id: string, startTime: Date, endTime: Date): SyncableEvent => ({
   id,
@@ -71,7 +72,14 @@ describe("executeRemoteOperations", () => {
   it("counts failed pushes without accumulating changes", async () => {
     const event = makeEvent("ev-1", new Date("2026-03-15T09:00:00Z"), new Date("2026-03-15T10:00:00Z"));
     const operations: SyncOperation[] = [{ type: "add", event }];
-    const provider = makeProvider({ pushEvents: () => Promise.resolve([{ success: false, error: "rate limited" }]) });
+    const provider = makeProvider({
+      pushEvents: () => Promise.resolve([{
+        success: false,
+        error: "CalDAV create failed: 503 Service Unavailable",
+        errorType: "CalDAVHttpError",
+        statusCode: 503,
+      }]),
+    });
 
     const outcome = await executeRemoteOperations(operations, [], "dest-cal-1", provider);
 
@@ -79,6 +87,12 @@ describe("executeRemoteOperations", () => {
     expect(outcome.result.added).toBe(0);
     expect(outcome.result.addFailed).toBe(1);
     expect(outcome.changes.inserts).toHaveLength(0);
+    expect(outcome.errors).toEqual([{
+      type: "add",
+      error: "CalDAV create failed: 503 Service Unavailable",
+      errorType: "CalDAVHttpError",
+      statusCode: 503,
+    }]);
   });
 
   it("treats success without remoteId as a skip, not a failure", async () => {
@@ -91,6 +105,29 @@ describe("executeRemoteOperations", () => {
 
     expect(outcome.result.added).toBe(0);
     expect(outcome.result.addFailed).toBe(0);
+    expect(outcome.changes.inserts).toHaveLength(0);
+  });
+
+  it("removes the stale mapping when a replacement is intentionally skipped", async () => {
+    const event = makeEvent("ev-1", new Date("2026-03-15T11:00:00Z"), new Date("2026-03-15T12:00:00Z"));
+    const mapping = makeMapping("map-1", "ev-1", "remote-1");
+    const operations: SyncOperation[] = [{
+      deleteId: "remote-1",
+      event,
+      staleMappingId: mapping.id,
+      type: "replace",
+      uid: "remote-1",
+    }];
+    const provider = makeProvider({
+      deleteEvents: () => Promise.resolve([{ success: true }]),
+      pushEvents: () => Promise.resolve([{ success: true }]),
+    });
+
+    const outcome = await executeRemoteOperations(operations, [mapping], "dest-cal-1", provider);
+
+    expect(outcome.result.removed).toBe(1);
+    expect(outcome.result.addFailed).toBe(0);
+    expect(outcome.changes.deletes).toEqual([mapping.id]);
     expect(outcome.changes.inserts).toHaveLength(0);
   });
 
@@ -126,6 +163,44 @@ describe("executeRemoteOperations", () => {
     expect(outcome.result.removed).toBe(1);
     expect(outcome.changes.inserts).toHaveLength(1);
     expect(outcome.changes.deletes).toHaveLength(1);
+  });
+
+  it("does not delete a remote UID that was recovered by an earlier add", async () => {
+    const event = makeEvent("ev-1", new Date("2026-03-15T09:00:00Z"), new Date("2026-03-15T10:00:00Z"));
+    const addOperations: SyncOperation[] = [
+      { event, type: "add" },
+      ...Array.from({ length: 49 }, (_value, index): SyncOperation => ({
+        event: makeEvent(
+          `ev-extra-${index}`,
+          new Date(Date.UTC(2026, 2, 15, 11, index)),
+          new Date(Date.UTC(2026, 2, 15, 12, index)),
+        ),
+        type: "add",
+      })),
+    ];
+    const operations: SyncOperation[] = [
+      ...addOperations,
+      { type: "remove", uid: "remote-1", deleteId: "remote-1", startTime: event.startTime },
+    ];
+    let deleteCalled = false;
+    const provider = makeProvider({
+      pushEvents: (events) => Promise.resolve(events.map((pushedEvent) => {
+        let remoteId = `remote-${pushedEvent.id}`;
+        if (pushedEvent.id === event.id) {
+          remoteId = "remote-1";
+        }
+        return { remoteId, success: true };
+      })),
+      deleteEvents: () => {
+        deleteCalled = true;
+        return Promise.resolve([{ success: true }]);
+      },
+    });
+
+    const outcome = await executeRemoteOperations(operations, [], "dest-cal-1", provider);
+
+    expect(outcome.result.added).toBe(50);
+    expect(deleteCalled).toBe(false);
   });
 
   it("uses remoteId as deleteIdentifier fallback when pushResult has no deleteId", async () => {
@@ -181,7 +256,7 @@ describe("executeRemoteOperations", () => {
     expect(outcome.changes.inserts).toHaveLength(1);
   });
 
-  it("skips deletes but returns partial add changes when superseded between adds and deletes", async () => {
+  it("checkpoints removals before adds and skips adds when superseded", async () => {
     const event1 = makeEvent("ev-1", new Date("2026-03-15T09:00:00Z"), new Date("2026-03-15T10:00:00Z"));
     const mapping = makeMapping("map-1", "ev-1", "remote-1");
     const operations: SyncOperation[] = [
@@ -201,9 +276,120 @@ describe("executeRemoteOperations", () => {
     const outcome = await executeRemoteOperations(operations, [mapping], "dest-cal-1", provider, () => Promise.resolve(false));
 
     expect(outcome.superseded).toBe(true);
+    expect(outcome.changes.inserts).toHaveLength(0);
+    expect(outcome.changes.deletes).toEqual([mapping.id]);
+    expect(deleteCount).toBe(1);
+  });
+
+  it("finishes a replacement before observing that the generation is stale", async () => {
+    const event = makeEvent("ev-1", new Date("2026-03-15T11:00:00Z"), new Date("2026-03-15T12:00:00Z"));
+    const mapping = makeMapping("map-1", "ev-1", "remote-1");
+    const operations: SyncOperation[] = [{
+      deleteId: "remote-1",
+      event,
+      staleMappingId: mapping.id,
+      type: "replace",
+      uid: "remote-1",
+    }];
+    const calls: string[] = [];
+    const provider = makeProvider({
+      deleteEvents: () => {
+        calls.push("delete");
+        return Promise.resolve([{ success: true }]);
+      },
+      pushEvents: () => {
+        calls.push("add");
+        return Promise.resolve([{ remoteId: "remote-new", success: true }]);
+      },
+    });
+
+    const outcome = await executeRemoteOperations(
+      operations,
+      [mapping],
+      "dest-cal-1",
+      provider,
+      () => {
+        calls.push("current");
+        return Promise.resolve(false);
+      },
+    );
+
+    expect(calls).toEqual(["delete", "add", "current"]);
+    expect(outcome.superseded).toBe(true);
+    expect(outcome.changes.deletes).toEqual([mapping.id]);
     expect(outcome.changes.inserts).toHaveLength(1);
+  });
+
+  it("keeps the stale mapping when recreation fails after a successful delete", async () => {
+    const event = makeEvent("ev-1", new Date("2026-03-15T11:00:00Z"), new Date("2026-03-15T12:00:00Z"));
+    const mapping = makeMapping("map-1", "ev-1", "remote-1");
+    const operations: SyncOperation[] = [{
+      deleteId: "remote-1",
+      event,
+      staleMappingId: mapping.id,
+      type: "replace",
+      uid: "remote-1",
+    }];
+    const provider = makeProvider({
+      deleteEvents: () => Promise.resolve([{ success: true }]),
+      pushEvents: () => Promise.resolve([{ error: "provider unavailable", success: false }]),
+    });
+    const checkpoints: PendingChanges[] = [];
+    let progressUpdates = 0;
+
+    const outcome = await executeRemoteOperations(
+      operations,
+      [mapping],
+      "dest-cal-1",
+      provider,
+      () => Promise.resolve(true),
+      () => { progressUpdates += 1; },
+      (changes) => {
+        checkpoints.push(changes);
+        return Promise.resolve(true);
+      },
+    );
+
+    expect(outcome.result.removed).toBe(1);
+    expect(outcome.result.addFailed).toBe(1);
     expect(outcome.changes.deletes).toHaveLength(0);
-    expect(deleteCount).toBe(0);
+    expect(outcome.changes.inserts).toHaveLength(0);
+    expect(checkpoints).toHaveLength(0);
+    expect(progressUpdates).toBe(1);
+  });
+
+  it("does not checkpoint the stale mapping when recreation aborts after deletion", async () => {
+    const event = makeEvent("ev-1", new Date("2026-03-15T11:00:00Z"), new Date("2026-03-15T12:00:00Z"));
+    const mapping = makeMapping("map-1", "ev-1", "remote-1");
+    const operations: SyncOperation[] = [{
+      deleteId: "remote-1",
+      event,
+      staleMappingId: mapping.id,
+      type: "replace",
+      uid: "remote-1",
+    }];
+    const abortError = new Error("job deadline exceeded");
+    abortError.name = "AbortError";
+    const provider = makeProvider({
+      deleteEvents: () => Promise.resolve([{ success: true }]),
+      pushEvents: () => Promise.reject(abortError),
+    });
+    const checkpoints: PendingChanges[] = [];
+
+    await expect(executeRemoteOperations(
+      operations,
+      [mapping],
+      "dest-cal-1",
+      provider,
+      () => Promise.resolve(true),
+      (processed, total) => { expect(processed).toBeLessThanOrEqual(total); },
+      (changes) => {
+        checkpoints.push(changes);
+        return Promise.resolve(true);
+      },
+    )).rejects.toBe(abortError);
+
+    expect(checkpoints).toHaveLength(0);
   });
 
   it("processes all operations when generation stays current", async () => {
@@ -223,6 +409,47 @@ describe("executeRemoteOperations", () => {
 });
 
 describe("syncCalendar", () => {
+  it("uses a stable weighted progress total for replacements", async () => {
+    const { syncCalendar } = await import("../../../src/core/sync-engine/index");
+    const previousEvent = makeEvent("ev-1", new Date("2026-03-15T09:00:00Z"), new Date("2026-03-15T10:00:00Z"));
+    const movedEvent = makeEvent("ev-1", new Date("2026-03-15T11:00:00Z"), new Date("2026-03-15T12:00:00Z"));
+    const mapping = {
+      ...makeMapping("map-1", "ev-1", "remote-1"),
+      syncEventHash: createSyncEventContentHash(previousEvent),
+    };
+    const provider = makeProvider({
+      deleteEvents: () => Promise.resolve([{ success: true }]),
+      pushEvents: () => Promise.resolve([{ remoteId: "remote-new", success: true }]),
+    });
+    const progressTotals: number[] = [];
+
+    await syncCalendar({
+      userId: "user-1",
+      calendarId: "dest-cal-1",
+      provider,
+      readState: () => Promise.resolve({
+        localEvents: [movedEvent],
+        existingMappings: [mapping],
+        remoteEvents: [{
+          deleteId: "remote-1",
+          endTime: previousEvent.endTime,
+          isKeeperEvent: true,
+          startTime: previousEvent.startTime,
+          uid: "remote-1",
+        }],
+      }),
+      isCurrent: () => Promise.resolve(true),
+      flush: () => Promise.resolve(),
+      onProgress: (update) => {
+        if (update.stage === "processing" && update.progress) {
+          progressTotals.push(update.progress.total);
+        }
+      },
+    });
+
+    expect(progressTotals).toEqual([2, 2]);
+  });
+
   it("pushes new events and flushes accumulated changes at the end", async () => {
     const { syncCalendar } = await import("../../../src/core/sync-engine/index");
     const localEvent = makeEvent("ev-1", new Date("2026-03-15T09:00:00Z"), new Date("2026-03-15T10:00:00Z"));
@@ -265,6 +492,41 @@ describe("syncCalendar", () => {
 
     expect(result.added).toBe(1);
     expect(flushCalled).toBe(true);
+  });
+
+  it("checkpoints a successful chunk before a later chunk fails", async () => {
+    const { syncCalendar } = await import("../../../src/core/sync-engine/index");
+    const localEvents = Array.from({ length: 51 }, (_value, index) => makeEvent(
+      `ev-${index}`,
+      new Date(Date.UTC(2026, 2, 15, 9, index)),
+      new Date(Date.UTC(2026, 2, 15, 10, index)),
+    ));
+    let pushCount = 0;
+    const provider = makeProvider({
+      pushEvents: (events) => {
+        pushCount += 1;
+        if (pushCount === 2) {
+          return Promise.reject(new Error("provider stopped responding"));
+        }
+        return Promise.resolve(events.map((event) => ({ success: true, remoteId: `remote-${event.id}` })));
+      },
+    });
+    const checkpoints: PendingChanges[] = [];
+
+    await expect(syncCalendar({
+      userId: "user-1",
+      calendarId: "dest-cal-1",
+      provider,
+      readState: () => Promise.resolve({ localEvents, existingMappings: [], remoteEvents: [] }),
+      isCurrent: () => Promise.resolve(true),
+      flush: (changes) => {
+        checkpoints.push(changes);
+        return Promise.resolve();
+      },
+    })).rejects.toThrow("provider stopped responding");
+
+    expect(checkpoints).toHaveLength(1);
+    expect(checkpoints[0]?.inserts).toHaveLength(50);
   });
 
   it("returns empty result when there are no operations", async () => {

--- a/packages/calendar/tests/core/sync/aggregate-runtime.test.ts
+++ b/packages/calendar/tests/core/sync/aggregate-runtime.test.ts
@@ -228,6 +228,36 @@ describe("createSyncAggregateRuntime", () => {
       expect(persisted).toHaveLength(0);
     });
 
+    it("finalizes failed attempts without advancing lastSyncedAt", async () => {
+      const broadcasts: { data: unknown }[] = [];
+      const persisted: unknown[] = [];
+      const tracker = new SyncAggregateTracker({ progressThrottleMs: 0 });
+      const runtime = createSyncAggregateRuntime(createRuntimeConfig({
+        broadcast: (_userId, _eventName, data) => {
+          broadcasts.push({ data });
+        },
+        persistSyncStatus: () => {
+          persisted.push(true);
+          return Promise.resolve();
+        },
+        tracker,
+      }));
+      tracker.trackProgress(
+        createProgressUpdate({ calendarId: "cal-1", progress: { current: 5, total: 10 } }),
+      );
+
+      await runtime.onDestinationSync(createDestinationResult({ completedSuccessfully: false }));
+
+      expect(persisted).toHaveLength(0);
+      const lastBroadcast = broadcasts.at(-1);
+      expect(lastBroadcast).toBeDefined();
+      if (!lastBroadcast || !isRecord(lastBroadcast.data)) {
+        throw new TypeError("Expected broadcast data object");
+      }
+      expect(lastBroadcast.data.syncing).toBe(false);
+      expect(lastBroadcast.data).not.toHaveProperty("lastSyncedAt");
+    });
+
     it("finalizes and broadcasts completion even when persistence fails", async () => {
       const broadcasts: { data: unknown }[] = [];
       const tracker = new SyncAggregateTracker({ progressThrottleMs: 0 });
@@ -256,6 +286,7 @@ describe("createSyncAggregateRuntime", () => {
       }
       expect(lastBroadcast.data.syncing).toBe(false);
       expect(lastBroadcast.data.syncEventsRemaining).toBe(0);
+      expect(lastBroadcast.data).not.toHaveProperty("lastSyncedAt");
     });
   });
 

--- a/packages/calendar/tests/core/sync/operations.test.ts
+++ b/packages/calendar/tests/core/sync/operations.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildRemoveOperations } from "../../../src/core/sync/operations";
+import { buildRemoveOperations, computeSyncOperations } from "../../../src/core/sync/operations";
+import { createSyncEventContentHash } from "../../../src/core/events/content-hash";
 import type { EventMapping } from "../../../src/core/events/mappings";
-import type { RemoteEvent } from "../../../src/core/types";
+import type { RemoteEvent, SyncableEvent } from "../../../src/core/types";
 
 const createEventMapping = (overrides: Partial<EventMapping>): EventMapping => ({
   calendarId: "destination-calendar-id",
@@ -21,6 +22,18 @@ const createRemoteEvent = (overrides: Partial<RemoteEvent>): RemoteEvent => ({
   isKeeperEvent: false,
   startTime: new Date("2026-03-08T14:00:00.000Z"),
   uid: "remote-uid-1",
+  ...overrides,
+});
+
+const createLocalEvent = (overrides: Partial<SyncableEvent>): SyncableEvent => ({
+  calendarId: "source-calendar-id",
+  calendarName: "Source",
+  calendarUrl: null,
+  endTime: new Date("2026-03-08T15:00:00.000Z"),
+  id: "event-state-id-1",
+  sourceEventUid: "source-event-uid-1",
+  startTime: new Date("2026-03-08T14:00:00.000Z"),
+  summary: "Meeting",
   ...overrides,
 });
 
@@ -124,5 +137,54 @@ describe("buildRemoveOperations", () => {
     );
 
     expect(operations).toHaveLength(0);
+  });
+});
+
+describe("computeSyncOperations", () => {
+  it("retries an add and retains the stale mapping identity when the remote copy is missing", () => {
+    const event = createLocalEvent({});
+    const mapping = createEventMapping({
+      eventStateId: event.id,
+      syncEventHash: createSyncEventContentHash(event),
+    });
+
+    const result = computeSyncOperations([event], [mapping], []);
+
+    expect(result.staleMappingIds).toEqual([mapping.id]);
+    expect(result.operations).toEqual([
+      { event, staleMappingId: mapping.id, type: "add" },
+    ]);
+  });
+
+  it("recreates a mapped event when the same event ID moves", () => {
+    const previousEvent = createLocalEvent({});
+    const movedEvent = createLocalEvent({
+      endTime: new Date("2026-03-08T17:00:00.000Z"),
+      startTime: new Date("2026-03-08T16:00:00.000Z"),
+    });
+    const mapping = createEventMapping({
+      destinationEventUid: "destination-uid-1",
+      syncEventHash: createSyncEventContentHash(previousEvent),
+    });
+    const remoteEvent = createRemoteEvent({
+      deleteId: mapping.deleteIdentifier,
+      endTime: previousEvent.endTime,
+      isKeeperEvent: true,
+      startTime: previousEvent.startTime,
+      uid: mapping.destinationEventUid,
+    });
+
+    const result = computeSyncOperations([movedEvent], [mapping], [remoteEvent]);
+
+    expect(result.staleMappingIds).toEqual([mapping.id]);
+    expect(result.operations).toEqual([
+      {
+        deleteId: mapping.deleteIdentifier,
+        event: movedEvent,
+        staleMappingId: mapping.id,
+        type: "replace",
+        uid: mapping.destinationEventUid,
+      },
+    ]);
   });
 });

--- a/packages/calendar/tests/core/utils/rate-limiter.test.ts
+++ b/packages/calendar/tests/core/utils/rate-limiter.test.ts
@@ -98,6 +98,26 @@ describe("RateLimiter", () => {
       await allDone;
       expect(order).toEqual([1, 2]);
     });
+
+    it("rejects an aborted queued task without starting it", async () => {
+      const limiter = new RateLimiter({ concurrency: 1 });
+      const first = Promise.withResolvers<boolean>();
+      const firstTask = limiter.execute(() => first.promise);
+      const controller = new AbortController();
+      let secondStarted = false;
+      const secondTask = limiter.execute(() => {
+        secondStarted = true;
+        return Promise.resolve();
+      }, controller.signal);
+
+      controller.abort(new Error("job deadline exceeded"));
+
+      await expect(secondTask).rejects.toThrow("job deadline exceeded");
+      expect(secondStarted).toBe(false);
+
+      first.resolve(true);
+      await firstTask;
+    });
   });
 
   describe("rate limiting", () => {

--- a/packages/calendar/tests/providers/caldav/destination/provider.test.ts
+++ b/packages/calendar/tests/providers/caldav/destination/provider.test.ts
@@ -1,18 +1,171 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateDeterministicEventUid } from "../../../../src/core/events/identity";
+import type { SyncableEvent } from "../../../../src/core/types";
+import { createCalDAVSyncProvider } from "../../../../src/providers/caldav/destination/provider";
+import { CalDAVCreateConflictError, CalDAVHttpError } from "../../../../src/providers/caldav/shared/client";
+import { eventToICalString } from "../../../../src/providers/caldav/shared/ics";
+
+const clientMocks = vi.hoisted(() => ({
+  createCalendarObject: vi.fn(),
+  deleteCalendarObject: vi.fn(),
+  fetchCalendarObject: vi.fn(),
+  fetchCalendarObjects: vi.fn(),
+  resolveCalendarUrl: vi.fn(),
+}));
+
+vi.mock("../../../../src/providers/caldav/shared/client", () => {
+  class MockCalDAVHttpError extends Error {
+    status: number;
+
+    constructor(response: Response) {
+      super(`CalDAV request failed: ${response.status}`);
+      this.name = "CalDAVHttpError";
+      this.status = response.status;
+    }
+  }
+
+  class MockCalDAVCreateConflictError extends MockCalDAVHttpError {
+    constructor(response: Response) {
+      super(response);
+      this.name = "CalDAVCreateConflictError";
+    }
+  }
+
+  class CalDAVClient {
+    createCalendarObject = clientMocks.createCalendarObject;
+    deleteCalendarObject = clientMocks.deleteCalendarObject;
+    fetchCalendarObject = clientMocks.fetchCalendarObject;
+    fetchCalendarObjects = clientMocks.fetchCalendarObjects;
+    resolveCalendarUrl = clientMocks.resolveCalendarUrl;
+  }
+
+  return {
+    CalDAVClient,
+    CalDAVCreateConflictError: MockCalDAVCreateConflictError,
+    CalDAVHttpError: MockCalDAVHttpError,
+  };
+});
+
+const createEvent = (overrides: Partial<SyncableEvent> = {}): SyncableEvent => ({
+  calendarId: "source-calendar-id",
+  calendarName: "Source",
+  calendarUrl: null,
+  endTime: new Date("2026-03-08T15:00:00.000Z"),
+  id: "event-state-id-1",
+  sourceEventUid: "source-event-uid-1",
+  startTime: new Date("2026-03-08T14:00:00.000Z"),
+  summary: "Meeting",
+  ...overrides,
+});
+
+const createProvider = () =>
+  createCalDAVSyncProvider({
+    calendarUrl: "https://caldav.example.com/calendar/",
+    password: "pass",
+    serverUrl: "https://caldav.example.com",
+    username: "user",
+  });
 
 describe("createCalDAVSyncProvider", () => {
-  it("returns a provider with pushEvents, deleteEvents, and listRemoteEvents", async () => {
-    const { createCalDAVSyncProvider } = await import("../../../../src/providers/caldav/destination/provider");
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-    const provider = createCalDAVSyncProvider({
-      calendarUrl: "https://caldav.example.com/calendar/",
-      serverUrl: "https://caldav.example.com",
-      username: "user",
-      password: "pass",
-    });
+  it("returns a provider with pushEvents, deleteEvents, and listRemoteEvents", () => {
+    const provider = createProvider();
 
     expect(typeof provider.pushEvents).toBe("function");
     expect(typeof provider.deleteEvents).toBe("function");
     expect(typeof provider.listRemoteEvents).toBe("function");
+  });
+
+  it("restores the mapping when a create conflict contains identical event content", async () => {
+    const event = createEvent();
+    const existingData = eventToICalString(event, generateDeterministicEventUid(event.id));
+    clientMocks.createCalendarObject.mockRejectedValueOnce(
+      new CalDAVCreateConflictError(new Response(null, { status: 412 })),
+    );
+    clientMocks.fetchCalendarObject.mockResolvedValueOnce({
+      data: existingData,
+      etag: "etag-1",
+      url: "https://caldav.example.com/calendar/existing-uid.ics",
+    });
+    const provider = createProvider();
+
+    const results = await provider.pushEvents([event]);
+
+    expect(results).toEqual([expect.objectContaining({ conflictResolved: true, success: true })]);
+    expect(clientMocks.deleteCalendarObject).not.toHaveBeenCalled();
+    expect(clientMocks.createCalendarObject).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes and recreates an event when a create conflict contains stale content", async () => {
+    const previousEvent = createEvent();
+    const movedEvent = createEvent({
+      endTime: new Date("2026-03-08T17:00:00.000Z"),
+      startTime: new Date("2026-03-08T16:00:00.000Z"),
+    });
+    clientMocks.createCalendarObject
+      .mockRejectedValueOnce(new CalDAVCreateConflictError(new Response(null, { status: 412 })))
+      .mockImplementationOnce(() => Promise.resolve());
+    clientMocks.fetchCalendarObject.mockResolvedValueOnce({
+      data: eventToICalString(previousEvent, generateDeterministicEventUid(previousEvent.id)),
+      etag: "etag-1",
+      url: "https://caldav.example.com/calendar/existing-uid.ics",
+    });
+    clientMocks.deleteCalendarObject.mockImplementationOnce(() => Promise.resolve());
+    const provider = createProvider();
+
+    const results = await provider.pushEvents([movedEvent]);
+
+    expect(results).toEqual([expect.objectContaining({ conflictResolved: true, success: true })]);
+    expect(clientMocks.deleteCalendarObject).toHaveBeenCalledWith(expect.objectContaining({
+      etag: "etag-1",
+    }));
+    expect(clientMocks.createCalendarObject).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns structured diagnostics for a failed CalDAV write", async () => {
+    const event = createEvent();
+    clientMocks.createCalendarObject.mockRejectedValueOnce(
+      new CalDAVHttpError(new Response(null, { status: 503, statusText: "Service Unavailable" }), "create"),
+    );
+    const provider = createProvider();
+
+    const results = await provider.pushEvents([event]);
+
+    expect(results).toEqual([expect.objectContaining({
+      errorType: "CalDAVHttpError",
+      statusCode: 503,
+      success: false,
+    })]);
+  });
+
+  it("preserves the HTTP status and recovery phase when conflict recovery fails", async () => {
+    const previousEvent = createEvent();
+    const movedEvent = createEvent({
+      startTime: new Date("2026-03-08T16:00:00.000Z"),
+      endTime: new Date("2026-03-08T17:00:00.000Z"),
+    });
+    clientMocks.createCalendarObject.mockRejectedValueOnce(
+      new CalDAVCreateConflictError(new Response(null, { status: 412 })),
+    );
+    clientMocks.fetchCalendarObject.mockResolvedValueOnce({
+      data: eventToICalString(previousEvent, generateDeterministicEventUid(previousEvent.id)),
+      etag: "etag-1",
+    });
+    clientMocks.deleteCalendarObject.mockRejectedValueOnce(
+      new CalDAVHttpError(new Response(null, { status: 503, statusText: "Service Unavailable" }), "delete"),
+    );
+    const provider = createProvider();
+
+    const results = await provider.pushEvents([movedEvent]);
+
+    expect(results).toEqual([expect.objectContaining({
+      error: expect.stringContaining("CalDAV create conflict recovery failed"),
+      errorType: "CalDAVConflictRecoveryError",
+      statusCode: 503,
+      success: false,
+    })]);
   });
 });

--- a/packages/calendar/tests/providers/caldav/shared/client.test.ts
+++ b/packages/calendar/tests/providers/caldav/shared/client.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CalDAVClient,
+  CalDAVCreateConflictError,
+} from "../../../../src/providers/caldav/shared/client";
+
+const davMocks = vi.hoisted(() => ({
+  createCalendarObject: vi.fn(),
+  deleteCalendarObject: vi.fn(),
+}));
+
+vi.mock("tsdav", () => ({
+  createDAVClient: () => Promise.resolve({
+    createCalendarObject: davMocks.createCalendarObject,
+    deleteCalendarObject: davMocks.deleteCalendarObject,
+  }),
+}));
+
+const createClient = () =>
+  new CalDAVClient({
+    credentials: { password: "pass", username: "user" },
+    serverUrl: "https://caldav.example.com",
+  });
+
+describe("CalDAVClient write responses", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("classifies a 412 from create as a create conflict", async () => {
+    davMocks.createCalendarObject.mockResolvedValueOnce(
+      new Response(null, { status: 412, statusText: "Precondition Failed" }),
+    );
+    const client = createClient();
+
+    await expect(client.createCalendarObject({
+      calendarUrl: "https://caldav.example.com/calendar/",
+      filename: "event.ics",
+      iCalString: "BEGIN:VCALENDAR\r\nEND:VCALENDAR",
+    })).rejects.toBeInstanceOf(CalDAVCreateConflictError);
+  });
+
+  it("rejects unsuccessful delete responses", async () => {
+    davMocks.deleteCalendarObject.mockResolvedValueOnce(
+      new Response(null, { status: 500, statusText: "Server Error" }),
+    );
+    const client = createClient();
+
+    await expect(client.deleteCalendarObject({
+      calendarUrl: "https://caldav.example.com/calendar/",
+      filename: "event.ics",
+    })).rejects.toMatchObject({
+      name: "CalDAVHttpError",
+      operation: "delete",
+      status: 500,
+    });
+  });
+});

--- a/packages/calendar/tests/providers/google/destination/provider.test.ts
+++ b/packages/calendar/tests/providers/google/destination/provider.test.ts
@@ -1,20 +1,161 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createGoogleSyncProvider } from "../../../../src/providers/google/destination/provider";
+
+const batchMocks = vi.hoisted(() => ({
+  executeBatchChunked: vi.fn(),
+}));
+
+vi.mock("../../../../src/providers/google/shared/batch", () => ({
+  executeBatchChunked: batchMocks.executeBatchChunked,
+}));
+
+const createProvider = () => createGoogleSyncProvider({
+  accessToken: "test-token",
+  refreshToken: "test-refresh",
+  accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+  externalCalendarId: "primary",
+  calendarId: "cal-1",
+  userId: "user-1",
+});
+
+const batchResponse = (statusCode: number, body: unknown) => ({
+  body,
+  headers: {},
+  statusCode,
+});
 
 describe("createGoogleSyncProvider", () => {
-  it("returns a provider with pushEvents, deleteEvents, and listRemoteEvents", async () => {
-    const { createGoogleSyncProvider } = await import("../../../../src/providers/google/destination/provider");
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-    const provider = createGoogleSyncProvider({
-      accessToken: "test-token",
-      refreshToken: "test-refresh",
-      accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
-      externalCalendarId: "primary",
-      calendarId: "cal-1",
-      userId: "user-1",
-    });
+  it("returns a provider with pushEvents, deleteEvents, and listRemoteEvents", () => {
+    const provider = createProvider();
 
     expect(typeof provider.pushEvents).toBe("function");
     expect(typeof provider.deleteEvents).toBe("function");
     expect(typeof provider.listRemoteEvents).toBe("function");
+  });
+
+  it.each([{ items: [] }, {}])(
+    "treats a valid empty lookup response as an already-absent event",
+    async (body) => {
+      batchMocks.executeBatchChunked.mockResolvedValueOnce([
+        batchResponse(200, body),
+      ]);
+
+      await expect(createProvider().deleteEvents(["keeper-event@keeper.sh"])).resolves.toEqual([
+        { success: true },
+      ]);
+      expect(batchMocks.executeBatchChunked).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("deletes the event ID returned by a valid lookup response", async () => {
+    batchMocks.executeBatchChunked
+      .mockResolvedValueOnce([batchResponse(200, { items: [{ id: "google-event-id" }] })])
+      .mockResolvedValueOnce([batchResponse(204, null)]);
+
+    await expect(createProvider().deleteEvents(["keeper-event@keeper.sh"])).resolves.toEqual([
+      { success: true },
+    ]);
+    expect(batchMocks.executeBatchChunked).toHaveBeenCalledTimes(2);
+    expect(batchMocks.executeBatchChunked.mock.calls[1]?.[0]).toEqual([
+      {
+        method: "DELETE",
+        path: "/calendar/v3/calendars/primary/events/google-event-id",
+      },
+    ]);
+  });
+
+  it.each([401, 403, 404, 429, 503])(
+    "retains the mapping when the lookup returns HTTP %i",
+    async (statusCode) => {
+      batchMocks.executeBatchChunked.mockResolvedValueOnce([
+        batchResponse(statusCode, { error: { message: "lookup failed" } }),
+      ]);
+
+      await expect(createProvider().deleteEvents(["keeper-event@keeper.sh"])).resolves.toEqual([
+        {
+          error: "lookup failed",
+          errorType: "GoogleCalendarApiError",
+          statusCode,
+          success: false,
+        },
+      ]);
+      expect(batchMocks.executeBatchChunked).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("retains the mapping when a successful lookup has an invalid body", async () => {
+    batchMocks.executeBatchChunked.mockResolvedValueOnce([
+      batchResponse(200, { items: "not-an-array" }),
+    ]);
+
+    await expect(createProvider().deleteEvents(["keeper-event@keeper.sh"])).resolves.toEqual([
+      {
+        error: "Invalid Google event lookup response",
+        errorType: "GoogleBatchProtocolError",
+        statusCode: 200,
+        success: false,
+      },
+    ]);
+    expect(batchMocks.executeBatchChunked).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains the mapping when the lookup batch response is missing", async () => {
+    batchMocks.executeBatchChunked.mockResolvedValueOnce([]);
+
+    await expect(createProvider().deleteEvents(["keeper-event@keeper.sh"])).resolves.toEqual([
+      {
+        error: "Missing batch response for Google event lookup",
+        errorType: "GoogleBatchProtocolError",
+        success: false,
+      },
+    ]);
+    expect(batchMocks.executeBatchChunked).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([404, 410])("treats HTTP %i from the actual delete as success", async (statusCode) => {
+    batchMocks.executeBatchChunked
+      .mockResolvedValueOnce([batchResponse(200, { items: [{ id: "google-event-id" }] })])
+      .mockResolvedValueOnce([batchResponse(statusCode, { error: { message: "gone" } })]);
+
+    await expect(createProvider().deleteEvents(["keeper-event@keeper.sh"])).resolves.toEqual([
+      { success: true },
+    ]);
+    expect(batchMocks.executeBatchChunked).toHaveBeenCalledTimes(2);
+  });
+
+  it("retains the mapping when the lookup response is ambiguous", async () => {
+    batchMocks.executeBatchChunked.mockResolvedValueOnce([
+      batchResponse(200, { items: [{ id: "first" }, { id: "second" }] }),
+    ]);
+
+    await expect(createProvider().deleteEvents(["keeper-event@keeper.sh"])).resolves.toEqual([
+      {
+        error: "Google event lookup returned 2 matching events",
+        errorType: "GoogleBatchProtocolError",
+        statusCode: 200,
+        success: false,
+      },
+    ]);
+    expect(batchMocks.executeBatchChunked).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains the mapping when the lookup match has no event ID", async () => {
+    batchMocks.executeBatchChunked.mockResolvedValueOnce([
+      batchResponse(200, { items: [{ summary: "No identifier" }] }),
+    ]);
+
+    await expect(createProvider().deleteEvents(["keeper-event@keeper.sh"])).resolves.toEqual([
+      {
+        error: "Google event lookup response is missing the event ID",
+        errorType: "GoogleBatchProtocolError",
+        statusCode: 200,
+        success: false,
+      },
+    ]);
+    expect(batchMocks.executeBatchChunked).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/calendar/tests/providers/outlook/destination/provider.test.ts
+++ b/packages/calendar/tests/providers/outlook/destination/provider.test.ts
@@ -1,20 +1,90 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SyncableEvent } from "../../../../src/core/types";
+import { createOutlookSyncProvider } from "../../../../src/providers/outlook/destination/provider";
+
+const createProvider = (signal?: AbortSignal) =>
+  createOutlookSyncProvider({
+    accessToken: "test-token",
+    refreshToken: "test-refresh",
+    accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+    externalCalendarId: "external-cal-1",
+    calendarId: "cal-1",
+    userId: "user-1",
+    signal,
+  });
+
+const createEvent = (): SyncableEvent => ({
+  calendarId: "source-calendar-id",
+  calendarName: "Source",
+  calendarUrl: null,
+  endTime: new Date("2026-07-17T19:00:00.000Z"),
+  id: "event-state-id-1",
+  sourceEventUid: "source-event-uid-1",
+  startTime: new Date("2026-07-17T18:00:00.000Z"),
+  summary: "Meeting",
+});
+
+const installAbortableFetch = (): void => {
+  vi.stubGlobal("fetch", vi.fn((_input: string | URL | Request, init?: RequestInit) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (signal?.aborted) {
+        reject(signal.reason);
+        return;
+      }
+      signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+    })));
+};
 
 describe("createOutlookSyncProvider", () => {
-  it("returns a provider with pushEvents, deleteEvents, and listRemoteEvents", async () => {
-    const { createOutlookSyncProvider } = await import("../../../../src/providers/outlook/destination/provider");
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
 
-    const provider = createOutlookSyncProvider({
-      accessToken: "test-token",
-      refreshToken: "test-refresh",
-      accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
-      externalCalendarId: "external-cal-1",
-      calendarId: "cal-1",
-      userId: "user-1",
-    });
+  it("returns a provider with pushEvents, deleteEvents, and listRemoteEvents", () => {
+    const provider = createProvider();
 
     expect(typeof provider.pushEvents).toBe("function");
     expect(typeof provider.deleteEvents).toBe("function");
     expect(typeof provider.listRemoteEvents).toBe("function");
+  });
+
+  it("aborts a pending Graph event creation", async () => {
+    installAbortableFetch();
+    const controller = new AbortController();
+    const provider = createProvider(controller.signal);
+    const abortError = new Error("job deadline exceeded");
+
+    const pending = provider.pushEvents([createEvent()]);
+    await vi.waitFor(() => { expect(fetch).toHaveBeenCalledOnce(); });
+    controller.abort(abortError);
+
+    await expect(pending).rejects.toBe(abortError);
+  });
+
+  it("aborts a pending Graph event deletion", async () => {
+    installAbortableFetch();
+    const controller = new AbortController();
+    const provider = createProvider(controller.signal);
+    const abortError = new Error("job deadline exceeded");
+
+    const pending = provider.deleteEvents(["outlook-event-id"]);
+    await vi.waitFor(() => { expect(fetch).toHaveBeenCalledOnce(); });
+    controller.abort(abortError);
+
+    await expect(pending).rejects.toBe(abortError);
+  });
+
+  it("aborts a pending Graph event listing request", async () => {
+    installAbortableFetch();
+    const controller = new AbortController();
+    const provider = createProvider(controller.signal);
+    const abortError = new Error("job deadline exceeded");
+
+    const pending = provider.listRemoteEvents();
+    await vi.waitFor(() => { expect(fetch).toHaveBeenCalledOnce(); });
+    controller.abort(abortError);
+
+    await expect(pending).rejects.toBe(abortError);
   });
 });

--- a/packages/calendar/tests/utils/safe-fetch.test.ts
+++ b/packages/calendar/tests/utils/safe-fetch.test.ts
@@ -348,4 +348,23 @@ describe("createSafeFetch", () => {
 
     expect(response.status).toBe(200);
   });
+
+  it("propagates a configured abort signal to requests", async () => {
+    const controller = new AbortController();
+    const mockFetch = vi.fn<FetchFn>();
+    mockFetch.mockImplementation((_input, init) => new Promise((_resolve, reject) => {
+      if (init?.signal?.aborted) {
+        reject(init.signal.reason);
+        return;
+      }
+      init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+    }));
+    installMockFetch(mockFetch);
+
+    const safeFetch = createSafeFetch({ signal: controller.signal });
+    const request = safeFetch("https://example.com/calendar");
+    controller.abort(new Error("job deadline exceeded"));
+
+    await expect(request).rejects.toThrow("job deadline exceeded");
+  });
 });

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -1,5 +1,5 @@
 export { syncDestinationsForUser } from "./sync-user";
 export { invalidateCalendar, isCalendarInvalidated, SyncLockRenewalError } from "./sync-lock";
 export type { InvalidationRedis } from "./sync-lock";
-export type { SyncConfig, SyncDestinationsResult } from "./sync-user";
+export type { CalendarSyncCompletion, CalendarSyncFailure, SyncConfig, SyncDestinationsResult } from "./sync-user";
 export type { OAuthConfig } from "./resolve-provider";

--- a/packages/sync/src/resolve-provider.ts
+++ b/packages/sync/src/resolve-provider.ts
@@ -118,6 +118,7 @@ const resolveCalDAVProvider = async (
   database: BunSQLDatabase,
   calendarId: string,
   encryptionKey: string,
+  signal?: AbortSignal,
 ): Promise<CalendarSyncProvider | null> => {
   const [caldavCred] = await database
     .select({
@@ -145,7 +146,7 @@ const resolveCalDAVProvider = async (
     serverUrl: caldavCred.serverUrl,
     username: caldavCred.username,
     password,
-    safeFetchOptions: { timeoutMs: PROVIDER_PUSH_REQUEST_TIMEOUT_MS },
+    safeFetchOptions: { timeoutMs: PROVIDER_PUSH_REQUEST_TIMEOUT_MS, signal },
   });
 };
 
@@ -182,6 +183,7 @@ const resolveSyncProvider = (options: ResolveProviderOptions): Promise<CalendarS
       options.database,
       options.calendarId,
       options.encryptionKey,
+      options.signal,
     );
   }
 

--- a/packages/sync/src/resolve-provider.ts
+++ b/packages/sync/src/resolve-provider.ts
@@ -108,6 +108,7 @@ const resolveOAuthProvider = async (
         refreshLockStore,
         rawRefresh: (refreshToken) => refreshMicrosoftToken(refreshToken),
       }),
+      signal,
     });
   }
 

--- a/packages/sync/src/sync-user.ts
+++ b/packages/sync/src/sync-user.ts
@@ -45,7 +45,7 @@ const applyDestinationBackoff = async (
     .where(eq(calendarsTable.id, calendarId));
 };
 
-const extractNumericField = (event: Record<string, unknown> | undefined, key: string): number => {
+const extractNumericField = (event: Record<string, unknown> | null | undefined, key: string): number => {
   if (!event) {
     return 0;
   }
@@ -96,12 +96,24 @@ interface CalendarSyncCompletion {
   conflictsResolved: number;
   errors: string[];
   durationMs: number;
+  syncEvent?: Record<string, unknown>;
+}
+
+interface CalendarSyncFailure {
+  provider: string;
+  accountId: string;
+  calendarId: string;
+  userId: string;
+  error: unknown;
+  durationMs: number;
+  syncEvent?: Record<string, unknown>;
 }
 
 interface SyncCallbacks {
   onSyncEvent?: (event: Record<string, unknown>) => void;
   onProgress?: (update: SyncProgressUpdate) => void;
   onCalendarComplete?: (completion: CalendarSyncCompletion) => void;
+  onCalendarError?: (failure: CalendarSyncFailure) => void;
 }
 
 const syncDestinationsForUser = async (
@@ -164,6 +176,7 @@ const syncDestinationsForUser = async (
     }
 
     const { handle } = lockResult;
+    const calendarAttempt: { syncEvent: Record<string, unknown> | null } = { syncEvent: null };
 
     try {
       const syncProvider = await resolveSyncProvider({
@@ -209,15 +222,35 @@ const syncDestinationsForUser = async (
         onSyncEvent: (event) => {
           const enrichedEvent = {
             ...event,
-            "destination.provider": destination.provider,
+            "provider.name": destination.provider,
+            "provider.account_id": destination.accountId,
+            "provider.calendar_id": destination.calendarId,
             "user.id": destination.userId,
           };
+          calendarAttempt.syncEvent = enrichedEvent;
           syncEvents.push(enrichedEvent);
           if (callbacks?.onSyncEvent) {
             callbacks.onSyncEvent(enrichedEvent);
           }
         },
       });
+
+      if (callbacks?.onCalendarComplete) {
+        callbacks.onCalendarComplete({
+          provider: destination.provider,
+          accountId: destination.accountId,
+          calendarId: destination.calendarId,
+          userId: destination.userId,
+          added: result.added,
+          addFailed: result.addFailed,
+          removed: result.removed,
+          removeFailed: result.removeFailed,
+          conflictsResolved: result.conflictsResolved,
+          errors: result.errors,
+          durationMs: extractNumericField(calendarAttempt.syncEvent, "duration_ms"),
+          ...(calendarAttempt.syncEvent && { syncEvent: calendarAttempt.syncEvent }),
+        });
+      }
 
       if (!(await handle.isCurrent())) {
         continue;
@@ -237,25 +270,6 @@ const syncDestinationsForUser = async (
       removed += result.removed;
       removeFailed += result.removeFailed;
       errors.push(...result.errors);
-
-      if (callbacks?.onCalendarComplete) {
-        const syncEvent = syncEvents.at(-1);
-        const durationMs = extractNumericField(syncEvent, "duration_ms");
-
-        callbacks.onCalendarComplete({
-          provider: destination.provider,
-          accountId: destination.accountId,
-          calendarId: destination.calendarId,
-          userId: destination.userId,
-          added: result.added,
-          addFailed: result.addFailed,
-          removed: result.removed,
-          removeFailed: result.removeFailed,
-          conflictsResolved: result.conflictsResolved,
-          errors: result.errors,
-          durationMs,
-        });
-      }
     } catch (error) {
       if (!isBackoffEligibleError(error)) {
         throw error;
@@ -263,6 +277,15 @@ const syncDestinationsForUser = async (
 
       await applyDestinationBackoff(database, destination.calendarId, destination.failureCount);
       errors.push(getErrorMessage(error));
+      callbacks?.onCalendarError?.({
+        provider: destination.provider,
+        accountId: destination.accountId,
+        calendarId: destination.calendarId,
+        userId: destination.userId,
+        error,
+        durationMs: extractNumericField(calendarAttempt.syncEvent, "duration_ms"),
+        ...(calendarAttempt.syncEvent && { syncEvent: calendarAttempt.syncEvent }),
+      });
     } finally {
       await handle.release();
     }
@@ -272,4 +295,4 @@ const syncDestinationsForUser = async (
 };
 
 export { syncDestinationsForUser };
-export type { CalendarSyncCompletion, SyncConfig, SyncDestinationsResult };
+export type { CalendarSyncCompletion, CalendarSyncFailure, SyncConfig, SyncDestinationsResult };

--- a/services/worker/src/processor.ts
+++ b/services/worker/src/processor.ts
@@ -24,22 +24,113 @@ const toError = (value: unknown): Error => {
   return new Error(String(value));
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const resolveErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  if (isRecord(error) && typeof error.error === "string") {
+    return error.error;
+  }
+  return String(error);
+};
+
+const resolveErrorStatusCode = (error: unknown): number | null => {
+  if (!isRecord(error)) {
+    return null;
+  }
+  if (typeof error.statusCode === "number") {
+    return error.statusCode;
+  }
+  if (typeof error.status === "number") {
+    return error.status;
+  }
+  return null;
+};
+
 const classifySyncError = (error: unknown): string => {
   if (error instanceof SyncLockRenewalError) {
     return "sync-lock-renewal-failed";
   }
-  if (typeof error === "string") {
-    if (error.includes("conflict") || error.includes("409")) {
-      return "sync-push-conflict";
-    }
-    if (error.includes("timeout")) {
-      return "provider-api-timeout";
-    }
-    if (error.includes("rate") || error.includes("429")) {
-      return "provider-rate-limited";
-    }
+
+  const statusCode = resolveErrorStatusCode(error);
+  if (statusCode === 401 || statusCode === 403) {
+    return "provider-auth-failed";
+  }
+  if (statusCode === 409 || statusCode === 412) {
+    return "sync-push-conflict";
+  }
+  if (statusCode === 429) {
+    return "provider-rate-limited";
+  }
+  if (statusCode !== null && statusCode >= 500) {
+    return "provider-api-error";
+  }
+
+  const message = resolveErrorMessage(error).toLowerCase();
+  let errorType = "";
+  if (error instanceof Error) {
+    errorType = error.name;
+  } else if (isRecord(error) && typeof error.errorType === "string") {
+    ({ errorType } = error);
+  }
+  if (message.includes("conflict") || message.includes("409") || message.includes("412")) {
+    return "sync-push-conflict";
+  }
+  if (errorType.includes("Timeout") || message.includes("timeout") || message.includes("timed out")) {
+    return "provider-api-timeout";
+  }
+  if (message.includes("rate") || message.includes("429")) {
+    return "provider-rate-limited";
   }
   return "sync-push-failed";
+};
+
+const recordOperationFailures = (syncEvent: Record<string, unknown>): void => {
+  const operationErrors = syncEvent.operation_errors;
+  if (!Array.isArray(operationErrors)) {
+    return;
+  }
+
+  let samples = 0;
+  for (const operationError of operationErrors) {
+    widelog.error("sync.failures", operationError);
+    if (!isRecord(operationError)) {
+      continue;
+    }
+
+    if (typeof operationError.type === "string") {
+      widelog.append("sync.failure_operations", operationError.type);
+    }
+    if (typeof operationError.errorType === "string") {
+      widelog.append("sync.failure_error_types", operationError.errorType);
+    }
+    if (typeof operationError.statusCode === "number") {
+      widelog.append("sync.failure_status_codes", operationError.statusCode);
+    }
+    if (samples < 3 && typeof operationError.error === "string") {
+      let operation = "unknown";
+      if (typeof operationError.type === "string") {
+        operation = operationError.type;
+      }
+      widelog.append("sync.error_samples", `[${operation}] ${operationError.error}`.slice(0, 500));
+      samples += 1;
+    }
+  }
+};
+
+const applySyncEventFields = (syncEvent: Record<string, unknown>): void => {
+  for (const [key, value] of Object.entries(syncEvent)) {
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      widelog.set(key, value);
+    }
+  }
+  recordOperationFailures(syncEvent);
 };
 
 const broadcastService = createBroadcastService({ redis: refreshLockRedis });
@@ -64,7 +155,16 @@ const persistSyncStatus = async (result: DestinationSyncResult, syncedAt: Date):
 };
 
 const reportAggregateError = (scope: string, error: Error): void => {
+  widelog.set("operation.name", "sync-aggregate");
+  widelog.set("operation.type", "internal");
+  widelog.set("sync_aggregate.scope", scope);
+  widelog.set("outcome", "error");
   widelog.error(`sync_aggregate.${scope}`, error);
+  widelog.errorFields(error, {
+    prefix: "sync_aggregate.error",
+    slug: classifySyncError(error),
+  });
+  widelog.flush();
 };
 
 const syncAggregateRuntime = createSyncAggregateRuntime({
@@ -112,7 +212,7 @@ const processJob = (
 
     const deadlineController = new AbortController();
     const deadlineTimer = setTimeout(() => deadlineController.abort(), USER_TIMEOUT_MS);
-    let flushed = false;
+    let needsFlush = true;
     const pendingDestinationSyncs: Promise<void>[] = [];
 
     try {
@@ -140,9 +240,16 @@ const processJob = (
           });
         },
         onSyncEvent: (syncEvent) => {
+          applySyncEventFields(syncEvent);
+          needsFlush = true;
+
           const calendarId = syncEvent["calendar.id"];
           const localCount = syncEvent["local_events.count"];
           const remoteCount = syncEvent["remote_events.count"];
+          const addFailed = resolveCount(syncEvent["events.add_failed"]);
+          const removeFailed = resolveCount(syncEvent["events.remove_failed"]);
+          const completedOutcome = syncEvent["outcome"] === "success"
+            || syncEvent["outcome"] === "in-sync";
 
           if (typeof calendarId !== "string") {
             return;
@@ -153,6 +260,7 @@ const processJob = (
               .onDestinationSync({
                 userId,
                 calendarId,
+                completedSuccessfully: completedOutcome && addFailed === 0 && removeFailed === 0,
                 localEventCount: resolveCount(localCount),
                 remoteEventCount: resolveCount(remoteCount),
               })
@@ -171,25 +279,42 @@ const processJob = (
           widelog.set("sync.conflicts_resolved", completion.conflictsResolved);
           widelog.set("duration_ms", completion.durationMs);
 
-          for (const syncError of completion.errors) {
-            widelog.error("sync.failures", syncError);
-          }
-
-          const unclassifiedErrors = completion.errors
-            .filter((syncError) => classifySyncError(syncError) === "sync-push-failed")
-            .slice(0, 3);
-
-          for (const sample of unclassifiedErrors) {
-            widelog.append("sync.error_samples", sample.slice(0, 200));
+          if (!completion.syncEvent) {
+            for (const syncError of completion.errors) {
+              widelog.error("sync.failures", syncError);
+            }
           }
 
           const totalFailed = completion.addFailed + completion.removeFailed;
           const totalAttempted = completion.added + completion.removed + totalFailed;
-          widelog.set("outcome", resolveSyncOutcome(totalFailed, totalAttempted));
+          const syncOutcome = completion.syncEvent?.outcome;
+          let outcome = "success";
+          if (totalFailed > 0) {
+            outcome = resolveSyncOutcome(totalFailed, totalAttempted);
+          } else if (typeof syncOutcome === "string") {
+            outcome = syncOutcome;
+          }
+          widelog.set("outcome", outcome);
           widelog.flush();
-          flushed = true;
+          needsFlush = false;
+        },
+        onCalendarError: (failure) => {
+          widelog.set("provider.name", failure.provider);
+          widelog.set("provider.account_id", failure.accountId);
+          widelog.set("provider.calendar_id", failure.calendarId);
+          widelog.set("duration_ms", failure.durationMs);
+          widelog.set("retry.backoff_applied", true);
+          widelog.set("outcome", "error");
+          widelog.errorFields(failure.error, { slug: classifySyncError(failure.error) });
+          widelog.flush();
+          needsFlush = false;
         },
       });
+
+      if (result.syncEvents.length === 0) {
+        widelog.set("outcome", "success");
+        needsFlush = true;
+      }
 
       return {
         added: result.added,
@@ -201,6 +326,7 @@ const processJob = (
     } catch (error) {
       widelog.set("outcome", "error");
       widelog.errorFields(error, { slug: classifySyncError(error) });
+      needsFlush = true;
       throw error;
     } finally {
       await Promise.all(pendingDestinationSyncs);
@@ -210,8 +336,9 @@ const processJob = (
         widelog.set("timeout.kind", "job_deadline");
         widelog.set("timeout.limit_ms", USER_TIMEOUT_MS);
         widelog.set("error.slug", "sync-deadline-exceeded");
+        needsFlush = true;
       }
-      if (!flushed) {
+      if (needsFlush) {
         widelog.flush();
       }
     }


### PR DESCRIPTION
## What changed

- propagate the worker deadline/abort signal through provider resolution, safe fetch, CalDAV requests, and queued rate-limiter work
- reject non-successful CalDAV write responses and classify create conflicts explicitly
- recover deterministic CalDAV create conflicts by reconciling the exact object and recreating stale Keeper copies
- include time and timezone fields in destination content hashes so moved events are detected
- model mismatched mapped events as explicit delete/recreate replacements and checkpoint mapping changes incrementally
- retain stale mappings when recreation fails so a later sync retries the missing destination copy
- only advance `lastSyncedAt` after a fully successful destination sync, and preserve the last known timestamp when aggregate messages omit it
- emit queryable worker wide events with provider identity, operation counts, error slugs, bounded samples, error types, HTTP statuses, and correct outcomes

## Root cause

CalDAV push work could outlive the worker deadline because the abort signal stopped before the provider's fetch and queue layers. CalDAV write responses were also treated as successful without checking HTTP status. Separately, the persisted event hash did not include movement fields, failed attempts could still finalize the aggregate timestamp, and the worker discarded most structured calendar diagnostics before flushing its wide event.

## Impact

Stalled or failed destination syncs now terminate at the worker deadline, retain enough mapping state to reconcile on a later run, and no longer present a failed attempt as a successful recent sync. Grafana events contain the provider, calendar, failure class, HTTP status, and bounded diagnostic samples needed to investigate individual failures.

The content-hash format intentionally changes. The first post-deploy sync can recreate existing mapped destination events; checkpointing limits retry work if that run is interrupted. Source/reference events are never modified.

## Validation

- Calendar: typecheck, lint, 58 test files / 436 tests
- Sync: typecheck, lint, 24 tests
- Web: typecheck, lint, focused 14 tests
- Worker: typecheck, lint, production build
- `git diff --check`
