### PR TITLE
Log destination stale mapping reasons

### DIFF
--- a/packages/calendar/src/core/sync-engine/index.ts
+++ b/packages/calendar/src/core/sync-engine/index.ts
@@ -11,7 +11,7 @@ import { getDatabaseErrorDetails } from "@keeper.sh/database";
 import type { SyncProgressUpdate } from "../sync/types";
 import { createSyncEventContentHash } from "../events/content-hash";
 import { computeSyncOperations } from "../sync/operations";
-import type { RemoveOperationTimeBoundary } from "../sync/operations";
+import type { RemoveOperationTimeBoundary, StaleReasonCounts } from "../sync/operations";
 import type { CalendarSyncProvider, PendingChanges } from "./types";
 
 const resolveOutcome = (superseded: boolean, invalidated: boolean): string => {
@@ -519,6 +519,26 @@ const appendDatabaseErrorFields = (
   }
 };
 
+const appendStaleReasonFields = (
+  event: Record<string, unknown>,
+  counts: StaleReasonCounts,
+): void => {
+  const fields: [string, number][] = [
+    ["stale_mappings.local_hash_changed_count", counts.localHashChanged],
+    ["stale_mappings.occurrence_reassigned_count", counts.occurrenceReassigned],
+    ["stale_mappings.remote_availability_changed_count", counts.remoteAvailabilityChanged],
+    ["stale_mappings.remote_content_changed_count", counts.remoteContentChanged],
+    ["stale_mappings.remote_missing_count", counts.remoteMissing],
+    ["stale_mappings.remote_time_changed_count", counts.remoteTimeChanged],
+  ];
+
+  for (const [field, count] of fields) {
+    if (count > 0) {
+      event[field] = count;
+    }
+  }
+};
+
 const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarResult> => {
   const {
     userId,
@@ -575,7 +595,13 @@ const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarR
     }
 
     emitProgress("comparing", state.localEvents.length, state.remoteEvents.length);
-    const { mappingIdsToPrune, mappingUpdates, operations, staleMappingIds } = computeSyncOperations(
+    const {
+      mappingIdsToPrune,
+      mappingUpdates,
+      operations,
+      staleMappingIds,
+      staleReasonCounts,
+    } = computeSyncOperations(
       state.localEvents,
       state.existingMappings,
       state.remoteEvents,
@@ -589,6 +615,7 @@ const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarR
     wideEvent["operations.remove_count"] = removeCount;
     wideEvent["operations.total"] = addCount + removeCount;
     wideEvent["stale_mappings.count"] = staleMappingIds.length;
+    appendStaleReasonFields(wideEvent, staleReasonCounts);
     wideEvent["mapping_updates.count"] = mappingUpdates.length;
 
     if (

--- a/packages/calendar/src/core/sync/operations.ts
+++ b/packages/calendar/src/core/sync/operations.ts
@@ -15,6 +15,7 @@ interface RemoveOperationTimeBoundary {
 }
 
 interface StaleMappingResult {
+  staleReasonCounts: StaleReasonCounts;
   staleMappingIds: string[];
   staleMappedEventIds: Set<string>;
   staleRemoteMappings: EventMapping[];
@@ -24,7 +25,23 @@ interface ComputeSyncOperationsResult {
   mappingUpdates: MappingUpdate[];
   mappingIdsToPrune: string[];
   operations: SyncOperation[];
+  staleReasonCounts: StaleReasonCounts;
   staleMappingIds: string[];
+}
+
+interface StaleReasonCounts {
+  localHashChanged: number;
+  occurrenceReassigned: number;
+  remoteAvailabilityChanged: number;
+  remoteContentChanged: number;
+  remoteMissing: number;
+  remoteTimeChanged: number;
+}
+
+interface RemoteStateChanges {
+  availability: boolean;
+  content: boolean;
+  time: boolean;
 }
 
 interface MappingUpdate {
@@ -41,6 +58,15 @@ interface OccurrenceReassignment {
 
 const getDefaultTimeBoundary = (): RemoveOperationTimeBoundary => ({
   syncWindowStart: getOAuthSyncWindowStart(),
+});
+
+const createStaleReasonCounts = (): StaleReasonCounts => ({
+  localHashChanged: 0,
+  occurrenceReassigned: 0,
+  remoteAvailabilityChanged: 0,
+  remoteContentChanged: 0,
+  remoteMissing: 0,
+  remoteTimeChanged: 0,
 });
 
 const getMappingSyncEventId = (mapping: EventMapping): string =>
@@ -180,11 +206,11 @@ const matchRemoteEventsToMappings = (
   return matches;
 };
 
-const hasRemoteStateChanged = (
+const getRemoteStateChanges = (
   mapping: EventMapping,
   localEvent: MaterializedSyncableEvent,
   remoteEvent: RemoteEvent,
-): boolean => {
+): RemoteStateChanges => {
   const remoteContentChanged = typeof remoteEvent.editableContentHash === "string"
     && remoteEvent.editableContentHash !== createEditableEventContentHash(localEvent);
   const localAvailability = localEvent.availability ?? "busy";
@@ -198,7 +224,20 @@ const hasRemoteStateChanged = (
   const remoteTimeChanged = !isSameSerializedSecond(remoteEvent.startTime, mapping.startTime)
     || !isSameSerializedSecond(remoteEvent.endTime, mapping.endTime);
 
-  return remoteAvailabilityChanged || remoteContentChanged || remoteTimeChanged;
+  return {
+    availability: remoteAvailabilityChanged,
+    content: remoteContentChanged,
+    time: remoteTimeChanged,
+  };
+};
+
+const hasRemoteStateChanged = (
+  mapping: EventMapping,
+  localEvent: MaterializedSyncableEvent,
+  remoteEvent: RemoteEvent,
+): boolean => {
+  const changes = getRemoteStateChanges(mapping, localEvent, remoteEvent);
+  return changes.availability || changes.content || changes.time;
 };
 
 const identifyStaleMappings = (
@@ -210,12 +249,14 @@ const identifyStaleMappings = (
   const staleMappingIds: string[] = [];
   const staleMappedEventIds = new Set<string>();
   const staleRemoteMappings: EventMapping[] = [];
+  const staleReasonCounts = createStaleReasonCounts();
 
   for (const mapping of mappings) {
     const syncEventId = getMappingSyncEventId(mapping);
     const localEventExists = localEventIds.has(syncEventId);
     const remoteEvent = remoteEventsByMappingId.get(mapping.id);
     if (localEventExists && !remoteEvent) {
+      staleReasonCounts.remoteMissing += 1;
       staleMappingIds.push(mapping.id);
       staleMappedEventIds.add(syncEventId);
       staleRemoteMappings.push(mapping);
@@ -232,16 +273,37 @@ const identifyStaleMappings = (
     }
 
     const localEventHash = createSyncEventContentHash(localEvent);
-    const eventContentChanged = mapping.syncEventHash !== localEventHash;
+    const localHashChanged = mapping.syncEventHash !== localEventHash;
+    const remoteChanges = getRemoteStateChanges(mapping, localEvent, remoteEvent);
+    const remoteStateChanged = remoteChanges.availability
+      || remoteChanges.content
+      || remoteChanges.time;
 
-    if (eventContentChanged || hasRemoteStateChanged(mapping, localEvent, remoteEvent)) {
+    if (localHashChanged || remoteStateChanged) {
+      if (localHashChanged) {
+        staleReasonCounts.localHashChanged += 1;
+      }
+      if (remoteChanges.availability) {
+        staleReasonCounts.remoteAvailabilityChanged += 1;
+      }
+      if (remoteChanges.content) {
+        staleReasonCounts.remoteContentChanged += 1;
+      }
+      if (remoteChanges.time) {
+        staleReasonCounts.remoteTimeChanged += 1;
+      }
       staleMappingIds.push(mapping.id);
       staleMappedEventIds.add(syncEventId);
       staleRemoteMappings.push(mapping);
     }
   }
 
-  return { staleMappedEventIds, staleMappingIds, staleRemoteMappings };
+  return {
+    staleMappedEventIds,
+    staleMappingIds,
+    staleReasonCounts,
+    staleRemoteMappings,
+  };
 };
 
 const buildAddOperations = (
@@ -441,7 +503,7 @@ const computeSyncOperations = (
       getRemoteIdentity(remoteEvent.uid, remoteEvent.deleteId)),
   );
 
-  const { staleMappingIds, staleMappedEventIds, staleRemoteMappings } =
+  const { staleMappingIds, staleMappedEventIds, staleReasonCounts, staleRemoteMappings } =
     identifyStaleMappings(
       standardMappings,
       localEventIds,
@@ -517,6 +579,10 @@ const computeSyncOperations = (
       ...replacementOperations,
       ...reassignmentOperations,
     ]),
+    staleReasonCounts: {
+      ...staleReasonCounts,
+      occurrenceReassigned: remoteReassignments.length,
+    },
     staleMappingIds: [
       ...staleMappingIds,
       ...remoteReassignments.map(({ mapping }) => mapping.id),
@@ -540,4 +606,5 @@ export type {
   OccurrenceReassignment,
   RemoveOperationTimeBoundary,
   StaleMappingResult,
+  StaleReasonCounts,
 };

--- a/packages/calendar/tests/core/sync-engine/index.test.ts
+++ b/packages/calendar/tests/core/sync-engine/index.test.ts
@@ -737,6 +737,60 @@ describe("syncCalendar", () => {
     expect(typeof event?.["duration_ms"]).toBe("number");
   });
 
+  it("emits only nonzero stale mapping reason counts", async () => {
+    const { syncCalendar } = await import("../../../src/core/sync-engine/index");
+    const localEvent = makeEvent(
+      "ev-1",
+      new Date("2026-03-15T09:00:00Z"),
+      new Date("2026-03-15T10:00:00Z"),
+    );
+    const mapping = {
+      ...makeMapping("map-1", localEvent.id, "remote-1"),
+      syncEventHash: createSyncEventContentHash(localEvent),
+    };
+    const provider = makeProvider({
+      deleteEvents: () => Promise.resolve([{ success: true }]),
+      pushEvents: () => Promise.resolve([{ remoteId: "remote-new", success: true }]),
+    });
+    const emittedEvents: Record<string, unknown>[] = [];
+
+    await syncCalendar({
+      userId: "user-1",
+      calendarId: "dest-cal-1",
+      provider,
+      readState: () => Promise.resolve({
+        localEvents: [localEvent],
+        existingMappings: [mapping],
+        remoteEvents: [{
+          deleteId: "remote-1",
+          editableContentHash: createEditableEventContentHash({
+            ...localEvent,
+            summary: "Edited remotely",
+          }),
+          endTime: localEvent.endTime,
+          isKeeperEvent: true,
+          startTime: localEvent.startTime,
+          uid: "remote-1",
+        }],
+      }),
+      isCurrent: () => Promise.resolve(true),
+      flush: () => Promise.resolve(),
+      onSyncEvent: (event) => { emittedEvents.push(event); },
+    });
+
+    expect(emittedEvents).toHaveLength(1);
+    expect(emittedEvents[0]).toMatchObject({
+      "stale_mappings.count": 1,
+      "stale_mappings.remote_content_changed_count": 1,
+    });
+    expect(emittedEvents[0]).not.toHaveProperty(
+      "stale_mappings.local_hash_changed_count",
+    );
+    expect(emittedEvents[0]).not.toHaveProperty(
+      "stale_mappings.remote_time_changed_count",
+    );
+  });
+
   it("emits a wide event with outcome superseded but flushed when generation becomes stale", async () => {
     const { syncCalendar } = await import("../../../src/core/sync-engine/index");
     const localEvent = makeEvent("ev-1", new Date("2026-03-15T09:00:00Z"), new Date("2026-03-15T10:00:00Z"));

--- a/packages/calendar/tests/core/sync/operations.test.ts
+++ b/packages/calendar/tests/core/sync/operations.test.ts
@@ -50,6 +50,15 @@ const createLocalEvent = (
   ...overrides,
 });
 
+const EMPTY_STALE_REASON_COUNTS = {
+  localHashChanged: 0,
+  occurrenceReassigned: 0,
+  remoteAvailabilityChanged: 0,
+  remoteContentChanged: 0,
+  remoteMissing: 0,
+  remoteTimeChanged: 0,
+};
+
 describe("buildRemoveOperations", () => {
   it("does not remove mapped events from before the sync window", () => {
     const historicalMapping = createEventMapping({
@@ -220,6 +229,7 @@ describe("computeSyncOperations", () => {
       mappingIdsToPrune: [],
       operations: [],
       staleMappingIds: [],
+      staleReasonCounts: EMPTY_STALE_REASON_COUNTS,
     });
   });
 
@@ -256,6 +266,7 @@ describe("computeSyncOperations", () => {
       mappingIdsToPrune: [],
       operations: [],
       staleMappingIds: [],
+      staleReasonCounts: EMPTY_STALE_REASON_COUNTS,
     });
   });
 
@@ -275,6 +286,7 @@ describe("computeSyncOperations", () => {
       mappingIdsToPrune: [mapping.id],
       operations: [],
       staleMappingIds: [],
+      staleReasonCounts: EMPTY_STALE_REASON_COUNTS,
     });
   });
 
@@ -289,6 +301,10 @@ describe("computeSyncOperations", () => {
     const result = computeSyncOperations([event], [mapping], []);
 
     expect(result.staleMappingIds).toEqual([mapping.id]);
+    expect(result.staleReasonCounts).toEqual({
+      ...EMPTY_STALE_REASON_COUNTS,
+      remoteMissing: 1,
+    });
     expect(result.operations).toEqual([{
       deleteId: mapping.deleteIdentifier,
       event,
@@ -319,6 +335,10 @@ describe("computeSyncOperations", () => {
     const result = computeSyncOperations([movedEvent], [mapping], [remoteEvent]);
 
     expect(result.staleMappingIds).toEqual([mapping.id]);
+    expect(result.staleReasonCounts).toEqual({
+      ...EMPTY_STALE_REASON_COUNTS,
+      localHashChanged: 1,
+    });
     expect(result.operations).toEqual([
       {
         deleteId: mapping.deleteIdentifier,
@@ -348,6 +368,10 @@ describe("computeSyncOperations", () => {
 
     const result = computeSyncOperations([event], [mapping], [movedRemoteEvent]);
 
+    expect(result.staleReasonCounts).toEqual({
+      ...EMPTY_STALE_REASON_COUNTS,
+      remoteTimeChanged: 1,
+    });
     expect(result.operations).toEqual([{
       deleteId: mapping.deleteIdentifier,
       event,
@@ -379,6 +403,7 @@ describe("computeSyncOperations", () => {
       mappingIdsToPrune: [],
       operations: [],
       staleMappingIds: [],
+      staleReasonCounts: EMPTY_STALE_REASON_COUNTS,
     });
   });
 
@@ -397,8 +422,13 @@ describe("computeSyncOperations", () => {
       startTime: event.startTime,
     });
 
-    expect(computeSyncOperations([event], [mapping], [editedRemote]).operations)
-      .toEqual([{
+    const result = computeSyncOperations([event], [mapping], [editedRemote]);
+
+    expect(result.staleReasonCounts).toEqual({
+      ...EMPTY_STALE_REASON_COUNTS,
+      remoteContentChanged: 1,
+    });
+    expect(result.operations).toEqual([{
         deleteId: mapping.deleteIdentifier,
         event,
         staleMappingId: mapping.id,
@@ -432,6 +462,7 @@ describe("computeSyncOperations", () => {
       mappingIdsToPrune: [],
       operations: [],
       staleMappingIds: [],
+      staleReasonCounts: EMPTY_STALE_REASON_COUNTS,
     });
   });
 
@@ -452,8 +483,13 @@ describe("computeSyncOperations", () => {
       supportedAvailabilities: ["busy", "free"],
     });
 
-    expect(computeSyncOperations([event], [mapping], [remoteEvent]).operations)
-      .toHaveLength(1);
+    const result = computeSyncOperations([event], [mapping], [remoteEvent]);
+
+    expect(result.operations).toHaveLength(1);
+    expect(result.staleReasonCounts).toEqual({
+      ...EMPTY_STALE_REASON_COUNTS,
+      remoteAvailabilityChanged: 1,
+    });
   });
 
   it("matches a legacy Google UID delete identifier to the provider event ID", () => {
@@ -485,6 +521,7 @@ describe("computeSyncOperations", () => {
       }],
       operations: [],
       staleMappingIds: [],
+      staleReasonCounts: EMPTY_STALE_REASON_COUNTS,
     });
   });
 
@@ -535,6 +572,7 @@ describe("computeSyncOperations", () => {
       }],
       operations: [],
       staleMappingIds: [],
+      staleReasonCounts: EMPTY_STALE_REASON_COUNTS,
     });
   });
 
@@ -628,6 +666,10 @@ describe("computeSyncOperations", () => {
     const result = computeSyncOperations([event], [mapping], [remoteEvent]);
 
     expect(result.mappingUpdates).toEqual([]);
+    expect(result.staleReasonCounts).toEqual({
+      ...EMPTY_STALE_REASON_COUNTS,
+      occurrenceReassigned: 1,
+    });
     expect(result.operations).toEqual([{
       deleteId: mapping.deleteIdentifier,
       event,

--- a/packages/calendar/tests/providers/google/destination/provider.test.ts
+++ b/packages/calendar/tests/providers/google/destination/provider.test.ts
@@ -121,6 +121,14 @@ describe("createGoogleSyncProvider", () => {
       mappingUpdates: [],
       mappingIdsToPrune: [],
       operations: [],
+      staleReasonCounts: {
+        localHashChanged: 0,
+        occurrenceReassigned: 0,
+        remoteAvailabilityChanged: 0,
+        remoteContentChanged: 0,
+        remoteMissing: 0,
+        remoteTimeChanged: 0,
+      },
       staleMappingIds: [],
     });
 
@@ -138,6 +146,14 @@ describe("createGoogleSyncProvider", () => {
       }],
       mappingIdsToPrune: [],
       operations: [],
+      staleReasonCounts: {
+        localHashChanged: 0,
+        occurrenceReassigned: 0,
+        remoteAvailabilityChanged: 0,
+        remoteContentChanged: 0,
+        remoteMissing: 0,
+        remoteTimeChanged: 0,
+      },
       staleMappingIds: [],
     });
   });


### PR DESCRIPTION
## What

- classify stale destination mappings as local hash changes, missing remote events, remote content/availability/time changes, or occurrence reassignments
- emit only nonzero reason counters on the existing destination sync wide event
- cover each classification and verify zero-valued telemetry fields are omitted

## Why

Production reconciliation is repeatedly replacing the same freshly persisted mappings on several calendars. Database checks confirmed the replacements persist, but the existing stale mapping count cannot distinguish local hash instability from provider read-back normalization or missing remote events. These counters make that distinction without logging calendar contents or identifiers.

Reason counters are diagnostic and may overlap when both local and remote state changed for the same mapping.

## Impact

Observability only. This does not change reconciliation decisions, provider reads/writes, or mapping persistence.

## Validation

- `bun run --cwd packages/calendar test` (66 files, 654 tests)
- `bun run --cwd packages/calendar types`
- `bun run --cwd packages/calendar lint`
- `git diff --check`
