### PR TITLE
feat: emit FAQPage JSON-LD on the homepage

### DIFF
--- a/applications/web/src/lib/seo.ts
+++ b/applications/web/src/lib/seo.ts
@@ -137,6 +137,29 @@ export function softwareApplicationSchema() {
   };
 }
 
+export function faqSchema(items: Array<{ question: string; answer: string }>) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "@id": `${SITE_URL}/#faq`,
+    isPartOf: { "@id": `${SITE_URL}/#website` },
+    mainEntity: items.map((item) => {
+      const question = item.question.trim();
+      const answer = item.answer.trim();
+      if (!question || !answer) {
+        throw new Error(
+          `faqSchema requires a question and answer for every item, received ${JSON.stringify(item)}`,
+        );
+      }
+      return {
+        "@type": "Question",
+        name: question,
+        acceptedAnswer: { "@type": "Answer", text: answer },
+      };
+    }),
+  };
+}
+
 export function collectionPageSchema(posts: Array<{ slug: string; metadata: { title: string } }>) {
   return {
     "@context": "https://schema.org",

--- a/applications/web/src/routes/(marketing)/index.tsx
+++ b/applications/web/src/routes/(marketing)/index.tsx
@@ -1,6 +1,6 @@
 import { useSetAtom } from 'jotai'
 import { createFileRoute } from '@tanstack/react-router'
-import { canonicalUrl, jsonLdScript, seoMeta, softwareApplicationSchema } from '../../lib/seo'
+import { canonicalUrl, faqSchema, jsonLdScript, seoMeta, softwareApplicationSchema } from '../../lib/seo'
 import { Heading1, Heading2, Heading3 } from '../../components/ui/primitives/heading'
 import { Text } from '../../components/ui/primitives/text'
 import {
@@ -238,7 +238,10 @@ export const Route = createFileRoute('/(marketing)/')({
       path: "/",
       brandPosition: "before",
     }),
-    scripts: [jsonLdScript(softwareApplicationSchema())],
+    scripts: [
+      jsonLdScript(softwareApplicationSchema()),
+      jsonLdScript(faqSchema(FAQ_ITEMS)),
+    ],
   }),
 })
 


### PR DESCRIPTION
The homepage renders an FAQ section but emitted no `FAQPage` structured data, so it was ineligible for FAQ rich results. This adds an `faqSchema()` builder to `lib/seo.ts` alongside the existing schema builders and wires it into the marketing index route's scripts array. The schema is derived from the existing `FAQ_ITEMS` array so the copy cannot drift.

- `faqSchema()` follows the same signature/return shape as the other builders, `@id` `https://keeper.sh/#faq`, `isPartOf` the website node
- Uses each item's plain-text `answer` field, not the optional JSX `content`, so answers stay markup-free
- Throws on a blank question or answer rather than emitting a partial entity
- Verified against rendered SSR HTML: parses clean, `mainEntity` has 7 `Question` entries for the 7 FAQ items

Closes #467