### PR TITLE
fix: point canonical URLs and sitemap at the www host

### DIFF
--- a/applications/web/plugins/sitemap.ts
+++ b/applications/web/plugins/sitemap.ts
@@ -4,7 +4,7 @@ import type { Plugin } from "vite";
 import { XMLBuilder } from "fast-xml-parser";
 import { parse as parseYaml } from "yaml";
 
-const SITE_URL = "https://keeper.sh";
+const SITE_URL = "https://www.keeper.sh";
 const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---/;
 
 interface SitemapEntry {

--- a/applications/web/public/llms-full.txt
+++ b/applications/web/public/llms-full.txt
@@ -112,10 +112,10 @@ MCP is fully optional — all related environment variables are optional across 
 
 ## Links
 
-- Homepage: https://keeper.sh
-- Blog: https://keeper.sh/blog
-- Privacy Policy: https://keeper.sh/privacy
-- Terms & Conditions: https://keeper.sh/terms
+- Homepage: https://www.keeper.sh
+- Blog: https://www.keeper.sh/blog
+- Privacy Policy: https://www.keeper.sh/privacy
+- Terms & Conditions: https://www.keeper.sh/terms
 - GitHub: https://github.com/ridafkih/keeper.sh
 
 ## Maintainer

--- a/applications/web/public/llms.txt
+++ b/applications/web/public/llms.txt
@@ -15,9 +15,9 @@ Keeper.sh is an open-source (AGPL-3.0) calendar synchronization service that kee
 
 ## Links
 
-- [Homepage](https://keeper.sh)
-- [Blog](https://keeper.sh/blog)
-- [Privacy Policy](https://keeper.sh/privacy)
-- [Terms & Conditions](https://keeper.sh/terms)
+- [Homepage](https://www.keeper.sh)
+- [Blog](https://www.keeper.sh/blog)
+- [Privacy Policy](https://www.keeper.sh/privacy)
+- [Terms & Conditions](https://www.keeper.sh/terms)
 - [GitHub Repository](https://github.com/ridafkih/keeper.sh)
-- [Full LLM Context](https://keeper.sh/llms-full.txt)
+- [Full LLM Context](https://www.keeper.sh/llms-full.txt)

--- a/applications/web/public/robots.txt
+++ b/applications/web/public/robots.txt
@@ -108,4 +108,4 @@ Disallow: /verify-authentication
 Disallow: /reset-password
 Disallow: /forgot-password
 
-Sitemap: https://keeper.sh/sitemap.xml
+Sitemap: https://www.keeper.sh/sitemap.xml

--- a/applications/web/src/content/blog/introducing-keeper-blog.mdx
+++ b/applications/web/src/content/blog/introducing-keeper-blog.mdx
@@ -153,4 +153,4 @@ Thanks to user feedback, Keeper.sh has grown way beyond the original basic slot-
 
 Those improvements made Keeper.sh much more flexible for different workflows and privacy preferences, and there's still more coming as people keep sharing real-world use cases.
 
-If you want to try Keeper.sh, you can [sign up for the hosted version](https://keeper.sh/register) or [grab the source on GitHub](https://github.com/ridafkih/keeper.sh).
+If you want to try Keeper.sh, you can [sign up for the hosted version](https://www.keeper.sh/register) or [grab the source on GitHub](https://github.com/ridafkih/keeper.sh).

--- a/applications/web/src/lib/seo.ts
+++ b/applications/web/src/lib/seo.ts
@@ -1,4 +1,4 @@
-const SITE_URL = "https://keeper.sh";
+const SITE_URL = "https://www.keeper.sh";
 const SITE_NAME = "Keeper.sh";
 
 export function canonicalUrl(path: string): string {


### PR DESCRIPTION
`https://keeper.sh/` 301-redirects to `https://www.keeper.sh/`, but `SITE_URL` was set to the apex, so every canonical tag, `og:url`, JSON-LD `@id`/`url`, sitemap `<loc>`, and the `Sitemap:` directive pointed at a redirecting URL. This aligns everything to the www host that actually serves 200 and is the one search engines have indexed. Verified against a production build: sitemap, robots, canonical, og:url, and structured data all emit www.

- `SITE_URL` updated in `src/lib/seo.ts` and `plugins/sitemap.ts` — left as two independent constants since the Vite plugin lives outside `src` and imports nothing from it
- `Sitemap:` directive in `public/robots.txt`
- Site links in `public/llms.txt` and `public/llms-full.txt`
- One hosted-signup link in the existing blog MDX
- Left alone: `github.com/ridafkih/keeper.sh` repo URLs, `@keeper.sh` email addresses, the `api.`/`mcp.` subdomains in tests, and the `@keeper.sh` UID suffix / category marker in `llms-full.txt` (not site origins)

Closes #466