### PR TITLE
fix(calendar): accept null Outlook series master IDs

### DIFF
--- a/packages/calendar/src/providers/outlook/source/types.ts
+++ b/packages/calendar/src/providers/outlook/source/types.ts
@@ -40,7 +40,7 @@ interface OutlookCalendarEvent {
   lastModifiedDateTime?: string;
   originalEndTimeZone?: string;
   originalStartTimeZone?: string;
-  seriesMasterId?: string;
+  seriesMasterId?: string | null;
   type?: string;
   "@removed"?: OutlookRemovedInfo;
 }

--- a/packages/calendar/tests/providers/outlook/destination/provider.test.ts
+++ b/packages/calendar/tests/providers/outlook/destination/provider.test.ts
@@ -63,6 +63,22 @@ describe("createOutlookSyncProvider", () => {
     await expect(pending).rejects.toBe(abortError);
   });
 
+  it("accepts a null series master ID when Graph creates a standalone event", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(Response.json({
+      iCalUId: "created-event-uid",
+      id: "created-event-id",
+      seriesMasterId: null,
+      type: "singleInstance",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(createProvider().pushEvents([createEvent()])).resolves.toEqual([{
+      deleteId: "created-event-id",
+      remoteId: "created-event-uid",
+      success: true,
+    }]);
+  });
+
   it("aborts a pending Graph event deletion", async () => {
     installAbortableFetch();
     const controller = new AbortController();

--- a/packages/calendar/tests/providers/outlook/source/utils/fetch-events.test.ts
+++ b/packages/calendar/tests/providers/outlook/source/utils/fetch-events.test.ts
@@ -264,6 +264,26 @@ describe("fetchCalendarEvents", () => {
     expect(result.events[0]?.originalEndTimeZone).toBe("Mountain Standard Time");
   });
 
+  it("accepts a null series master ID in a standalone Graph event", async () => {
+    globalThis.fetch = createFetchQueue([createJsonResponse({
+      "@odata.deltaLink": "https://graph.microsoft.com/delta?$deltatoken=next",
+      value: [createOutlookEvent({
+        seriesMasterId: null,
+        type: "singleInstance",
+      })],
+    })], []);
+
+    const result = await fetchCalendarEvents({
+      accessToken: "token",
+      calendarId: "calendar-id",
+      timeMax: new Date("2026-07-31T00:00:00.000Z"),
+      timeMin: new Date("2026-07-01T00:00:00.000Z"),
+    });
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.seriesMasterId).toBeNull();
+  });
+
   it("expands an Outlook series master into all paged instances during full sync", async () => {
     const requestedUrls: string[] = [];
     const instancesNextLink = "https://graph.microsoft.com/v1.0/instances?$skiptoken=next";

--- a/packages/data-schemas/src/index.ts
+++ b/packages/data-schemas/src/index.ts
@@ -141,7 +141,7 @@ const outlookEventSchema = type({
   "showAs?": "string",
   "start?": { "dateTime?": "string", "timeZone?": "string" },
   "subject?": "string",
-  "seriesMasterId?": "string",
+  "seriesMasterId?": "string | null",
   "type?": "string",
 });
 type OutlookEvent = typeof outlookEventSchema.infer;


### PR DESCRIPTION
## What changed

- Accept Microsoft Graph's `seriesMasterId: null` response for standalone Outlook events.
- Keep the Outlook source event type aligned with the validated provider shape.
- Cover both destination create responses and source list responses with regression tests.

## Why

Microsoft Graph returns `seriesMasterId: null` for standalone events. The stricter shared schema treated that valid response as a traversal failure. Destination creates had already succeeded remotely, but Keeper then reported them as failed and did not checkpoint mappings; source ingestion failed validation for the same response shape.

## Validation

- `bun run --cwd packages/calendar test` — 66 files, 650 tests passed
- `bun run --cwd packages/calendar types`
- `bun run --cwd packages/calendar lint`
- `bun run --cwd packages/data-schemas types`
- `bun run --cwd packages/data-schemas lint`
