### PR TITLE
Log destination reconciliation inputs

### DIFF
--- a/packages/calendar/src/core/events/events.ts
+++ b/packages/calendar/src/core/events/events.ts
@@ -19,6 +19,29 @@ import { materializeRecurrenceEvents } from "./recurrence-materializer";
 const EMPTY_SOURCES_COUNT = 0;
 const YEARS_UNTIL_FUTURE = 2;
 
+interface DestinationEventReadDiagnostics {
+  candidateEventStateCount: number;
+  excludedBySyncPolicyCount: number;
+  materializedEventCount: number;
+  missingSourceEventUidCount: number;
+  outsideReconciliationWindowCount: number;
+  syncableEventCount: number;
+}
+
+interface DestinationEventReadResult {
+  diagnostics: DestinationEventReadDiagnostics;
+  events: MaterializedSyncableEvent[];
+}
+
+const EMPTY_DESTINATION_EVENT_READ_DIAGNOSTICS: DestinationEventReadDiagnostics = {
+  candidateEventStateCount: 0,
+  excludedBySyncPolicyCount: 0,
+  materializedEventCount: 0,
+  missingSourceEventUidCount: 0,
+  outsideReconciliationWindowCount: 0,
+  syncableEventCount: 0,
+};
+
 const isEventInDestinationReconciliationWindow = (
   event: Pick<SyncableEvent, "endTime">,
   timeMin: Date,
@@ -129,13 +152,16 @@ const getMappedSourceCalendarIds = async (
   return mappings.map((mapping) => mapping.sourceCalendarId);
 };
 
-const getEventsForCalendars = async (
+const getEventsForCalendarsWithDiagnostics = async (
   database: BunSQLClient,
   calendarIds: string[],
   syncWindow: OAuthSyncWindow = getOAuthSyncWindow(YEARS_UNTIL_FUTURE),
-): Promise<MaterializedSyncableEvent[]> => {
+): Promise<DestinationEventReadResult> => {
   if (calendarIds.length === EMPTY_SOURCES_COUNT) {
-    return [];
+    return {
+      diagnostics: EMPTY_DESTINATION_EVENT_READ_DIAGNOSTICS,
+      events: [],
+    };
   }
 
   const results = await database
@@ -180,12 +206,17 @@ const getEventsForCalendars = async (
     .orderBy(asc(eventStatesTable.startTime));
 
   const syncableEvents: SyncableEvent[] = [];
+  let excludedBySyncPolicyCount = 0;
+  let missingSourceEventUidCount = 0;
+  let outsideReconciliationWindowCount = 0;
 
   for (const result of results) {
     if (result.sourceEventUid === null) {
+      missingSourceEventUidCount += 1;
       continue;
     }
     if (shouldExcludeSyncEvent(result)) {
+      excludedBySyncPolicyCount += 1;
       continue;
     }
 
@@ -201,6 +232,7 @@ const getEventsForCalendars = async (
       && !recurrence.recurrenceId
       && !recurrence.recurrenceRule
     ) {
+      outsideReconciliationWindowCount += 1;
       continue;
     }
 
@@ -235,12 +267,33 @@ const getEventsForCalendars = async (
     });
   }
 
-  return materializeRecurrenceEvents(syncableEvents, {
+  const events = materializeRecurrenceEvents(syncableEvents, {
     end: syncWindow.timeMax,
     start: syncWindow.timeMin,
   }, {
     retainOneOffEventsAfterWindowEnd: true,
   });
+
+  return {
+    diagnostics: {
+      candidateEventStateCount: results.length,
+      excludedBySyncPolicyCount,
+      materializedEventCount: events.length,
+      missingSourceEventUidCount,
+      outsideReconciliationWindowCount,
+      syncableEventCount: syncableEvents.length,
+    },
+    events,
+  };
+};
+
+const getEventsForCalendars = async (
+  database: BunSQLClient,
+  calendarIds: string[],
+  syncWindow: OAuthSyncWindow = getOAuthSyncWindow(YEARS_UNTIL_FUTURE),
+): Promise<MaterializedSyncableEvent[]> => {
+  const result = await getEventsForCalendarsWithDiagnostics(database, calendarIds, syncWindow);
+  return result.events;
 };
 
 const getEventsForDestination = async (
@@ -259,8 +312,10 @@ const getEventsForDestination = async (
 
 export {
   getEventsForCalendars,
+  getEventsForCalendarsWithDiagnostics,
   getEventsForDestination,
   getMappedSourceCalendarIds,
   isEventInDestinationReconciliationWindow,
   shouldExcludeSyncEvent,
 };
+export type { DestinationEventReadDiagnostics, DestinationEventReadResult };

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -76,8 +76,11 @@ export {
 } from "./core/utils/fetch-with-timeout";
 export {
   getEventsForCalendars,
+  getEventsForCalendarsWithDiagnostics,
   getEventsForDestination,
   getMappedSourceCalendarIds,
+  type DestinationEventReadDiagnostics,
+  type DestinationEventReadResult,
 } from "./core/events/events";
 export {
   assertSourceRecurrenceMaterializationWithinBudget,

--- a/packages/sync/src/sync-user.ts
+++ b/packages/sync/src/sync-user.ts
@@ -1,6 +1,6 @@
 import {
   syncCalendar,
-  getEventsForCalendars,
+  getEventsForCalendarsWithDiagnostics,
   getEventMappingsForDestination,
   createDatabaseFlush,
   createRedisRateLimiter,
@@ -12,6 +12,7 @@ import {
 } from "@keeper.sh/calendar";
 import type {
   EventMapping,
+  DestinationEventReadDiagnostics,
   MaterializedSyncableEvent,
   RefreshLockStore,
   RemoteEvent,
@@ -99,6 +100,57 @@ interface DestinationLocalState {
   localEvents: MaterializedSyncableEvent[];
   existingMappings: EventMapping[];
 }
+
+interface DestinationReconciliationContext {
+  eventReadDiagnostics: DestinationEventReadDiagnostics;
+  localReadDurationMs: number;
+  reconciliationWindow: {
+    timeMax: Date;
+    timeMin: Date;
+  };
+  remoteReadDurationMs: number;
+  sourceCalendarIdsAtLocalRead: string[];
+  sourceCalendarIdsBeforeRemoteRead: string[];
+}
+
+const roundDuration = (durationMs: number): number =>
+  Math.round(durationMs * 100) / 100;
+
+const haveSourceCalendarsChanged = (
+  beforeRemoteRead: string[],
+  atLocalRead: string[],
+): boolean => {
+  if (beforeRemoteRead.length !== atLocalRead.length) {
+    return true;
+  }
+
+  const orderedBeforeRemoteRead = beforeRemoteRead.toSorted();
+  const orderedAtLocalRead = atLocalRead.toSorted();
+  return orderedBeforeRemoteRead.some(
+    (calendarId, index) => calendarId !== orderedAtLocalRead[index],
+  );
+};
+
+const createDestinationReconciliationWideEventFields = (
+  context: DestinationReconciliationContext,
+): Record<string, string | number | boolean> => ({
+  "local_event_states.candidate_count": context.eventReadDiagnostics.candidateEventStateCount,
+  "local_event_states.excluded_by_sync_policy_count": context.eventReadDiagnostics.excludedBySyncPolicyCount,
+  "local_event_states.materialized_count": context.eventReadDiagnostics.materializedEventCount,
+  "local_event_states.missing_source_event_uid_count": context.eventReadDiagnostics.missingSourceEventUidCount,
+  "local_event_states.outside_reconciliation_window_count": context.eventReadDiagnostics.outsideReconciliationWindowCount,
+  "local_event_states.syncable_count": context.eventReadDiagnostics.syncableEventCount,
+  "reconciliation.local_read.duration_ms": context.localReadDurationMs,
+  "reconciliation.remote_read.duration_ms": context.remoteReadDurationMs,
+  "reconciliation.source_calendars.at_local_read_count": context.sourceCalendarIdsAtLocalRead.length,
+  "reconciliation.source_calendars.before_remote_read_count": context.sourceCalendarIdsBeforeRemoteRead.length,
+  "reconciliation.source_calendars.changed_during_remote_read": haveSourceCalendarsChanged(
+    context.sourceCalendarIdsBeforeRemoteRead,
+    context.sourceCalendarIdsAtLocalRead,
+  ),
+  "reconciliation.window.recurrence_time_max": context.reconciliationWindow.timeMax.toISOString(),
+  "reconciliation.window.time_min": context.reconciliationWindow.timeMin.toISOString(),
+});
 
 const readDestinationReconciliationState = async (
   readRemoteEvents: () => Promise<RemoteEvent[]>,
@@ -228,26 +280,67 @@ const syncDestinationsForUser = async (
         destination.calendarId,
       );
       const reconciliationWindow = getOAuthSyncWindow(DESTINATION_RECURRENCE_YEARS);
+      let eventReadDiagnostics: DestinationEventReadDiagnostics = {
+        candidateEventStateCount: 0,
+        excludedBySyncPolicyCount: 0,
+        materializedEventCount: 0,
+        missingSourceEventUidCount: 0,
+        outsideReconciliationWindowCount: 0,
+        syncableEventCount: 0,
+      };
+      let localReadDurationMs = 0;
+      let remoteReadDurationMs = 0;
+      let sourceCalendarIdsAtLocalRead = sourceCalendarIds;
       const reconciliationState = await readDestinationReconciliationState(
-        () => providerRef.listRemoteEvents({
-          timeMin: reconciliationWindow.timeMin,
-        }),
-        () => withSourceIngestLocks(
-          database,
-          sourceCalendarIds,
-          async (lockedDatabase) => ({
-            localEvents: await getEventsForCalendars(
-              lockedDatabase,
+        async () => {
+          const startedAt = performance.now();
+          try {
+            return await providerRef.listRemoteEvents({
+              timeMin: reconciliationWindow.timeMin,
+            });
+          } finally {
+            remoteReadDurationMs = roundDuration(performance.now() - startedAt);
+          }
+        },
+        async () => {
+          const startedAt = performance.now();
+          try {
+            return await withSourceIngestLocks(
+              database,
               sourceCalendarIds,
-              reconciliationWindow,
-            ),
-            existingMappings: await getEventMappingsForDestination(
-              lockedDatabase,
-              destination.calendarId,
-            ),
-          }),
-        ),
+              async (lockedDatabase) => {
+                sourceCalendarIdsAtLocalRead = await getMappedSourceCalendarIds(
+                  lockedDatabase,
+                  destination.calendarId,
+                );
+                const eventRead = await getEventsForCalendarsWithDiagnostics(
+                  lockedDatabase,
+                  sourceCalendarIds,
+                  reconciliationWindow,
+                );
+                eventReadDiagnostics = eventRead.diagnostics;
+                return {
+                  localEvents: eventRead.events,
+                  existingMappings: await getEventMappingsForDestination(
+                    lockedDatabase,
+                    destination.calendarId,
+                  ),
+                };
+              },
+            );
+          } finally {
+            localReadDurationMs = roundDuration(performance.now() - startedAt);
+          }
+        },
       );
+      const reconciliationWideEventFields = createDestinationReconciliationWideEventFields({
+        eventReadDiagnostics,
+        localReadDurationMs,
+        reconciliationWindow,
+        remoteReadDurationMs,
+        sourceCalendarIdsAtLocalRead,
+        sourceCalendarIdsBeforeRemoteRead: sourceCalendarIds,
+      });
       const result = await syncCalendar({
         userId: destination.userId,
         calendarId: destination.calendarId,
@@ -268,6 +361,7 @@ const syncDestinationsForUser = async (
         onSyncEvent: (event) => {
           const enrichedEvent = {
             ...event,
+            ...reconciliationWideEventFields,
             "provider.name": destination.provider,
             "provider.account_id": destination.accountId,
             "provider.calendar_id": destination.calendarId,
@@ -343,5 +437,9 @@ const syncDestinationsForUser = async (
   return { added, addFailed, removed, removeFailed, errors, syncEvents };
 };
 
-export { readDestinationReconciliationState, syncDestinationsForUser };
+export {
+  createDestinationReconciliationWideEventFields,
+  readDestinationReconciliationState,
+  syncDestinationsForUser,
+};
 export type { CalendarSyncCompletion, CalendarSyncFailure, SyncConfig, SyncDestinationsResult };

--- a/packages/sync/tests/sync-user.test.ts
+++ b/packages/sync/tests/sync-user.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { readDestinationReconciliationState } from "../src/sync-user";
+import {
+  createDestinationReconciliationWideEventFields,
+  readDestinationReconciliationState,
+} from "../src/sync-user";
 
 describe("readDestinationReconciliationState", () => {
   it("finishes remote I/O before entering the local snapshot transaction", async () => {
@@ -32,5 +35,72 @@ describe("readDestinationReconciliationState", () => {
     )).rejects.toThrow("remote read failed");
 
     expect(readLocalState).not.toHaveBeenCalled();
+  });
+});
+
+describe("createDestinationReconciliationWideEventFields", () => {
+  const eventReadDiagnostics = {
+    candidateEventStateCount: 8,
+    excludedBySyncPolicyCount: 2,
+    materializedEventCount: 5,
+    missingSourceEventUidCount: 1,
+    outsideReconciliationWindowCount: 1,
+    syncableEventCount: 4,
+  };
+
+  it("records each stage that can reduce the local destination snapshot to zero", () => {
+    expect(createDestinationReconciliationWideEventFields({
+      eventReadDiagnostics,
+      localReadDurationMs: 12.5,
+      reconciliationWindow: {
+        timeMax: new Date("2028-07-18T00:00:00.000Z"),
+        timeMin: new Date("2026-07-11T00:00:00.000Z"),
+      },
+      remoteReadDurationMs: 42.25,
+      sourceCalendarIdsAtLocalRead: ["source-1", "source-2"],
+      sourceCalendarIdsBeforeRemoteRead: ["source-1", "source-2"],
+    })).toEqual({
+      "local_event_states.candidate_count": 8,
+      "local_event_states.excluded_by_sync_policy_count": 2,
+      "local_event_states.materialized_count": 5,
+      "local_event_states.missing_source_event_uid_count": 1,
+      "local_event_states.outside_reconciliation_window_count": 1,
+      "local_event_states.syncable_count": 4,
+      "reconciliation.local_read.duration_ms": 12.5,
+      "reconciliation.remote_read.duration_ms": 42.25,
+      "reconciliation.source_calendars.at_local_read_count": 2,
+      "reconciliation.source_calendars.before_remote_read_count": 2,
+      "reconciliation.source_calendars.changed_during_remote_read": false,
+      "reconciliation.window.recurrence_time_max": "2028-07-18T00:00:00.000Z",
+      "reconciliation.window.time_min": "2026-07-11T00:00:00.000Z",
+    });
+  });
+
+  it("detects a same-sized source mapping replacement without depending on query order", () => {
+    const reordered = createDestinationReconciliationWideEventFields({
+      eventReadDiagnostics,
+      localReadDurationMs: 1,
+      reconciliationWindow: {
+        timeMax: new Date("2028-07-18T00:00:00.000Z"),
+        timeMin: new Date("2026-07-11T00:00:00.000Z"),
+      },
+      remoteReadDurationMs: 2,
+      sourceCalendarIdsAtLocalRead: ["source-2", "source-1"],
+      sourceCalendarIdsBeforeRemoteRead: ["source-1", "source-2"],
+    });
+    const replaced = createDestinationReconciliationWideEventFields({
+      eventReadDiagnostics,
+      localReadDurationMs: 1,
+      reconciliationWindow: {
+        timeMax: new Date("2028-07-18T00:00:00.000Z"),
+        timeMin: new Date("2026-07-11T00:00:00.000Z"),
+      },
+      remoteReadDurationMs: 2,
+      sourceCalendarIdsAtLocalRead: ["source-1", "source-3"],
+      sourceCalendarIdsBeforeRemoteRead: ["source-1", "source-2"],
+    });
+
+    expect(reordered["reconciliation.source_calendars.changed_during_remote_read"]).toBe(false);
+    expect(replaced["reconciliation.source_calendars.changed_during_remote_read"]).toBe(true);
   });
 });


### PR DESCRIPTION
## What changed

- add destination event-read diagnostics without issuing a second event-state query
- record mapped-source counts before remote I/O and at the local snapshot boundary
- detect same-size source mapping replacements without logging raw calendar IDs
- record remote/local read durations and the captured reconciliation window
- emit all fields through the existing per-calendar wide event

## Why

Production showed destination reconciliation occasionally receiving zero local events while remote events and mappings still existed. Existing logs could not distinguish an empty source mapping set from an empty database query, filtering, or recurrence materialization. These fields make that boundary observable without changing reconciliation behavior or creating separate log lines.

## Validation

- bun run test (9 test tasks, 1,027 tests passed)
- bun run --filter @keeper.sh/calendar types
- bun run --filter @keeper.sh/calendar lint
- bun run --filter @keeper.sh/sync types
- bun run --filter @keeper.sh/sync lint