### PR TITLE
feat(web): add /features and /pricing pages

### DIFF
--- a/applications/web/src/content/pages.yaml
+++ b/applications/web/src/content/pages.yaml
@@ -1,5 +1,9 @@
 - path: /
   updatedAt: "2026-08-11"
+- path: /features
+  updatedAt: "2026-08-11"
+- path: /pricing
+  updatedAt: "2026-08-11"
 - path: /privacy
   updatedAt: "2025-12-01"
 - path: /terms

--- a/applications/web/src/features/marketing/pricing-plans.ts
+++ b/applications/web/src/features/marketing/pricing-plans.ts
@@ -1,0 +1,51 @@
+import type { MarketingPricingFeatureValueKind } from "./components/marketing-pricing-section";
+
+export type PricingPlan = {
+  id: string;
+  name: string;
+  price: string;
+  period: string;
+  description: string;
+  ctaLabel: string;
+  tone?: "default" | "inverse";
+};
+
+export type PricingFeature = {
+  label: string;
+  free: MarketingPricingFeatureValueKind;
+  pro: MarketingPricingFeatureValueKind;
+};
+
+export const PRICING_PLANS: PricingPlan[] = [
+  {
+    id: 'free',
+    name: 'Free',
+    price: '$0',
+    period: 'per month',
+    description:
+      'For personal use and getting started with calendar sync.',
+    ctaLabel: 'Get Started',
+  },
+  {
+    id: 'pro',
+    name: 'Pro',
+    price: '$5',
+    period: 'per month',
+    description:
+      'For power users who need fast syncs, advanced feed controls, and unlimited syncing.',
+    ctaLabel: 'Get Started',
+    tone: "inverse" as const,
+  },
+];
+
+export const PRICING_FEATURES: PricingFeature[] = [
+  { label: 'Reading Your Calendars', free: 'Every 1 minute', pro: 'Every 1 minute' },
+  { label: 'Updating Your Calendars', free: 'Every 30 minutes', pro: 'Every 1 minute' },
+  { label: 'Linked Accounts', free: 'Up to 2', pro: 'infinity' },
+  { label: 'Sync Mappings', free: 'Up to 3', pro: 'infinity' },
+  { label: 'Aggregated iCal Feed', free: 'check', pro: 'check' },
+  { label: 'iCal Feed Customization', free: 'minus', pro: 'check' },
+  { label: 'Event Filters & Exclusions', free: 'minus', pro: 'check' },
+  { label: 'API & MCP Access', free: '25 calls/day', pro: 'infinity' },
+  { label: 'Priority Support', free: 'minus', pro: 'check' },
+];

--- a/applications/web/src/generated/tanstack/route-tree.generated.ts
+++ b/applications/web/src/generated/tanstack/route-tree.generated.ts
@@ -16,6 +16,8 @@ import { Route as authRouteRouteImport } from './../../routes/(auth)/route'
 import { Route as marketingIndexRouteImport } from './../../routes/(marketing)/index'
 import { Route as marketingTermsRouteImport } from './../../routes/(marketing)/terms'
 import { Route as marketingPrivacyRouteImport } from './../../routes/(marketing)/privacy'
+import { Route as marketingPricingRouteImport } from './../../routes/(marketing)/pricing'
+import { Route as marketingFeaturesRouteImport } from './../../routes/(marketing)/features'
 import { Route as authVerifyEmailRouteImport } from './../../routes/(auth)/verify-email'
 import { Route as authVerifyAuthenticationRouteImport } from './../../routes/(auth)/verify-authentication'
 import { Route as authResetPasswordRouteImport } from './../../routes/(auth)/reset-password'
@@ -87,6 +89,16 @@ const marketingTermsRoute = marketingTermsRouteImport.update({
 const marketingPrivacyRoute = marketingPrivacyRouteImport.update({
   id: '/privacy',
   path: '/privacy',
+  getParentRoute: () => marketingRouteRoute,
+} as any)
+const marketingPricingRoute = marketingPricingRouteImport.update({
+  id: '/pricing',
+  path: '/pricing',
+  getParentRoute: () => marketingRouteRoute,
+} as any)
+const marketingFeaturesRoute = marketingFeaturesRouteImport.update({
+  id: '/features',
+  path: '/features',
   getParentRoute: () => marketingRouteRoute,
 } as any)
 const authVerifyEmailRoute = authVerifyEmailRouteImport.update({
@@ -331,6 +343,8 @@ export interface FileRoutesByFullPath {
   '/reset-password': typeof authResetPasswordRoute
   '/verify-authentication': typeof authVerifyAuthenticationRoute
   '/verify-email': typeof authVerifyEmailRoute
+  '/features': typeof marketingFeaturesRoute
+  '/pricing': typeof marketingPricingRoute
   '/privacy': typeof marketingPrivacyRoute
   '/terms': typeof marketingTermsRoute
   '/': typeof marketingIndexRoute
@@ -375,6 +389,8 @@ export interface FileRoutesByTo {
   '/reset-password': typeof authResetPasswordRoute
   '/verify-authentication': typeof authVerifyAuthenticationRoute
   '/verify-email': typeof authVerifyEmailRoute
+  '/features': typeof marketingFeaturesRoute
+  '/pricing': typeof marketingPricingRoute
   '/privacy': typeof marketingPrivacyRoute
   '/terms': typeof marketingTermsRoute
   '/': typeof marketingIndexRoute
@@ -422,6 +438,8 @@ export interface FileRoutesById {
   '/(auth)/reset-password': typeof authResetPasswordRoute
   '/(auth)/verify-authentication': typeof authVerifyAuthenticationRoute
   '/(auth)/verify-email': typeof authVerifyEmailRoute
+  '/(marketing)/features': typeof marketingFeaturesRoute
+  '/(marketing)/pricing': typeof marketingPricingRoute
   '/(marketing)/privacy': typeof marketingPrivacyRoute
   '/(marketing)/terms': typeof marketingTermsRoute
   '/(marketing)/': typeof marketingIndexRoute
@@ -470,6 +488,8 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/verify-authentication'
     | '/verify-email'
+    | '/features'
+    | '/pricing'
     | '/privacy'
     | '/terms'
     | '/'
@@ -514,6 +534,8 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/verify-authentication'
     | '/verify-email'
+    | '/features'
+    | '/pricing'
     | '/privacy'
     | '/terms'
     | '/'
@@ -560,6 +582,8 @@ export interface FileRouteTypes {
     | '/(auth)/reset-password'
     | '/(auth)/verify-authentication'
     | '/(auth)/verify-email'
+    | '/(marketing)/features'
+    | '/(marketing)/pricing'
     | '/(marketing)/privacy'
     | '/(marketing)/terms'
     | '/(marketing)/'
@@ -653,6 +677,20 @@ declare module '@tanstack/react-router' {
       path: '/privacy'
       fullPath: '/privacy'
       preLoaderRoute: typeof marketingPrivacyRouteImport
+      parentRoute: typeof marketingRouteRoute
+    }
+    '/(marketing)/pricing': {
+      id: '/(marketing)/pricing'
+      path: '/pricing'
+      fullPath: '/pricing'
+      preLoaderRoute: typeof marketingPricingRouteImport
+      parentRoute: typeof marketingRouteRoute
+    }
+    '/(marketing)/features': {
+      id: '/(marketing)/features'
+      path: '/features'
+      fullPath: '/features'
+      preLoaderRoute: typeof marketingFeaturesRouteImport
       parentRoute: typeof marketingRouteRoute
     }
     '/(auth)/verify-email': {
@@ -1074,6 +1112,8 @@ const marketingBlogRouteRouteWithChildren =
 
 interface marketingRouteRouteChildren {
   marketingBlogRouteRoute: typeof marketingBlogRouteRouteWithChildren
+  marketingFeaturesRoute: typeof marketingFeaturesRoute
+  marketingPricingRoute: typeof marketingPricingRoute
   marketingPrivacyRoute: typeof marketingPrivacyRoute
   marketingTermsRoute: typeof marketingTermsRoute
   marketingIndexRoute: typeof marketingIndexRoute
@@ -1081,6 +1121,8 @@ interface marketingRouteRouteChildren {
 
 const marketingRouteRouteChildren: marketingRouteRouteChildren = {
   marketingBlogRouteRoute: marketingBlogRouteRouteWithChildren,
+  marketingFeaturesRoute: marketingFeaturesRoute,
+  marketingPricingRoute: marketingPricingRoute,
   marketingPrivacyRoute: marketingPrivacyRoute,
   marketingTermsRoute: marketingTermsRoute,
   marketingIndexRoute: marketingIndexRoute,

--- a/applications/web/src/lib/seo.ts
+++ b/applications/web/src/lib/seo.ts
@@ -150,29 +150,6 @@ export function softwareApplicationSchema() {
   };
 }
 
-export function faqSchema(items: Array<{ question: string; answer: string }>) {
-  return {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "@id": `${SITE_URL}/#faq`,
-    isPartOf: { "@id": `${SITE_URL}/#website` },
-    mainEntity: items.map((item) => {
-      const question = item.question.trim();
-      const answer = item.answer.trim();
-      if (!question || !answer) {
-        throw new Error(
-          `faqSchema requires a question and answer for every item, received ${JSON.stringify(item)}`,
-        );
-      }
-      return {
-        "@type": "Question",
-        name: question,
-        acceptedAnswer: { "@type": "Answer", text: answer },
-      };
-    }),
-  };
-}
-
 export function offerCatalogSchema(
   path: string,
   offers: Array<{ name: string; price: string; description: string }>,
@@ -197,6 +174,32 @@ export function offerCatalogSchema(
       description: offer.description,
       itemOffered: { "@id": `${SITE_URL}/#software` },
     })),
+  };
+}
+
+export function faqSchema(
+  path: string,
+  items: Array<{ question: string; answer: string }>,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "@id": `${canonicalUrl(path)}/#faq`,
+    isPartOf: { "@id": `${SITE_URL}/#website` },
+    mainEntity: items.map((item) => {
+      const question = item.question.trim();
+      const answer = item.answer.trim();
+      if (!question || !answer) {
+        throw new Error(
+          `faqSchema requires a question and answer for every item, received ${JSON.stringify(item)}`,
+        );
+      }
+      return {
+        "@type": "Question",
+        name: question,
+        acceptedAnswer: { "@type": "Answer", text: answer },
+      };
+    }),
   };
 }
 

--- a/applications/web/src/lib/seo.ts
+++ b/applications/web/src/lib/seo.ts
@@ -173,6 +173,33 @@ export function faqSchema(items: Array<{ question: string; answer: string }>) {
   };
 }
 
+export function offerCatalogSchema(
+  path: string,
+  offers: Array<{ name: string; price: string; description: string }>,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "OfferCatalog",
+    "@id": `${canonicalUrl(path)}/#offercatalog`,
+    name: `${SITE_NAME} Plans`,
+    url: canonicalUrl(path),
+    itemListElement: offers.map((offer) => ({
+      "@type": "Offer",
+      name: offer.name,
+      price: offer.price,
+      priceCurrency: "USD",
+      priceSpecification: {
+        "@type": "UnitPriceSpecification",
+        price: offer.price,
+        priceCurrency: "USD",
+        billingDuration: "P1M",
+      },
+      description: offer.description,
+      itemOffered: { "@id": `${SITE_URL}/#software` },
+    })),
+  };
+}
+
 export function collectionPageSchema(posts: Array<{ slug: string; metadata: { title: string } }>) {
   return {
     "@context": "https://schema.org",

--- a/applications/web/src/routes/(marketing)/features.tsx
+++ b/applications/web/src/routes/(marketing)/features.tsx
@@ -1,0 +1,218 @@
+import type { PropsWithChildren } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import { Heading1, Heading2, Heading3 } from "@/components/ui/primitives/heading";
+import { Text } from "@/components/ui/primitives/text";
+import { ButtonIcon, ButtonText, ExternalLinkButton, LinkButton } from "@/components/ui/primitives/button";
+import { MarketingCtaCard, MarketingCtaSection } from "@/features/marketing/components/marketing-cta";
+import { canonicalUrl, jsonLdScript, seoMeta, webPageSchema, breadcrumbSchema } from "@/lib/seo";
+import { ANALYTICS_EVENTS } from "@/lib/analytics";
+import ArrowRightIcon from "lucide-react/dist/esm/icons/arrow-right";
+import ArrowUpRightIcon from "lucide-react/dist/esm/icons/arrow-up-right";
+
+const PAGE_DESCRIPTION =
+  "Two-way calendar sync for Google Calendar, Outlook, iCloud, Fastmail, and CalDAV, plus read-only ICS feeds, an anonymized iCal feed, a REST API, and an MCP server.";
+
+type ProviderSupport = {
+  name: string;
+  role: string;
+  detail: string;
+};
+
+const PROVIDER_SUPPORT: ProviderSupport[] = [
+  {
+    name: "Google Calendar",
+    role: "Source and destination",
+    detail: "Connected over OAuth. Pulls incrementally using sync tokens.",
+  },
+  {
+    name: "Microsoft Outlook",
+    role: "Source and destination",
+    detail: "Connected over OAuth. Pulls incrementally using delta links.",
+  },
+  {
+    name: "Apple iCloud",
+    role: "Source and destination",
+    detail: "Connected with an app-specific password over CalDAV.",
+  },
+  {
+    name: "Fastmail",
+    role: "Source and destination",
+    detail: "Connected with an app password over CalDAV.",
+  },
+  {
+    name: "CalDAV",
+    role: "Source and destination",
+    detail: "Any CalDAV server, authenticated with a username and password.",
+  },
+  {
+    name: "ICS / iCal links",
+    role: "Source only",
+    detail: "Any publicly reachable feed. ICS cannot be written to, so it is never a destination.",
+  },
+];
+
+type FeatureSection = {
+  title: string;
+  body: string[];
+  points?: string[];
+};
+
+const FEATURE_SECTIONS: FeatureSection[] = [
+  {
+    title: "Syncing that reconciles instead of duplicating",
+    body: [
+      "Events are pulled from every source you connect, then pushed to every destination you map them to. Updates and deletions propagate, so destination calendars are corrected rather than accumulating copies.",
+      "Google and Outlook are pulled incrementally: Keeper stores a sync token or delta link per account and asks the provider only for what changed. CalDAV and ICS sources are re-read on each pass.",
+    ],
+    points: [
+      "Free plan: destinations are pushed every 30 minutes",
+      "Pro plan: destinations are pushed every minute",
+    ],
+  },
+  {
+    title: "One aggregated iCal feed",
+    body: [
+      "Every source you connect is combined into a single iCal feed you can subscribe to from any calendar app. By default the feed is anonymized: titles, descriptions, and locations are stripped and every event reads as “Busy”, so you can share availability without sharing your schedule.",
+      "On Pro you can customize the feed, choosing which details are included and what the placeholder title says.",
+    ],
+  },
+  {
+    title: "Control over what gets synced",
+    body: [
+      "Display settings are configured per destination calendar, so a work calendar can show full details while a shared one shows a generic block.",
+      "Pro adds event filters and exclusions for skipping events you do not want mirrored at all.",
+    ],
+  },
+  {
+    title: "REST API",
+    body: [
+      "Keeper exposes a REST API under /api/v1, authenticated with a bearer token you create under Settings → API Tokens. It covers accounts, calendars, events, invites, and the iCal feed.",
+      "The free plan allows 25 API calls per day. Pro is uncapped.",
+    ],
+  },
+  {
+    title: "MCP server",
+    body: [
+      "Keeper ships an MCP server so an assistant can read and write your calendars directly, authenticated with OAuth 2.1 and a consent screen you approve in the browser.",
+    ],
+    points: [
+      "Read: list_calendars, list_accounts, get_events, get_event, get_event_count, get_pending_invites, get_ical_feed",
+      "Write: create_event, update_event, delete_event, rsvp_event",
+    ],
+  },
+  {
+    title: "Self-hosting",
+    body: [
+      "Keeper is open-source under the AGPL-3.0 license and publishes Docker images. A self-hosted instance runs with commercial mode off, which means every account on it gets the Pro feature set and no plan limits.",
+    ],
+  },
+];
+
+export const Route = createFileRoute("/(marketing)/features")({
+  component: FeaturesPage,
+  head: () => ({
+    links: [{ rel: "canonical", href: canonicalUrl("/features") }],
+    meta: seoMeta({
+      title: "Features",
+      description: PAGE_DESCRIPTION,
+      path: "/features",
+    }),
+    scripts: [
+      jsonLdScript(webPageSchema("Features", PAGE_DESCRIPTION, "/features")),
+      jsonLdScript(breadcrumbSchema([{ name: "Home", path: "/" }, { name: "Features", path: "/features" }])),
+    ],
+  }),
+});
+
+function FeaturesPage() {
+  return (
+    <div className="flex flex-col gap-6 py-16">
+      <header className="flex flex-col gap-1.5">
+        <Heading1>Features</Heading1>
+        <Text size="base" tone="muted" className="max-w-[64ch] leading-6">
+          {PAGE_DESCRIPTION}
+        </Text>
+      </header>
+
+      <div className="flex flex-col gap-8">
+        <Section title="Supported providers">
+          <Text size="sm">
+            Five providers are supported directly, and each one can act as both a source and a destination. ICS feeds
+            are read-only by nature, so they can only be a source.
+          </Text>
+          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2 list-none">
+            {PROVIDER_SUPPORT.map((provider) => (
+              <li
+                key={provider.name}
+                className="flex flex-col gap-1 rounded-2xl border border-interactive-border bg-background p-4 shadow-xs"
+              >
+                <Heading3 as="h3">{provider.name}</Heading3>
+                <Text size="xs" tone="default">{provider.role}</Text>
+                <Text size="sm" tone="muted">{provider.detail}</Text>
+              </li>
+            ))}
+          </ul>
+        </Section>
+
+        {FEATURE_SECTIONS.map((section) => (
+          <Section key={section.title} title={section.title}>
+            {section.body.map((paragraph) => (
+              <Text key={paragraph} size="sm">{paragraph}</Text>
+            ))}
+            {section.points && (
+              <ul className="list-disc list-inside flex flex-col gap-1 ml-2 text-sm tracking-tight text-foreground-muted">
+                {section.points.map((point) => (
+                  <li key={point}>{point}</li>
+                ))}
+              </ul>
+            )}
+          </Section>
+        ))}
+      </div>
+
+      <MarketingCtaSection>
+        <MarketingCtaCard>
+          <Heading2 className="text-center text-white">Ready to sync your calendars?</Heading2>
+          <Text size="sm" align="center" tone="highlight" className="max-w-[46ch]">
+            Start syncing your calendars in seconds. Free to use, no credit card required.
+          </Text>
+          <div className="flex items-center gap-2 mt-2">
+            <LinkButton
+              to="/register"
+              size="compact"
+              variant="inverse"
+              data-visitors-event={ANALYTICS_EVENTS.marketing_cta_clicked}
+              data-visitors-cta="features"
+            >
+              <ButtonText>Get Started</ButtonText>
+              <ButtonIcon>
+                <ArrowRightIcon size={16} />
+              </ButtonIcon>
+            </LinkButton>
+            <ExternalLinkButton
+              href="https://github.com/ridafkih/keeper.sh"
+              target="_blank"
+              rel="noreferrer"
+              size="compact"
+              variant="inverse-ghost"
+            >
+              <ButtonText>View on GitHub</ButtonText>
+              <ButtonIcon>
+                <ArrowUpRightIcon size={16} />
+              </ButtonIcon>
+            </ExternalLinkButton>
+          </div>
+        </MarketingCtaCard>
+      </MarketingCtaSection>
+    </div>
+  );
+}
+
+function Section({ title, children }: PropsWithChildren<{ title: string }>) {
+  return (
+    <section className="flex flex-col gap-3">
+      <Heading2 as="h2">{title}</Heading2>
+      {children}
+    </section>
+  );
+}

--- a/applications/web/src/routes/(marketing)/features.tsx
+++ b/applications/web/src/routes/(marketing)/features.tsx
@@ -34,7 +34,7 @@ import ArrowUpRightIcon from "lucide-react/dist/esm/icons/arrow-up-right";
 const breadcrumbs = breadcrumbTrail({ name: "Features", path: "/features" });
 
 const PAGE_DESCRIPTION =
-  "Keeper copies events from one calendar into another and combines everything you connect into a single feed. Works with Google Calendar, Outlook, iCloud, Fastmail, and more.";
+  "Keeper.sh copies events from one calendar into another and combines everything you connect into a single feed. Works with Google Calendar, Outlook, iCloud, Fastmail, and more.";
 
 type FeatureCard = {
   title: string;
@@ -74,7 +74,7 @@ const FEATURE_CARDS: FeatureCard[] = [
   },
   {
     title: "Open-source, and yours to run",
-    body: "Keeper is open-source under AGPL-3.0, with Docker images ready to deploy. Run it yourself and every account on it gets the Pro feature set, with no plan limits.",
+    body: "Keeper.sh is open-source under AGPL-3.0, with Docker images ready to deploy. Run it yourself and every account on it gets the Pro feature set, with no plan limits.",
     gridClassName: "lg:col-start-6 lg:col-span-5 lg:row-start-3",
     illustration: <MarketingIllustrationContributors />,
   },
@@ -96,7 +96,7 @@ const UPDATE_STEPS: UpdateStep[] = [
     body: "You set this per calendar. A work calendar can carry the title, description, and location while a shared one shows a plain block. On Pro you can also filter out events you would rather not copy at all.",
   },
   {
-    title: "Keeper takes it from there",
+    title: "Keeper.sh takes it from there",
     body: "Your calendars are checked every minute on both plans. Google and Outlook only report what changed, so checking stays quick even on a packed calendar. A change reaches your other calendars within 30 minutes on Free, and within a minute on Pro.",
     note: "Calendars connected by a link are read in full each time.",
   },
@@ -153,7 +153,7 @@ function FeaturesPage() {
       <MarketingHowItWorksSection>
         <Heading2>How your calendars stay in step</Heading2>
         <Text size="sm" tone="muted" className="mt-2 max-w-[64ch]">
-          You set a connection up once. After that, Keeper keeps the copies right.
+          You set a connection up once. After that, Keeper.sh keeps the copies right.
         </Text>
         <MarketingHowItWorksCard>
           <MarketingHowItWorksRow>
@@ -192,14 +192,14 @@ function FeaturesPage() {
       <MarketingFeatureBentoSection>
         <Heading2>For developers</Heading2>
         <Text size="sm" tone="muted" className="mt-2 mb-8 max-w-[64ch]">
-          Skip this part unless you want to drive Keeper from your own code or from an assistant.
+          Skip this part unless you want to drive Keeper.sh from your own code or from an assistant.
         </Text>
         <MarketingFeatureBentoGrid>
           <MarketingFeatureBentoCard className="lg:col-start-1 lg:col-span-5 lg:row-start-1">
             <MarketingFeatureBentoBody>
               <Heading3 as="h3">REST API</Heading3>
               <Text size="sm" className="text-left">
-                Keeper exposes a REST API under /api/v1, authenticated with a bearer token you create under Settings → API Tokens.
+                Keeper.sh exposes a REST API under /api/v1, authenticated with a bearer token you create under Settings → API Tokens.
                 It covers accounts, calendars, events, invites, and the calendar link.
               </Text>
               <Text size="sm" tone="muted" className="text-left">
@@ -212,7 +212,7 @@ function FeaturesPage() {
             <MarketingFeatureBentoBody>
               <Heading3 as="h3">MCP server</Heading3>
               <Text size="sm" className="text-left">
-                An assistant can read and write your calendars through Keeper&rsquo;s MCP server. You approve it once on a consent
+                An assistant can read and write your calendars through Keeper.sh&rsquo;s MCP server. You approve it once on a consent
                 screen in your browser, and it signs in with OAuth 2.1 rather than a password.
               </Text>
               <ul className="list-disc list-inside flex flex-col gap-1 ml-2 text-sm tracking-tight text-foreground-muted">

--- a/applications/web/src/routes/(marketing)/features.tsx
+++ b/applications/web/src/routes/(marketing)/features.tsx
@@ -10,7 +10,7 @@ import ArrowRightIcon from "lucide-react/dist/esm/icons/arrow-right";
 import ArrowUpRightIcon from "lucide-react/dist/esm/icons/arrow-up-right";
 
 const PAGE_DESCRIPTION =
-  "Two-way calendar sync for Google Calendar, Outlook, iCloud, Fastmail, and CalDAV, plus read-only ICS feeds, an anonymized iCal feed, a REST API, and an MCP server.";
+  "Keeper copies events from one calendar into another and combines everything you connect into a single feed. Works with Google Calendar, Outlook, iCloud, Fastmail, and more.";
 
 type FeatureSection = {
   title: string;
@@ -26,8 +26,9 @@ const FEATURE_SECTIONS: FeatureSection[] = [
       "Google and Outlook are pulled incrementally: Keeper stores a sync token or delta link per account and asks the provider only for what changed. CalDAV and ICS sources are re-read on each pass.",
     ],
     points: [
-      "Free plan: destinations are pushed every 30 minutes",
-      "Pro plan: destinations are pushed every minute",
+      "Both plans: changes are picked up from your calendars every minute",
+      "Free plan: those changes reach your other calendars every 30 minutes",
+      "Pro plan: those changes reach your other calendars every minute",
     ],
   },
   {
@@ -40,7 +41,7 @@ const FEATURE_SECTIONS: FeatureSection[] = [
   {
     title: "Control over what gets synced",
     body: [
-      "Display settings are configured per destination calendar, so a work calendar can show full details while a shared one shows a generic block.",
+      "Display settings are configured per destination calendar, so a work calendar can carry the title, description, and location while a shared one shows a generic block.",
       "Pro adds event filters and exclusions for skipping events you do not want mirrored at all.",
     ],
   },

--- a/applications/web/src/routes/(marketing)/features.tsx
+++ b/applications/web/src/routes/(marketing)/features.tsx
@@ -1,9 +1,30 @@
-import type { PropsWithChildren } from "react";
+import type { ReactNode } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import { Heading1, Heading2 } from "@/components/ui/primitives/heading";
+import { Heading1, Heading2, Heading3 } from "@/components/ui/primitives/heading";
 import { Text } from "@/components/ui/primitives/text";
 import { ButtonIcon, ButtonText, ExternalLinkButton, LinkButton } from "@/components/ui/primitives/button";
 import { MarketingCtaCard, MarketingCtaSection } from "@/features/marketing/components/marketing-cta";
+import {
+  MarketingFeatureBentoBody,
+  MarketingFeatureBentoCard,
+  MarketingFeatureBentoGrid,
+  MarketingFeatureBentoIllustration,
+  MarketingFeatureBentoSection,
+} from "@/features/marketing/components/marketing-feature-bento";
+import {
+  MarketingHowItWorksCard,
+  MarketingHowItWorksRow,
+  MarketingHowItWorksSection,
+  MarketingHowItWorksStepBody,
+  MarketingHowItWorksStepIllustration,
+} from "@/features/marketing/components/marketing-how-it-works";
+import { MarketingIllustrationContributors } from "@/illustrations/marketing-illustration-contributors";
+import { MarketingIllustrationProviders } from "@/illustrations/marketing-illustration-providers";
+import { MarketingIllustrationSetup } from "@/illustrations/marketing-illustration-setup";
+import { MarketingIllustrationSync } from "@/illustrations/marketing-illustration-sync";
+import { HowItWorksConnect } from "@/illustrations/how-it-works-connect";
+import { HowItWorksConfigure } from "@/illustrations/how-it-works-configure";
+import { HowItWorksSync } from "@/illustrations/how-it-works-sync";
 import { canonicalUrl, jsonLdScript, seoMeta, webPageSchema, breadcrumbSchema, breadcrumbTrail } from "@/lib/seo";
 import { Breadcrumb } from "@/components/ui/primitives/breadcrumb";
 import { ANALYTICS_EVENTS } from "@/lib/analytics";
@@ -15,63 +36,76 @@ const breadcrumbs = breadcrumbTrail({ name: "Features", path: "/features" });
 const PAGE_DESCRIPTION =
   "Keeper copies events from one calendar into another and combines everything you connect into a single feed. Works with Google Calendar, Outlook, iCloud, Fastmail, and more.";
 
-type FeatureSection = {
+type FeatureCard = {
   title: string;
-  body: string[];
-  points?: string[];
+  body: string;
+  gridClassName: string;
+  illustration?: ReactNode;
 };
 
-const FEATURE_SECTIONS: FeatureSection[] = [
+const FEATURE_CARDS: FeatureCard[] = [
   {
-    title: "Syncing that reconciles instead of duplicating",
-    body: [
-      "Events are pulled from every source you connect, then pushed to every destination you map them to. Updates and deletions propagate, so destination calendars are corrected rather than accumulating copies.",
-      "Google and Outlook are pulled incrementally: Keeper stores a sync token or delta link per account and asks the provider only for what changed. CalDAV and ICS sources are re-read on each pass.",
-    ],
-    points: [
-      "Both plans: changes are picked up from your calendars every minute",
-      "Free plan: those changes reach your other calendars every 30 minutes",
-      "Pro plan: those changes reach your other calendars every minute",
-    ],
+    title: "Works with the calendars you already use",
+    body: "Sign in to Google Calendar, Outlook, iCloud, or Fastmail. Other calendars connect with a link you paste in, or over the CalDAV standard they already support.",
+    gridClassName: "lg:col-start-1 lg:col-span-4 lg:row-start-1",
+    illustration: <MarketingIllustrationProviders />,
   },
   {
-    title: "One aggregated iCal feed",
-    body: [
-      "Every source you connect is combined into a single iCal feed you can subscribe to from any calendar app. By default the feed is anonymized: titles, descriptions, and locations are stripped and every event reads as “Busy”, so you can share availability without sharing your schedule.",
-      "On Pro you can customize the feed, choosing which details are included and what the placeholder title says.",
-    ],
+    title: "One calendar link with everything in it",
+    body: "Every calendar you connect also lands in a single link. Subscribe to it from any calendar app and your whole week shows up in one place.",
+    gridClassName: "lg:col-start-5 lg:col-span-6 lg:row-start-1",
+    illustration: <MarketingIllustrationSync />,
   },
   {
-    title: "Control over what gets synced",
-    body: [
-      "Display settings are configured per destination calendar, so a work calendar can carry the title, description, and location while a shared one shows a generic block.",
-      "Pro adds event filters and exclusions for skipping events you do not want mirrored at all.",
-    ],
+    title: "Share that you are busy, not what you are doing",
+    body: "The link hides titles, descriptions, and locations by default. Every event reads “Busy”, so you can hand it to a colleague without handing over your schedule. On Pro you pick which details it keeps and what the stand-in title says.",
+    gridClassName: "lg:col-start-1 lg:col-span-6 lg:row-start-2",
   },
   {
-    title: "REST API",
-    body: [
-      "Keeper exposes a REST API under /api/v1, authenticated with a bearer token you create under Settings → API Tokens. It covers accounts, calendars, events, invites, and the iCal feed.",
-      "The free plan allows 25 API calls per day. Pro is uncapped.",
-    ],
+    title: "Connections go one way",
+    body: "A connection copies events from one calendar into another. If you want both calendars to match, connect them in both directions.",
+    gridClassName: "lg:col-start-7 lg:col-span-4 lg:row-start-2",
+    illustration: <MarketingIllustrationSetup />,
   },
   {
-    title: "MCP server",
-    body: [
-      "Keeper ships an MCP server so an assistant can read and write your calendars directly, authenticated with OAuth 2.1 and a consent screen you approve in the browser.",
-    ],
-    points: [
-      "Read: list_calendars, list_accounts, get_events, get_event, get_event_count, get_pending_invites, get_ical_feed",
-      "Write: create_event, update_event, delete_event, rsvp_event",
-    ],
+    title: "Copies that stay right",
+    body: "Move an event and the copy moves. Delete it and the copy goes too. Your other calendar gets corrected instead of collecting duplicates.",
+    gridClassName: "lg:col-start-1 lg:col-span-5 lg:row-start-3",
   },
   {
-    title: "Self-hosting",
-    body: [
-      "Keeper is open-source under the AGPL-3.0 license and publishes Docker images. A self-hosted instance runs with commercial mode off, which means every account on it gets the Pro feature set and no plan limits.",
-    ],
+    title: "Open-source, and yours to run",
+    body: "Keeper is open-source under AGPL-3.0, with Docker images ready to deploy. Run it yourself and every account on it gets the Pro feature set, with no plan limits.",
+    gridClassName: "lg:col-start-6 lg:col-span-5 lg:row-start-3",
+    illustration: <MarketingIllustrationContributors />,
   },
 ];
+
+type UpdateStep = {
+  title: string;
+  body: string;
+  note?: string;
+};
+
+const UPDATE_STEPS: UpdateStep[] = [
+  {
+    title: "Connect a calendar, then say where it copies to",
+    body: "Connecting takes a sign-in or a pasted link. You then point that calendar at the one you want its events to land in.",
+  },
+  {
+    title: "Choose what each calendar shows",
+    body: "You set this per calendar. A work calendar can carry the title, description, and location while a shared one shows a plain block. On Pro you can also filter out events you would rather not copy at all.",
+  },
+  {
+    title: "Keeper takes it from there",
+    body: "Your calendars are checked every minute on both plans. Google and Outlook only report what changed, so checking stays quick even on a packed calendar. A change reaches your other calendars within 30 minutes on Free, and within a minute on Pro.",
+    note: "Calendars connected by a link are read in full each time.",
+  },
+];
+
+const MCP_READ_TOOLS =
+  "Read: list_calendars, list_accounts, get_events, get_event, get_event_count, get_pending_invites, get_ical_feed";
+
+const MCP_WRITE_TOOLS = "Write: create_event, update_event, delete_event, rsvp_event";
 
 export const Route = createFileRoute("/(marketing)/features")({
   component: FeaturesPage,
@@ -100,22 +134,95 @@ function FeaturesPage() {
         </Text>
       </header>
 
-      <div className="flex flex-col gap-8">
-        {FEATURE_SECTIONS.map((section) => (
-          <Section key={section.title} title={section.title}>
-            {section.body.map((paragraph) => (
-              <Text key={paragraph} size="sm">{paragraph}</Text>
-            ))}
-            {section.points && (
+      <MarketingFeatureBentoSection>
+        <MarketingFeatureBentoGrid>
+          {FEATURE_CARDS.map((card) => (
+            <MarketingFeatureBentoCard key={card.title} className={card.gridClassName}>
+              <MarketingFeatureBentoIllustration plain={!!card.illustration}>
+                {card.illustration}
+              </MarketingFeatureBentoIllustration>
+              <MarketingFeatureBentoBody>
+                <Heading3 as="h2">{card.title}</Heading3>
+                <Text size="sm" className="text-left">{card.body}</Text>
+              </MarketingFeatureBentoBody>
+            </MarketingFeatureBentoCard>
+          ))}
+        </MarketingFeatureBentoGrid>
+      </MarketingFeatureBentoSection>
+
+      <MarketingHowItWorksSection>
+        <Heading2>How your calendars stay in step</Heading2>
+        <Text size="sm" tone="muted" className="mt-2 max-w-[64ch]">
+          You set a connection up once. After that, Keeper keeps the copies right.
+        </Text>
+        <MarketingHowItWorksCard>
+          <MarketingHowItWorksRow>
+            <MarketingHowItWorksStepBody step={1}>
+              <Heading3 as="h3">{UPDATE_STEPS[0].title}</Heading3>
+              <Text size="sm" tone="muted">{UPDATE_STEPS[0].body}</Text>
+            </MarketingHowItWorksStepBody>
+            <MarketingHowItWorksStepIllustration align="right">
+              <HowItWorksConnect />
+            </MarketingHowItWorksStepIllustration>
+          </MarketingHowItWorksRow>
+
+          <MarketingHowItWorksRow reverse>
+            <MarketingHowItWorksStepBody step={2}>
+              <Heading3 as="h3">{UPDATE_STEPS[1].title}</Heading3>
+              <Text size="sm" tone="muted">{UPDATE_STEPS[1].body}</Text>
+            </MarketingHowItWorksStepBody>
+            <MarketingHowItWorksStepIllustration align="left">
+              <HowItWorksConfigure />
+            </MarketingHowItWorksStepIllustration>
+          </MarketingHowItWorksRow>
+
+          <MarketingHowItWorksRow>
+            <MarketingHowItWorksStepBody step={3}>
+              <Heading3 as="h3">{UPDATE_STEPS[2].title}</Heading3>
+              <Text size="sm" tone="muted">{UPDATE_STEPS[2].body}</Text>
+              <Text size="sm" tone="muted">{UPDATE_STEPS[2].note}</Text>
+            </MarketingHowItWorksStepBody>
+            <MarketingHowItWorksStepIllustration align="right">
+              <HowItWorksSync />
+            </MarketingHowItWorksStepIllustration>
+          </MarketingHowItWorksRow>
+        </MarketingHowItWorksCard>
+      </MarketingHowItWorksSection>
+
+      <MarketingFeatureBentoSection>
+        <Heading2>For developers</Heading2>
+        <Text size="sm" tone="muted" className="mt-2 mb-8 max-w-[64ch]">
+          Skip this part unless you want to drive Keeper from your own code or from an assistant.
+        </Text>
+        <MarketingFeatureBentoGrid>
+          <MarketingFeatureBentoCard className="lg:col-start-1 lg:col-span-5 lg:row-start-1">
+            <MarketingFeatureBentoBody>
+              <Heading3 as="h3">REST API</Heading3>
+              <Text size="sm" className="text-left">
+                Keeper exposes a REST API under /api/v1, authenticated with a bearer token you create under Settings → API Tokens.
+                It covers accounts, calendars, events, invites, and the calendar link.
+              </Text>
+              <Text size="sm" tone="muted" className="text-left">
+                The free plan allows 25 API calls per day. Pro is uncapped.
+              </Text>
+            </MarketingFeatureBentoBody>
+          </MarketingFeatureBentoCard>
+
+          <MarketingFeatureBentoCard className="lg:col-start-6 lg:col-span-5 lg:row-start-1">
+            <MarketingFeatureBentoBody>
+              <Heading3 as="h3">MCP server</Heading3>
+              <Text size="sm" className="text-left">
+                An assistant can read and write your calendars through Keeper&rsquo;s MCP server. You approve it once on a consent
+                screen in your browser, and it signs in with OAuth 2.1 rather than a password.
+              </Text>
               <ul className="list-disc list-inside flex flex-col gap-1 ml-2 text-sm tracking-tight text-foreground-muted">
-                {section.points.map((point) => (
-                  <li key={point}>{point}</li>
-                ))}
+                <li>{MCP_READ_TOOLS}</li>
+                <li>{MCP_WRITE_TOOLS}</li>
               </ul>
-            )}
-          </Section>
-        ))}
-      </div>
+            </MarketingFeatureBentoBody>
+          </MarketingFeatureBentoCard>
+        </MarketingFeatureBentoGrid>
+      </MarketingFeatureBentoSection>
 
       <MarketingCtaSection>
         <MarketingCtaCard>
@@ -152,14 +259,5 @@ function FeaturesPage() {
         </MarketingCtaCard>
       </MarketingCtaSection>
     </div>
-  );
-}
-
-function Section({ title, children }: PropsWithChildren<{ title: string }>) {
-  return (
-    <section className="flex flex-col gap-3">
-      <Heading2 as="h2">{title}</Heading2>
-      {children}
-    </section>
   );
 }

--- a/applications/web/src/routes/(marketing)/features.tsx
+++ b/applications/web/src/routes/(marketing)/features.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import { Heading1, Heading2, Heading3 } from "@/components/ui/primitives/heading";
+import { Heading1, Heading2 } from "@/components/ui/primitives/heading";
 import { Text } from "@/components/ui/primitives/text";
 import { ButtonIcon, ButtonText, ExternalLinkButton, LinkButton } from "@/components/ui/primitives/button";
 import { MarketingCtaCard, MarketingCtaSection } from "@/features/marketing/components/marketing-cta";
@@ -11,45 +11,6 @@ import ArrowUpRightIcon from "lucide-react/dist/esm/icons/arrow-up-right";
 
 const PAGE_DESCRIPTION =
   "Two-way calendar sync for Google Calendar, Outlook, iCloud, Fastmail, and CalDAV, plus read-only ICS feeds, an anonymized iCal feed, a REST API, and an MCP server.";
-
-type ProviderSupport = {
-  name: string;
-  role: string;
-  detail: string;
-};
-
-const PROVIDER_SUPPORT: ProviderSupport[] = [
-  {
-    name: "Google Calendar",
-    role: "Source and destination",
-    detail: "Connected over OAuth. Pulls incrementally using sync tokens.",
-  },
-  {
-    name: "Microsoft Outlook",
-    role: "Source and destination",
-    detail: "Connected over OAuth. Pulls incrementally using delta links.",
-  },
-  {
-    name: "Apple iCloud",
-    role: "Source and destination",
-    detail: "Connected with an app-specific password over CalDAV.",
-  },
-  {
-    name: "Fastmail",
-    role: "Source and destination",
-    detail: "Connected with an app password over CalDAV.",
-  },
-  {
-    name: "CalDAV",
-    role: "Source and destination",
-    detail: "Any CalDAV server, authenticated with a username and password.",
-  },
-  {
-    name: "ICS / iCal links",
-    role: "Source only",
-    detail: "Any publicly reachable feed. ICS cannot be written to, so it is never a destination.",
-  },
-];
 
 type FeatureSection = {
   title: string;
@@ -135,25 +96,6 @@ function FeaturesPage() {
       </header>
 
       <div className="flex flex-col gap-8">
-        <Section title="Supported providers">
-          <Text size="sm">
-            Five providers are supported directly, and each one can act as both a source and a destination. ICS feeds
-            are read-only by nature, so they can only be a source.
-          </Text>
-          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2 list-none">
-            {PROVIDER_SUPPORT.map((provider) => (
-              <li
-                key={provider.name}
-                className="flex flex-col gap-1 rounded-2xl border border-interactive-border bg-background p-4 shadow-xs"
-              >
-                <Heading3 as="h3">{provider.name}</Heading3>
-                <Text size="xs" tone="default">{provider.role}</Text>
-                <Text size="sm" tone="muted">{provider.detail}</Text>
-              </li>
-            ))}
-          </ul>
-        </Section>
-
         {FEATURE_SECTIONS.map((section) => (
           <Section key={section.title} title={section.title}>
             {section.body.map((paragraph) => (

--- a/applications/web/src/routes/(marketing)/features.tsx
+++ b/applications/web/src/routes/(marketing)/features.tsx
@@ -4,10 +4,13 @@ import { Heading1, Heading2 } from "@/components/ui/primitives/heading";
 import { Text } from "@/components/ui/primitives/text";
 import { ButtonIcon, ButtonText, ExternalLinkButton, LinkButton } from "@/components/ui/primitives/button";
 import { MarketingCtaCard, MarketingCtaSection } from "@/features/marketing/components/marketing-cta";
-import { canonicalUrl, jsonLdScript, seoMeta, webPageSchema, breadcrumbSchema } from "@/lib/seo";
+import { canonicalUrl, jsonLdScript, seoMeta, webPageSchema, breadcrumbSchema, breadcrumbTrail } from "@/lib/seo";
+import { Breadcrumb } from "@/components/ui/primitives/breadcrumb";
 import { ANALYTICS_EVENTS } from "@/lib/analytics";
 import ArrowRightIcon from "lucide-react/dist/esm/icons/arrow-right";
 import ArrowUpRightIcon from "lucide-react/dist/esm/icons/arrow-up-right";
+
+const breadcrumbs = breadcrumbTrail({ name: "Features", path: "/features" });
 
 const PAGE_DESCRIPTION =
   "Keeper copies events from one calendar into another and combines everything you connect into a single feed. Works with Google Calendar, Outlook, iCloud, Fastmail, and more.";
@@ -81,7 +84,7 @@ export const Route = createFileRoute("/(marketing)/features")({
     }),
     scripts: [
       jsonLdScript(webPageSchema("Features", PAGE_DESCRIPTION, "/features")),
-      jsonLdScript(breadcrumbSchema([{ name: "Home", path: "/" }, { name: "Features", path: "/features" }])),
+      jsonLdScript(breadcrumbSchema(breadcrumbs)),
     ],
   }),
 });
@@ -89,6 +92,7 @@ export const Route = createFileRoute("/(marketing)/features")({
 function FeaturesPage() {
   return (
     <div className="flex flex-col gap-6 py-16">
+      <Breadcrumb items={breadcrumbs} />
       <header className="flex flex-col gap-1.5">
         <Heading1>Features</Heading1>
         <Text size="base" tone="muted" className="max-w-[64ch] leading-6">

--- a/applications/web/src/routes/(marketing)/index.tsx
+++ b/applications/web/src/routes/(marketing)/index.tsx
@@ -191,7 +191,7 @@ export const Route = createFileRoute('/(marketing)/')({
     }),
     scripts: [
       jsonLdScript(softwareApplicationSchema()),
-      jsonLdScript(faqSchema(FAQ_ITEMS)),
+      jsonLdScript(faqSchema("", FAQ_ITEMS)),
     ],
   }),
 })

--- a/applications/web/src/routes/(marketing)/index.tsx
+++ b/applications/web/src/routes/(marketing)/index.tsx
@@ -34,7 +34,6 @@ import {
   MarketingPricingComparisonSpacer,
   MarketingPricingFeatureDisplay,
   MarketingPricingFeatureLabel,
-  type MarketingPricingFeatureValueKind,
   MarketingPricingFeatureMatrix,
   MarketingPricingFeatureRow,
   MarketingPricingFeatureValue,
@@ -42,6 +41,7 @@ import {
   MarketingPricingPlanCard,
   MarketingPricingSection,
 } from '../../features/marketing/components/marketing-pricing-section'
+import { PRICING_FEATURES, PRICING_PLANS } from '../../features/marketing/pricing-plans'
 import { calendarEmphasizedAtom } from '../../state/calendar-emphasized'
 import { ANALYTICS_EVENTS } from '../../lib/analytics'
 import ArrowRightIcon from "lucide-react/dist/esm/icons/arrow-right";
@@ -108,56 +108,6 @@ const MARKETING_FEATURES: MarketingFeature[] = [
     gridClassName: 'lg:col-start-7 lg:col-span-4 lg:row-start-2',
     illustration: <MarketingIllustrationSetup />,
   },
-]
-
-type PricingFeature = {
-  label: string
-  free: MarketingPricingFeatureValueKind
-  pro: MarketingPricingFeatureValueKind
-}
-
-type PricingPlan = {
-  id: string
-  name: string
-  price: string
-  period: string
-  description: string
-  ctaLabel: string
-  tone?: "default" | "inverse"
-}
-
-const PRICING_PLANS: PricingPlan[] = [
-  {
-    id: 'free',
-    name: 'Free',
-    price: '$0',
-    period: 'per month',
-    description:
-      'For personal use and getting started with calendar sync.',
-    ctaLabel: 'Get Started',
-  },
-  {
-    id: 'pro',
-    name: 'Pro',
-    price: '$5',
-    period: 'per month',
-    description:
-      'For power users who need fast syncs, advanced feed controls, and unlimited syncing.',
-    ctaLabel: 'Get Started',
-    tone: "inverse" as const,
-  },
-]
-
-const PRICING_FEATURES: PricingFeature[] = [
-  { label: 'Reading Your Calendars', free: 'Every 1 minute', pro: 'Every 1 minute' },
-  { label: 'Updating Your Calendars', free: 'Every 30 minutes', pro: 'Every 1 minute' },
-  { label: 'Linked Accounts', free: 'Up to 2', pro: 'infinity' },
-  { label: 'Sync Mappings', free: 'Up to 3', pro: 'infinity' },
-  { label: 'Aggregated iCal Feed', free: 'check', pro: 'check' },
-  { label: 'iCal Feed Customization', free: 'minus', pro: 'check' },
-  { label: 'Event Filters & Exclusions', free: 'minus', pro: 'check' },
-  { label: 'API & MCP Access', free: '25 calls/day', pro: 'infinity' },
-  { label: 'Priority Support', free: 'minus', pro: 'check' },
 ]
 
 type HowItWorksStep = {

--- a/applications/web/src/routes/(marketing)/pricing.tsx
+++ b/applications/web/src/routes/(marketing)/pricing.tsx
@@ -1,0 +1,130 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Heading1, Heading2 } from "@/components/ui/primitives/heading";
+import { Text } from "@/components/ui/primitives/text";
+import {
+  MarketingPricingComparisonGrid,
+  MarketingPricingComparisonSpacer,
+  MarketingPricingFeatureDisplay,
+  MarketingPricingFeatureLabel,
+  MarketingPricingFeatureMatrix,
+  MarketingPricingFeatureRow,
+  MarketingPricingFeatureValue,
+  MarketingPricingPlanCard,
+  MarketingPricingSection,
+} from "@/features/marketing/components/marketing-pricing-section";
+import { PRICING_FEATURES, PRICING_PLANS } from "@/features/marketing/pricing-plans";
+import { canonicalUrl, jsonLdScript, seoMeta, webPageSchema, breadcrumbSchema, offerCatalogSchema } from "@/lib/seo";
+
+const PAGE_DESCRIPTION =
+  "Keeper.sh pricing. Free covers 2 linked accounts, 3 sync mappings, and syncing every 30 minutes. Pro is $5 per month for unlimited accounts and mappings, syncing every minute, and uncapped API access.";
+
+type PricingNote = {
+  title: string;
+  body: string;
+};
+
+const PRICING_NOTES: PricingNote[] = [
+  {
+    title: "What counts as a linked account",
+    body: "An account is one connected calendar provider, such as a Google or Outlook login or a CalDAV server. Free allows 2, Pro is unlimited.",
+  },
+  {
+    title: "What counts as a sync mapping",
+    body: "A mapping is one source calendar pushed to one destination calendar. Free allows 3, Pro is unlimited.",
+  },
+  {
+    title: "Annual billing",
+    body: "Pro is $5 per month, or $42 per year if you pay annually.",
+  },
+  {
+    title: "Self-hosting is free",
+    body: "Keeper is open-source under AGPL-3.0. A self-hosted instance runs without commercial mode, so every account on it gets the Pro feature set and no plan limits.",
+  },
+  {
+    title: "Cancelling",
+    body: "Billing is handled by Polar. You can manage or cancel your subscription from the customer portal linked in your account settings.",
+  },
+];
+
+export const Route = createFileRoute("/(marketing)/pricing")({
+  component: PricingPage,
+  head: () => ({
+    links: [{ rel: "canonical", href: canonicalUrl("/pricing") }],
+    meta: seoMeta({
+      title: "Pricing",
+      description: PAGE_DESCRIPTION,
+      path: "/pricing",
+    }),
+    scripts: [
+      jsonLdScript(webPageSchema("Pricing", PAGE_DESCRIPTION, "/pricing")),
+      jsonLdScript(breadcrumbSchema([{ name: "Home", path: "/" }, { name: "Pricing", path: "/pricing" }])),
+      jsonLdScript(offerCatalogSchema("/pricing", PRICING_PLANS.map((plan) => ({
+        name: plan.name,
+        price: plan.price.replace("$", ""),
+        description: plan.description,
+      })))),
+    ],
+  }),
+});
+
+function PricingPage() {
+  return (
+    <div className="flex flex-col gap-6 py-16">
+      <header className="flex flex-col gap-1.5">
+        <Heading1>Pricing</Heading1>
+        <Text size="base" tone="muted" className="max-w-[64ch] leading-6">
+          Keeper.sh uses a low-cost freemium model to give you a solid range of choice. Self-hosting is free and
+          includes every Pro feature.
+        </Text>
+      </header>
+
+      <MarketingPricingSection>
+        <MarketingPricingComparisonGrid>
+          <MarketingPricingComparisonSpacer />
+
+          {PRICING_PLANS.map((plan) => (
+            <MarketingPricingPlanCard
+              key={plan.id}
+              tone={plan.tone}
+              name={plan.name}
+              price={plan.price}
+              period={plan.period}
+              description={plan.description}
+              ctaLabel={plan.ctaLabel}
+            />
+          ))}
+
+          <MarketingPricingFeatureMatrix>
+            {PRICING_FEATURES.map((feature) => (
+              <MarketingPricingFeatureRow key={feature.label}>
+                <MarketingPricingFeatureLabel>
+                  <Text size="sm" className="text-left text-nowrap">{feature.label}</Text>
+                </MarketingPricingFeatureLabel>
+                <MarketingPricingFeatureValue>
+                  <MarketingPricingFeatureDisplay value={feature.free} tone="muted" />
+                </MarketingPricingFeatureValue>
+                <MarketingPricingFeatureValue>
+                  <MarketingPricingFeatureDisplay value={feature.pro} tone="muted" />
+                </MarketingPricingFeatureValue>
+              </MarketingPricingFeatureRow>
+            ))}
+          </MarketingPricingFeatureMatrix>
+        </MarketingPricingComparisonGrid>
+      </MarketingPricingSection>
+
+      <section className="flex flex-col gap-3">
+        <Heading2 as="h2">Details</Heading2>
+        <dl className="flex flex-col gap-4">
+          {PRICING_NOTES.map((note) => (
+            <div key={note.title} className="flex flex-col gap-1">
+              <dt className="text-sm tracking-tight text-foreground">{note.title}</dt>
+              <dd>
+                <Text size="sm">{note.body}</Text>
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+    </div>
+  );
+}

--- a/applications/web/src/routes/(marketing)/pricing.tsx
+++ b/applications/web/src/routes/(marketing)/pricing.tsx
@@ -20,7 +20,10 @@ import {
 } from "@/features/marketing/components/marketing-faq";
 import { Collapsible } from "@/components/ui/primitives/collapsible";
 import { PRICING_FEATURES, PRICING_PLANS } from "@/features/marketing/pricing-plans";
-import { canonicalUrl, jsonLdScript, seoMeta, webPageSchema, breadcrumbSchema, offerCatalogSchema, faqSchema } from "@/lib/seo";
+import { canonicalUrl, jsonLdScript, seoMeta, webPageSchema, breadcrumbSchema, breadcrumbTrail, offerCatalogSchema, faqSchema } from "@/lib/seo";
+import { Breadcrumb } from "@/components/ui/primitives/breadcrumb";
+
+const breadcrumbs = breadcrumbTrail({ name: "Pricing", path: "/pricing" });
 
 const PAGE_DESCRIPTION =
   "Keeper.sh pricing. Free covers 2 linked accounts, 3 sync mappings, and changes reaching your other calendars every 30 minutes. Pro is $5 per month for unlimited accounts and mappings, changes every minute, and uncapped API access.";
@@ -68,7 +71,7 @@ export const Route = createFileRoute("/(marketing)/pricing")({
     }),
     scripts: [
       jsonLdScript(webPageSchema("Pricing", PAGE_DESCRIPTION, "/pricing")),
-      jsonLdScript(breadcrumbSchema([{ name: "Home", path: "/" }, { name: "Pricing", path: "/pricing" }])),
+      jsonLdScript(breadcrumbSchema(breadcrumbs)),
       jsonLdScript(offerCatalogSchema("/pricing", PRICING_PLANS.map((plan) => ({
         name: plan.name,
         price: plan.price.replace("$", ""),
@@ -82,6 +85,7 @@ export const Route = createFileRoute("/(marketing)/pricing")({
 function PricingPage() {
   return (
     <div className="flex flex-col gap-6 py-16">
+      <Breadcrumb items={breadcrumbs} />
       <header className="flex flex-col gap-1.5">
         <Heading1>Pricing</Heading1>
         <Text size="base" tone="muted" className="max-w-[64ch] leading-6">

--- a/applications/web/src/routes/(marketing)/pricing.tsx
+++ b/applications/web/src/routes/(marketing)/pricing.tsx
@@ -12,37 +12,48 @@ import {
   MarketingPricingPlanCard,
   MarketingPricingSection,
 } from "@/features/marketing/components/marketing-pricing-section";
+import {
+  MarketingFaqItem,
+  MarketingFaqList,
+  MarketingFaqQuestion,
+  MarketingFaqSection,
+} from "@/features/marketing/components/marketing-faq";
+import { Collapsible } from "@/components/ui/primitives/collapsible";
 import { PRICING_FEATURES, PRICING_PLANS } from "@/features/marketing/pricing-plans";
-import { canonicalUrl, jsonLdScript, seoMeta, webPageSchema, breadcrumbSchema, offerCatalogSchema } from "@/lib/seo";
+import { canonicalUrl, jsonLdScript, seoMeta, webPageSchema, breadcrumbSchema, offerCatalogSchema, faqSchema } from "@/lib/seo";
 
 const PAGE_DESCRIPTION =
   "Keeper.sh pricing. Free covers 2 linked accounts, 3 sync mappings, and changes reaching your other calendars every 30 minutes. Pro is $5 per month for unlimited accounts and mappings, changes every minute, and uncapped API access.";
 
-type PricingNote = {
-  title: string;
-  body: string;
+type FaqItem = {
+  question: string;
+  answer: string;
 };
 
-const PRICING_NOTES: PricingNote[] = [
+const FAQ_ITEMS: FaqItem[] = [
   {
-    title: "What counts as a linked account",
-    body: "An account is one connected calendar provider, such as a Google or Outlook login or a CalDAV server. Free allows 2, Pro is unlimited.",
+    question: "What counts as a linked account?",
+    answer: "An account is one connected calendar provider, such as a Google or Outlook login or a CalDAV server. Free allows 2, Pro is unlimited.",
   },
   {
-    title: "What counts as a sync mapping",
-    body: "A mapping is one source calendar pushed to one destination calendar. Free allows 3, Pro is unlimited.",
+    question: "What counts as a sync mapping?",
+    answer: "A mapping is one source calendar pushed to one destination calendar. Free allows 3, Pro is unlimited.",
   },
   {
-    title: "Annual billing",
-    body: "Pro is $5 per month, or $42 per year if you pay annually.",
+    question: "How quickly do changes show up?",
+    answer: "Changes are picked up from your calendars every minute on both plans. On Free they reach your other calendars every 30 minutes, and on Pro every minute.",
   },
   {
-    title: "Self-hosting is free",
-    body: "Keeper is open-source under AGPL-3.0. A self-hosted instance runs without commercial mode, so every account on it gets the Pro feature set and no plan limits.",
+    question: "Is there a discount for paying annually?",
+    answer: "Pro is $5 per month, or $42 per year if you pay annually.",
   },
   {
-    title: "Cancelling",
-    body: "Billing is handled by Polar. You can manage or cancel your subscription from the customer portal linked in your account settings.",
+    question: "Is self-hosting free?",
+    answer: "Keeper is open-source under AGPL-3.0. A self-hosted instance runs without commercial mode, so every account on it gets the Pro feature set and no plan limits.",
+  },
+  {
+    question: "Can I cancel my subscription?",
+    answer: "Billing is handled by Polar. You can manage or cancel your subscription from the customer portal linked in your account settings.",
   },
 ];
 
@@ -63,6 +74,7 @@ export const Route = createFileRoute("/(marketing)/pricing")({
         price: plan.price.replace("$", ""),
         description: plan.description,
       })))),
+      jsonLdScript(faqSchema(FAQ_ITEMS)),
     ],
   }),
 });
@@ -112,19 +124,20 @@ function PricingPage() {
         </MarketingPricingComparisonGrid>
       </MarketingPricingSection>
 
-      <section className="flex flex-col gap-3">
-        <Heading2 as="h2">Details</Heading2>
-        <dl className="flex flex-col gap-4">
-          {PRICING_NOTES.map((note) => (
-            <div key={note.title} className="flex flex-col gap-1">
-              <dt className="text-sm tracking-tight text-foreground">{note.title}</dt>
-              <dd>
-                <Text size="sm">{note.body}</Text>
-              </dd>
-            </div>
+      <MarketingFaqSection>
+        <Heading2 className="text-center">Frequently Asked Questions</Heading2>
+        <MarketingFaqList>
+          {FAQ_ITEMS.map((item) => (
+            <MarketingFaqItem key={item.question}>
+              <Collapsible
+                trigger={<MarketingFaqQuestion>{item.question}</MarketingFaqQuestion>}
+              >
+                <Text size="sm" tone="muted">{item.answer}</Text>
+              </Collapsible>
+            </MarketingFaqItem>
           ))}
-        </dl>
-      </section>
+        </MarketingFaqList>
+      </MarketingFaqSection>
     </div>
   );
 }

--- a/applications/web/src/routes/(marketing)/pricing.tsx
+++ b/applications/web/src/routes/(marketing)/pricing.tsx
@@ -74,7 +74,7 @@ export const Route = createFileRoute("/(marketing)/pricing")({
         price: plan.price.replace("$", ""),
         description: plan.description,
       })))),
-      jsonLdScript(faqSchema(FAQ_ITEMS)),
+      jsonLdScript(faqSchema("/pricing", FAQ_ITEMS)),
     ],
   }),
 });

--- a/applications/web/src/routes/(marketing)/pricing.tsx
+++ b/applications/web/src/routes/(marketing)/pricing.tsx
@@ -52,7 +52,7 @@ const FAQ_ITEMS: FaqItem[] = [
   },
   {
     question: "Is self-hosting free?",
-    answer: "Keeper is open-source under AGPL-3.0. A self-hosted instance runs without commercial mode, so every account on it gets the Pro feature set and no plan limits.",
+    answer: "Keeper.sh is open-source under AGPL-3.0. A self-hosted instance runs without commercial mode, so every account on it gets the Pro feature set and no plan limits.",
   },
   {
     question: "Can I cancel my subscription?",

--- a/applications/web/src/routes/(marketing)/pricing.tsx
+++ b/applications/web/src/routes/(marketing)/pricing.tsx
@@ -16,7 +16,7 @@ import { PRICING_FEATURES, PRICING_PLANS } from "@/features/marketing/pricing-pl
 import { canonicalUrl, jsonLdScript, seoMeta, webPageSchema, breadcrumbSchema, offerCatalogSchema } from "@/lib/seo";
 
 const PAGE_DESCRIPTION =
-  "Keeper.sh pricing. Free covers 2 linked accounts, 3 sync mappings, and syncing every 30 minutes. Pro is $5 per month for unlimited accounts and mappings, syncing every minute, and uncapped API access.";
+  "Keeper.sh pricing. Free covers 2 linked accounts, 3 sync mappings, and changes reaching your other calendars every 30 minutes. Pro is $5 per month for unlimited accounts and mappings, changes every minute, and uncapped API access.";
 
 type PricingNote = {
   title: string;

--- a/applications/web/src/routes/(marketing)/route.tsx
+++ b/applications/web/src/routes/(marketing)/route.tsx
@@ -94,8 +94,8 @@ function MarketingLayout() {
             <MarketingFooterNavGroup>
               <MarketingFooterNavGroupLabel>Product</MarketingFooterNavGroupLabel>
               <MarketingFooterNavItem to="/register">Get Started</MarketingFooterNavItem>
-              <MarketingFooterNavItem to="/#features">Features</MarketingFooterNavItem>
-              <MarketingFooterNavItem to="/#pricing">Pricing</MarketingFooterNavItem>
+              <MarketingFooterNavItem to="/features">Features</MarketingFooterNavItem>
+              <MarketingFooterNavItem to="/pricing">Pricing</MarketingFooterNavItem>
             </MarketingFooterNavGroup>
             <MarketingFooterNavGroup>
               <MarketingFooterNavGroupLabel>Resources</MarketingFooterNavGroupLabel>


### PR DESCRIPTION
Adds `/features` and `/pricing` as real indexable marketing routes so both are linkable and crawlable, replacing the `/#features` and `/#pricing` footer anchors. Copy is sourced from the codebase only: provider capabilities from the calendar registry, plan limits from `@keeper.sh/premium`, the 25/day API cap, and the 30 min / 1 min push cadences. Closes #468.

- Pricing plan and comparison data moved to `features/marketing/pricing-plans.ts` and shared with the homepage section so the two cannot drift
- `/pricing` emits WebPage, BreadcrumbList, and an OfferCatalog of Offer nodes matching the shape `softwareApplicationSchema` already uses
- `/features` emits WebPage and BreadcrumbList
- Both routes added to the sitemap `staticEntries`
- Verified rendered canonicals, titles, and JSON-LD against a running dev server; `types` and `lint` pass for `@keeper.sh/web`