### PR TITLE
docs: pillar explainer on how calendar sync actually works

### DIFF
--- a/applications/web/src/content/blog/how-calendar-sync-actually-works.mdx
+++ b/applications/web/src/content/blog/how-calendar-sync-actually-works.mdx
@@ -1,0 +1,173 @@
+---
+title: "How Calendar Sync Actually Works"
+description: "A deep explanation of calendar sync: incremental sync tokens and delta links, 410 full resyncs, deduplication, loop prevention, recurrence exceptions, all-day and timezone handling, and deletion propagation."
+blurb: "Everything I learned building a two-way calendar sync engine — sync tokens, 410 GONE, RRULE expansion across DST, loop prevention between mirrored calendars, and why deletions are the hard part."
+createdAt: "2026-08-11"
+slug: "how-calendar-sync-actually-works"
+updatedAt: "2026-08-11"
+tags:
+  - "calendar"
+  - "sync"
+  - "caldav"
+  - "engineering"
+---
+
+Calendar sync looks like a solved problem from the outside. You read events from one calendar, you write them to another, and you do it on a timer. I thought that too. Then I built [Keeper.sh](https://github.com/ridafkih/keeper.sh) and spent a year finding out where the bodies are buried.
+
+This is a walkthrough of what a real sync engine has to do, written from ours. I'm not going to paste the source — I'll explain the mechanisms and the failure modes that forced them. Everything here describes behaviour that actually ships. Where our implementation is uglier than the ideal, I've said so, because the ugly parts are the interesting ones.
+
+## The shape of the problem
+
+The naive model of sync is a pipe: source calendar in, destination calendar out. That model breaks the first time anything goes wrong, because a pipe has no memory. If a write fails halfway, you don't know what you already wrote. If someone deletes an event on the destination, you don't know whether to put it back. If someone deletes it on the source, you don't know which destination event corresponded to it.
+
+So the real model has three stores, not two:
+
+1. **Remote source state.** What the provider says is on the calendar right now.
+2. **Local state.** Our own copy of the source events, in our database.
+3. **Mappings.** For each destination calendar, a row per event we created there: which local event it came from, what identifier it has remotely, what identifier we need to delete it, and a hash of the content we pushed.
+
+Ingest moves (1) into (2). Reconciliation compares (2) against the destination and updates (3). They're separate passes with separate failure modes, and keeping them separate is the single most useful structural decision in the whole engine. Ingest can fail without corrupting destinations. Reconciliation can run without touching the network for sources.
+
+Everything below is one of those two passes.
+
+## Incremental sync: tokens, delta links, and the 410
+
+Polling a calendar in full, every minute, is fine for a hundred events and hostile for ten thousand. Both Google and Microsoft offer an incremental protocol, and the shape is the same in both: you make a full request once, the provider hands you an opaque token, and on the next request you send the token back and get only what changed.
+
+For **Google Calendar**, the token comes back as `nextSyncToken` on the last page of an `events.list` response, and you replay it as the `syncToken` parameter. The important constraint, documented in Google's [guide to synchronizing resources efficiently](https://developers.google.com/workspace/calendar/api/guides/sync), is that a sync token cannot be combined with most query parameters. So the request you make with a token is not the request you made without one. Our full request is bounded — `timeMin` seven days before today, `timeMax` two years out — and the incremental request carries no bounds at all, because it isn't allowed to. The window has to be re-applied on our side after the response comes back, and events that fall outside it get dropped and, if we'd stored them before, deleted.
+
+For **Microsoft Graph**, the equivalent is a delta query. We call `calendarView/delta` on the calendar with a `startDateTime` and `endDateTime`, page through `@odata.nextLink`, and the final page carries an `@odata.deltaLink`. That link is the whole request, URL and all, and you replay it verbatim next time. Graph's [delta query overview](https://learn.microsoft.com/en-us/graph/delta-query-overview) describes the pattern generally; the [calendarView delta reference](https://learn.microsoft.com/en-us/graph/api/event-delta) is the one that matters here, because the delta is scoped to the time window you originally asked for.
+
+Then there's the failure everybody hits eventually. Tokens expire. When they do, both providers answer with **HTTP 410 Gone**, which means: your token is too old, I've thrown away the change history you'd need, start over. This is not an error condition in any meaningful sense — it's a normal, expected state transition, and it will happen to every long-lived integration. The only correct response is to discard the token, do a full bounded fetch, and rebuild.
+
+Ours handles 410 at the page level: any page of a paginated pull that returns 410 aborts the whole pull and reports that a full sync is required. The layer above clears the stored token and immediately re-runs the same fetch with no token. That "immediately re-run" matters — a design that waits for the next cron tick to recover leaves the calendar stale for a whole interval, and if the interval is 30 minutes, the user notices.
+
+We also expire tokens ourselves, on purpose. A stored token is wrapped with a version number, and the version encodes two things: which sync-window shape the code was using when the token was issued, and a time bucket that rolls over about every seven days. If either has moved on, the token is dropped and a full fetch runs. The window part is defensive — if we widen the window in a release, every existing token was minted against a narrower one and would silently never backfill the newly-covered range. The seven-day part is a hedge against drift: incremental sync is a claim about the past, and if we've mis-handled a single tombstone somewhere, that error persists until something forces a full read. The bucket is offset by a hash of the calendar ID, so calendars don't all resync on the same day and stampede the API.
+
+One thing we don't do: subscribe to push notifications. Google supports [push channels](https://developers.google.com/workspace/calendar/api/guides/push) and Graph supports change notifications, and both would cut latency substantially. We poll. That's a real limitation, not a design principle.
+
+## Why our CalDAV source has no sync token
+
+CalDAV is the odd one out. Our CalDAV source path returns a null sync token on every single cycle, always, by construction. It fetches a `calendar-query` REPORT over the entire time window each time and diffs the whole result against stored state.
+
+There is a standard for doing better. [RFC 6578](https://www.rfc-editor.org/rfc/rfc6578) defines WebDAV `sync-collection`, which gives you a sync token over a collection and reports changed and removed members. We don't use it. Support across servers is uneven, and — more to the point — a sync-collection report is scoped to the collection, not to a time range, so on a calendar with a decade of history it hands you a firehose you then have to filter anyway. Fetching a bounded window turned out to be simpler and, at our window size, not much more expensive.
+
+The consequence is worth stating plainly, because it's the thing that makes full listing genuinely attractive: **when you fetch everything, deletion detection is free.** An event that's missing from the response is deleted. There's no tombstone to miss, no token to mishandle, no ordering subtlety. Every bug in the following section exists only because incremental sync is an optimization that trades that guarantee away.
+
+## Deletions, tombstones, and the ways they go wrong
+
+In a full listing, "gone" means "absent". In a delta, absence means nothing at all — a delta only contains what changed, so almost everything is absent from almost every response. Deletion has to be reported explicitly, and each provider reports it differently.
+
+Google marks a deleted event as `status: "cancelled"` and includes it in the delta. Graph emits a tombstone object carrying an `@removed` annotation. In both cases you extract the IDs, delete the corresponding local rows, and exclude the tombstones from the set of events you're about to store.
+
+Two failure modes here cost us real bugs.
+
+The first is that a delta response can contain the same event ID more than once. You're paginating a live calendar; someone edits an event between page two and page five; you get two versions. If you process them in arrival order you may persist the older one. We key changed events by provider ID and keep the highest revision, comparing `updated` on Google and `lastModifiedDateTime` on Graph, falling back to creation time when the modification stamp is missing.
+
+The second is specific to Graph and took a while to pin down. `calendarView/delta` normally returns expanded occurrences, not recurring masters — which is what you want. But a delta round can hand you a `seriesMaster` anyway, and it can hand you an `@removed` tombstone with no type on it at all. A bare ID with no type could be a series master, and our local state for that series is a set of expanded occurrences with different IDs. Deleting the one row whose ID matches and then advancing the delta link would strand every occurrence of that series in our database forever, invisible to all future deltas. So when either of those shows up, we throw the whole delta away and force a full resync of that calendar. It's blunt. It's also the only response I trust, because the alternative is silent, permanent, per-series corruption that nobody notices for months.
+
+Note the asymmetry that makes this survivable: dropping a delta costs one expensive request. Advancing past a tombstone you didn't understand costs correctness until someone reconnects the account. When those are the options, throw the delta away.
+
+## Deduplication, and detecting change without trusting anyone
+
+Both passes need to answer "is this the same event I already have?", and they answer it differently.
+
+On ingest, we build an identity key per event covering essentially all of it: provider event ID, UID, an instance key, start and end, all-day flag, availability, event type, title, description, location, timezone, and the full recurrence triple of rule, exception dates, and recurrence ID. It's a stable serialization — object keys sorted, arrays canonicalized — because otherwise two structurally identical recurrence rules hash differently depending on the order a parser happened to emit their fields, and you rewrite the entire calendar every cycle for no reason. Incoming events whose identity key already exists are skipped entirely. No write, no version bump, no downstream churn.
+
+Incoming events are also deduplicated against each other before the diff, keyed by provider ID where one exists and by a UID-plus-instance key where one doesn't. iCal feeds in particular will hand you the same VEVENT twice without apology.
+
+On the push side there are two hashes, and the split matters more than it looks.
+
+The **sync hash** covers everything that determines what we'd write: summary, description, location, availability, all-day, start, end, timezone, recurrence rule, recurrence duration, exception dates, recurrence ID. It's stored on the mapping. If the local event's sync hash no longer matches the one on the mapping, the source changed and the destination copy is stale.
+
+The **editable hash** covers only summary, description, location, and all-day — the fields we can reliably read back from a destination event across every provider. It's the drift detector. Each reconciliation lists the events we own on the destination and recomputes this hash from what's actually there. If it doesn't match what we'd produce today, someone edited our mirrored copy by hand, and we overwrite it.
+
+The same pass checks two other things the hash can't see. Availability drift is compared against what we'd have written given what that destination actually supports — Google can express busy and free, Graph can also express out-of-office and working-elsewhere, so the expected value is provider-dependent rather than absolute. And time drift is compared at whole-second granularity, deliberately, because providers round sub-second precision and a strict comparison flags every event on every cycle forever.
+
+When a mapping goes stale, the fix is a replace: delete the remote event, create it fresh, swap the mapping. We don't do partial updates. Update semantics differ enough between providers — especially around recurrence and attendees — that delete-and-recreate is the only operation with the same meaning everywhere.
+
+## Loop prevention
+
+This is the failure that scares people, and it should. Mirror A into B and B into A, and without a marker you get an infinite fork bomb: A's event lands in B, B's copy is a new event that lands back in A, and by the fourth cycle the user has sixteen copies of a dentist appointment.
+
+The break is that pushed events must be identifiable as ours, and every source must skip them.
+
+Everywhere UIDs are writable, we mint one deterministically: SHA-256 over the local event ID and the destination calendar ID, truncated, with `@keeper.sh` appended. Two properties matter. It's **deterministic**, so a retry after an ambiguous failure targets the same object rather than creating a second one. And it's **suffixed**, so recognizing our own work is a string check with no database lookup — which is what lets an ingest path filter loops before it has any context at all.
+
+Every source ingest drops events whose UID ends in that suffix. Google's source drops them by `iCalUID`. CalDAV's does the same, and because we store each pushed event at `<uid>.ics`, the destination listing can filter by filename before parsing a byte of iCalendar.
+
+On Google the write goes through `events.import` rather than `events.insert`, specifically because import accepts a caller-supplied `iCalUID` and upserts on it. Re-pushing an event we've already pushed updates it instead of returning a conflict, which makes the whole path idempotent.
+
+**Outlook doesn't let you do any of this.** Graph assigns `iCalUId` itself on create and there's no way to supply one. So on Outlook the marker moves to a category: every event we create carries a `keeper.sh` category, the Outlook source skips any event carrying it, and the destination listing uses it to decide which events are ours to manage.
+
+I want to be honest about the cost. A category is user-visible in the Outlook UI and a user can remove it. If they do, the next reconciliation sees an unmarked event it doesn't own, stops managing it, and creates a fresh copy — and if that calendar is also a source, the now-unmarked event ingests as a real event and starts propagating. It's the weakest link in the design and it exists because the platform gave us no stronger one.
+
+## Recurrence: the part that's genuinely hard
+
+[RFC 5545](https://www.rfc-editor.org/rfc/rfc5545) models a repeating event as a master `VEVENT` carrying an `RRULE`, plus `EXDATE` for cancelled slots, plus separate `VEVENT`s carrying `RECURRENCE-ID` for modified ones. A weekly standup that got cancelled once and moved once is three components, and reconstructing what the user sees means expanding the rule, subtracting the exception dates, subtracting the slots claimed by overrides, and adding the overrides back at their new times.
+
+The first thing to know is that **you may not have to do this at all**, depending on the provider. We ask Google for `singleEvents=true`, which makes the API expand the series server-side. Graph's `calendarView/delta` returns expanded occurrences too, and where a series master does slip through we expand it explicitly through the `/instances` endpoint. So for our OAuth sources, no recurrence rule is ever stored — the events land pre-expanded. Full recurrence structure only reaches our database from CalDAV and ICS sources, where the raw iCalendar is what's on the wire. The same logical calendar is represented two completely different ways in our storage depending on where it came from, and both paths have to produce the same output.
+
+When we do expand a rule ourselves, the part that matters most is the domain you expand in. A weekly 09:00 meeting in `America/Toronto` crossing the March DST boundary is 09:00 local on both sides, which is *not* a fixed number of milliseconds apart. Expand in absolute time and every occurrence after the transition lands an hour off. So we convert the series start into the wall-clock domain of its `TZID`, expand there, and convert each resulting occurrence back to an instant. `UNTIL` gets the same treatment. This is the single most common recurrence bug I've seen in calendar tooling, and it's invisible until a Sunday in March.
+
+Occurrence duration comes from the master's `DURATION` when it has one, applied nominally, rather than from a millisecond delta — for the same reason. An event defined as one day long stays one day long across a transition; an event defined as 86,400,000 milliseconds does not.
+
+Slots covered by an `EXDATE`, and slots claimed by an override's `RECURRENCE-ID`, are dropped from the expansion. The override itself flows through as its own event with its own times. Overrides are only matched to a master when the series has exactly one unambiguous master in the batch — if a feed contains two masters for the same UID, we don't guess.
+
+Expanded occurrences need stable IDs, and this is where it gets subtle. Ours are synthetic: a hash of the calendar, the source UID, the master's start and end, and the occurrence's own start and end. That's stable while nothing changes — and every single occurrence ID changes the moment the master moves, because the master's times are in the hash. A naive engine would then see the entire series as deleted and recreated, and would delete and recreate every occurrence on the destination. Users see their whole recurring meeting flicker.
+
+So there's a re-pairing step. New occurrence IDs with no mapping, and mappings whose occurrence IDs no longer exist, are grouped by the event they descend from and matched up: first by identical start/end slot, then by order for whatever's left. If the paired remote event is still verifiably correct — same times, matching editable hash, matching availability — we rewrite the mapping row and touch nothing remotely. If it isn't, we fall back to replacing it. Most master edits that don't move the occurrences (a title change, say) end up costing zero remote writes.
+
+There's a guardrail on all of this. An `RRULE` with `SECONDLY` frequency and no `BY*` selectors will happily generate tens of millions of occurrences in a two-year window and take the process with it. Series are capped at 10,000 occurrences, and unfiltered high-frequency rules are checked arithmetically — computing how many occurrences the interval implies — before expansion starts, so a hostile rule is rejected without ever being enumerated. The check runs at ingest, before anything is persisted. Today, a series that blows the budget aborts the entire ingest for that calendar and logs the offending UID; nothing is stored and nothing is corrupted, but one bad series stops the rest of the calendar from updating. Failing loudly with the culprit named beats writing a partial calendar, but it's coarser than it should be.
+
+Finally: **we never write recurrence rules to destinations.** Every occurrence is pushed as an individual, standalone event. That costs writes, and on a busy calendar it costs a lot of them. What it buys is that we never have to reason about what "edit this occurrence" means on four different providers with four different interpretations. The one place we do preserve series structure is the aggregated iCal feed, which emits real masters with `RRULE`, `EXDATE`, and `RECURRENCE-ID` overrides — because a feed is consumed by clients that expect proper iCalendar, and there's no write path to go wrong.
+
+## All-day events and timezones
+
+RFC 5545 distinguishes a `DATE` value from a `DATE-TIME` value, and an all-day event is one whose `DTSTART` is a bare date. `DTEND` is exclusive, so a single-day event on the 5th ends on the 6th — which is the source of roughly every off-by-one-day bug in the genre.
+
+Providers disagree on how to tell you. Google signals it by returning `start.date` instead of `start.dateTime`. Graph gives you an explicit `isAllDay` boolean. iCalendar gives you the value type. And plenty of sources give you nothing useful, so we infer: if the duration is a whole multiple of 24 hours and both ends sit exactly on UTC midnight, treat it as all-day. An explicit flag from the provider always wins over the inference.
+
+There's a second, opt-in interpretation for a case that shows up on real servers: an event marked as *timed* that starts at local midnight and ends at local midnight on a later date. Some clients write day-long events that way. Turned on, we reinterpret those as all-day, using the event's own timezone where it has one and the calendar's default where it doesn't.
+
+Writing them back out, every provider wants something different. iCalendar wants a bare `DATE`. Google wants `date` rather than `dateTime`. Graph wants a datetime with the all-day flag set. Timed events are worse: for CalDAV we emit `DTSTART;TZID=<zone>` with the local wall-clock time, for Graph we send wall-clock plus an explicit `timeZone`, and for Google we send a UTC instant. The stored instant never changes — only its representation does.
+
+`VTIMEZONE` is the piece most implementations skip, and skipping it is legal-ish but rude: a `TZID` referencing a zone the client doesn't know, with no accompanying definition, is unresolvable. We emit them in the aggregated feed. They're generated from the IANA database via `Intl` by walking actual offset transitions across a projection window of about a century, and then — this is the part I like — checking whether all those transitions collapse into exactly two stable annual patterns. Most zones do. When they do, we emit two `RRULE`-based observances instead of a hundred and fifty literal ones, which is what RFC 5545 §3.6.5 intends and what keeps the feed from being megabytes of DST history. Zones with irregular political history fall back to enumerating every transition, correctly, if verbosely.
+
+## Ordering, concurrency, and why deletes are dangerous
+
+Reconciliation produces three operation types: add, remove, and replace. They're sorted by event time, then executed in chunks, and within each chunk removes run first, then replaces, then adds. Ordering deletes ahead of creates frees a UID before anything tries to reuse it, which matters on providers that enforce uniqueness on it.
+
+Removes come from three different places, and it's worth separating them:
+
+- A mapping exists, the local event is gone → delete the remote event. This is normal deletion propagation.
+- A remote event carries our marker and has no mapping at all → delete it. This is orphan cleanup, and it's the dangerous one.
+- A mapping's local event is gone, its event ended before the sync window started, and no remote copy appears in the listing → just delete the mapping row. There's nothing remote to delete and the event has aged out.
+
+Orphan cleanup exists because writes fail. We create an event remotely and then persist the mapping; a crash between those two steps leaves an event on the destination that nothing points at, and without a sweep it lives forever. But the same sweep, run against a partially-loaded view of local state, will cheerfully delete a user's entire mirrored calendar. Everything about how the run is structured is downstream of that risk.
+
+Concurrency is handled with a per-calendar generation counter in Redis. Each run increments it, holds the value it got, and re-checks between operation chunks. If the counter has moved, a newer run started and this one is no longer authoritative, so it stops where it is rather than finishing against stale state. Combined with a per-calendar ingest lock, that keeps two overlapping cron ticks from fighting.
+
+Within a run, mappings are flushed after each chunk rather than at the end, so an interruption doesn't lose the record of what was already created. Events inserted during the run are also protected from removal later in the same run — a set of UIDs the orphan sweep won't touch — because a mapping created two chunks ago might not be in the snapshot the sweep is reasoning about.
+
+The gap I mentioned is still real: between a successful remote create and the flush that records it, a hard crash leaves an orphan. The next run deletes it and creates a replacement. The user sees an event blink. I'd rather have the blink than the alternative, which is an accumulating pile of undeletable duplicates.
+
+Deletes are treated as idempotent throughout. Both 404 and 410 on a delete count as success, because both mean the event isn't there, which is the state we were trying to reach.
+
+## What I'd tell someone starting one
+
+If you're building this, or evaluating something that claims to have built it:
+
+**Keep local state.** Everything above depends on having a copy of what you believe the source contains. Without it there's no meaningful diff, and every cycle is a guess.
+
+**Treat 410 as normal.** Not an error, not an alert. A state transition with a defined recovery. If your recovery is "wait for the next tick", make the tick short.
+
+**Force full resyncs when you don't understand a delta.** A wasted request is cheap. Advancing past a change you misread is permanent.
+
+**Make your loop marker deterministic and cheap to check.** And find out early whether your target platform will even let you set a UID, because if it won't, the workaround shapes the whole integration.
+
+**Expand recurrence in wall-clock time.** Then test it across a DST boundary in a zone that isn't yours.
+
+**Be paranoid about deletes specifically.** Every other bug produces a duplicate or a stale title. Delete bugs produce missing meetings, and nobody forgives those.
+
+The whole engine is [open source](https://github.com/ridafkih/keeper.sh), so if any of this sounded like it must be more complicated than I've made it out to be — it is, and you can go read it.

--- a/applications/web/src/routes/(marketing)/route.tsx
+++ b/applications/web/src/routes/(marketing)/route.tsx
@@ -102,6 +102,7 @@ function MarketingLayout() {
             <MarketingFooterNavGroup>
               <MarketingFooterNavGroupLabel>Resources</MarketingFooterNavGroupLabel>
               <MarketingFooterNavItem to="/blog">Blog</MarketingFooterNavItem>
+              <MarketingFooterNavItem to="/blog/how-calendar-sync-actually-works">How Calendar Sync Works</MarketingFooterNavItem>
               <MarketingFooterNavItem href="https://github.com/ridafkih/keeper.sh">GitHub</MarketingFooterNavItem>
             </MarketingFooterNavGroup>
             <MarketingFooterNavGroup>


### PR DESCRIPTION
Adds a long-form explainer on how calendar sync actually works, written from our own engine rather than from the general lore, and links it from the marketing footer under Resources so it isn't buried in the blog index. Every claim about our behaviour was checked against the code on main, including the parts where the real behaviour is coarser than the ideal. Closes #471.

- Incremental sync: Google sync tokens, Graph delta links, 410 GONE recovery, and our own version-stamped token expiry
- Why the CalDAV source returns a null token every cycle, and what full listing buys you on deletions
- Deduplication and the split between the sync hash and the editable drift hash
- Loop prevention via the deterministic `@keeper.sh` UID, and the Outlook category marker with its weaknesses stated
- RRULE expansion in wall-clock time, EXDATE and RECURRENCE-ID handling, occurrence re-pairing, and the materialization budget
- All-day inference, VTIMEZONE generation for the feed, and the three sources of delete operations
