### PR TITLE
Fix cron startup and preserve unstructured logs

### DIFF
--- a/packages/otelemetry/src/index.ts
+++ b/packages/otelemetry/src/index.ts
@@ -36,11 +36,35 @@ const parseLogLine = (line: string) => {
   return { message, level, time, service, attributes };
 };
 
+const parseStructuredLogLine = (
+  line: string,
+): ReturnType<typeof parseLogLine> | undefined => {
+  try {
+    return parseLogLine(line);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return;
+    }
+    throw error;
+  }
+};
+
 const forwardToCollector = (
   logger: ReturnType<LoggerProvider["getLogger"]>,
   line: string,
-  { message, level, time, attributes }: ReturnType<typeof parseLogLine>,
+  entry: ReturnType<typeof parseLogLine> | undefined,
 ) => {
+  if (!entry) {
+    logger.emit({
+      body: line,
+      severityNumber: SeverityNumber.ERROR,
+      severityText: "ERROR",
+      attributes: { "log.format": "unstructured" },
+    });
+    return;
+  }
+
+  const { message, level, time, attributes } = entry;
   logger.emit({
     body: message ?? line,
     severityNumber: PINO_SEVERITY[level] ?? SeverityNumber.INFO,
@@ -52,18 +76,7 @@ const forwardToCollector = (
 
 if (process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {
   const lineReader = createInterface({ input: process.stdin });
-  const lineIterator = lineReader[Symbol.asyncIterator]();
-
-  const firstResult = await lineIterator.next();
-
-  if (firstResult.done) {
-    process.exit(0);
-  }
-
-  process.stdout.write(`${firstResult.value}\n`);
-
-  const firstLogEntry = parseLogLine(firstResult.value);
-  const serviceName = firstLogEntry.service ?? "unknown";
+  const serviceName = process.env.OTEL_SERVICE_NAME ?? "unknown";
 
   const resource = detectResources({
     detectors: [envDetector, hostDetector, osDetector, processDetector],
@@ -81,15 +94,9 @@ if (process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {
 
   const logger = provider.getLogger(serviceName);
 
-  forwardToCollector(logger, firstResult.value, firstLogEntry);
-
-  for await (const line of lineIterator) {
+  for await (const line of lineReader) {
     process.stdout.write(`${line}\n`);
-    try {
-      forwardToCollector(logger, line, parseLogLine(line));
-    } catch {
-      // Non-JSON line, pass through only
-    }
+    forwardToCollector(logger, line, parseStructuredLogLine(line));
   }
 
   await provider.shutdown();

--- a/services/api/entrypoint.sh
+++ b/services/api/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+export OTEL_SERVICE_NAME=keeper-api
+
 bun /app/packages/database/scripts/migrate.ts
 
 exec bun services/api/dist/index.js 2>&1 | keeper-otelemetry

--- a/services/cron/entrypoint.sh
+++ b/services/cron/entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 set -e
 
+export OTEL_SERVICE_NAME=keeper-cron
+
 exec bun services/cron/dist/index.js 2>&1 | keeper-otelemetry

--- a/services/cron/src/jobs/push-destinations.ts
+++ b/services/cron/src/jobs/push-destinations.ts
@@ -4,8 +4,8 @@ import { createPushSyncQueue } from "@keeper.sh/queue";
 import { withCronWideEvent } from "@/utils/with-wide-event";
 import { widelog } from "@/utils/logging";
 import { getDestinationCalendarsByPlan } from "@/utils/get-sources";
+import { buildPushDestinationJobs } from "@/utils/push-destination-jobs";
 import env from "@/env";
-import { buildPushDestinationJobs } from "./push-destination-jobs";
 
 const runEgressJob = async (plan: Plan): Promise<void> => {
   if (env.WORKER_JOB_QUEUE_ENABLED === false) {

--- a/services/cron/src/utils/push-destination-jobs.ts
+++ b/services/cron/src/utils/push-destination-jobs.ts
@@ -1,6 +1,6 @@
 import type { Plan } from "@keeper.sh/data-schemas";
 import type { PushSyncJobPayload } from "@keeper.sh/queue";
-import type { DestinationCalendarRef } from "@/utils/get-sources";
+import type { DestinationCalendarRef } from "./get-sources";
 
 interface PushDestinationJob {
   data: PushSyncJobPayload;

--- a/services/cron/tests/utils/push-destination-jobs.test.ts
+++ b/services/cron/tests/utils/push-destination-jobs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildPushDestinationJobs } from "../../src/jobs/push-destination-jobs";
+import { buildPushDestinationJobs } from "../../src/utils/push-destination-jobs";
 
 describe("buildPushDestinationJobs", () => {
   it("creates an independent job for every destination calendar", () => {

--- a/services/mcp/entrypoint.sh
+++ b/services/mcp/entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 set -e
 
+export OTEL_SERVICE_NAME=keeper-mcp
+
 exec bun services/mcp/dist/index.js 2>&1 | keeper-otelemetry

--- a/services/worker/entrypoint.sh
+++ b/services/worker/entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 set -e
 
+export OTEL_SERVICE_NAME=keeper-worker
+
 exec bun services/worker/dist/index.js 2>&1 | keeper-otelemetry


### PR DESCRIPTION
## Root cause

PR #446 placed a pure helper in `services/cron/src/jobs`. Cron discovers every built module in that directory and requires a default scheduled-job export, so the new helper caused cron startup to fail.

The telemetry wrapper then attempted to parse Bun's first plain-text error line as JSON and crashed, masking the original startup failure.

## Fix

- move the destination job builder to `src/utils` while preserving cron job discovery
- move its test to the corresponding test directory
- give each service an explicit `OTEL_SERVICE_NAME`
- export every child-process line to OpenTelemetry
- mark non-JSON output as `log.format=unstructured` at ERROR severity
- remove the first-line parsing, mutable sentinel, explicit process exit, and swallowed catch behavior

## Validation

- cron tests: 21 passed
- cron types and lint
- cron production build
- telemetry types and lint
- `git diff --check`
