### PR TITLE
Fix recurrence mapping update persistence

### DIFF
--- a/packages/calendar/src/core/sync-engine/flush.ts
+++ b/packages/calendar/src/core/sync-engine/flush.ts
@@ -1,6 +1,6 @@
 import type { BunSQLClient } from "../database-client";
 import { eventMappingsTable } from "@keeper.sh/database/schema";
-import { inArray, sql } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import type { PendingChanges } from "./types";
 
 const FLUSH_BATCH_SIZE = 5000;
@@ -51,27 +51,16 @@ const createDatabaseFlush = (database: BunSQLClient): (changes: PendingChanges) 
       if (updates.length > 0) {
         const updateBatches = chunk(updates, FLUSH_BATCH_SIZE);
         for (const batch of updateBatches) {
-          const serializedUpdates = JSON.stringify(batch.map((update) => ({
-            deleteIdentifier: update.deleteIdentifier,
-            id: update.id,
-            syncEventHash: update.syncEventHash,
-            syncEventId: update.syncEventId,
-          })));
-          await transaction.execute(sql`
-            update ${eventMappingsTable}
-            set
-              "deleteIdentifier" = mapping_updates."deleteIdentifier",
-              "syncEventHash" = mapping_updates."syncEventHash",
-              "syncEventId" = mapping_updates."syncEventId"
-            from jsonb_to_recordset(${serializedUpdates}::jsonb)
-              as mapping_updates(
-                "deleteIdentifier" text,
-                id uuid,
-                "syncEventHash" text,
-                "syncEventId" text
-              )
-            where ${eventMappingsTable.id} = mapping_updates.id
-          `);
+          for (const update of batch) {
+            await transaction
+              .update(eventMappingsTable)
+              .set({
+                deleteIdentifier: update.deleteIdentifier,
+                syncEventHash: update.syncEventHash,
+                syncEventId: update.syncEventId,
+              })
+              .where(eq(eventMappingsTable.id, update.id));
+          }
         }
       }
     });

--- a/packages/calendar/src/core/sync-engine/index.ts
+++ b/packages/calendar/src/core/sync-engine/index.ts
@@ -7,6 +7,7 @@ import type {
   SyncResult,
 } from "../types";
 import type { EventMapping } from "../events/mappings";
+import { getDatabaseErrorDetails } from "@keeper.sh/database";
 import type { SyncProgressUpdate } from "../sync/types";
 import { createSyncEventContentHash } from "../events/content-hash";
 import { computeSyncOperations } from "../sync/operations";
@@ -496,6 +497,28 @@ interface SyncCalendarResult extends SyncResult {
 
 const EMPTY_RESULT: SyncCalendarResult = { added: 0, addFailed: 0, removed: 0, removeFailed: 0, conflictsResolved: 0, errors: [] };
 
+const appendDatabaseErrorFields = (
+  event: Record<string, unknown>,
+  error: unknown,
+): void => {
+  const databaseError = getDatabaseErrorDetails(error);
+  if (!databaseError) {
+    return;
+  }
+  if (databaseError.sqlState) {
+    event["error.database.sqlstate"] = databaseError.sqlState;
+  }
+  if (databaseError.message) {
+    event["error.database.message"] = databaseError.message;
+  }
+  if (databaseError.detail) {
+    event["error.database.detail"] = databaseError.detail;
+  }
+  if (databaseError.constraint) {
+    event["error.database.constraint"] = databaseError.constraint;
+  }
+};
+
 const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarResult> => {
   const {
     userId,
@@ -643,6 +666,8 @@ const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarR
       wideEvent["error.message"] = error.message;
       wideEvent["error.type"] = error.constructor.name;
     }
+
+    appendDatabaseErrorFields(wideEvent, error);
 
     throw error;
   } finally {

--- a/packages/calendar/tests/core/sync-engine/index.test.ts
+++ b/packages/calendar/tests/core/sync-engine/index.test.ts
@@ -806,6 +806,37 @@ describe("syncCalendar", () => {
     expect(emittedEvents[0]?.["error.message"]).toBe("db connection failed");
     expect(typeof emittedEvents[0]?.["duration_ms"]).toBe("number");
   });
+
+  it("emits the underlying PostgreSQL error details when a database query throws", async () => {
+    const { syncCalendar } = await import("../../../src/core/sync-engine/index");
+    const provider = makeProvider();
+    const emittedEvents: Record<string, unknown>[] = [];
+    const cause = Object.assign(new Error("duplicate key value violates unique constraint"), {
+      constraint: "event_mappings_sync_event_cal_idx",
+      detail: "Key already exists.",
+      errno: "23505",
+    });
+    const error = new Error("Failed query", { cause });
+
+    await expect(syncCalendar({
+      userId: "user-1",
+      calendarId: "dest-cal-1",
+      provider,
+      readState: () => Promise.reject(error),
+      isCurrent: () => Promise.resolve(true),
+      flush: () => Promise.resolve(),
+      onSyncEvent: (event) => { emittedEvents.push(event); },
+    })).rejects.toThrow("Failed query");
+
+    expect(emittedEvents[0]).toMatchObject({
+      "error.database.constraint": "event_mappings_sync_event_cal_idx",
+      "error.database.detail": "Key already exists.",
+      "error.database.message": "duplicate key value violates unique constraint",
+      "error.database.sqlstate": "23505",
+      "error.message": "Failed query",
+      outcome: "error",
+    });
+  });
 });
 
 describe("createRedisGenerationCheck", () => {
@@ -866,7 +897,12 @@ describe("createDatabaseFlush", () => {
     const fakeDatabase = {
       transaction: (callback: (tx: unknown) => Promise<void>) => {
         const tx = {
-          execute: () => { executedOperations.push("update"); return Promise.resolve(); },
+          update: () => ({
+            set: () => {
+              executedOperations.push("update");
+              return { where: () => Promise.resolve() };
+            },
+          }),
           insert: () => { executedOperations.push("insert"); return { values: () => ({ onConflictDoNothing: () => Promise.resolve() }) }; },
           delete: () => { executedOperations.push("delete"); return { where: () => Promise.resolve() }; },
         };
@@ -892,6 +928,61 @@ describe("createDatabaseFlush", () => {
     });
 
     expect(executedOperations).toEqual(["delete", "insert", "update"]);
+  });
+
+  it("updates every mapping through the typed update builder", async () => {
+    const { createDatabaseFlush } = await import("../../../src/core/sync-engine/flush");
+    const updateValues: unknown[] = [];
+    let whereCallCount = 0;
+    const fakeDatabase = {
+      transaction: (callback: (tx: unknown) => Promise<void>) => callback({
+        update: () => ({
+          set: (values: unknown) => {
+            updateValues.push(values);
+            return {
+              where: () => {
+                whereCallCount += 1;
+                return Promise.resolve();
+              },
+            };
+          },
+        }),
+      }),
+    };
+
+    const flush = createDatabaseFlush(fakeDatabase as never);
+    await flush({
+      deletes: [],
+      inserts: [],
+      updates: [
+        {
+          deleteIdentifier: "remote-delete-1",
+          id: "019c0000-0000-7000-8000-000000000001",
+          syncEventHash: "hash-1",
+          syncEventId: "recurrence-1",
+        },
+        {
+          deleteIdentifier: "remote-delete-2",
+          id: "019c0000-0000-7000-8000-000000000002",
+          syncEventHash: "hash-2",
+          syncEventId: "recurrence-2",
+        },
+      ],
+    });
+
+    expect(updateValues).toEqual([
+      {
+        deleteIdentifier: "remote-delete-1",
+        syncEventHash: "hash-1",
+        syncEventId: "recurrence-1",
+      },
+      {
+        deleteIdentifier: "remote-delete-2",
+        syncEventHash: "hash-2",
+        syncEventId: "recurrence-2",
+      },
+    ]);
+    expect(whereCallCount).toBe(2);
   });
 
   it("skips delete when there are no deletes", async () => {

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -1,5 +1,5 @@
 export { createDatabase, closeDatabase } from "./utils/database";
-export { classifyDatabaseError } from "./utils/errors";
-export type { DatabaseErrorClassification } from "./utils/errors";
+export { classifyDatabaseError, getDatabaseErrorDetails } from "./utils/errors";
+export type { DatabaseErrorClassification, DatabaseErrorDetails } from "./utils/errors";
 export { account, user } from "./database/auth-schema";
 export { encryptPassword, decryptPassword } from "./encryption";

--- a/packages/database/src/utils/errors.ts
+++ b/packages/database/src/utils/errors.ts
@@ -8,6 +8,13 @@ interface DatabaseErrorClassification {
   sqlState: string | null;
 }
 
+interface DatabaseErrorDetails {
+  constraint: string | null;
+  detail: string | null;
+  message: string | null;
+  sqlState: string | null;
+}
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
@@ -16,6 +23,31 @@ const readCause = (error: unknown): Record<string, unknown> | null => {
     return error.cause;
   }
   return null;
+};
+
+const readString = (value: unknown): string | null => {
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+  return null;
+};
+
+const getDatabaseErrorDetails = (error: unknown): DatabaseErrorDetails | null => {
+  const cause = readCause(error);
+  if (!cause) {
+    return null;
+  }
+
+  const details = {
+    constraint: readString(cause.constraint),
+    detail: readString(cause.detail),
+    message: readString(cause.message),
+    sqlState: readString(cause.errno) ?? readString(cause.code),
+  };
+  if (Object.values(details).every((value) => value === null)) {
+    return null;
+  }
+  return details;
 };
 
 const classifyDatabaseError = (error: unknown): DatabaseErrorClassification | null => {
@@ -31,5 +63,5 @@ const classifyDatabaseError = (error: unknown): DatabaseErrorClassification | nu
   return null;
 };
 
-export { classifyDatabaseError };
-export type { DatabaseErrorClassification };
+export { classifyDatabaseError, getDatabaseErrorDetails };
+export type { DatabaseErrorClassification, DatabaseErrorDetails };

--- a/packages/database/tests/utils/errors.test.ts
+++ b/packages/database/tests/utils/errors.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { getDatabaseErrorDetails } from "../../src/utils/errors";
+
+describe("getDatabaseErrorDetails", () => {
+  it("extracts PostgreSQL diagnostics from a wrapped query error", () => {
+    const cause = Object.assign(new Error("duplicate key"), {
+      constraint: "event_mappings_sync_event_cal_idx",
+      detail: "Key already exists.",
+      errno: "23505",
+    });
+
+    expect(getDatabaseErrorDetails(new Error("Failed query", { cause }))).toEqual({
+      constraint: "event_mappings_sync_event_cal_idx",
+      detail: "Key already exists.",
+      message: "duplicate key",
+      sqlState: "23505",
+    });
+  });
+
+  it("returns null when an error has no database cause", () => {
+    expect(getDatabaseErrorDetails(new Error("network failed"))).toBeNull();
+  });
+});


### PR DESCRIPTION
## What changed

- Replace the unverified raw `jsonb_to_recordset` mapping-update statement with typed Drizzle updates inside the existing transaction.
- Preserve the existing delete, insert, and update ordering.
- Add structured PostgreSQL cause fields: SQLSTATE, message, detail, and constraint.
- Add regression coverage for multiple mapping updates and wrapped database diagnostics.

## Why

Production recurrence identity migrations were deterministically failing in the raw bulk-update path. A rollback-only production diagnostic proved that PostgreSQL accepts the exact statement and updates both rows, while every application mapping update observed over ten minutes failed. Seven calendars were repeatedly affected in a five-minute sample.

These migrations perform no remote provider operations, but the failures prevent affected calendars from reaching an in-sync state and repeatedly fail their push jobs.

## Validation

- `@keeper.sh/calendar`: 66 test files, 652 tests passed
- `@keeper.sh/database`: 4 test files, 14 tests passed
- TypeScript checks passed for both packages
- Oxlint passed for both packages
- Production diagnostic returned `DIAGNOSTIC_SUCCESS rows=2` and rolled back by design