### PR TITLE
docs: add CalDAV provider-pair sync guides

### DIFF
--- a/applications/web/src/content/blog/sync-fastmail-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/sync-fastmail-calendar-with-outlook.mdx
@@ -14,8 +14,6 @@ tags:
 
 Your own life lives in Fastmail. Work runs on Outlook. Neither knows the other exists, so colleagues book meetings on top of things you already committed to.
 
-Outlook will subscribe to a calendar link and refresh it on its own unhurried schedule. That is not enough when someone needs to know you are busy on Thursday.
-
 Keeper signs into both calendars and keeps copies of your events in step.
 
 ## What does this actually do?
@@ -24,17 +22,13 @@ Add something to your Fastmail calendar and a copy appears in Outlook. Move it, 
 
 By default the copy is a block of busy time, not a readable event. Colleagues see you are unavailable, not what you are doing.
 
-Copies travel one way per connection. You decide whether events go from Fastmail to Outlook, from Outlook to Fastmail, or both. Both means two connections, one each way.
-
-There is no single "two-way" switch.
+Copies travel one way per connection: Fastmail to Outlook, or Outlook to Fastmail. Want both? That is two connections, not a single "two-way" switch.
 
 ## Which Fastmail password do you need?
 
-Fastmail will not accept your account password here, and you would not want it to. You make a separate app password instead, which you can cancel on its own without changing anything else.
+Fastmail will not accept your account password here. You make a separate app password instead, which you can cancel on its own without changing anything else.
 
-The scope matters, and this is the part to get right. Fastmail's **Access** dropdown offers nine options. Pick **Calendars (CalDAV)** — it is the narrowest one that works, and Keeper needs nothing else.
-
-Fastmail's own help article about app passwords is out of date and lists only two options. Trust the dropdown in front of you, not the article.
+The scope matters. Fastmail's **Access** dropdown offers nine options, and you want **Calendars (CalDAV)** — the narrowest one that works. Fastmail's own help article is out of date and lists only two, so trust the dropdown in front of you.
 
 Keeper's connect page lists the steps in the right order:
 
@@ -56,26 +50,17 @@ The page is headed **Connect Fastmail** and has two boxes:
 - **Fastmail Email Address** — the address you sign in with
 - **App-Specific Password** — the one you just generated
 
-There is no server address to fill in. Keeper already knows where Fastmail keeps calendars, which is why Fastmail has its own button.
+There is no server address to fill in. Keeper already knows where Fastmail keeps calendars.
 
-Click **Connect**. Every calendar on the account is imported at once and you land in a short setup flow. Task lists stay behind, because Keeper only takes collections that hold events.
+Click **Connect**. Every calendar on the account is imported at once and you land in a short setup flow. Task lists stay behind.
 
 ## How do you connect Outlook?
 
-Back on **Import Calendars** there are two Microsoft buttons.
-
-**Connect Outlook** is for personal Outlook and Hotmail accounts. **Connect Microsoft 365** is for work and school accounts. Pick the one matching the account you are signing into.
-
-Either page shows what it will ask Microsoft for before sending you anywhere:
-
-- See your email address
-- View a list of your calendars
-- View events, summaries and details
-- Add or remove calendar events
+Back on **Import Calendars** there are two Microsoft buttons. **Connect Outlook** is for personal Outlook and Hotmail accounts. **Connect Microsoft 365** is for work and school accounts.
 
 Click **Connect** and approve it on Microsoft's screen. Keeper never sees your Microsoft password.
 
-If work manages your account, an administrator may have to approve Keeper before you can. That is your employer's policy and there is nothing Keeper can do about it from this end.
+If work manages your account, an administrator may have to approve Keeper first. That is your employer's policy, not something Keeper can change.
 
 ## How do you tell Keeper which way events travel?
 
@@ -92,55 +77,41 @@ Change any of it later from the calendar under **Calendars**, in the **Send Even
 
 ## Will my colleagues see my private event titles?
 
-Check this yourself before you trust it. It takes thirty seconds, and one end of this pairing is a work account.
+Check this yourself, because one end of this pairing is a work account.
 
 Open the calendar under **Calendars** and find **Sync Settings**. Three switches decide what travels: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
 
-Calendars added through **Import Calendars** arrive with all three off. A therapy appointment reaches Outlook as a block named after the Fastmail calendar it came from.
+Calendars added through **Import Calendars** arrive with all three off. A therapy appointment reaches Outlook as a block named after the Fastmail calendar it came from. Turn **Sync Event Name** on for real titles, shaped by the **Event Name** box, which understands `{{calendar_name}}` and `{{event_name}}`.
 
-The name on the copy comes from the **Event Name** box, which understands `{{calendar_name}}` and `{{event_name}}`. Turn **Sync Event Name** on to let real titles through.
-
-On keeper.sh these are a Pro feature — the dashboard says **Advanced sync settings are a Pro feature.** On free they stay off, so titles stay private by default.
-
-Below them, **Exclusions** can drop **Exclude All Day Events**.
+On keeper.sh these are a Pro feature — the dashboard says **Advanced sync settings are a Pro feature.** Below them, **Exclusions** can drop **Exclude All Day Events**.
 
 ## How fast do changes show up?
 
-Keeper reads both calendars every minute, on every plan. That never gets slower.
-
-Getting a change onto the other calendar depends on your plan. On free it takes up to thirty minutes. On Pro it is about a minute.
+Keeper reads both calendars every minute, on every plan. Getting that change onto the other calendar depends on your plan: up to thirty minutes on free, about a minute on Pro.
 
 If you are marking yourself busy so colleagues stop double-booking you, thirty minutes is fine. If people book you through a scheduling link, it is too slow.
 
 ## What does not come across?
 
-Guest lists, video call links and reminders do not travel at all. Keeper has nowhere to store them.
-
-A copied meeting is a block of time, not a working invite. Nobody can join a Teams call from the copy, and no invitations are sent.
-
-Guest lists are read for one thing only: showing you invitations you have not answered yet, so you can reply from Keeper.
+Guest lists, video call links and reminders do not travel at all. A copied meeting is a block of time, not a working invite — nobody can join a Teams call from it, and no invitations are sent. Guest lists are read only to show you invitations you have not answered yet.
 
 Keeper also looks at a fixed stretch of time — from a week ago to two years ahead. A one-off event further out is not copied. A repeating event that began before the window is still picked up, so its dates inside the window survive.
 
 ## Why do Keeper's events have a category in Outlook?
 
-Keeper marks the events it creates so it can find and clean them up later. On most calendars it does that invisibly, in an identifier you never see.
+Keeper marks the events it creates so it can clean them up later. On most calendars that is invisible, but on Outlook it uses a `keeper.sh` category.
 
-On Outlook it uses a `keeper.sh` category instead.
-
-Two consequences. The copies on your Outlook calendar carry a visible category. And if you strip that category off an event by hand, Keeper stops recognising it as its own and leaves it behind.
+So the copies carry a visible category. Strip it off by hand and Keeper stops recognising the event as its own, and leaves it behind.
 
 ## What goes wrong, and what does it look like?
 
-**The page says "Invalid credentials".** Fastmail turned Keeper away. Usually it is your account password pasted instead of the app password. The other common cause is an app password whose **Access** does not include **Calendars (CalDAV)**.
+**The page says "Invalid credentials".** Fastmail was reached and turned Keeper away. Usually it is your account password pasted instead of the app password. The other common cause is an app password whose **Access** does not include **Calendars (CalDAV)**.
 
 **The page says "Failed to discover calendars".** That is a different problem, and your password is probably fine. Keeper could not reach Fastmail at all, so it never got as far as checking. Wait a minute and try again.
 
-**Microsoft refuses the sign-in on a work account.** Managed Microsoft 365 tenants can block outside calendar apps outright. If you cannot get an administrator to approve it, the read-only feed below is your fallback.
+**Microsoft refuses the sign-in on a work account.** Managed Microsoft 365 tenants can block outside calendar apps outright. If no administrator will approve it, the read-only feed below is your fallback.
 
-**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper refuses to work through a repeating series that would produce more than 10,000 dates in two years. Today that refusal stops the whole calendar, not just the one series. Look for something repeating every minute or hour. Delete it and the calendar catches up on its own.
-
-**A calendar goes quiet for hours, then recovers.** After a rejected or timed-out request, Keeper waits five minutes, then ten, then twenty, up to six hours. It backs off deliberately and comes back by itself.
+**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper refuses to work through a repeating series producing more than 10,000 dates in two years, and today that stops the whole calendar. Delete the event repeating every minute or hour and it catches up.
 
 **A repeating Outlook meeting arrives in Fastmail as a single event.** Repeating series coming out of Microsoft do not always survive the trip whole. That is a known gap on our side, not something you configured wrong.
 
@@ -148,32 +119,20 @@ Two consequences. The copies on your Outlook calendar carry a visible category. 
 
 ## What does the free plan cover?
 
-Two calendar accounts and three connections.
-
-Fastmail is one account no matter how many calendars it holds. Outlook is the second. So this pairing uses both, and adding Google later means upgrading.
+Two calendar accounts and three connections. Fastmail is one account no matter how many calendars it holds, and Outlook is the second, so this pairing uses both. Adding Google later means upgrading.
 
 Three connections covers both directions here with one spare. There is no cap on how many calendars an account brings in.
 
 ## What if Outlook will not let Keeper in at all?
 
-You can still get your Fastmail availability visible in Outlook without an approved sign-in.
+Keeper builds a single feed from whichever calendars you tick, at **iCal Link** in the dashboard. Outlook can subscribe to it without an approved sign-in. It is read-only, and Outlook picks its own refresh schedule.
 
-Keeper builds a single feed from whichever calendars you tick, at **iCal Link** in the dashboard. Outlook can subscribe to it like any other calendar link.
-
-Know what you are getting. It is read-only, so nothing travels back from Outlook, and Outlook picks its own refresh schedule, usually measured in hours.
-
-Before sharing the link, open that page and check two things. **Include Event Name** decides whether real titles appear or everything reads "Busy". The **Sources** list decides which calendars are in the feed at all.
-
-Feed settings are a Pro feature on keeper.sh, shown as **Feed settings are Pro-only.**
+Before sharing the link, check two things there. **Include Event Name** decides whether real titles appear or everything reads "Busy", and the **Sources** list decides which calendars are in the feed at all. Both are Pro on keeper.sh, shown as **Feed settings are Pro-only.**
 
 ## Would you rather run Keeper yourself?
 
-Keeper is open source under AGPL-3.0, and self-hosting is a genuine alternative rather than a downgrade. Every Pro feature is included: real event titles, exclusions, feed settings, unlimited accounts and connections, and updates every minute.
+Keeper is open source under AGPL-3.0, and self-hosting is a genuine alternative rather than a downgrade. Every Pro feature is included, including real event titles and updates every minute. It is a Docker Compose stack with Postgres and Redis behind it, documented in the [repository](https://github.com/ridafkih/keeper.sh).
 
-It is a Docker Compose stack with Postgres and Redis behind it, and the setup guide is in the [repository](https://github.com/ridafkih/keeper.sh).
+One catch is specific to this pairing. Connecting Outlook needs a Microsoft app registration of your own, created in Azure. Fastmail needs nothing of the kind.
 
-One catch specific to this pairing. Connecting Outlook needs a Microsoft app registration of your own, which you create in Azure. Fastmail needs nothing of the kind.
-
-And be honest about the running cost. A server, a domain, a certificate, upgrades and backups — plus being the person who fixes it when it breaks.
-
-If that appeals, it is a good trade. If not, use keeper.sh.
+The running cost is a server, a domain, a certificate, upgrades and backups — plus being the person who fixes it when it breaks. If that appeals, it is a good trade. If not, use keeper.sh.

--- a/applications/web/src/content/blog/sync-fastmail-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/sync-fastmail-calendar-with-outlook.mdx
@@ -132,7 +132,9 @@ Two consequences. The copies on your Outlook calendar carry a visible category. 
 
 ## What goes wrong, and what does it look like?
 
-**The page shows `401 /api/sources/caldav/discover` in red.** That means the password was wrong, shown badly. Keeper's server does say "Invalid credentials", but the dashboard prints the status code instead of the message. Usually it is your account password pasted instead of the app password, or an app password whose access does not include calendars.
+**The page says "Invalid credentials".** Fastmail turned Keeper away. Usually it is your account password pasted instead of the app password. The other common cause is an app password whose **Access** does not include **Calendars (CalDAV)**.
+
+**The page says "Failed to discover calendars".** That is a different problem, and your password is probably fine. Keeper could not reach Fastmail at all, so it never got as far as checking. Wait a minute and try again.
 
 **Microsoft refuses the sign-in on a work account.** Managed Microsoft 365 tenants can block outside calendar apps outright. If you cannot get an administrator to approve it, the read-only feed below is your fallback.
 

--- a/applications/web/src/content/blog/sync-fastmail-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/sync-fastmail-calendar-with-outlook.mdx
@@ -1,0 +1,116 @@
+---
+title: "How to Sync Fastmail Calendar with Outlook"
+description: "A step-by-step guide to two-way syncing a Fastmail calendar with Outlook or Microsoft 365 using Keeper.sh, including Fastmail app passwords and what the sync covers."
+blurb: "Fastmail and Outlook have no path between them that survives contact with reality. Here is how I bridge the two, starting with a Fastmail app password scoped to CalDAV."
+createdAt: "2026-08-11"
+slug: "sync-fastmail-calendar-with-outlook"
+updatedAt: "2026-08-11"
+tags:
+  - "fastmail"
+  - "outlook"
+  - "caldav"
+  - "sync"
+  - "calendar"
+---
+
+I keep a business-personal calendar on Fastmail and deal with Outlook wherever work requires it. The two have no meeting point. Outlook will subscribe to an ICS URL and refresh it whenever it feels like it, which is neither two-way nor timely, and Fastmail has no idea Outlook exists.
+
+Fastmail speaks CalDAV properly, and Outlook speaks the Microsoft Graph API. Bridging them is a matter of holding credentials for both and mapping calendars in each direction.
+
+## Get a Fastmail app password first
+
+Fastmail will not accept your account password over CalDAV, and you would not want it to. You need an app password, which is a separate credential you can scope and revoke on its own. Fastmail documents this in [App passwords](https://www.fastmail.help/hc/en-us/articles/360058752854-App-passwords).
+
+The short version:
+
+1. Go to [Fastmail's app password settings](https://www.fastmail.com/settings/security/devicekeys)
+2. Click **Manage app passwords and access**
+3. Click **New app password**
+4. Give it a name you will recognise later, like "Keeper"
+5. Under **Access**, choose a scope that includes calendars. The default covers mail, contacts and calendars; if you would rather Keeper never see your mail, pick the narrower calendar-only option
+6. Click **Generate password** and copy it
+
+Fastmail shows the password once. If you lose it, generate another and delete the old one.
+
+Scoping matters more here than with most providers, because Fastmail lets you be specific about it. Keeper needs CalDAV and nothing else, so give it CalDAV and nothing else.
+
+## Connect Fastmail
+
+From the dashboard, open **Import Calendars** and choose **Connect Fastmail**. Two fields:
+
+- **Fastmail Email Address** — the address you sign in with
+- **App-Specific Password** — the password you just generated
+
+There is no server URL field. Keeper already knows Fastmail's CalDAV endpoint is `https://caldav.fastmail.com/` and fills it in, which is why Fastmail gets a dedicated tile rather than going through the generic CalDAV form.
+
+Press **Connect**. Keeper discovers the calendars on the account, imports all of them at once, and moves you into setup. Collections that do not hold events are skipped, so your task lists stay behind.
+
+An `Invalid credentials` error at this point means the password: either your account password went in instead of the app password, or the app password's access scope does not include calendars.
+
+## Connect Outlook
+
+Back on **Import Calendars**, there are two Microsoft tiles. **Connect Outlook** covers personal Outlook accounts, and **Connect Microsoft 365** covers work and school accounts. Both authorise against the same Microsoft Graph integration behind the scenes; pick the one matching the account you are signing into.
+
+Either way, Keeper lists what it will ask Microsoft for before redirecting you:
+
+- See your email address
+- View a list of your calendars
+- View events, summaries and details
+- Add or remove calendar events
+
+Press **Connect** and complete Microsoft's consent screen. If you are on a managed work tenant, your administrator may need to approve the app before consent will go through. That is a tenant policy, not something Keeper can route around.
+
+If you self-host Keeper, you need your own Microsoft OAuth app registered in Azure for this to work at all. Fastmail needs no such setup, which is one of the quiet advantages of CalDAV.
+
+## Wire up the mapping
+
+Setup asks four things:
+
+1. **Which calendars would you like to configure?** Tick what you want to set up now. Everything was already imported.
+2. **Rename Your Calendars.** Fastmail's default is usually "Calendar" and Outlook's is "Calendar" too, so renaming is worth the ten seconds. It is Keeper-local and does not touch either provider.
+3. **Where should 'Calendar' send events?** The outbound direction.
+4. **Where should 'Calendar' pull events from?** The inbound direction.
+
+Setting both gives you two-way syncing at the cost of two mappings, out of three on the free tier.
+
+You can change any of this later from a calendar's detail page under **Calendars**, in the **Send Events to Calendars** section.
+
+## A detail specific to Outlook
+
+Keeper marks the events it creates so it can recognise and clean them up later. On most providers it does this by suffixing the remote UID with `@keeper.sh`. Outlook does not allow custom UIDs, so Keeper tags its events with a `keeper.sh` category instead.
+
+This is invisible in normal use, but it has two consequences worth knowing. Keeper-created events on your Outlook calendar carry a visible category. And if you delete that category from an event by hand, Keeper loses track of it — the event becomes an orphan it can no longer manage.
+
+## What actually gets synced
+
+Time, not detail. Every newly connected calendar defaults to stripping the event name, description and location, titling the copy after the source calendar instead. Anything private on your Fastmail calendar reaches Outlook as an opaque block, which is the right default when one end of the pairing is a work account.
+
+To let real detail through, the calendar detail page has a **Sync Settings** section with **Sync Event Name**, **Sync Event Description** and **Sync Event Location** toggles, all off initially. Turning **Sync Event Name** on switches the **Event Name** template to `{{event_name}}` and passes the true title. While it is off, the template field stays editable and accepts `{{event_name}}` and `{{calendar_name}}`, letting you reword the placeholder without revealing anything. An **Exclusions** section can drop all-day events.
+
+These are Pro features on the hosted plan, and available to everyone on self-hosted instances.
+
+New sources are added to your aggregated iCal feed by default; untick them under **iCal Link** if you would rather they were not.
+
+The sync window is fixed at seven days back to two years forward. One-off events outside it are not copied, though recurring series whose master starts before the window are still collected so their in-window occurrences survive.
+
+## How often it runs
+
+Ingestion from Fastmail and Outlook into Keeper's database runs every minute regardless of plan. Pushing to destinations runs every minute on Pro and self-hosted, every thirty minutes on free.
+
+Outlook supports incremental sync through Graph delta links, so a cycle only asks for what changed. Fastmail does not get that: as a CalDAV source it is refetched within the sync window on every ingestion run and diffed against what Keeper already stored. Correct, but more work per cycle.
+
+## Limits and rough edges
+
+- **Free tier.** Two linked accounts and three sync mappings. Fastmail is one account regardless of calendar count, Outlook is another, so this pairing fills the account allowance exactly. Self-hosting removes both limits.
+- **Tenant restrictions.** Managed Microsoft 365 tenants can block third-party calendar apps outright. If consent fails and you cannot get an administrator to approve it, the ICS feed route below is the fallback.
+- **Directions are separate.** Each mapping is one-way. "Fastmail sends to Outlook" does not imply the reverse.
+- **Recurring events.** Keeper will not materialise a series expanding past ten thousand occurrences in the two-year window, and that check currently fails the entire calendar's ingestion rather than isolating the offending series. One event with a runaway repeat rule can stall a whole calendar, which then backs off and retries on a widening interval.
+- **Outlook recurrence is its own problem.** Recurring series coming *from* Microsoft 365 do not always survive the trip intact; there are open reports of only the first instance arriving. If a recurring Outlook meeting shows up on Fastmail as a single event, that is a known gap rather than a misconfiguration on your side.
+
+## The read-only fallback
+
+If you cannot get an OAuth connection to your work tenant, you can still get your Fastmail availability visible in Outlook. Keeper generates an aggregated iCal feed under **iCal Link**, a token-authenticated URL combining whichever sources you tick, and Outlook can subscribe to it.
+
+Be clear-eyed about what that gives you. It is pull-only, so nothing travels back from Outlook, and Outlook decides its own refresh cadence for subscribed calendars, which tends to be measured in hours. The feed starts private too: events appear as "Busy" with no title until you turn **Include Event Name** on.
+
+It is a worse sync and a better privacy story. Which one you want depends on whether the calendar is yours to expose.

--- a/applications/web/src/content/blog/sync-fastmail-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/sync-fastmail-calendar-with-outlook.mdx
@@ -1,116 +1,177 @@
 ---
 title: "How to Sync Fastmail Calendar with Outlook"
-description: "A step-by-step guide to two-way syncing a Fastmail calendar with Outlook or Microsoft 365 using Keeper.sh, including Fastmail app passwords and what the sync covers."
-blurb: "Fastmail and Outlook have no path between them that survives contact with reality. Here is how I bridge the two, starting with a Fastmail app password scoped to CalDAV."
+description: "Get your Fastmail events showing up in Outlook or Microsoft 365 with Keeper.sh: the app password to make, what to click, and who can see your event titles."
+blurb: "Fastmail and Outlook have no way to talk to each other. Here is how to get your Fastmail events appearing in Outlook, starting with the right app password."
 createdAt: "2026-08-11"
 slug: "sync-fastmail-calendar-with-outlook"
 updatedAt: "2026-08-11"
 tags:
   - "fastmail"
   - "outlook"
-  - "caldav"
+  - "microsoft-365"
   - "sync"
-  - "calendar"
 ---
 
-I keep a business-personal calendar on Fastmail and deal with Outlook wherever work requires it. The two have no meeting point. Outlook will subscribe to an ICS URL and refresh it whenever it feels like it, which is neither two-way nor timely, and Fastmail has no idea Outlook exists.
+Your own life lives in Fastmail. Work runs on Outlook. Neither knows the other exists, so colleagues book meetings on top of things you already committed to.
 
-Fastmail speaks CalDAV properly, and Outlook speaks the Microsoft Graph API. Bridging them is a matter of holding credentials for both and mapping calendars in each direction.
+Outlook will subscribe to a calendar link and refresh it on its own unhurried schedule. That is not enough when someone needs to know you are busy on Thursday.
 
-## Get a Fastmail app password first
+Keeper signs into both calendars and keeps copies of your events in step.
 
-Fastmail will not accept your account password over CalDAV, and you would not want it to. You need an app password, which is a separate credential you can scope and revoke on its own. Fastmail documents this in [App passwords](https://www.fastmail.help/hc/en-us/articles/360058752854-App-passwords).
+## What does this actually do?
 
-The short version:
+Add something to your Fastmail calendar and a copy appears in Outlook. Move it, the copy moves. Delete it, the copy goes.
 
-1. Go to [Fastmail's app password settings](https://www.fastmail.com/settings/security/devicekeys)
-2. Click **Manage app passwords and access**
-3. Click **New app password**
-4. Give it a name you will recognise later, like "Keeper"
-5. Under **Access**, choose a scope that includes calendars. The default covers mail, contacts and calendars; if you would rather Keeper never see your mail, pick the narrower calendar-only option
-6. Click **Generate password** and copy it
+By default the copy is a block of busy time, not a readable event. Colleagues see you are unavailable, not what you are doing.
 
-Fastmail shows the password once. If you lose it, generate another and delete the old one.
+Copies travel one way per connection. You decide whether events go from Fastmail to Outlook, from Outlook to Fastmail, or both. Both means two connections, one each way.
 
-Scoping matters more here than with most providers, because Fastmail lets you be specific about it. Keeper needs CalDAV and nothing else, so give it CalDAV and nothing else.
+There is no single "two-way" switch.
 
-## Connect Fastmail
+## Which Fastmail password do you need?
 
-From the dashboard, open **Import Calendars** and choose **Connect Fastmail**. Two fields:
+Fastmail will not accept your account password here, and you would not want it to. You make a separate app password instead, which you can cancel on its own without changing anything else.
+
+The scope matters, and this is the part to get right. Fastmail's **Access** dropdown offers nine options. Pick **Calendars (CalDAV)** — it is the narrowest one that works, and Keeper needs nothing else.
+
+Fastmail's own help article about app passwords is out of date and lists only two options. Trust the dropdown in front of you, not the article.
+
+Keeper's connect page lists the steps in the right order:
+
+1. Navigate to Fastmail Settings
+2. Click "Manage app password and access"
+3. Click "New app password"
+4. Under "Access", select "Calendars (CalDAV)"
+5. Click "Generate password"
+6. Copy the password, and paste it below
+
+Fastmail shows the password once. Lose it and you make another, then delete the old one.
+
+## How do you connect Fastmail?
+
+From the dashboard, click **Import Calendars**, then **Connect Fastmail**.
+
+The page is headed **Connect Fastmail** and has two boxes:
 
 - **Fastmail Email Address** — the address you sign in with
-- **App-Specific Password** — the password you just generated
+- **App-Specific Password** — the one you just generated
 
-There is no server URL field. Keeper already knows Fastmail's CalDAV endpoint is `https://caldav.fastmail.com/` and fills it in, which is why Fastmail gets a dedicated tile rather than going through the generic CalDAV form.
+There is no server address to fill in. Keeper already knows where Fastmail keeps calendars, which is why Fastmail has its own button.
 
-Press **Connect**. Keeper discovers the calendars on the account, imports all of them at once, and moves you into setup. Collections that do not hold events are skipped, so your task lists stay behind.
+Click **Connect**. Every calendar on the account is imported at once and you land in a short setup flow. Task lists stay behind, because Keeper only takes collections that hold events.
 
-An `Invalid credentials` error at this point means the password: either your account password went in instead of the app password, or the app password's access scope does not include calendars.
+## How do you connect Outlook?
 
-## Connect Outlook
+Back on **Import Calendars** there are two Microsoft buttons.
 
-Back on **Import Calendars**, there are two Microsoft tiles. **Connect Outlook** covers personal Outlook accounts, and **Connect Microsoft 365** covers work and school accounts. Both authorise against the same Microsoft Graph integration behind the scenes; pick the one matching the account you are signing into.
+**Connect Outlook** is for personal Outlook and Hotmail accounts. **Connect Microsoft 365** is for work and school accounts. Pick the one matching the account you are signing into.
 
-Either way, Keeper lists what it will ask Microsoft for before redirecting you:
+Either page shows what it will ask Microsoft for before sending you anywhere:
 
 - See your email address
 - View a list of your calendars
 - View events, summaries and details
 - Add or remove calendar events
 
-Press **Connect** and complete Microsoft's consent screen. If you are on a managed work tenant, your administrator may need to approve the app before consent will go through. That is a tenant policy, not something Keeper can route around.
+Click **Connect** and approve it on Microsoft's screen. Keeper never sees your Microsoft password.
 
-If you self-host Keeper, you need your own Microsoft OAuth app registered in Azure for this to work at all. Fastmail needs no such setup, which is one of the quiet advantages of CalDAV.
+If work manages your account, an administrator may have to approve Keeper before you can. That is your employer's policy and there is nothing Keeper can do about it from this end.
 
-## Wire up the mapping
+## How do you tell Keeper which way events travel?
 
-Setup asks four things:
+Setup asks four questions, word for word:
 
-1. **Which calendars would you like to configure?** Tick what you want to set up now. Everything was already imported.
-2. **Rename Your Calendars.** Fastmail's default is usually "Calendar" and Outlook's is "Calendar" too, so renaming is worth the ten seconds. It is Keeper-local and does not touch either provider.
-3. **Where should 'Calendar' send events?** The outbound direction.
-4. **Where should 'Calendar' pull events from?** The inbound direction.
+1. **Which calendars would you like to configure?** Tick the ones you want now.
+2. **Rename Your Calendars.** Fastmail and Outlook both default to "Calendar", so this is worth ten seconds. Renaming only changes what you see in Keeper.
+3. **Where should 'Calendar' send events?** Tick Outlook, and copies of your Fastmail events start appearing there.
+4. **Where should 'Calendar' pull events from?** Tick Outlook here for the reverse.
 
-Setting both gives you two-way syncing at the cost of two mappings, out of three on the free tier.
+Each tick is one connection. Both directions is two connections.
 
-You can change any of this later from a calendar's detail page under **Calendars**, in the **Send Events to Calendars** section.
+Change any of it later from the calendar under **Calendars**, in the **Send Events to Calendars** section.
 
-## A detail specific to Outlook
+## Will my colleagues see my private event titles?
 
-Keeper marks the events it creates so it can recognise and clean them up later. On most providers it does this by suffixing the remote UID with `@keeper.sh`. Outlook does not allow custom UIDs, so Keeper tags its events with a `keeper.sh` category instead.
+Check this yourself before you trust it. It takes thirty seconds, and one end of this pairing is a work account.
 
-This is invisible in normal use, but it has two consequences worth knowing. Keeper-created events on your Outlook calendar carry a visible category. And if you delete that category from an event by hand, Keeper loses track of it — the event becomes an orphan it can no longer manage.
+Open the calendar under **Calendars** and find **Sync Settings**. Three switches decide what travels: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
 
-## What actually gets synced
+Calendars added through **Import Calendars** arrive with all three off. A therapy appointment reaches Outlook as a block named after the Fastmail calendar it came from.
 
-Time, not detail. Every newly connected calendar defaults to stripping the event name, description and location, titling the copy after the source calendar instead. Anything private on your Fastmail calendar reaches Outlook as an opaque block, which is the right default when one end of the pairing is a work account.
+The name on the copy comes from the **Event Name** box, which understands `{{calendar_name}}` and `{{event_name}}`. Turn **Sync Event Name** on to let real titles through.
 
-To let real detail through, the calendar detail page has a **Sync Settings** section with **Sync Event Name**, **Sync Event Description** and **Sync Event Location** toggles, all off initially. Turning **Sync Event Name** on switches the **Event Name** template to `{{event_name}}` and passes the true title. While it is off, the template field stays editable and accepts `{{event_name}}` and `{{calendar_name}}`, letting you reword the placeholder without revealing anything. An **Exclusions** section can drop all-day events.
+On keeper.sh these are a Pro feature — the dashboard says **Advanced sync settings are a Pro feature.** On free they stay off, so titles stay private by default.
 
-These are Pro features on the hosted plan, and available to everyone on self-hosted instances.
+Below them, **Exclusions** can drop **Exclude All Day Events**.
 
-New sources are added to your aggregated iCal feed by default; untick them under **iCal Link** if you would rather they were not.
+## How fast do changes show up?
 
-The sync window is fixed at seven days back to two years forward. One-off events outside it are not copied, though recurring series whose master starts before the window are still collected so their in-window occurrences survive.
+Keeper reads both calendars every minute, on every plan. That never gets slower.
 
-## How often it runs
+Getting a change onto the other calendar depends on your plan. On free it takes up to thirty minutes. On Pro it is about a minute.
 
-Ingestion from Fastmail and Outlook into Keeper's database runs every minute regardless of plan. Pushing to destinations runs every minute on Pro and self-hosted, every thirty minutes on free.
+If you are marking yourself busy so colleagues stop double-booking you, thirty minutes is fine. If people book you through a scheduling link, it is too slow.
 
-Outlook supports incremental sync through Graph delta links, so a cycle only asks for what changed. Fastmail does not get that: as a CalDAV source it is refetched within the sync window on every ingestion run and diffed against what Keeper already stored. Correct, but more work per cycle.
+## What does not come across?
 
-## Limits and rough edges
+Guest lists, video call links and reminders do not travel at all. Keeper has nowhere to store them.
 
-- **Free tier.** Two linked accounts and three sync mappings. Fastmail is one account regardless of calendar count, Outlook is another, so this pairing fills the account allowance exactly. Self-hosting removes both limits.
-- **Tenant restrictions.** Managed Microsoft 365 tenants can block third-party calendar apps outright. If consent fails and you cannot get an administrator to approve it, the ICS feed route below is the fallback.
-- **Directions are separate.** Each mapping is one-way. "Fastmail sends to Outlook" does not imply the reverse.
-- **Recurring events.** Keeper will not materialise a series expanding past ten thousand occurrences in the two-year window, and that check currently fails the entire calendar's ingestion rather than isolating the offending series. One event with a runaway repeat rule can stall a whole calendar, which then backs off and retries on a widening interval.
-- **Outlook recurrence is its own problem.** Recurring series coming *from* Microsoft 365 do not always survive the trip intact; there are open reports of only the first instance arriving. If a recurring Outlook meeting shows up on Fastmail as a single event, that is a known gap rather than a misconfiguration on your side.
+A copied meeting is a block of time, not a working invite. Nobody can join a Teams call from the copy, and no invitations are sent.
 
-## The read-only fallback
+Guest lists are read for one thing only: showing you invitations you have not answered yet, so you can reply from Keeper.
 
-If you cannot get an OAuth connection to your work tenant, you can still get your Fastmail availability visible in Outlook. Keeper generates an aggregated iCal feed under **iCal Link**, a token-authenticated URL combining whichever sources you tick, and Outlook can subscribe to it.
+Keeper also looks at a fixed stretch of time — from a week ago to two years ahead. A one-off event further out is not copied. A repeating event that began before the window is still picked up, so its dates inside the window survive.
 
-Be clear-eyed about what that gives you. It is pull-only, so nothing travels back from Outlook, and Outlook decides its own refresh cadence for subscribed calendars, which tends to be measured in hours. The feed starts private too: events appear as "Busy" with no title until you turn **Include Event Name** on.
+## Why do Keeper's events have a category in Outlook?
 
-It is a worse sync and a better privacy story. Which one you want depends on whether the calendar is yours to expose.
+Keeper marks the events it creates so it can find and clean them up later. On most calendars it does that invisibly, in an identifier you never see.
+
+On Outlook it uses a `keeper.sh` category instead.
+
+Two consequences. The copies on your Outlook calendar carry a visible category. And if you strip that category off an event by hand, Keeper stops recognising it as its own and leaves it behind.
+
+## What goes wrong, and what does it look like?
+
+**The page shows `401 /api/sources/caldav/discover` in red.** That means the password was wrong, shown badly. Keeper's server does say "Invalid credentials", but the dashboard prints the status code instead of the message. Usually it is your account password pasted instead of the app password, or an app password whose access does not include calendars.
+
+**Microsoft refuses the sign-in on a work account.** Managed Microsoft 365 tenants can block outside calendar apps outright. If you cannot get an administrator to approve it, the read-only feed below is your fallback.
+
+**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper refuses to work through a repeating series that would produce more than 10,000 dates in two years. Today that refusal stops the whole calendar, not just the one series. Look for something repeating every minute or hour. Delete it and the calendar catches up on its own.
+
+**A calendar goes quiet for hours, then recovers.** After a rejected or timed-out request, Keeper waits five minutes, then ten, then twenty, up to six hours. It backs off deliberately and comes back by itself.
+
+**A repeating Outlook meeting arrives in Fastmail as a single event.** Repeating series coming out of Microsoft do not always survive the trip whole. That is a known gap on our side, not something you configured wrong.
+
+**There is no "sync now" button.** You wait for the next round. Removing the account and adding it again is the blunt way to start clean.
+
+## What does the free plan cover?
+
+Two calendar accounts and three connections.
+
+Fastmail is one account no matter how many calendars it holds. Outlook is the second. So this pairing uses both, and adding Google later means upgrading.
+
+Three connections covers both directions here with one spare. There is no cap on how many calendars an account brings in.
+
+## What if Outlook will not let Keeper in at all?
+
+You can still get your Fastmail availability visible in Outlook without an approved sign-in.
+
+Keeper builds a single feed from whichever calendars you tick, at **iCal Link** in the dashboard. Outlook can subscribe to it like any other calendar link.
+
+Know what you are getting. It is read-only, so nothing travels back from Outlook, and Outlook picks its own refresh schedule, usually measured in hours.
+
+Before sharing the link, open that page and check two things. **Include Event Name** decides whether real titles appear or everything reads "Busy". The **Sources** list decides which calendars are in the feed at all.
+
+Feed settings are a Pro feature on keeper.sh, shown as **Feed settings are Pro-only.**
+
+## Would you rather run Keeper yourself?
+
+Keeper is open source under AGPL-3.0, and self-hosting is a genuine alternative rather than a downgrade. Every Pro feature is included: real event titles, exclusions, feed settings, unlimited accounts and connections, and updates every minute.
+
+It is a Docker Compose stack with Postgres and Redis behind it, and the setup guide is in the [repository](https://github.com/ridafkih/keeper.sh).
+
+One catch specific to this pairing. Connecting Outlook needs a Microsoft app registration of your own, which you create in Azure. Fastmail needs nothing of the kind.
+
+And be honest about the running cost. A server, a domain, a certificate, upgrades and backups — plus being the person who fixes it when it breaks.
+
+If that appeals, it is a good trade. If not, use keeper.sh.

--- a/applications/web/src/content/blog/sync-fastmail-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/sync-fastmail-calendar-with-outlook.mdx
@@ -14,7 +14,7 @@ tags:
 
 Your own life lives in Fastmail. Work runs on Outlook. Neither knows the other exists, so colleagues book meetings on top of things you already committed to.
 
-Keeper signs into both calendars and keeps copies of your events in step.
+Keeper.sh signs into both calendars and keeps copies of your events in step.
 
 ## What does this actually do?
 
@@ -30,7 +30,7 @@ Fastmail will not accept your account password here. You make a separate app pas
 
 The scope matters. Fastmail's **Access** dropdown offers nine options, and you want **Calendars (CalDAV)** — the narrowest one that works. Fastmail's own help article is out of date and lists only two, so trust the dropdown in front of you.
 
-Keeper's connect page lists the steps in the right order:
+Keeper.sh's connect page lists the steps in the right order:
 
 1. Navigate to Fastmail Settings
 2. Click "Manage app password and access"
@@ -50,7 +50,7 @@ The page is headed **Connect Fastmail** and has two boxes:
 - **Fastmail Email Address** — the address you sign in with
 - **App-Specific Password** — the one you just generated
 
-There is no server address to fill in. Keeper already knows where Fastmail keeps calendars.
+There is no server address to fill in. Keeper.sh already knows where Fastmail keeps calendars.
 
 Click **Connect**. Every calendar on the account is imported at once and you land in a short setup flow. Task lists stay behind.
 
@@ -58,16 +58,16 @@ Click **Connect**. Every calendar on the account is imported at once and you lan
 
 Back on **Import Calendars** there are two Microsoft buttons. **Connect Outlook** is for personal Outlook and Hotmail accounts. **Connect Microsoft 365** is for work and school accounts.
 
-Click **Connect** and approve it on Microsoft's screen. Keeper never sees your Microsoft password.
+Click **Connect** and approve it on Microsoft's screen. Keeper.sh never sees your Microsoft password.
 
-If work manages your account, an administrator may have to approve Keeper first. That is your employer's policy, not something Keeper can change.
+If work manages your account, an administrator may have to approve Keeper.sh first. That is your employer's policy, not something Keeper.sh can change.
 
-## How do you tell Keeper which way events travel?
+## How do you tell Keeper.sh which way events travel?
 
 Setup asks four questions, word for word:
 
 1. **Which calendars would you like to configure?** Tick the ones you want now.
-2. **Rename Your Calendars.** Fastmail and Outlook both default to "Calendar", so this is worth ten seconds. Renaming only changes what you see in Keeper.
+2. **Rename Your Calendars.** Fastmail and Outlook both default to "Calendar", so this is worth ten seconds. Renaming only changes what you see in Keeper.sh.
 3. **Where should 'Calendar' send events?** Tick Outlook, and copies of your Fastmail events start appearing there.
 4. **Where should 'Calendar' pull events from?** Tick Outlook here for the reverse.
 
@@ -83,11 +83,11 @@ Open the calendar under **Calendars** and find **Sync Settings**. Three switches
 
 Calendars added through **Import Calendars** arrive with all three off. A therapy appointment reaches Outlook as a block named after the Fastmail calendar it came from. Turn **Sync Event Name** on for real titles, shaped by the **Event Name** box, which understands `{{calendar_name}}` and `{{event_name}}`.
 
-On keeper.sh these are a Pro feature — the dashboard says **Advanced sync settings are a Pro feature.** Below them, **Exclusions** can drop **Exclude All Day Events**.
+On Keeper.sh these are a Pro feature — the dashboard says **Advanced sync settings are a Pro feature.** Below them, **Exclusions** can drop **Exclude All Day Events**.
 
 ## How fast do changes show up?
 
-Keeper reads both calendars every minute, on every plan. Getting that change onto the other calendar depends on your plan: up to thirty minutes on free, about a minute on Pro.
+Keeper.sh reads both calendars every minute, on every plan. Getting that change onto the other calendar depends on your plan: up to thirty minutes on free, about a minute on Pro.
 
 If you are marking yourself busy so colleagues stop double-booking you, thirty minutes is fine. If people book you through a scheduling link, it is too slow.
 
@@ -95,23 +95,23 @@ If you are marking yourself busy so colleagues stop double-booking you, thirty m
 
 Guest lists, video call links and reminders do not travel at all. A copied meeting is a block of time, not a working invite — nobody can join a Teams call from it, and no invitations are sent. Guest lists are read only to show you invitations you have not answered yet.
 
-Keeper also looks at a fixed stretch of time — from a week ago to two years ahead. A one-off event further out is not copied. A repeating event that began before the window is still picked up, so its dates inside the window survive.
+Keeper.sh also looks at a fixed stretch of time — from a week ago to two years ahead. A one-off event further out is not copied. A repeating event that began before the window is still picked up, so its dates inside the window survive.
 
-## Why do Keeper's events have a category in Outlook?
+## Why do Keeper.sh's events have a category in Outlook?
 
-Keeper marks the events it creates so it can clean them up later. On most calendars that is invisible, but on Outlook it uses a `keeper.sh` category.
+Keeper.sh marks the events it creates so it can clean them up later. On most calendars that is invisible, but on Outlook it uses a `keeper.sh` category.
 
-So the copies carry a visible category. Strip it off by hand and Keeper stops recognising the event as its own, and leaves it behind.
+So the copies carry a visible category. Strip it off by hand and Keeper.sh stops recognising the event as its own, and leaves it behind.
 
 ## What goes wrong, and what does it look like?
 
-**The page says "Invalid credentials".** Fastmail was reached and turned Keeper away. Usually it is your account password pasted instead of the app password. The other common cause is an app password whose **Access** does not include **Calendars (CalDAV)**.
+**The page says "Invalid credentials".** Fastmail was reached and turned Keeper.sh away. Usually it is your account password pasted instead of the app password. The other common cause is an app password whose **Access** does not include **Calendars (CalDAV)**.
 
-**The page says "Failed to discover calendars".** That is a different problem, and your password is probably fine. Keeper could not reach Fastmail at all, so it never got as far as checking. Wait a minute and try again.
+**The page says "Failed to discover calendars".** That is a different problem, and your password is probably fine. Keeper.sh could not reach Fastmail at all, so it never got as far as checking. Wait a minute and try again.
 
 **Microsoft refuses the sign-in on a work account.** Managed Microsoft 365 tenants can block outside calendar apps outright. If no administrator will approve it, the read-only feed below is your fallback.
 
-**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper refuses to work through a repeating series producing more than 10,000 dates in two years, and today that stops the whole calendar. Delete the event repeating every minute or hour and it catches up.
+**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper.sh refuses to work through a repeating series producing more than 10,000 dates in two years, and today that stops the whole calendar. Delete the event repeating every minute or hour and it catches up.
 
 **A repeating Outlook meeting arrives in Fastmail as a single event.** Repeating series coming out of Microsoft do not always survive the trip whole. That is a known gap on our side, not something you configured wrong.
 
@@ -123,16 +123,16 @@ Two calendar accounts and three connections. Fastmail is one account no matter h
 
 Three connections covers both directions here with one spare. There is no cap on how many calendars an account brings in.
 
-## What if Outlook will not let Keeper in at all?
+## What if Outlook will not let Keeper.sh in at all?
 
-Keeper builds a single feed from whichever calendars you tick, at **iCal Link** in the dashboard. Outlook can subscribe to it without an approved sign-in. It is read-only, and Outlook picks its own refresh schedule.
+Keeper.sh builds a single feed from whichever calendars you tick, at **iCal Link** in the dashboard. Outlook can subscribe to it without an approved sign-in. It is read-only, and Outlook picks its own refresh schedule.
 
-Before sharing the link, check two things there. **Include Event Name** decides whether real titles appear or everything reads "Busy", and the **Sources** list decides which calendars are in the feed at all. Both are Pro on keeper.sh, shown as **Feed settings are Pro-only.**
+Before sharing the link, check two things there. **Include Event Name** decides whether real titles appear or everything reads "Busy", and the **Sources** list decides which calendars are in the feed at all. Both are Pro on Keeper.sh, shown as **Feed settings are Pro-only.**
 
-## Would you rather run Keeper yourself?
+## Would you rather run Keeper.sh yourself?
 
-Keeper is open source under AGPL-3.0, and self-hosting is a genuine alternative rather than a downgrade. Every Pro feature is included, including real event titles and updates every minute. It is a Docker Compose stack with Postgres and Redis behind it, documented in the [repository](https://github.com/ridafkih/keeper.sh).
+Keeper.sh is open source under AGPL-3.0, and self-hosting is a genuine alternative rather than a downgrade. Every Pro feature is included, including real event titles and updates every minute. It is a Docker Compose stack with Postgres and Redis behind it, documented in the [repository](https://github.com/ridafkih/keeper.sh).
 
 One catch is specific to this pairing. Connecting Outlook needs a Microsoft app registration of your own, created in Azure. Fastmail needs nothing of the kind.
 
-The running cost is a server, a domain, a certificate, upgrades and backups — plus being the person who fixes it when it breaks. If that appeals, it is a good trade. If not, use keeper.sh.
+The running cost is a server, a domain, a certificate, upgrades and backups — plus being the person who fixes it when it breaks. If that appeals, it is a good trade. If not, use Keeper.sh.

--- a/applications/web/src/content/blog/sync-icloud-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/sync-icloud-calendar-with-google-calendar.mdx
@@ -122,7 +122,9 @@ Keeper also looks at a fixed stretch of time — from a week ago to two years ah
 
 ## What goes wrong, and what does it look like?
 
-**The page shows `401 /api/sources/caldav/discover` in red.** That means the password was wrong, shown badly. Keeper's server does say "Invalid credentials", but the dashboard throws away the message and prints the status code. In practice it is one of two things. You pasted your normal Apple password instead of the app-specific one, or the app-specific one has been cancelled.
+**The page says "Invalid credentials".** Apple turned Keeper away. In practice it is one of two things. You pasted your normal Apple password instead of the app-specific one, or the app-specific one has been cancelled.
+
+**The page says "Failed to discover calendars".** That is a different problem, and your password is probably fine. Keeper could not reach Apple at all, so it never got as far as checking. Wait a minute and try again.
 
 **Everything stopped, and Apple gave no warning.** Changing your Apple password cancels every app-specific password. Nothing in iCloud tells you a sync broke — you find out when events stop appearing. Generate a new one and paste it in.
 

--- a/applications/web/src/content/blog/sync-icloud-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/sync-icloud-calendar-with-google-calendar.mdx
@@ -1,0 +1,106 @@
+---
+title: "How to Sync iCloud Calendar with Google Calendar"
+description: "A step-by-step guide to two-way syncing iCloud Calendar with Google Calendar using Keeper.sh, including how to generate an Apple app-specific password and what the sync covers."
+blurb: "Apple will publish an iCloud calendar as a read-only link and nothing more. Here is how I get real two-way syncing between iCloud and Google, starting with the app-specific password."
+createdAt: "2026-08-11"
+slug: "sync-icloud-calendar-with-google-calendar"
+updatedAt: "2026-08-11"
+tags:
+  - "icloud"
+  - "apple-calendar"
+  - "google-calendar"
+  - "caldav"
+  - "sync"
+---
+
+Apple gives you exactly one way to share an iCloud calendar with something outside Apple's world: a public read-only link. Google will subscribe to that link, refresh it on its own unhurried schedule, and give you no way to send anything back. If what you want is for a personal iCloud appointment to block time on your work Google calendar, that is not enough.
+
+iCloud does speak CalDAV, though, and that is the door worth using.
+
+## Get an app-specific password first
+
+This is the step people get stuck on, so do it before you open Keeper.
+
+iCloud will not accept your Apple Account password over CalDAV. You need an app-specific password, which is a 16-character credential scoped to one application and revocable on its own. Apple documents the process in [Sign in to apps with your Apple Account using app-specific passwords](https://support.apple.com/en-us/102654).
+
+Keeper's connect screen walks you through the same steps:
+
+1. Navigate to [appleid.apple.com](https://appleid.apple.com)
+2. Sign in with your Apple ID
+3. Select **App-Specific Passwords**
+4. Click the **+** next to **Passwords**
+5. Label and generate the password, then copy it
+6. Paste the app-specific password into Keeper
+
+Two things worth knowing. Your Apple Account needs two-factor authentication turned on before the App-Specific Passwords section appears at all. And Apple shows you the password once — if you close the sheet without copying it, generate another one.
+
+## Connect iCloud
+
+From the dashboard, open **Import Calendars** and choose **Connect iCloud**. There are two fields:
+
+- **Apple ID** — the email address you sign in to Apple with
+- **App-Specific Password** — the 16-character password you just generated, not your Apple Account password
+
+You are not asked for a server URL. Keeper already knows iCloud lives at `https://caldav.icloud.com/` and fills that in for you, which is the whole reason iCloud gets its own tile instead of going through the generic CalDAV form.
+
+Press **Connect**. Keeper discovers every calendar on the account, imports all of them, and moves you into setup. Only collections that support events come across, so your Reminders lists stay behind.
+
+If you get `Invalid credentials` here, it is almost always the password: either the Apple Account password was pasted instead of the app-specific one, or the app-specific password has been revoked. Apple invalidates every app-specific password when you change your Apple Account password, so a working sync that suddenly starts failing after a password change needs a fresh one.
+
+## Connect Google Calendar
+
+Back on **Import Calendars**, choose **Connect Google Calendar**. Keeper lists the access it is about to request before redirecting you:
+
+- See your email address
+- View a list of your calendars
+- View events, summaries and details
+- Add or remove calendar events
+
+Press **Connect** and finish Google's consent screen.
+
+## Wire up the mapping
+
+The setup flow asks four things in order:
+
+1. **Which calendars would you like to configure?** Tick the ones you want to set up now.
+2. **Rename Your Calendars.** iCloud calendars usually arrive as "Home" or "Work", and Google's default calendar arrives named after your email address. Renaming is Keeper-local only.
+3. **Where should 'Home' send events?** Pick the calendars that should receive copies from this one.
+4. **Where should 'Home' pull events from?** The reverse direction.
+
+For genuine two-way syncing between one iCloud calendar and one Google calendar, you set both directions, which is two of the three mappings the free tier allows.
+
+Everything here is editable later from the calendar's detail page under **Calendars**, in the **Send Events to Calendars** section.
+
+## What actually gets synced
+
+Time, not detail — that is the default. Every newly connected calendar is set to strip the event name, description and location, and to title the copy after the source calendar instead. Your dentist appointment reaches the work calendar as a block named after the iCloud calendar it came from, which is the behaviour most people are actually after.
+
+If you want the real titles to come through, the calendar detail page has a **Sync Settings** section with **Sync Event Name**, **Sync Event Description** and **Sync Event Location** toggles, all off to start with. Turning **Sync Event Name** on switches the **Event Name** template to `{{event_name}}` and lets the true title through. While it is off, that template field remains editable and understands `{{event_name}}` and `{{calendar_name}}`, which is how you change the placeholder wording without exposing anything. An **Exclusions** section can drop all-day events, and for Google sources adds Focus Time and Out of Office toggles. Google's Working Location entries are always dropped and have no toggle.
+
+On the hosted plan these are Pro features. Self-hosted instances give them to everyone.
+
+New sources also join your aggregated iCal feed automatically. Untick them under **iCal Link** if you would rather they did not.
+
+The sync window runs from seven days ago to two years ahead and is fixed. One-off events beyond it are not copied. Recurring series get more latitude — a series whose master starts before the window is still collected so its in-window occurrences survive.
+
+## How often it runs
+
+Ingestion, meaning the pull from iCloud and Google into Keeper's database, runs every minute on every plan. The push out to destinations runs every minute on Pro and self-hosted, and every thirty minutes on free.
+
+Google supports incremental sync, so Keeper hands back a sync token each cycle and only receives what changed. iCloud does not get that treatment: CalDAV sources are refetched within the sync window on every ingestion run and diffed against stored state. It is correct, just heavier.
+
+## Limits and rough edges
+
+- **Free tier.** Two linked accounts and three sync mappings. iCloud counts as one account no matter how many calendars it has, Google as another, so this pairing uses your full account allowance. Self-hosting lifts both.
+- **Failures back off rather than break.** When iCloud rejects or times out a request, Keeper records the failure and pushes the calendar's next attempt further out, retrying on a widening interval instead of hammering it or dropping the calendar. A calendar that stops updating for a while and then recovers on its own is this at work.
+- **Revoked passwords are silent on Apple's side.** Nothing in iCloud tells you a sync broke. Changing your Apple Account password kills every app-specific password, and you will find out when events stop moving.
+- **Shared and subscribed calendars.** Calendars shared to you by other people, and calendars you subscribed to from a URL, tend to arrive read-only over CalDAV. They work as sources and fail as destinations.
+- **Recurring events can stall a calendar.** Keeper will not materialise a series expanding past ten thousand occurrences within the two-year window, and that check currently fails the whole calendar's ingestion rather than just the offending series. One imported event with an absurd repeat rule can therefore stop an entire iCloud calendar from updating. If everything goes quiet at once, look there first.
+- **Directions are separate.** Each mapping is one-way. Only setting up "iCloud sends to Google" means Google edits never reach iCloud.
+- **No manual resync.** There is no "sync now" button; you wait for the next cycle. Removing and re-adding the account is the only way to force a clean start.
+
+## If you only need one direction
+
+If all you want is your iCloud availability visible elsewhere without writing anything into iCloud, skip the destination mapping and use the aggregated iCal feed instead. Keeper generates a token-authenticated URL under **iCal Link** that combines whichever sources you tick. Like calendar sync, the feed starts private: events appear as "Busy" with no title until you turn **Include Event Name** on.
+
+It is read-only by nature, which is the point. You hand out the URL without handing over your calendar.

--- a/applications/web/src/content/blog/sync-icloud-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/sync-icloud-calendar-with-google-calendar.mdx
@@ -1,7 +1,7 @@
 ---
 title: "How to Sync iCloud Calendar with Google Calendar"
-description: "A step-by-step guide to two-way syncing iCloud Calendar with Google Calendar using Keeper.sh, including how to generate an Apple app-specific password and what the sync covers."
-blurb: "Apple will publish an iCloud calendar as a read-only link and nothing more. Here is how I get real two-way syncing between iCloud and Google, starting with the app-specific password."
+description: "Get your iCloud events showing up on Google Calendar with Keeper.sh: the Apple password you need, what to click, and who can see your event titles."
+blurb: "Apple only lets you share an iCloud calendar as a read-only link that never quite updates. Here is how to get your iCloud events onto Google Calendar properly."
 createdAt: "2026-08-11"
 slug: "sync-icloud-calendar-with-google-calendar"
 updatedAt: "2026-08-11"
@@ -9,98 +9,155 @@ tags:
   - "icloud"
   - "apple-calendar"
   - "google-calendar"
-  - "caldav"
   - "sync"
 ---
 
-Apple gives you exactly one way to share an iCloud calendar with something outside Apple's world: a public read-only link. Google will subscribe to that link, refresh it on its own unhurried schedule, and give you no way to send anything back. If what you want is for a personal iCloud appointment to block time on your work Google calendar, that is not enough.
+You book personal things on your iPhone, and they land in iCloud. Work books you in Google Calendar. Nobody at work can see the personal side, so they book straight over it.
 
-iCloud does speak CalDAV, though, and that is the door worth using.
+Apple offers one way out: publish the calendar as a public link. Google will subscribe to that link, refresh it whenever it feels like it, and never send anything back.
 
-## Get an app-specific password first
+Keeper does the real thing instead. It signs into both calendars and keeps copies of your events in step.
 
-This is the step people get stuck on, so do it before you open Keeper.
+## What does this actually do?
 
-iCloud will not accept your Apple Account password over CalDAV. You need an app-specific password, which is a 16-character credential scoped to one application and revocable on its own. Apple documents the process in [Sign in to apps with your Apple Account using app-specific passwords](https://support.apple.com/en-us/102654).
+Add a dentist appointment in iCloud and a copy appears on your Google calendar. Move it, the copy moves. Cancel it, the copy disappears.
 
-Keeper's connect screen walks you through the same steps:
+By default that copy is a block of busy time, not a readable event. Your coworkers see that you are unavailable, not why.
 
-1. Navigate to [appleid.apple.com](https://appleid.apple.com)
+Copies travel one way per connection. You choose whether events go from iCloud to Google, from Google to iCloud, or both. Both means setting up two connections, one for each direction.
+
+There is no single "two-way" switch.
+
+## Why do you need a special Apple password?
+
+Do this first, because it is where people get stuck.
+
+Apple will not let outside apps sign in with your normal Apple password. That password opens your photos, your purchases and Find My.
+
+Instead you generate a separate one, called an app-specific password. It only reaches your calendar, and you can cancel it without touching anything else.
+
+Keeper's connect page lists the steps, and they match Apple's own [instructions](https://support.apple.com/en-us/102654):
+
+1. Navigate to iCloud Apple ID
 2. Sign in with your Apple ID
-3. Select **App-Specific Passwords**
-4. Click the **+** next to **Passwords**
+3. Select "App-Specific Passwords"
+4. Click the "+" next to "Passwords"
 5. Label and generate the password, then copy it
-6. Paste the app-specific password into Keeper
+6. Paste the app-specific password below
 
-Two things worth knowing. Your Apple Account needs two-factor authentication turned on before the App-Specific Passwords section appears at all. And Apple shows you the password once — if you close the sheet without copying it, generate another one.
+Two things to know. The App-Specific Passwords section only appears if you have two-factor login switched on. And Apple shows the password once, so copy it before you close the box.
 
-## Connect iCloud
+Changing your Apple password later cancels every app-specific password you ever made. Your calendars will quietly stop updating, and Apple will not tell you. Make a new one and paste it in.
 
-From the dashboard, open **Import Calendars** and choose **Connect iCloud**. There are two fields:
+## How do you connect iCloud?
+
+From the dashboard, click **Import Calendars**, then **Connect iCloud**.
+
+The page you land on is headed **Connect Apple Calendar**, which is the same thing under Apple's newer name. There are two boxes:
 
 - **Apple ID** — the email address you sign in to Apple with
-- **App-Specific Password** — the 16-character password you just generated, not your Apple Account password
+- **App-Specific Password** — the one you just generated, not your normal password
 
-You are not asked for a server URL. Keeper already knows iCloud lives at `https://caldav.icloud.com/` and fills that in for you, which is the whole reason iCloud gets its own tile instead of going through the generic CalDAV form.
+You are not asked for a server address. Keeper already knows where iCloud keeps calendars, which is why iCloud gets its own button.
 
-Press **Connect**. Keeper discovers every calendar on the account, imports all of them, and moves you into setup. Only collections that support events come across, so your Reminders lists stay behind.
+Click **Connect**. Every calendar on the account is imported at once and you land in a short setup flow. Your Reminders lists stay behind — Keeper only takes collections that hold events.
 
-If you get `Invalid credentials` here, it is almost always the password: either the Apple Account password was pasted instead of the app-specific one, or the app-specific password has been revoked. Apple invalidates every app-specific password when you change your Apple Account password, so a working sync that suddenly starts failing after a password change needs a fresh one.
+## How do you connect Google Calendar?
 
-## Connect Google Calendar
+Go back to **Import Calendars** and click **Connect Google Calendar**.
 
-Back on **Import Calendars**, choose **Connect Google Calendar**. Keeper lists the access it is about to request before redirecting you:
+The page is headed **Connect Google** and shows what it will ask Google for before sending you anywhere:
 
 - See your email address
 - View a list of your calendars
 - View events, summaries and details
 - Add or remove calendar events
 
-Press **Connect** and finish Google's consent screen.
+Click **Connect** and approve it on Google's own screen. Keeper never sees your Google password.
 
-## Wire up the mapping
+## How do you tell Keeper which way events travel?
 
-The setup flow asks four things in order:
+Setup asks four questions. Here they are word for word:
 
-1. **Which calendars would you like to configure?** Tick the ones you want to set up now.
-2. **Rename Your Calendars.** iCloud calendars usually arrive as "Home" or "Work", and Google's default calendar arrives named after your email address. Renaming is Keeper-local only.
-3. **Where should 'Home' send events?** Pick the calendars that should receive copies from this one.
-4. **Where should 'Home' pull events from?** The reverse direction.
+1. **Which calendars would you like to configure?** Tick the ones you want now.
+2. **Rename Your Calendars.** iCloud calendars arrive as "Home" or "Work", and Google's as your email address. Renaming only changes what you see in Keeper.
+3. **Where should 'Home' send events?** Tick Google, and copies of your iCloud events start appearing there.
+4. **Where should 'Home' pull events from?** Tick Google here for the reverse direction.
 
-For genuine two-way syncing between one iCloud calendar and one Google calendar, you set both directions, which is two of the three mappings the free tier allows.
+Each tick is one connection. Both directions is two connections.
 
-Everything here is editable later from the calendar's detail page under **Calendars**, in the **Send Events to Calendars** section.
+You can change any of it later. Open the calendar under **Calendars** and use the **Send Events to Calendars** section.
 
-## What actually gets synced
+## Will my coworkers see my private event titles?
 
-Time, not detail — that is the default. Every newly connected calendar is set to strip the event name, description and location, and to title the copy after the source calendar instead. Your dentist appointment reaches the work calendar as a block named after the iCloud calendar it came from, which is the behaviour most people are actually after.
+Check this yourself before you trust it. It takes thirty seconds.
 
-If you want the real titles to come through, the calendar detail page has a **Sync Settings** section with **Sync Event Name**, **Sync Event Description** and **Sync Event Location** toggles, all off to start with. Turning **Sync Event Name** on switches the **Event Name** template to `{{event_name}}` and lets the true title through. While it is off, that template field remains editable and understands `{{event_name}}` and `{{calendar_name}}`, which is how you change the placeholder wording without exposing anything. An **Exclusions** section can drop all-day events, and for Google sources adds Focus Time and Out of Office toggles. Google's Working Location entries are always dropped and have no toggle.
+Open the calendar under **Calendars** and find **Sync Settings**. Three switches decide what travels: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
 
-On the hosted plan these are Pro features. Self-hosted instances give them to everyone.
+Calendars you add through **Import Calendars** arrive with all three off. Your dentist appointment reaches Google as a block named after the iCloud calendar it came from.
 
-New sources also join your aggregated iCal feed automatically. Untick them under **iCal Link** if you would rather they did not.
+The name on the copy comes from the **Event Name** box, which understands `{{calendar_name}}` and `{{event_name}}`. Turn **Sync Event Name** on if you want real titles to come through.
 
-The sync window runs from seven days ago to two years ahead and is fixed. One-off events beyond it are not copied. Recurring series get more latitude — a series whose master starts before the window is still collected so its in-window occurrences survive.
+On keeper.sh these switches are a Pro feature — the dashboard says **Advanced sync settings are a Pro feature.** On free they stay off, so your titles stay private whether you meant it or not.
 
-## How often it runs
+Below them, **Exclusions** can drop **Exclude All Day Events**. Google calendars also offer **Exclude Focus Time Events** and **Exclude Out of Office Events**.
 
-Ingestion, meaning the pull from iCloud and Google into Keeper's database, runs every minute on every plan. The push out to destinations runs every minute on Pro and self-hosted, and every thirty minutes on free.
+## How fast do changes show up?
 
-Google supports incremental sync, so Keeper hands back a sync token each cycle and only receives what changed. iCloud does not get that treatment: CalDAV sources are refetched within the sync window on every ingestion run and diffed against stored state. It is correct, just heavier.
+Keeper reads both calendars every minute, on every plan. That never gets slower.
 
-## Limits and rough edges
+Getting a change onto the other calendar is the part your plan decides. On free it takes up to thirty minutes. On Pro it is about a minute.
 
-- **Free tier.** Two linked accounts and three sync mappings. iCloud counts as one account no matter how many calendars it has, Google as another, so this pairing uses your full account allowance. Self-hosting lifts both.
-- **Failures back off rather than break.** When iCloud rejects or times out a request, Keeper records the failure and pushes the calendar's next attempt further out, retrying on a widening interval instead of hammering it or dropping the calendar. A calendar that stops updating for a while and then recovers on its own is this at work.
-- **Revoked passwords are silent on Apple's side.** Nothing in iCloud tells you a sync broke. Changing your Apple Account password kills every app-specific password, and you will find out when events stop moving.
-- **Shared and subscribed calendars.** Calendars shared to you by other people, and calendars you subscribed to from a URL, tend to arrive read-only over CalDAV. They work as sources and fail as destinations.
-- **Recurring events can stall a calendar.** Keeper will not materialise a series expanding past ten thousand occurrences within the two-year window, and that check currently fails the whole calendar's ingestion rather than just the offending series. One imported event with an absurd repeat rule can therefore stop an entire iCloud calendar from updating. If everything goes quiet at once, look there first.
-- **Directions are separate.** Each mapping is one-way. Only setting up "iCloud sends to Google" means Google edits never reach iCloud.
-- **No manual resync.** There is no "sync now" button; you wait for the next cycle. Removing and re-adding the account is the only way to force a clean start.
+If you are blocking out evenings so nobody books them, thirty minutes changes nothing. If people book you through a scheduling link, it is too slow. Do not pay for speed you will not notice.
 
-## If you only need one direction
+## What does not come across?
 
-If all you want is your iCloud availability visible elsewhere without writing anything into iCloud, skip the destination mapping and use the aggregated iCal feed instead. Keeper generates a token-authenticated URL under **iCal Link** that combines whichever sources you tick. Like calendar sync, the feed starts private: events appear as "Busy" with no title until you turn **Include Event Name** on.
+Guest lists, video call links and reminders do not travel at all. Keeper has nowhere to store them.
 
-It is read-only by nature, which is the point. You hand out the URL without handing over your calendar.
+So a copied meeting is a block of time, not a working invite. You cannot join the call from the copy, and nobody gets notified by it.
+
+Guest lists are read for one thing only: showing you invitations you have not answered yet, so you can reply from Keeper.
+
+Keeper also looks at a fixed stretch of time — from a week ago to two years ahead. A one-off event further out is not copied. A repeating event that began before that window is still picked up, so its dates inside the window survive.
+
+## What goes wrong, and what does it look like?
+
+**The page shows `401 /api/sources/caldav/discover` in red.** That means the password was wrong, shown badly. Keeper's server does say "Invalid credentials", but the dashboard throws away the message and prints the status code. In practice it is one of two things. You pasted your normal Apple password instead of the app-specific one, or the app-specific one has been cancelled.
+
+**Everything stopped, and Apple gave no warning.** Changing your Apple password cancels every app-specific password. Nothing in iCloud tells you a sync broke — you find out when events stop appearing. Generate a new one and paste it in.
+
+**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops. Keeper refuses to work through a repeating series that would produce more than 10,000 dates in two years. Today that refusal stops the whole calendar, not just the one series. Look for something set to repeat every minute or hour, usually dragged in from an old calendar. Delete it and the calendar catches up by itself.
+
+**A calendar goes quiet for a few hours, then comes back.** When iCloud rejects a request or times out, Keeper waits five minutes, then ten, then twenty, up to six hours. It backs off rather than hammering Apple, and recovers on its own.
+
+**A shared calendar will not accept copies.** Calendars other people shared with you, and ones you subscribed to from a link, usually arrive read-only. They work fine as the calendar events come from. They fail as the calendar events are copied to.
+
+**There is no "sync now" button.** You wait for the next round. Removing the account and adding it again is the blunt way to start clean.
+
+## What does the free plan cover?
+
+Two calendar accounts and three connections.
+
+iCloud is one account no matter how many calendars it holds. Google is the second. So this pairing uses both, and adding Outlook later means upgrading.
+
+Three connections covers both directions here with one spare. There is no cap on how many calendars an account brings in.
+
+## What if you only want your iCloud time visible elsewhere?
+
+If nothing needs to be written back into iCloud, skip the second direction entirely.
+
+Keeper builds a single feed from whichever calendars you tick, at **iCal Link** in the dashboard. It is a link you can subscribe to in almost any calendar app. The feed is read-only: you can see those events, but nothing you do changes them.
+
+Before you hand the link to anyone, open that page and check two things. **Include Event Name** decides whether real titles appear or everything reads "Busy". The **Sources** list decides which of your calendars are in it at all.
+
+Feed settings are a Pro feature on keeper.sh, shown as **Feed settings are Pro-only.**
+
+## Would you rather run Keeper yourself?
+
+Keeper is open source under AGPL-3.0, and self-hosting is a real alternative rather than a lesser one. Every Pro feature comes with it: real event titles, exclusions, feed settings, unlimited accounts and connections, and updates every minute.
+
+It is a Docker Compose stack with Postgres and Redis behind it, and the setup guide is in the [repository](https://github.com/ridafkih/keeper.sh).
+
+Be honest with yourself about the cost. You need a server, a domain and a certificate, and you handle upgrades and backups. When it stops working on a Monday morning, you are the person who fixes it.
+
+If that sounds like a fun weekend, it is a good trade. If it sounds like a chore, use keeper.sh and spend the time elsewhere.

--- a/applications/web/src/content/blog/sync-icloud-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/sync-icloud-calendar-with-google-calendar.mdx
@@ -14,7 +14,7 @@ tags:
 
 You book personal things on your iPhone, and they land in iCloud. Work books you in Google Calendar. Nobody at work can see the personal side, so they book straight over it.
 
-Apple offers one way out: publish the calendar as a public link that Google refreshes whenever it feels like it. Keeper does the real thing instead. It signs into both calendars and keeps copies of your events in step.
+Apple offers one way out: publish the calendar as a public link that Google refreshes whenever it feels like it. Keeper.sh does the real thing instead. It signs into both calendars and keeps copies of your events in step.
 
 ## What does this actually do?
 
@@ -30,7 +30,7 @@ Do this first, because it is where people get stuck.
 
 Apple will not let outside apps sign in with your normal Apple password, which opens your photos, your purchases and Find My. Instead you generate a separate one, called an app-specific password. It only reaches your calendar, and you can cancel it without touching anything else.
 
-Keeper's connect page lists the steps, and they match Apple's own [instructions](https://support.apple.com/en-us/102654):
+Keeper.sh's connect page lists the steps, and they match Apple's own [instructions](https://support.apple.com/en-us/102654):
 
 1. Navigate to iCloud Apple ID
 2. Sign in with your Apple ID
@@ -50,7 +50,7 @@ The page is headed **Connect Apple Calendar**, Apple's newer name for the same t
 - **Apple ID** — the email address you sign in to Apple with
 - **App-Specific Password** — the one you just generated, not your normal password
 
-You are not asked for a server address. Keeper already knows where iCloud keeps calendars.
+You are not asked for a server address. Keeper.sh already knows where iCloud keeps calendars.
 
 Click **Connect**. Every calendar on the account is imported at once and you land in a short setup flow. Your Reminders lists stay behind.
 
@@ -58,14 +58,14 @@ Click **Connect**. Every calendar on the account is imported at once and you lan
 
 Go back to **Import Calendars** and click **Connect Google Calendar**. The page is headed **Connect Google** and shows what it will ask Google for before sending you anywhere.
 
-Click **Connect** and approve it on Google's screen. Keeper never sees your Google password.
+Click **Connect** and approve it on Google's screen. Keeper.sh never sees your Google password.
 
-## How do you tell Keeper which way events travel?
+## How do you tell Keeper.sh which way events travel?
 
 Setup asks four questions, word for word:
 
 1. **Which calendars would you like to configure?** Tick the ones you want now.
-2. **Rename Your Calendars.** iCloud calendars arrive as "Home" or "Work", and Google's as your email address. Renaming only changes what you see in Keeper.
+2. **Rename Your Calendars.** iCloud calendars arrive as "Home" or "Work", and Google's as your email address. Renaming only changes what you see in Keeper.sh.
 3. **Where should 'Home' send events?** Tick Google, and copies of your iCloud events start appearing there.
 4. **Where should 'Home' pull events from?** Tick Google here for the reverse direction.
 
@@ -79,13 +79,13 @@ Check this yourself before you trust it. Open the calendar under **Calendars** a
 
 Calendars you add through **Import Calendars** arrive with all three off. Your dentist appointment reaches Google as a block named after the iCloud calendar it came from. Turn **Sync Event Name** on for real titles, shaped by the **Event Name** box, which understands `{{calendar_name}}` and `{{event_name}}`.
 
-On keeper.sh these switches are a Pro feature — the dashboard says **Advanced sync settings are a Pro feature.**
+On Keeper.sh these switches are a Pro feature — the dashboard says **Advanced sync settings are a Pro feature.**
 
 Below them, **Exclusions** can drop **Exclude All Day Events**. Google calendars also offer **Exclude Focus Time Events** and **Exclude Out of Office Events**.
 
 ## How fast do changes show up?
 
-Keeper reads both calendars every minute, on every plan. Getting that change onto the other calendar depends on your plan: up to thirty minutes on free, about a minute on Pro.
+Keeper.sh reads both calendars every minute, on every plan. Getting that change onto the other calendar depends on your plan: up to thirty minutes on free, about a minute on Pro.
 
 If you are blocking out evenings so nobody books them, thirty minutes changes nothing. If people book you through a scheduling link, it is too slow. Do not pay for speed you will not notice.
 
@@ -93,17 +93,17 @@ If you are blocking out evenings so nobody books them, thirty minutes changes no
 
 Guest lists, video call links and reminders do not travel at all. So a copied meeting is a block of time, not a working invite — you cannot join the call from it, and nobody gets notified. Guest lists are read only to show you invitations you have not answered yet.
 
-Keeper also looks at a fixed stretch of time — from a week ago to two years ahead. A one-off event further out is not copied. A repeating event that began before that window is still picked up, so its dates inside the window survive.
+Keeper.sh also looks at a fixed stretch of time — from a week ago to two years ahead. A one-off event further out is not copied. A repeating event that began before that window is still picked up, so its dates inside the window survive.
 
 ## What goes wrong, and what does it look like?
 
-**The page says "Invalid credentials".** Apple was reached and turned Keeper away. In practice it is one of two things. You pasted your normal Apple password instead of the app-specific one, or the app-specific one has been cancelled.
+**The page says "Invalid credentials".** Apple was reached and turned Keeper.sh away. In practice it is one of two things. You pasted your normal Apple password instead of the app-specific one, or the app-specific one has been cancelled.
 
-**The page says "Failed to discover calendars".** That is a different problem, and your password is probably fine. Keeper could not reach Apple at all, so it never got as far as checking. Wait a minute and try again.
+**The page says "Failed to discover calendars".** That is a different problem, and your password is probably fine. Keeper.sh could not reach Apple at all, so it never got as far as checking. Wait a minute and try again.
 
 **Everything stopped, and Apple gave no warning.** Changing your Apple password cancels every app-specific password. You find out when events stop appearing. Generate a new one and paste it in.
 
-**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops. Keeper refuses to work through a repeating series producing more than 10,000 dates in two years, and today that stops the whole calendar. Delete the event repeating every minute or hour and it catches up.
+**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops. Keeper.sh refuses to work through a repeating series producing more than 10,000 dates in two years, and today that stops the whole calendar. Delete the event repeating every minute or hour and it catches up.
 
 **A shared calendar will not accept copies.** Calendars other people shared with you, and ones you subscribed to from a link, usually arrive read-only. They work fine as the calendar events come from, and fail as the one events are copied to.
 
@@ -115,10 +115,10 @@ Two calendar accounts and three connections. iCloud is one account no matter how
 
 Three connections covers both directions here with one spare. There is no cap on how many calendars an account brings in.
 
-## Would you rather run Keeper yourself?
+## Would you rather run Keeper.sh yourself?
 
-Keeper is open source under AGPL-3.0, and self-hosting is a real alternative rather than a lesser one. Every Pro feature comes with it, including real event titles and updates every minute. It is a Docker Compose stack with Postgres and Redis behind it, documented in the [repository](https://github.com/ridafkih/keeper.sh).
+Keeper.sh is open source under AGPL-3.0, and self-hosting is a real alternative rather than a lesser one. Every Pro feature comes with it, including real event titles and updates every minute. It is a Docker Compose stack with Postgres and Redis behind it, documented in the [repository](https://github.com/ridafkih/keeper.sh).
 
 Be honest about the cost. A server, a domain and a certificate, plus upgrades and backups. When it stops on a Monday morning, you are the person who fixes it.
 
-If that sounds like a fun weekend, it is a good trade. If it sounds like a chore, use keeper.sh.
+If that sounds like a fun weekend, it is a good trade. If it sounds like a chore, use Keeper.sh.

--- a/applications/web/src/content/blog/sync-icloud-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/sync-icloud-calendar-with-google-calendar.mdx
@@ -14,9 +14,7 @@ tags:
 
 You book personal things on your iPhone, and they land in iCloud. Work books you in Google Calendar. Nobody at work can see the personal side, so they book straight over it.
 
-Apple offers one way out: publish the calendar as a public link. Google will subscribe to that link, refresh it whenever it feels like it, and never send anything back.
-
-Keeper does the real thing instead. It signs into both calendars and keeps copies of your events in step.
+Apple offers one way out: publish the calendar as a public link that Google refreshes whenever it feels like it. Keeper does the real thing instead. It signs into both calendars and keeps copies of your events in step.
 
 ## What does this actually do?
 
@@ -24,17 +22,13 @@ Add a dentist appointment in iCloud and a copy appears on your Google calendar. 
 
 By default that copy is a block of busy time, not a readable event. Your coworkers see that you are unavailable, not why.
 
-Copies travel one way per connection. You choose whether events go from iCloud to Google, from Google to iCloud, or both. Both means setting up two connections, one for each direction.
-
-There is no single "two-way" switch.
+Copies travel one way per connection: iCloud to Google, or Google to iCloud. Want both? That is two connections, not a single "two-way" switch.
 
 ## Why do you need a special Apple password?
 
 Do this first, because it is where people get stuck.
 
-Apple will not let outside apps sign in with your normal Apple password. That password opens your photos, your purchases and Find My.
-
-Instead you generate a separate one, called an app-specific password. It only reaches your calendar, and you can cancel it without touching anything else.
+Apple will not let outside apps sign in with your normal Apple password, which opens your photos, your purchases and Find My. Instead you generate a separate one, called an app-specific password. It only reaches your calendar, and you can cancel it without touching anything else.
 
 Keeper's connect page lists the steps, and they match Apple's own [instructions](https://support.apple.com/en-us/102654):
 
@@ -45,39 +39,30 @@ Keeper's connect page lists the steps, and they match Apple's own [instructions]
 5. Label and generate the password, then copy it
 6. Paste the app-specific password below
 
-Two things to know. The App-Specific Passwords section only appears if you have two-factor login switched on. And Apple shows the password once, so copy it before you close the box.
-
-Changing your Apple password later cancels every app-specific password you ever made. Your calendars will quietly stop updating, and Apple will not tell you. Make a new one and paste it in.
+Two things to know. That section only appears if you have two-factor login switched on. And Apple shows the password once, so copy it before you close the box.
 
 ## How do you connect iCloud?
 
 From the dashboard, click **Import Calendars**, then **Connect iCloud**.
 
-The page you land on is headed **Connect Apple Calendar**, which is the same thing under Apple's newer name. There are two boxes:
+The page is headed **Connect Apple Calendar**, Apple's newer name for the same thing. There are two boxes:
 
 - **Apple ID** — the email address you sign in to Apple with
 - **App-Specific Password** — the one you just generated, not your normal password
 
-You are not asked for a server address. Keeper already knows where iCloud keeps calendars, which is why iCloud gets its own button.
+You are not asked for a server address. Keeper already knows where iCloud keeps calendars.
 
-Click **Connect**. Every calendar on the account is imported at once and you land in a short setup flow. Your Reminders lists stay behind — Keeper only takes collections that hold events.
+Click **Connect**. Every calendar on the account is imported at once and you land in a short setup flow. Your Reminders lists stay behind.
 
 ## How do you connect Google Calendar?
 
-Go back to **Import Calendars** and click **Connect Google Calendar**.
+Go back to **Import Calendars** and click **Connect Google Calendar**. The page is headed **Connect Google** and shows what it will ask Google for before sending you anywhere.
 
-The page is headed **Connect Google** and shows what it will ask Google for before sending you anywhere:
-
-- See your email address
-- View a list of your calendars
-- View events, summaries and details
-- Add or remove calendar events
-
-Click **Connect** and approve it on Google's own screen. Keeper never sees your Google password.
+Click **Connect** and approve it on Google's screen. Keeper never sees your Google password.
 
 ## How do you tell Keeper which way events travel?
 
-Setup asks four questions. Here they are word for word:
+Setup asks four questions, word for word:
 
 1. **Which calendars would you like to configure?** Tick the ones you want now.
 2. **Rename Your Calendars.** iCloud calendars arrive as "Home" or "Work", and Google's as your email address. Renaming only changes what you see in Keeper.
@@ -90,76 +75,50 @@ You can change any of it later. Open the calendar under **Calendars** and use th
 
 ## Will my coworkers see my private event titles?
 
-Check this yourself before you trust it. It takes thirty seconds.
+Check this yourself before you trust it. Open the calendar under **Calendars** and find **Sync Settings**. Three switches decide what travels: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
 
-Open the calendar under **Calendars** and find **Sync Settings**. Three switches decide what travels: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
+Calendars you add through **Import Calendars** arrive with all three off. Your dentist appointment reaches Google as a block named after the iCloud calendar it came from. Turn **Sync Event Name** on for real titles, shaped by the **Event Name** box, which understands `{{calendar_name}}` and `{{event_name}}`.
 
-Calendars you add through **Import Calendars** arrive with all three off. Your dentist appointment reaches Google as a block named after the iCloud calendar it came from.
-
-The name on the copy comes from the **Event Name** box, which understands `{{calendar_name}}` and `{{event_name}}`. Turn **Sync Event Name** on if you want real titles to come through.
-
-On keeper.sh these switches are a Pro feature — the dashboard says **Advanced sync settings are a Pro feature.** On free they stay off, so your titles stay private whether you meant it or not.
+On keeper.sh these switches are a Pro feature — the dashboard says **Advanced sync settings are a Pro feature.**
 
 Below them, **Exclusions** can drop **Exclude All Day Events**. Google calendars also offer **Exclude Focus Time Events** and **Exclude Out of Office Events**.
 
 ## How fast do changes show up?
 
-Keeper reads both calendars every minute, on every plan. That never gets slower.
-
-Getting a change onto the other calendar is the part your plan decides. On free it takes up to thirty minutes. On Pro it is about a minute.
+Keeper reads both calendars every minute, on every plan. Getting that change onto the other calendar depends on your plan: up to thirty minutes on free, about a minute on Pro.
 
 If you are blocking out evenings so nobody books them, thirty minutes changes nothing. If people book you through a scheduling link, it is too slow. Do not pay for speed you will not notice.
 
 ## What does not come across?
 
-Guest lists, video call links and reminders do not travel at all. Keeper has nowhere to store them.
-
-So a copied meeting is a block of time, not a working invite. You cannot join the call from the copy, and nobody gets notified by it.
-
-Guest lists are read for one thing only: showing you invitations you have not answered yet, so you can reply from Keeper.
+Guest lists, video call links and reminders do not travel at all. So a copied meeting is a block of time, not a working invite — you cannot join the call from it, and nobody gets notified. Guest lists are read only to show you invitations you have not answered yet.
 
 Keeper also looks at a fixed stretch of time — from a week ago to two years ahead. A one-off event further out is not copied. A repeating event that began before that window is still picked up, so its dates inside the window survive.
 
 ## What goes wrong, and what does it look like?
 
-**The page says "Invalid credentials".** Apple turned Keeper away. In practice it is one of two things. You pasted your normal Apple password instead of the app-specific one, or the app-specific one has been cancelled.
+**The page says "Invalid credentials".** Apple was reached and turned Keeper away. In practice it is one of two things. You pasted your normal Apple password instead of the app-specific one, or the app-specific one has been cancelled.
 
 **The page says "Failed to discover calendars".** That is a different problem, and your password is probably fine. Keeper could not reach Apple at all, so it never got as far as checking. Wait a minute and try again.
 
-**Everything stopped, and Apple gave no warning.** Changing your Apple password cancels every app-specific password. Nothing in iCloud tells you a sync broke — you find out when events stop appearing. Generate a new one and paste it in.
+**Everything stopped, and Apple gave no warning.** Changing your Apple password cancels every app-specific password. You find out when events stop appearing. Generate a new one and paste it in.
 
-**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops. Keeper refuses to work through a repeating series that would produce more than 10,000 dates in two years. Today that refusal stops the whole calendar, not just the one series. Look for something set to repeat every minute or hour, usually dragged in from an old calendar. Delete it and the calendar catches up by itself.
+**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops. Keeper refuses to work through a repeating series producing more than 10,000 dates in two years, and today that stops the whole calendar. Delete the event repeating every minute or hour and it catches up.
 
-**A calendar goes quiet for a few hours, then comes back.** When iCloud rejects a request or times out, Keeper waits five minutes, then ten, then twenty, up to six hours. It backs off rather than hammering Apple, and recovers on its own.
-
-**A shared calendar will not accept copies.** Calendars other people shared with you, and ones you subscribed to from a link, usually arrive read-only. They work fine as the calendar events come from. They fail as the calendar events are copied to.
+**A shared calendar will not accept copies.** Calendars other people shared with you, and ones you subscribed to from a link, usually arrive read-only. They work fine as the calendar events come from, and fail as the one events are copied to.
 
 **There is no "sync now" button.** You wait for the next round. Removing the account and adding it again is the blunt way to start clean.
 
 ## What does the free plan cover?
 
-Two calendar accounts and three connections.
-
-iCloud is one account no matter how many calendars it holds. Google is the second. So this pairing uses both, and adding Outlook later means upgrading.
+Two calendar accounts and three connections. iCloud is one account no matter how many calendars it holds, and Google is the second, so this pairing uses both. Adding Outlook later means upgrading.
 
 Three connections covers both directions here with one spare. There is no cap on how many calendars an account brings in.
 
-## What if you only want your iCloud time visible elsewhere?
-
-If nothing needs to be written back into iCloud, skip the second direction entirely.
-
-Keeper builds a single feed from whichever calendars you tick, at **iCal Link** in the dashboard. It is a link you can subscribe to in almost any calendar app. The feed is read-only: you can see those events, but nothing you do changes them.
-
-Before you hand the link to anyone, open that page and check two things. **Include Event Name** decides whether real titles appear or everything reads "Busy". The **Sources** list decides which of your calendars are in it at all.
-
-Feed settings are a Pro feature on keeper.sh, shown as **Feed settings are Pro-only.**
-
 ## Would you rather run Keeper yourself?
 
-Keeper is open source under AGPL-3.0, and self-hosting is a real alternative rather than a lesser one. Every Pro feature comes with it: real event titles, exclusions, feed settings, unlimited accounts and connections, and updates every minute.
+Keeper is open source under AGPL-3.0, and self-hosting is a real alternative rather than a lesser one. Every Pro feature comes with it, including real event titles and updates every minute. It is a Docker Compose stack with Postgres and Redis behind it, documented in the [repository](https://github.com/ridafkih/keeper.sh).
 
-It is a Docker Compose stack with Postgres and Redis behind it, and the setup guide is in the [repository](https://github.com/ridafkih/keeper.sh).
+Be honest about the cost. A server, a domain and a certificate, plus upgrades and backups. When it stops on a Monday morning, you are the person who fixes it.
 
-Be honest with yourself about the cost. You need a server, a domain and a certificate, and you handle upgrades and backups. When it stops working on a Monday morning, you are the person who fixes it.
-
-If that sounds like a fun weekend, it is a good trade. If it sounds like a chore, use keeper.sh and spend the time elsewhere.
+If that sounds like a fun weekend, it is a good trade. If it sounds like a chore, use keeper.sh.

--- a/applications/web/src/content/blog/sync-nextcloud-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/sync-nextcloud-calendar-with-google-calendar.mdx
@@ -115,7 +115,11 @@ Keeper also looks at a fixed stretch of time — from a week ago to two years ah
 
 ## What goes wrong, and what does it look like?
 
-**The page shows `401 /api/sources/caldav/discover` in red.** That is a wrong username or password, shown badly. Keeper's server does say "Invalid credentials", but the dashboard throws the status code away before it reads the message. Almost always this is two-factor login. Nextcloud stops accepting your normal password once it is on. Generate an app password and use that instead.
+**The page says "Invalid credentials".** Keeper reached your Nextcloud, and Nextcloud turned it away. Almost always this is two-factor login, which stops your normal password working here. Generate an app password and use that instead. Check the username too, since it is often not your email address.
+
+**The page says "Failed to discover calendars".** This means something different, and it is worth telling apart. Keeper never got a usable answer from the address you gave, so your username and password were never tested. Check the web address for a typo, confirm the server is up, and confirm it can be reached from outside your own network.
+
+**The page says "No calendars found".** Your credentials worked. Keeper just could not find any calendars to import at that address. Try the longer `remote.php/dav/calendars/username/` form instead of the base address.
 
 **One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper refuses to work through a repeating series that would produce more than 10,000 dates in two years. Today that refusal stops the whole calendar, not just the one series. Look for something set to repeat every minute or hour, usually imported from an old calendar. Delete it and the calendar catches up on its own.
 
@@ -156,7 +160,9 @@ BLOCK_PRIVATE_RESOLUTION=true
 PRIVATE_RESOLUTION_WHITELIST=192.168.1.50,nextcloud.local
 ```
 
-Set both on `api` and `cron`, and whitelist the exact form you will paste into the connect form. If you skip it, the connection fails with a message about the address being private or reserved.
+Set both on `api` and `cron`, and whitelist the exact form you will paste into the connect form.
+
+Skip it and the connect page says **Failed to discover calendars**, because Keeper refused to make the request at all. It will not tell you that was the reason. The specific message about a private or reserved address only appears in the server logs.
 
 On hosted keeper.sh you cannot change either. Your Nextcloud has to be reachable from the internet.
 

--- a/applications/web/src/content/blog/sync-nextcloud-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/sync-nextcloud-calendar-with-google-calendar.mdx
@@ -1,0 +1,106 @@
+---
+title: "How to Sync Nextcloud Calendar with Google Calendar"
+description: "A step-by-step guide to two-way syncing a Nextcloud calendar with Google Calendar using Keeper.sh, including the CalDAV URL to use, app passwords, and what the sync actually covers."
+blurb: "Nextcloud speaks CalDAV and Google speaks OAuth, so nothing syncs between them out of the box. Here is how I wire the two together, what URL to paste, and where the sharp edges are."
+createdAt: "2026-08-11"
+slug: "sync-nextcloud-calendar-with-google-calendar"
+updatedAt: "2026-08-11"
+tags:
+  - "nextcloud"
+  - "google-calendar"
+  - "caldav"
+  - "sync"
+  - "self-hosting"
+---
+
+Nextcloud exposes calendars over CalDAV. Google Calendar exposes them over its own OAuth API. Neither one will subscribe to the other in a way that gives you writable, two-way availability, so the usual result is a Nextcloud calendar nobody at work can see and a work calendar your personal setup knows nothing about.
+
+This is the pairing I run myself, so it is the one I can describe honestly. Below is the actual flow, screen by screen, plus the parts that do not work the way you might expect.
+
+## What you need first
+
+- A Nextcloud instance you can reach over HTTPS from wherever Keeper runs
+- Your Nextcloud username and either your password or, if you have two-factor enabled, a [Nextcloud app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html)
+- A Google account
+- A Keeper.sh account, either on [keeper.sh](https://keeper.sh/register) or a [self-hosted instance](https://github.com/ridafkih/keeper.sh)
+
+If you self-host Keeper and use Google as a source or destination, you also need your own Google OAuth client from Google Cloud. Nextcloud itself needs no OAuth setup at all; CalDAV is just a username and a password.
+
+## Connect Nextcloud
+
+From the dashboard, open **Import Calendars**, then pick **Connect CalDAV Server** from the bottom group. Nextcloud does not have its own tile, and it does not need one. It is a standard CalDAV server.
+
+The form has three fields:
+
+- **CalDAV Server URL** — your Nextcloud base URL, for example `https://cloud.example.com`
+- **CalDAV Server Username** — your Nextcloud username, not your email address unless they happen to match
+- **CalDAV Server Password** — your password, or an app password if you use two-factor
+
+Use the base URL. Keeper runs standards discovery against it: it looks up the current-user principal, follows that to your calendar home set, and enumerates the collections it finds. You do not need to hunt down the `remote.php/dav/calendars/username/` path yourself. If discovery comes back empty, that longer form is a reasonable fallback, but try the base URL first.
+
+Two-factor is the thing that trips most people. Nextcloud rejects your login password on CalDAV once 2FA is enabled, and the failure surfaces in Keeper as `Invalid credentials`. Generate an app password under **Settings → Security → Devices & sessions** and paste that instead.
+
+Click **Connect**. Keeper imports *every* calendar it discovers on the account at once, then drops you into a short setup flow. There is no "pick which ones to import" step before that — the picking happens after.
+
+One quiet detail worth knowing: Keeper only keeps collections that advertise support for `VEVENT`. That is what you want for a task list or a contacts collection, which get skipped. It also means a calendar on a server that omits the supported-component property entirely will not show up, which is rare on Nextcloud but does happen behind some reverse proxies.
+
+## Connect Google Calendar
+
+Back on **Import Calendars**, choose **Connect Google Calendar**. The page lists what Keeper is about to ask Google for before it sends you anywhere:
+
+- See your email address
+- View a list of your calendars
+- View events, summaries and details
+- Add or remove calendar events
+
+Press **Connect**, complete Google's consent screen, and you land back in the same setup flow. Google calendars come in with both pull and push, so any of them can be a source, a destination, or both.
+
+## Wire up the mapping
+
+The setup flow is four screens:
+
+1. **Which calendars would you like to configure?** Check the ones you care about. Everything got imported; this is only about what you configure now.
+2. **Rename Your Calendars.** Nextcloud names default to things like "Personal", and Google to your email address. Renaming here is Keeper-local and does not touch the calendar on either provider.
+3. **Where should 'Personal' send events?** This is the outbound direction, asked once per calendar. Pick the destinations that should receive copies.
+4. **Where should 'Personal' pull events from?** The inbound direction for the same calendar.
+
+For a two-way setup between one Nextcloud calendar and one Google calendar, you check each in the other's list. That is two mappings, and the free tier allows three.
+
+If you skip the flow or want to change things later, every calendar has a detail page under **Calendars** in the dashboard with a **Send Events to Calendars** section that does the same thing.
+
+## What actually gets synced
+
+Newly connected calendars default to time only, not detail. Keeper sets every new source to strip the event name, description and location, and replaces the title with the source calendar's name. So a dentist appointment on Nextcloud lands on Google as a block titled after the calendar it came from, not "Dentist".
+
+That is the behaviour most people want, and it is the default precisely because the failure mode of the opposite default is leaking a private title onto a work calendar.
+
+If you do want real detail to pass through, the calendar detail page has a **Sync Settings** section with **Sync Event Name**, **Sync Event Description** and **Sync Event Location** toggles, all off to begin with. Turning **Sync Event Name** on switches the **Event Name** template to `{{event_name}}` and lets the true title through. While it is off, that template field stays editable and accepts `{{event_name}}` and `{{calendar_name}}`, which is how you customise the placeholder text without exposing titles. An **Exclusions** section below can drop all-day events, and for Google sources it adds **Exclude Focus Time Events** and **Exclude Out of Office Events**. Google's Working Location entries are always dropped, with no toggle.
+
+These settings are Pro-gated on the hosted plan. On a self-hosted instance every user gets them.
+
+New sources are also added to your aggregated iCal feed by default. If you do not want a calendar in the feed, untick it under **iCal Link**.
+
+The sync window runs from seven days ago to two years out and is not configurable. One-off events outside that range are not copied. Recurring series are treated more generously — a series whose master starts before the window is still picked up so its in-window occurrences survive.
+
+## How often it runs
+
+There are two halves, on separate schedules.
+
+Ingestion — pulling from Nextcloud and Google into Keeper's own database — runs every minute on every plan. Pushing out to your destinations is the interval the pricing page refers to: every minute on Pro and self-hosted, every thirty minutes on free.
+
+Google gets incremental sync. Keeper hands Google its sync token and only asks for what changed. CalDAV gets no such thing here: each ingestion run refetches the Nextcloud calendar within the sync window and diffs it against what Keeper already has. It works fine, but it is more work per cycle, and a very large Nextcloud calendar will feel that.
+
+## Limits and rough edges
+
+- **Free tier.** Two linked accounts and three sync mappings. Nextcloud is one account regardless of how many calendars it exposes, and Google is another, so a Nextcloud-plus-Google setup consumes the whole account allowance. Self-hosting removes both limits.
+- **Private addresses.** The bundled `compose.yaml` sets `BLOCK_PRIVATE_RESOLUTION=true`, which refuses to fetch anything resolving to a private or reserved address. If your Nextcloud lives at `192.168.1.50` or `nextcloud.local`, add it to `PRIVATE_RESOLUTION_WHITELIST`. On hosted keeper.sh you cannot do this, so your Nextcloud has to be publicly reachable.
+- **Recurring events.** Recurrence expansion is the least forgiving part of the engine. Keeper refuses to materialise a series expanding past ten thousand occurrences in the two-year window, and today that check fails the *whole calendar's* ingestion rather than just the offending series, after which the calendar backs off and retries on a widening interval. A single pathological rule — something repeating minutely, usually imported from elsewhere — can therefore stall a calendar. If a Nextcloud calendar stops updating entirely, look for a recurring event with an absurd rule before anything else.
+- **Large calendars and server response caps.** Because CalDAV is refetched in full each cycle, a server that silently caps how many objects it returns in one response will look to Keeper like a calendar that genuinely lost the remainder, and the diff will remove them from the destination. Nextcloud does not impose such a cap by default, but a reverse proxy with an aggressive response limit in front of it can produce the same effect.
+- **Nothing is bidirectional by accident.** A mapping is one direction. If you only set up "Nextcloud sends to Google", changes made in Google will not travel back.
+- **There is no force-resync button.** You wait for the next cycle. Disconnecting and reconnecting the account is the blunt instrument if you need to start clean.
+
+## Credentials
+
+Your Nextcloud password is encrypted at rest with a configurable encryption key before it is stored. If you self-host, that key is yours, generated during setup. Keeper needs the password in a reversible form because CalDAV basic and digest auth require replaying it on every request; there is no token exchange to hide behind.
+
+Revoking access is a matter of deleting the app password in Nextcloud, or deleting the account in Keeper under **Calendar Sources**, which removes the account and all its calendars.

--- a/applications/web/src/content/blog/sync-nextcloud-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/sync-nextcloud-calendar-with-google-calendar.mdx
@@ -14,7 +14,7 @@ tags:
 
 Your Nextcloud calendar holds your real life. Google Calendar holds your work. Neither one knows the other exists, so people book meetings over your evenings.
 
-You can fix that in about ten minutes. Keeper signs into both calendars and keeps copies of your events in step.
+Keeper signs into both calendars and keeps copies of your events in step. It takes about ten minutes.
 
 ## What does this actually do?
 
@@ -22,9 +22,7 @@ Add an event in Nextcloud and a copy appears on your Google calendar. Move it, a
 
 By default the copy is a block of busy time, not a readable event. Your coworkers see that you are unavailable, not what you are doing.
 
-Copies travel one way per connection. Events go from Nextcloud to Google, or from Google to Nextcloud, and you choose. If you want both, you set up one connection in each direction.
-
-There is no single "two-way" switch, and no button that merges the two calendars into one.
+Copies travel one way per connection: Nextcloud to Google, or Google to Nextcloud. Want both? That is one connection each way, not a single "two-way" switch.
 
 ## What you need before you start
 
@@ -33,15 +31,11 @@ There is no single "two-way" switch, and no button that merges the two calendars
 - A Google account
 - A free account on [keeper.sh](https://keeper.sh/register)
 
-If two-factor login is switched on in Nextcloud, your normal password will not work here. You need an app password: a second password that only reaches your calendar and can be cancelled on its own. Make one under **Settings → Security → Devices & sessions**.
-
-Prefer to run the whole thing on your own hardware? There is a section on that at the end. Everything up to it describes the hosted service.
+If two-factor login is switched on in Nextcloud, your normal password will not work here. An app password is a second password that only reaches your calendar and can be cancelled on its own. Make one under **Settings → Security → Devices & sessions**.
 
 ## How do you connect Nextcloud?
 
-From the dashboard, click **Import Calendars**, then **Connect CalDAV Server** at the bottom of the list.
-
-Nextcloud has no button of its own and does not need one. It speaks the same calendar standard as Google, Outlook, iCloud and Fastmail — CalDAV — so the general form is the right one.
+From the dashboard, click **Import Calendars**, then **Connect CalDAV Server** at the bottom of the list. Nextcloud has no button of its own — it speaks the same calendar standard as Google and Outlook.
 
 The page is headed **Connect CalDAV Server** and has three boxes:
 
@@ -49,28 +43,19 @@ The page is headed **Connect CalDAV Server** and has three boxes:
 2. **CalDAV Server Username** — your Nextcloud username, which is often not your email address
 3. **CalDAV Server Password** — your password, or the app password you just made
 
-Use the plain web address. Keeper asks the server where your calendars live and finds them itself. You do not need to dig out the long `remote.php/dav/` path.
+Use the plain web address. Keeper asks the server where your calendars live, so you do not need the long `remote.php/dav/` path.
 
-Click **Connect**. The button reads **Connecting...** while it works, then every calendar it found is imported at once and you land in a short setup flow.
-
-There is no "choose which ones to import" step first. You pick what to configure afterwards.
+Click **Connect**. Every calendar it found is imported at once, and you land in a short setup flow.
 
 ## How do you connect Google Calendar?
 
-Go back to **Import Calendars** and click **Connect Google Calendar**.
-
-The page is headed **Connect Google** and tells you what it will ask Google for before it sends you anywhere:
-
-- See your email address
-- View a list of your calendars
-- View events, summaries and details
-- Add or remove calendar events
+Go back to **Import Calendars** and click **Connect Google Calendar**. The page is headed **Connect Google** and lists what it will ask Google for before it sends you anywhere.
 
 Click **Connect** and approve it on Google's own screen. Keeper never sees your Google password.
 
 ## How do you tell Keeper which way events travel?
 
-The setup flow asks four things. The wording is exact, so you can follow along:
+The setup flow asks four things, word for word:
 
 1. **Which calendars would you like to configure?** Tick the ones you care about now.
 2. **Rename Your Calendars.** Nextcloud calendars arrive as "Personal", Google's as your email address. Renaming only changes what you see in Keeper.
@@ -83,93 +68,65 @@ You can change all of this later. Open the calendar under **Calendars** and use 
 
 ## Will people see my private event titles?
 
-Check this yourself before you trust it. It takes thirty seconds and it is worth doing.
+Check this yourself before you trust it. Open the calendar under **Calendars** and find **Sync Settings**. Three switches decide what travels: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
 
-Open the calendar under **Calendars** and find **Sync Settings**. Three switches decide what travels: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
+Calendars you add through **Import Calendars** arrive with all three off. Your dentist appointment reaches Google as a block named after the calendar it came from. Turn **Sync Event Name** on and real titles come through, using the **Event Name** box, which understands `{{calendar_name}}` and `{{event_name}}`.
 
-Calendars you add through **Import Calendars** arrive with all three off. Your dentist appointment reaches Google as a block named after the calendar it came from.
-
-The name on the copy comes from the **Event Name** box, which understands `{{calendar_name}}` and `{{event_name}}`. Turn **Sync Event Name** on and real titles come through.
-
-On keeper.sh these switches are a Pro feature. The dashboard says so: **Advanced sync settings are a Pro feature.** On free they stay off, which means your titles stay private whether you meant it or not.
+On keeper.sh these switches are a Pro feature. The dashboard says so: **Advanced sync settings are a Pro feature.**
 
 Below them, **Exclusions** can drop **Exclude All Day Events**. Google calendars also offer **Exclude Focus Time Events** and **Exclude Out of Office Events**.
 
 ## How fast do changes show up?
 
-Keeper reads both calendars every minute, on every plan. That part never gets slower.
-
-Getting a change onto the other calendar is the part that depends on what you pay. On free it takes up to thirty minutes. On Pro it is about a minute.
+Keeper reads both calendars every minute, on every plan. Getting that change onto the other calendar depends on your plan: up to thirty minutes on free, about a minute on Pro.
 
 If you are blocking out evenings so nobody books them, thirty minutes changes nothing. If people book you through a scheduling link, it is too slow. Do not pay for speed you will not notice.
 
 ## What does not come across?
 
-Guest lists, video call links and reminders do not travel at all. Keeper has nowhere to put them.
-
-That matters more than it sounds. A copied meeting on your Google calendar is a block of time, not a working invite. You cannot join the call from it, and nobody else on it gets notified.
-
-Guest lists are read for one thing only: showing you invitations you have not replied to yet, so you can answer them in Keeper.
+Guest lists, video call links and reminders do not travel at all. So a copied meeting is a block of time, not a working invite — you cannot join the call from it, and nobody else gets notified. Guest lists are read only to show you invitations you have not replied to yet.
 
 Keeper also looks at a fixed stretch of time — from a week ago to two years ahead. A one-off event further out than that is not copied. A repeating event that started before the window is still picked up, so its dates inside the window survive.
 
 ## What goes wrong, and what does it look like?
 
-**The page says "Invalid credentials".** Keeper reached your Nextcloud, and Nextcloud turned it away. Almost always this is two-factor login, which stops your normal password working here. Generate an app password and use that instead. Check the username too, since it is often not your email address.
+**The page says "Invalid credentials".** Keeper reached your Nextcloud, and Nextcloud turned it away. Almost always this is two-factor login, which stops your normal password working here. Use an app password instead, and check the username too.
 
-**The page says "Failed to discover calendars".** This means something different, and it is worth telling apart. Keeper never got a usable answer from the address you gave, so your username and password were never tested. Check the web address for a typo, confirm the server is up, and confirm it can be reached from outside your own network.
+**The page says "Failed to discover calendars".** This means something different. Keeper never got a usable answer from the address you gave, so your username and password were never tested. Check the web address for a typo, and confirm the server is reachable from outside your own network.
 
-**The page says "No calendars found".** Your credentials worked. Keeper just could not find any calendars to import at that address. Try the longer `remote.php/dav/calendars/username/` form instead of the base address.
+**The page says "No calendars found".** Your credentials worked, but Keeper found nothing to import at that address. Try the longer `remote.php/dav/calendars/username/` form instead.
 
-**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper refuses to work through a repeating series that would produce more than 10,000 dates in two years. Today that refusal stops the whole calendar, not just the one series. Look for something set to repeat every minute or hour, usually imported from an old calendar. Delete it and the calendar catches up on its own.
+**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper refuses to work through a repeating series producing more than 10,000 dates in two years, and today that stops the whole calendar. Delete the event repeating every minute or hour and it catches up.
 
-**A calendar goes quiet for hours after a server hiccup.** When Nextcloud stops answering, Keeper waits five minutes, then ten, then twenty, up to six hours. It backs off on purpose rather than hammering your server, and recovers by itself.
-
-**Events vanish from Google that still exist in Nextcloud.** Keeper reads your whole Nextcloud calendar each time and matches it against what it already has. If something in front of Nextcloud caps how much comes back in one response, Keeper sees a shorter calendar and removes the difference. Nextcloud does not do this on its own, but a reverse proxy with a tight response limit will.
-
-**A calendar you expected never appears.** Keeper keeps only collections that say they hold events, which is why your task lists and contacts stay behind. A calendar that does not declare it holds events is skipped too. That is rare on Nextcloud and usually a proxy stripping the answer.
+**Events vanish from Google that still exist in Nextcloud.** Keeper reads your whole Nextcloud calendar each time. If something in front of it caps how much comes back in one response, Keeper sees a shorter calendar and removes the difference. A reverse proxy with a tight response limit does this.
 
 **There is no "sync now" button.** You wait for the next round. Removing the account and adding it again is the blunt way to start clean.
 
 ## What does the free plan cover?
 
-Two calendar accounts and three connections.
+Two calendar accounts and three connections. Nextcloud is one account no matter how many calendars it holds, and Google is the second, so this pairing uses both. Adding Outlook later means upgrading.
 
-Nextcloud is one account no matter how many calendars it holds. Google is the second. So this pairing uses both, and adding Outlook later means upgrading.
-
-Three connections is enough for both directions here with one to spare. There is no cap on how many calendars an account brings in.
+Three connections covers both directions here with one to spare. There is no cap on how many calendars an account brings in.
 
 ## Do you want to run Keeper yourself?
 
-Keeper is open source under AGPL-3.0, and self-hosting it is a genuine option rather than a consolation prize. Every Pro feature is included: real event titles, exclusions, feed settings, unlimited accounts and connections, and updates every minute.
+Keeper is open source under AGPL-3.0, and self-hosting is a genuine option rather than a consolation prize. Every Pro feature is included. It is a Docker Compose stack with Postgres and Redis behind it.
 
-You already run Nextcloud, so none of this will surprise you. It is a Docker Compose stack with Postgres and Redis behind it.
+You already run Nextcloud, so you know the cost: a server, a domain, upgrades, backups, and being the one who gets paged at 7am.
 
-Be clear about the cost. You need a server, a domain and a certificate. You handle upgrades and backups. When it breaks at 7am, you are the one who gets paged. That is a real commitment on top of the Nextcloud instance you already maintain.
-
-Two settings matter for this pairing:
-
-`BLOCK_PRIVATE_RESOLUTION` stops Keeper fetching anything on a private network, which protects the server from being used to poke at things it should not reach. It is off by default, and the README says so.
-
-The deployment compose file at `deploy/compose.yaml` turns it on for the `api` and `cron` services. The compose file in the repository root does not set it at all, because it only runs Postgres, Redis and Caddy.
-
-`PRIVATE_RESOLUTION_WHITELIST` is the escape hatch when you do turn it on. It takes a comma-separated list of hostnames or addresses:
+One setting matters here. `BLOCK_PRIVATE_RESOLUTION` stops Keeper fetching anything on a private network, and `deploy/compose.yaml` turns it on for the `api` and `cron` services. `PRIVATE_RESOLUTION_WHITELIST` is the escape hatch:
 
 ```
 BLOCK_PRIVATE_RESOLUTION=true
 PRIVATE_RESOLUTION_WHITELIST=192.168.1.50,nextcloud.local
 ```
 
-Set both on `api` and `cron`, and whitelist the exact form you will paste into the connect form.
+Set both on `api` and `cron`, and whitelist the exact address you will paste into the connect form. Skip it and the connect page says **Failed to discover calendars**, without telling you why — the reason only appears in the logs.
 
-Skip it and the connect page says **Failed to discover calendars**, because Keeper refused to make the request at all. It will not tell you that was the reason. The specific message about a private or reserved address only appears in the server logs.
+On hosted keeper.sh neither setting can change, so your Nextcloud has to be reachable from the internet.
 
-On hosted keeper.sh you cannot change either. Your Nextcloud has to be reachable from the internet.
+## How do you cut access off?
 
-## One more thing about your password
+Delete the app password in Nextcloud, or delete the account under **Calendar Sources** in the dashboard.
 
-Keeper has to store your Nextcloud password in a form it can read back. CalDAV sends the password on every single request, so there is no token to hide behind.
-
-It is encrypted before it is stored, with a key you control if you self-host.
-
-Cancelling access takes one of two forms. Delete the app password in Nextcloud, or delete the account under **Calendar Sources** in the dashboard. The second removes the account and its calendars.
+Keeper stores that password in a form it can read back, because this kind of connection sends it on every request. It is encrypted before storage, with a key you control if you self-host.

--- a/applications/web/src/content/blog/sync-nextcloud-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/sync-nextcloud-calendar-with-google-calendar.mdx
@@ -14,7 +14,7 @@ tags:
 
 Your Nextcloud calendar holds your real life. Google Calendar holds your work. Neither one knows the other exists, so people book meetings over your evenings.
 
-Keeper signs into both calendars and keeps copies of your events in step. It takes about ten minutes.
+Keeper.sh signs into both calendars and keeps copies of your events in step. It takes about ten minutes.
 
 ## What does this actually do?
 
@@ -43,7 +43,7 @@ The page is headed **Connect CalDAV Server** and has three boxes:
 2. **CalDAV Server Username** — your Nextcloud username, which is often not your email address
 3. **CalDAV Server Password** — your password, or the app password you just made
 
-Use the plain web address. Keeper asks the server where your calendars live, so you do not need the long `remote.php/dav/` path.
+Use the plain web address. Keeper.sh asks the server where your calendars live, so you do not need the long `remote.php/dav/` path.
 
 Click **Connect**. Every calendar it found is imported at once, and you land in a short setup flow.
 
@@ -51,14 +51,14 @@ Click **Connect**. Every calendar it found is imported at once, and you land in 
 
 Go back to **Import Calendars** and click **Connect Google Calendar**. The page is headed **Connect Google** and lists what it will ask Google for before it sends you anywhere.
 
-Click **Connect** and approve it on Google's own screen. Keeper never sees your Google password.
+Click **Connect** and approve it on Google's own screen. Keeper.sh never sees your Google password.
 
-## How do you tell Keeper which way events travel?
+## How do you tell Keeper.sh which way events travel?
 
 The setup flow asks four things, word for word:
 
 1. **Which calendars would you like to configure?** Tick the ones you care about now.
-2. **Rename Your Calendars.** Nextcloud calendars arrive as "Personal", Google's as your email address. Renaming only changes what you see in Keeper.
+2. **Rename Your Calendars.** Nextcloud calendars arrive as "Personal", Google's as your email address. Renaming only changes what you see in Keeper.sh.
 3. **Where should 'Personal' send events?** Tick Google, and copies of your Nextcloud events start appearing there.
 4. **Where should 'Personal' pull events from?** Tick Google here to get the reverse.
 
@@ -72,13 +72,13 @@ Check this yourself before you trust it. Open the calendar under **Calendars** a
 
 Calendars you add through **Import Calendars** arrive with all three off. Your dentist appointment reaches Google as a block named after the calendar it came from. Turn **Sync Event Name** on and real titles come through, using the **Event Name** box, which understands `{{calendar_name}}` and `{{event_name}}`.
 
-On keeper.sh these switches are a Pro feature. The dashboard says so: **Advanced sync settings are a Pro feature.**
+On Keeper.sh these switches are a Pro feature. The dashboard says so: **Advanced sync settings are a Pro feature.**
 
 Below them, **Exclusions** can drop **Exclude All Day Events**. Google calendars also offer **Exclude Focus Time Events** and **Exclude Out of Office Events**.
 
 ## How fast do changes show up?
 
-Keeper reads both calendars every minute, on every plan. Getting that change onto the other calendar depends on your plan: up to thirty minutes on free, about a minute on Pro.
+Keeper.sh reads both calendars every minute, on every plan. Getting that change onto the other calendar depends on your plan: up to thirty minutes on free, about a minute on Pro.
 
 If you are blocking out evenings so nobody books them, thirty minutes changes nothing. If people book you through a scheduling link, it is too slow. Do not pay for speed you will not notice.
 
@@ -86,19 +86,19 @@ If you are blocking out evenings so nobody books them, thirty minutes changes no
 
 Guest lists, video call links and reminders do not travel at all. So a copied meeting is a block of time, not a working invite — you cannot join the call from it, and nobody else gets notified. Guest lists are read only to show you invitations you have not replied to yet.
 
-Keeper also looks at a fixed stretch of time — from a week ago to two years ahead. A one-off event further out than that is not copied. A repeating event that started before the window is still picked up, so its dates inside the window survive.
+Keeper.sh also looks at a fixed stretch of time — from a week ago to two years ahead. A one-off event further out than that is not copied. A repeating event that started before the window is still picked up, so its dates inside the window survive.
 
 ## What goes wrong, and what does it look like?
 
-**The page says "Invalid credentials".** Keeper reached your Nextcloud, and Nextcloud turned it away. Almost always this is two-factor login, which stops your normal password working here. Use an app password instead, and check the username too.
+**The page says "Invalid credentials".** Keeper.sh reached your Nextcloud, and Nextcloud turned it away. Almost always this is two-factor login, which stops your normal password working here. Use an app password instead, and check the username too.
 
-**The page says "Failed to discover calendars".** This means something different. Keeper never got a usable answer from the address you gave, so your username and password were never tested. Check the web address for a typo, and confirm the server is reachable from outside your own network.
+**The page says "Failed to discover calendars".** This means something different. Keeper.sh never got a usable answer from the address you gave, so your username and password were never tested. Check the web address for a typo, and confirm the server is reachable from outside your own network.
 
-**The page says "No calendars found".** Your credentials worked, but Keeper found nothing to import at that address. Try the longer `remote.php/dav/calendars/username/` form instead.
+**The page says "No calendars found".** Your credentials worked, but Keeper.sh found nothing to import at that address. Try the longer `remote.php/dav/calendars/username/` form instead.
 
-**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper refuses to work through a repeating series producing more than 10,000 dates in two years, and today that stops the whole calendar. Delete the event repeating every minute or hour and it catches up.
+**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper.sh refuses to work through a repeating series producing more than 10,000 dates in two years, and today that stops the whole calendar. Delete the event repeating every minute or hour and it catches up.
 
-**Events vanish from Google that still exist in Nextcloud.** Keeper reads your whole Nextcloud calendar each time. If something in front of it caps how much comes back in one response, Keeper sees a shorter calendar and removes the difference. A reverse proxy with a tight response limit does this.
+**Events vanish from Google that still exist in Nextcloud.** Keeper.sh reads your whole Nextcloud calendar each time. If something in front of it caps how much comes back in one response, Keeper.sh sees a shorter calendar and removes the difference. A reverse proxy with a tight response limit does this.
 
 **There is no "sync now" button.** You wait for the next round. Removing the account and adding it again is the blunt way to start clean.
 
@@ -108,13 +108,13 @@ Two calendar accounts and three connections. Nextcloud is one account no matter 
 
 Three connections covers both directions here with one to spare. There is no cap on how many calendars an account brings in.
 
-## Do you want to run Keeper yourself?
+## Do you want to run Keeper.sh yourself?
 
-Keeper is open source under AGPL-3.0, and self-hosting is a genuine option rather than a consolation prize. Every Pro feature is included. It is a Docker Compose stack with Postgres and Redis behind it.
+Keeper.sh is open source under AGPL-3.0, and self-hosting is a genuine option rather than a consolation prize. Every Pro feature is included. It is a Docker Compose stack with Postgres and Redis behind it.
 
 You already run Nextcloud, so you know the cost: a server, a domain, upgrades, backups, and being the one who gets paged at 7am.
 
-One setting matters here. `BLOCK_PRIVATE_RESOLUTION` stops Keeper fetching anything on a private network, and `deploy/compose.yaml` turns it on for the `api` and `cron` services. `PRIVATE_RESOLUTION_WHITELIST` is the escape hatch:
+One setting matters here. `BLOCK_PRIVATE_RESOLUTION` stops Keeper.sh fetching anything on a private network, and `deploy/compose.yaml` turns it on for the `api` and `cron` services. `PRIVATE_RESOLUTION_WHITELIST` is the escape hatch:
 
 ```
 BLOCK_PRIVATE_RESOLUTION=true
@@ -123,10 +123,10 @@ PRIVATE_RESOLUTION_WHITELIST=192.168.1.50,nextcloud.local
 
 Set both on `api` and `cron`, and whitelist the exact address you will paste into the connect form. Skip it and the connect page says **Failed to discover calendars**, without telling you why — the reason only appears in the logs.
 
-On hosted keeper.sh neither setting can change, so your Nextcloud has to be reachable from the internet.
+On hosted Keeper.sh neither setting can change, so your Nextcloud has to be reachable from the internet.
 
 ## How do you cut access off?
 
 Delete the app password in Nextcloud, or delete the account under **Calendar Sources** in the dashboard.
 
-Keeper stores that password in a form it can read back, because this kind of connection sends it on every request. It is encrypted before storage, with a key you control if you self-host.
+Keeper.sh stores that password in a form it can read back, because this kind of connection sends it on every request. It is encrypted before storage, with a key you control if you self-host.

--- a/applications/web/src/content/blog/sync-nextcloud-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/sync-nextcloud-calendar-with-google-calendar.mdx
@@ -1,106 +1,169 @@
 ---
 title: "How to Sync Nextcloud Calendar with Google Calendar"
-description: "A step-by-step guide to two-way syncing a Nextcloud calendar with Google Calendar using Keeper.sh, including the CalDAV URL to use, app passwords, and what the sync actually covers."
-blurb: "Nextcloud speaks CalDAV and Google speaks OAuth, so nothing syncs between them out of the box. Here is how I wire the two together, what URL to paste, and where the sharp edges are."
+description: "Copy events between a Nextcloud calendar and Google Calendar with Keeper.sh: what to click, who can see your event titles, and how fast changes land."
+blurb: "Your Nextcloud calendar has no idea your Google calendar exists. Here is how to get your events showing up on both, and what the copies actually look like."
 createdAt: "2026-08-11"
 slug: "sync-nextcloud-calendar-with-google-calendar"
 updatedAt: "2026-08-11"
 tags:
   - "nextcloud"
   - "google-calendar"
-  - "caldav"
   - "sync"
   - "self-hosting"
 ---
 
-Nextcloud exposes calendars over CalDAV. Google Calendar exposes them over its own OAuth API. Neither one will subscribe to the other in a way that gives you writable, two-way availability, so the usual result is a Nextcloud calendar nobody at work can see and a work calendar your personal setup knows nothing about.
+Your Nextcloud calendar holds your real life. Google Calendar holds your work. Neither one knows the other exists, so people book meetings over your evenings.
 
-This is the pairing I run myself, so it is the one I can describe honestly. Below is the actual flow, screen by screen, plus the parts that do not work the way you might expect.
+You can fix that in about ten minutes. Keeper signs into both calendars and keeps copies of your events in step.
 
-## What you need first
+## What does this actually do?
 
-- A Nextcloud instance you can reach over HTTPS from wherever Keeper runs
-- Your Nextcloud username and either your password or, if you have two-factor enabled, a [Nextcloud app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html)
+Add an event in Nextcloud and a copy appears on your Google calendar. Move it, and the copy moves. Delete it, and the copy disappears.
+
+By default the copy is a block of busy time, not a readable event. Your coworkers see that you are unavailable, not what you are doing.
+
+Copies travel one way per connection. Events go from Nextcloud to Google, or from Google to Nextcloud, and you choose. If you want both, you set up one connection in each direction.
+
+There is no single "two-way" switch, and no button that merges the two calendars into one.
+
+## What you need before you start
+
+- A Nextcloud server you can reach over the internet
+- Your Nextcloud username, and your password or an [app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html)
 - A Google account
-- A Keeper.sh account, either on [keeper.sh](https://keeper.sh/register) or a [self-hosted instance](https://github.com/ridafkih/keeper.sh)
+- A free account on [keeper.sh](https://keeper.sh/register)
 
-If you self-host Keeper and use Google as a source or destination, you also need your own Google OAuth client from Google Cloud. Nextcloud itself needs no OAuth setup at all; CalDAV is just a username and a password.
+If two-factor login is switched on in Nextcloud, your normal password will not work here. You need an app password: a second password that only reaches your calendar and can be cancelled on its own. Make one under **Settings → Security → Devices & sessions**.
 
-## Connect Nextcloud
+Prefer to run the whole thing on your own hardware? There is a section on that at the end. Everything up to it describes the hosted service.
 
-From the dashboard, open **Import Calendars**, then pick **Connect CalDAV Server** from the bottom group. Nextcloud does not have its own tile, and it does not need one. It is a standard CalDAV server.
+## How do you connect Nextcloud?
 
-The form has three fields:
+From the dashboard, click **Import Calendars**, then **Connect CalDAV Server** at the bottom of the list.
 
-- **CalDAV Server URL** — your Nextcloud base URL, for example `https://cloud.example.com`
-- **CalDAV Server Username** — your Nextcloud username, not your email address unless they happen to match
-- **CalDAV Server Password** — your password, or an app password if you use two-factor
+Nextcloud has no button of its own and does not need one. It speaks the same calendar standard as Google, Outlook, iCloud and Fastmail — CalDAV — so the general form is the right one.
 
-Use the base URL. Keeper runs standards discovery against it: it looks up the current-user principal, follows that to your calendar home set, and enumerates the collections it finds. You do not need to hunt down the `remote.php/dav/calendars/username/` path yourself. If discovery comes back empty, that longer form is a reasonable fallback, but try the base URL first.
+The page is headed **Connect CalDAV Server** and has three boxes:
 
-Two-factor is the thing that trips most people. Nextcloud rejects your login password on CalDAV once 2FA is enabled, and the failure surfaces in Keeper as `Invalid credentials`. Generate an app password under **Settings → Security → Devices & sessions** and paste that instead.
+1. **CalDAV Server URL** — your Nextcloud web address, like `https://cloud.example.com`
+2. **CalDAV Server Username** — your Nextcloud username, which is often not your email address
+3. **CalDAV Server Password** — your password, or the app password you just made
 
-Click **Connect**. Keeper imports *every* calendar it discovers on the account at once, then drops you into a short setup flow. There is no "pick which ones to import" step before that — the picking happens after.
+Use the plain web address. Keeper asks the server where your calendars live and finds them itself. You do not need to dig out the long `remote.php/dav/` path.
 
-One quiet detail worth knowing: Keeper only keeps collections that advertise support for `VEVENT`. That is what you want for a task list or a contacts collection, which get skipped. It also means a calendar on a server that omits the supported-component property entirely will not show up, which is rare on Nextcloud but does happen behind some reverse proxies.
+Click **Connect**. The button reads **Connecting...** while it works, then every calendar it found is imported at once and you land in a short setup flow.
 
-## Connect Google Calendar
+There is no "choose which ones to import" step first. You pick what to configure afterwards.
 
-Back on **Import Calendars**, choose **Connect Google Calendar**. The page lists what Keeper is about to ask Google for before it sends you anywhere:
+## How do you connect Google Calendar?
+
+Go back to **Import Calendars** and click **Connect Google Calendar**.
+
+The page is headed **Connect Google** and tells you what it will ask Google for before it sends you anywhere:
 
 - See your email address
 - View a list of your calendars
 - View events, summaries and details
 - Add or remove calendar events
 
-Press **Connect**, complete Google's consent screen, and you land back in the same setup flow. Google calendars come in with both pull and push, so any of them can be a source, a destination, or both.
+Click **Connect** and approve it on Google's own screen. Keeper never sees your Google password.
 
-## Wire up the mapping
+## How do you tell Keeper which way events travel?
 
-The setup flow is four screens:
+The setup flow asks four things. The wording is exact, so you can follow along:
 
-1. **Which calendars would you like to configure?** Check the ones you care about. Everything got imported; this is only about what you configure now.
-2. **Rename Your Calendars.** Nextcloud names default to things like "Personal", and Google to your email address. Renaming here is Keeper-local and does not touch the calendar on either provider.
-3. **Where should 'Personal' send events?** This is the outbound direction, asked once per calendar. Pick the destinations that should receive copies.
-4. **Where should 'Personal' pull events from?** The inbound direction for the same calendar.
+1. **Which calendars would you like to configure?** Tick the ones you care about now.
+2. **Rename Your Calendars.** Nextcloud calendars arrive as "Personal", Google's as your email address. Renaming only changes what you see in Keeper.
+3. **Where should 'Personal' send events?** Tick Google, and copies of your Nextcloud events start appearing there.
+4. **Where should 'Personal' pull events from?** Tick Google here to get the reverse.
 
-For a two-way setup between one Nextcloud calendar and one Google calendar, you check each in the other's list. That is two mappings, and the free tier allows three.
+Each tick is one connection. Ticking both directions is two connections, not one.
 
-If you skip the flow or want to change things later, every calendar has a detail page under **Calendars** in the dashboard with a **Send Events to Calendars** section that does the same thing.
+You can change all of this later. Open the calendar under **Calendars** and use the **Send Events to Calendars** section.
 
-## What actually gets synced
+## Will people see my private event titles?
 
-Newly connected calendars default to time only, not detail. Keeper sets every new source to strip the event name, description and location, and replaces the title with the source calendar's name. So a dentist appointment on Nextcloud lands on Google as a block titled after the calendar it came from, not "Dentist".
+Check this yourself before you trust it. It takes thirty seconds and it is worth doing.
 
-That is the behaviour most people want, and it is the default precisely because the failure mode of the opposite default is leaking a private title onto a work calendar.
+Open the calendar under **Calendars** and find **Sync Settings**. Three switches decide what travels: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
 
-If you do want real detail to pass through, the calendar detail page has a **Sync Settings** section with **Sync Event Name**, **Sync Event Description** and **Sync Event Location** toggles, all off to begin with. Turning **Sync Event Name** on switches the **Event Name** template to `{{event_name}}` and lets the true title through. While it is off, that template field stays editable and accepts `{{event_name}}` and `{{calendar_name}}`, which is how you customise the placeholder text without exposing titles. An **Exclusions** section below can drop all-day events, and for Google sources it adds **Exclude Focus Time Events** and **Exclude Out of Office Events**. Google's Working Location entries are always dropped, with no toggle.
+Calendars you add through **Import Calendars** arrive with all three off. Your dentist appointment reaches Google as a block named after the calendar it came from.
 
-These settings are Pro-gated on the hosted plan. On a self-hosted instance every user gets them.
+The name on the copy comes from the **Event Name** box, which understands `{{calendar_name}}` and `{{event_name}}`. Turn **Sync Event Name** on and real titles come through.
 
-New sources are also added to your aggregated iCal feed by default. If you do not want a calendar in the feed, untick it under **iCal Link**.
+On keeper.sh these switches are a Pro feature. The dashboard says so: **Advanced sync settings are a Pro feature.** On free they stay off, which means your titles stay private whether you meant it or not.
 
-The sync window runs from seven days ago to two years out and is not configurable. One-off events outside that range are not copied. Recurring series are treated more generously — a series whose master starts before the window is still picked up so its in-window occurrences survive.
+Below them, **Exclusions** can drop **Exclude All Day Events**. Google calendars also offer **Exclude Focus Time Events** and **Exclude Out of Office Events**.
 
-## How often it runs
+## How fast do changes show up?
 
-There are two halves, on separate schedules.
+Keeper reads both calendars every minute, on every plan. That part never gets slower.
 
-Ingestion — pulling from Nextcloud and Google into Keeper's own database — runs every minute on every plan. Pushing out to your destinations is the interval the pricing page refers to: every minute on Pro and self-hosted, every thirty minutes on free.
+Getting a change onto the other calendar is the part that depends on what you pay. On free it takes up to thirty minutes. On Pro it is about a minute.
 
-Google gets incremental sync. Keeper hands Google its sync token and only asks for what changed. CalDAV gets no such thing here: each ingestion run refetches the Nextcloud calendar within the sync window and diffs it against what Keeper already has. It works fine, but it is more work per cycle, and a very large Nextcloud calendar will feel that.
+If you are blocking out evenings so nobody books them, thirty minutes changes nothing. If people book you through a scheduling link, it is too slow. Do not pay for speed you will not notice.
 
-## Limits and rough edges
+## What does not come across?
 
-- **Free tier.** Two linked accounts and three sync mappings. Nextcloud is one account regardless of how many calendars it exposes, and Google is another, so a Nextcloud-plus-Google setup consumes the whole account allowance. Self-hosting removes both limits.
-- **Private addresses.** The bundled `compose.yaml` sets `BLOCK_PRIVATE_RESOLUTION=true`, which refuses to fetch anything resolving to a private or reserved address. If your Nextcloud lives at `192.168.1.50` or `nextcloud.local`, add it to `PRIVATE_RESOLUTION_WHITELIST`. On hosted keeper.sh you cannot do this, so your Nextcloud has to be publicly reachable.
-- **Recurring events.** Recurrence expansion is the least forgiving part of the engine. Keeper refuses to materialise a series expanding past ten thousand occurrences in the two-year window, and today that check fails the *whole calendar's* ingestion rather than just the offending series, after which the calendar backs off and retries on a widening interval. A single pathological rule — something repeating minutely, usually imported from elsewhere — can therefore stall a calendar. If a Nextcloud calendar stops updating entirely, look for a recurring event with an absurd rule before anything else.
-- **Large calendars and server response caps.** Because CalDAV is refetched in full each cycle, a server that silently caps how many objects it returns in one response will look to Keeper like a calendar that genuinely lost the remainder, and the diff will remove them from the destination. Nextcloud does not impose such a cap by default, but a reverse proxy with an aggressive response limit in front of it can produce the same effect.
-- **Nothing is bidirectional by accident.** A mapping is one direction. If you only set up "Nextcloud sends to Google", changes made in Google will not travel back.
-- **There is no force-resync button.** You wait for the next cycle. Disconnecting and reconnecting the account is the blunt instrument if you need to start clean.
+Guest lists, video call links and reminders do not travel at all. Keeper has nowhere to put them.
 
-## Credentials
+That matters more than it sounds. A copied meeting on your Google calendar is a block of time, not a working invite. You cannot join the call from it, and nobody else on it gets notified.
 
-Your Nextcloud password is encrypted at rest with a configurable encryption key before it is stored. If you self-host, that key is yours, generated during setup. Keeper needs the password in a reversible form because CalDAV basic and digest auth require replaying it on every request; there is no token exchange to hide behind.
+Guest lists are read for one thing only: showing you invitations you have not replied to yet, so you can answer them in Keeper.
 
-Revoking access is a matter of deleting the app password in Nextcloud, or deleting the account in Keeper under **Calendar Sources**, which removes the account and all its calendars.
+Keeper also looks at a fixed stretch of time — from a week ago to two years ahead. A one-off event further out than that is not copied. A repeating event that started before the window is still picked up, so its dates inside the window survive.
+
+## What goes wrong, and what does it look like?
+
+**The page shows `401 /api/sources/caldav/discover` in red.** That is a wrong username or password, shown badly. Keeper's server does say "Invalid credentials", but the dashboard throws the status code away before it reads the message. Almost always this is two-factor login. Nextcloud stops accepting your normal password once it is on. Generate an app password and use that instead.
+
+**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper refuses to work through a repeating series that would produce more than 10,000 dates in two years. Today that refusal stops the whole calendar, not just the one series. Look for something set to repeat every minute or hour, usually imported from an old calendar. Delete it and the calendar catches up on its own.
+
+**A calendar goes quiet for hours after a server hiccup.** When Nextcloud stops answering, Keeper waits five minutes, then ten, then twenty, up to six hours. It backs off on purpose rather than hammering your server, and recovers by itself.
+
+**Events vanish from Google that still exist in Nextcloud.** Keeper reads your whole Nextcloud calendar each time and matches it against what it already has. If something in front of Nextcloud caps how much comes back in one response, Keeper sees a shorter calendar and removes the difference. Nextcloud does not do this on its own, but a reverse proxy with a tight response limit will.
+
+**A calendar you expected never appears.** Keeper keeps only collections that say they hold events, which is why your task lists and contacts stay behind. A calendar that does not declare it holds events is skipped too. That is rare on Nextcloud and usually a proxy stripping the answer.
+
+**There is no "sync now" button.** You wait for the next round. Removing the account and adding it again is the blunt way to start clean.
+
+## What does the free plan cover?
+
+Two calendar accounts and three connections.
+
+Nextcloud is one account no matter how many calendars it holds. Google is the second. So this pairing uses both, and adding Outlook later means upgrading.
+
+Three connections is enough for both directions here with one to spare. There is no cap on how many calendars an account brings in.
+
+## Do you want to run Keeper yourself?
+
+Keeper is open source under AGPL-3.0, and self-hosting it is a genuine option rather than a consolation prize. Every Pro feature is included: real event titles, exclusions, feed settings, unlimited accounts and connections, and updates every minute.
+
+You already run Nextcloud, so none of this will surprise you. It is a Docker Compose stack with Postgres and Redis behind it.
+
+Be clear about the cost. You need a server, a domain and a certificate. You handle upgrades and backups. When it breaks at 7am, you are the one who gets paged. That is a real commitment on top of the Nextcloud instance you already maintain.
+
+Two settings matter for this pairing:
+
+`BLOCK_PRIVATE_RESOLUTION` stops Keeper fetching anything on a private network, which protects the server from being used to poke at things it should not reach. It is off by default, and the README says so.
+
+The deployment compose file at `deploy/compose.yaml` turns it on for the `api` and `cron` services. The compose file in the repository root does not set it at all, because it only runs Postgres, Redis and Caddy.
+
+`PRIVATE_RESOLUTION_WHITELIST` is the escape hatch when you do turn it on. It takes a comma-separated list of hostnames or addresses:
+
+```
+BLOCK_PRIVATE_RESOLUTION=true
+PRIVATE_RESOLUTION_WHITELIST=192.168.1.50,nextcloud.local
+```
+
+Set both on `api` and `cron`, and whitelist the exact form you will paste into the connect form. If you skip it, the connection fails with a message about the address being private or reserved.
+
+On hosted keeper.sh you cannot change either. Your Nextcloud has to be reachable from the internet.
+
+## One more thing about your password
+
+Keeper has to store your Nextcloud password in a form it can read back. CalDAV sends the password on every single request, so there is no token to hide behind.
+
+It is encrypted before it is stored, with a key you control if you self-host.
+
+Cancelling access takes one of two forms. Delete the app password in Nextcloud, or delete the account under **Calendar Sources** in the dashboard. The second removes the account and its calendars.

--- a/applications/web/src/content/blog/sync-radicale-with-icloud-calendar.mdx
+++ b/applications/web/src/content/blog/sync-radicale-with-icloud-calendar.mdx
@@ -14,7 +14,7 @@ tags:
 
 You run Radicale because your calendar should live on your own hardware. Then you pick up your iPhone, and none of it is there.
 
-Keeper signs into Radicale and iCloud and keeps copies of your events in step.
+Keeper.sh signs into Radicale and iCloud and keeps copies of your events in step.
 
 ## What does this actually do?
 
@@ -24,13 +24,13 @@ By default the copy is a block of busy time, not a readable event. Your notes do
 
 Copies travel one way per connection: Radicale to iCloud, or iCloud to Radicale. Want both? That is two connections, not a single "two-way" switch.
 
-## Can Keeper reach a Radicale on your home network?
+## Can Keeper.sh reach a Radicale on your home network?
 
-You need a username and password from your htpasswd file, an Apple Account with two-factor login on, and an account on [keeper.sh](https://keeper.sh/register). You also need Radicale answering on an address Keeper can reach, and that is the part to settle first.
+You need a username and password from your htpasswd file, an Apple Account with two-factor login on, and an account on [keeper.sh](https://keeper.sh/register). You also need Radicale answering on an address Keeper.sh can reach, and that is the part to settle first.
 
 Most Radicale instances sit on a home network — `192.168.1.x`, a `.local` hostname, or `localhost:5232`.
 
-**On hosted keeper.sh, private addresses are refused and you cannot change that.** Your Radicale needs to be reachable from the public internet, through a domain with a reverse proxy or a tunnel. If you will not expose it, run Keeper yourself on the same network instead.
+**On hosted Keeper.sh, private addresses are refused and you cannot change that.** Your Radicale needs to be reachable from the public internet, through a domain with a reverse proxy or a tunnel. If you will not expose it, run Keeper.sh yourself on the same network instead.
 
 The setting behind this is `BLOCK_PRIVATE_RESOLUTION`. It is off by default, but `deploy/compose.yaml` turns it on for the `api` and `cron` services. `PRIVATE_RESOLUTION_WHITELIST` is the exemption list:
 
@@ -59,7 +59,7 @@ Click **Connect**. Every calendar found is imported at once and you land in a sh
 
 Apple will not let outside apps sign in with your normal Apple password, which opens your photos, purchases and Find My. You generate a separate app-specific password instead, which only reaches your calendar.
 
-Keeper's connect page lists the steps, matching Apple's own [instructions](https://support.apple.com/en-us/102654):
+Keeper.sh's connect page lists the steps, matching Apple's own [instructions](https://support.apple.com/en-us/102654):
 
 1. Navigate to iCloud Apple ID
 2. Sign in with your Apple ID
@@ -77,12 +77,12 @@ Then click **Connect iCloud** on **Import Calendars**. The page is headed **Conn
 
 No server address is needed here.
 
-## How do you tell Keeper which way events travel?
+## How do you tell Keeper.sh which way events travel?
 
 Setup asks four questions, word for word:
 
 1. **Which calendars would you like to configure?** Tick the ones you want now.
-2. **Rename Your Calendars.** Radicale collections often arrive named after directories. Renaming only changes what you see in Keeper.
+2. **Rename Your Calendars.** Radicale collections often arrive named after directories. Renaming only changes what you see in Keeper.sh.
 3. **Where should 'Personal' send events?** Tick iCloud, and copies start appearing on your phone.
 4. **Where should 'Personal' pull events from?** Tick iCloud here for the reverse.
 
@@ -94,11 +94,11 @@ Open the calendar under **Calendars** and find **Sync Settings**. Three switches
 
 Calendars added through **Import Calendars** arrive with all three off, at both ends, so Radicale and iCloud exchange opaque blocks. Turn **Sync Event Name** on for real titles, shaped by the **Event Name** box, which understands `{{calendar_name}}` and `{{event_name}}`.
 
-On keeper.sh this is a Pro feature — the dashboard says **Advanced sync settings are a Pro feature.** Run Keeper yourself and every user on the instance gets it. Below, **Exclusions** can drop **Exclude All Day Events**.
+On Keeper.sh this is a Pro feature — the dashboard says **Advanced sync settings are a Pro feature.** Run Keeper.sh yourself and every user on the instance gets it. Below, **Exclusions** can drop **Exclude All Day Events**.
 
 ## How fast do changes show up?
 
-Keeper reads both calendars every minute, on every plan. Getting that change onto the other calendar depends on the plan: up to thirty minutes on free, about a minute on Pro and on your own instance.
+Keeper.sh reads both calendars every minute, on every plan. Getting that change onto the other calendar depends on the plan: up to thirty minutes on free, about a minute on Pro and on your own instance.
 
 If you are mirroring Radicale so your phone knows you are busy, thirty minutes changes nothing. If people book you through a scheduling link, it is too slow.
 
@@ -106,19 +106,19 @@ If you are mirroring Radicale so your phone knows you are busy, thirty minutes c
 
 Guest lists, video call links and reminders do not travel at all, so a copied meeting is a block of time rather than a working invite. Guest lists are read only to show you invitations you have not answered yet.
 
-Keeper also looks at a fixed stretch of time — from a week ago to two years ahead. A one-off event further out is not copied. A repeating event that began before the window is still picked up, so its dates inside the window survive.
+Keeper.sh also looks at a fixed stretch of time — from a week ago to two years ahead. A one-off event further out is not copied. A repeating event that began before the window is still picked up, so its dates inside the window survive.
 
 ## What goes wrong, and what does it look like?
 
 **The page says "Invalid credentials".** The server was reached and rejected the sign-in. On the Radicale side, check the details against your htpasswd file. On the iCloud side, the normal Apple password was pasted, or the app-specific one has been cancelled.
 
-**The page says "Failed to discover calendars".** This means something different. Keeper never got a usable answer from that address, so the credentials were never tested. Check the address for a typo, confirm Radicale is running, and if you self-host, check the private-address setting above.
+**The page says "Failed to discover calendars".** This means something different. Keeper.sh never got a usable answer from that address, so the credentials were never tested. Check the address for a typo, confirm Radicale is running, and if you self-host, check the private-address setting above.
 
-**The page says "No calendars found".** Your credentials worked, but Keeper found nothing to import at that address. This is when to try `https://radicale.example.com/username/` with the trailing slash.
+**The page says "No calendars found".** Your credentials worked, but Keeper.sh found nothing to import at that address. This is when to try `https://radicale.example.com/username/` with the trailing slash.
 
-**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper refuses to work through a repeating series producing more than 10,000 dates in two years, and today that stops the whole calendar. Delete the runaway event and it catches up.
+**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper.sh refuses to work through a repeating series producing more than 10,000 dates in two years, and today that stops the whole calendar. Delete the runaway event and it catches up.
 
-**Events disappear from iCloud that still exist in Radicale.** Keeper reads the whole calendar each round. If a proxy in front of Radicale caps how many items come back in one response, Keeper sees a shorter calendar and removes the difference.
+**Events disappear from iCloud that still exist in Radicale.** Keeper.sh reads the whole calendar each round. If a proxy in front of Radicale caps how many items come back in one response, Keeper.sh sees a shorter calendar and removes the difference.
 
 **There is no "sync now" button.** You wait for the next round.
 
@@ -130,9 +130,9 @@ Two calendar accounts and three connections. Radicale is one account no matter h
 
 Three connections covers both directions with one spare, and there is no cap on how many calendars an account brings in.
 
-## Would you rather run Keeper yourself?
+## Would you rather run Keeper.sh yourself?
 
-You already run Radicale, so this will not frighten you, and for a calendar server on your own network it is often the better fit. Keeper is open source under AGPL-3.0. Run it yourself and every user on the instance gets Pro behaviour, with nothing held back.
+You already run Radicale, so this will not frighten you, and for a calendar server on your own network it is often the better fit. Keeper.sh is open source under AGPL-3.0. Run it yourself and every user on the instance gets Pro behaviour, with nothing held back.
 
 It is a Docker Compose stack with Postgres and Redis behind it, documented in the [repository](https://github.com/ridafkih/keeper.sh). Running it beside Radicale is what makes `PRIVATE_RESOLUTION_WHITELIST` useful, and means you never expose Radicale at all.
 
@@ -142,4 +142,4 @@ The cost is real. Another service to upgrade, another database to back up, anoth
 
 Delete the app-specific password at Apple, or delete the account under **Calendar Sources** in the dashboard.
 
-Keeper stores both passwords in a form it can read back, because this kind of connection sends the password on every request. They are encrypted first, with a key you control if you self-host.
+Keeper.sh stores both passwords in a form it can read back, because this kind of connection sends the password on every request. They are encrypted first, with a key you control if you self-host.

--- a/applications/web/src/content/blog/sync-radicale-with-icloud-calendar.mdx
+++ b/applications/web/src/content/blog/sync-radicale-with-icloud-calendar.mdx
@@ -14,57 +14,36 @@ tags:
 
 You run Radicale because your calendar should live on your own hardware. Then you pick up your iPhone, and none of it is there.
 
-Radicale has no idea anything else exists. Whatever you put in it stays in it.
-
-Keeper signs into Radicale and iCloud and keeps copies of your events in step, so the same appointments show up in both.
+Keeper signs into Radicale and iCloud and keeps copies of your events in step.
 
 ## What does this actually do?
 
 Add an event in Radicale and a copy appears in iCloud, which means it appears on your iPhone. Move it, the copy moves. Delete it, the copy goes.
 
-By default the copy is a block of busy time, not a readable event. That is worth knowing before you assume your notes came along.
+By default the copy is a block of busy time, not a readable event. Your notes do not come along.
 
-Copies travel one way per connection. You choose Radicale to iCloud, iCloud to Radicale, or both. Both means two connections, one each way.
-
-There is no single "two-way" switch.
-
-## What you need before you start
-
-- A Radicale server reachable over HTTP or HTTPS from wherever Keeper runs
-- A username and password from your htpasswd file
-- An Apple Account with two-factor login switched on
-- An account on [keeper.sh](https://keeper.sh/register), or your own Keeper instance
-
-Only `http:` and `https:` addresses work. There is no way to point Keeper at a Unix socket.
-
-Most of this guide describes hosted keeper.sh, because that is the quickest way to get this working even if you already run servers. Running Keeper yourself is covered at the end, and it is a perfectly good choice.
+Copies travel one way per connection: Radicale to iCloud, or iCloud to Radicale. Want both? That is two connections, not a single "two-way" switch.
 
 ## Can Keeper reach a Radicale on your home network?
 
-Read this before anything else. It decides whether the hosted route works for you at all.
+You need a username and password from your htpasswd file, an Apple Account with two-factor login on, and an account on [keeper.sh](https://keeper.sh/register). You also need Radicale answering on an address Keeper can reach, and that is the part to settle first.
 
-Most Radicale instances sit on a home network — `192.168.1.x`, a `.local` hostname, or `localhost:5232` on the box that runs everything.
+Most Radicale instances sit on a home network — `192.168.1.x`, a `.local` hostname, or `localhost:5232`.
 
-**On hosted keeper.sh, private addresses are refused and you cannot change that.** Your Radicale needs to be reachable from the public internet. A domain with a reverse proxy in front works, or a tunnel. If you are not willing to expose it, run Keeper yourself on the same network instead.
+**On hosted keeper.sh, private addresses are refused and you cannot change that.** Your Radicale needs to be reachable from the public internet, through a domain with a reverse proxy or a tunnel. If you will not expose it, run Keeper yourself on the same network instead.
 
-The setting behind this is `BLOCK_PRIVATE_RESOLUTION`, which stops the server fetching anything that resolves to a private or reserved address. It is off by default in the code and in the compose file at the repository root, which only runs Postgres, Redis and Caddy. The deployment compose file at `deploy/compose.yaml` turns it on for the `api` and `cron` services, and the README documents the default as `false`.
-
-If you self-host and turn it on, `PRIVATE_RESOLUTION_WHITELIST` is the exemption list:
+The setting behind this is `BLOCK_PRIVATE_RESOLUTION`. It is off by default, but `deploy/compose.yaml` turns it on for the `api` and `cron` services. `PRIVATE_RESOLUTION_WHITELIST` is the exemption list:
 
 ```
 BLOCK_PRIVATE_RESOLUTION=true
 PRIVATE_RESOLUTION_WHITELIST=192.168.1.50,radicale.local,10.0.2.12
 ```
 
-Set both on `api` and `cron`, and whitelist the exact host and port you are going to paste into the form. Restart both afterwards.
-
-Skip it and the connect page says **Failed to discover calendars**, because Keeper refused to make the request at all. It will not tell you that was the reason. The specific message about a private or reserved address only appears in the server logs, so check there before assuming Radicale is at fault.
+Set both on `api` and `cron`, whitelist the exact host and port you will paste into the form, and restart both. Skip it and the connect page says **Failed to discover calendars**, without telling you why. The reason only appears in the logs.
 
 ## How do you connect Radicale?
 
-From the dashboard, click **Import Calendars**, then **Connect CalDAV Server** at the bottom.
-
-Radicale has no button of its own. It speaks the same calendar standard as iCloud, Google and Outlook — CalDAV — so the general form is the right one.
+From the dashboard, click **Import Calendars**, then **Connect CalDAV Server** at the bottom. Radicale has no button of its own, and does not need one.
 
 The page is headed **Connect CalDAV Server** and has three boxes:
 
@@ -72,19 +51,13 @@ The page is headed **Connect CalDAV Server** and has three boxes:
 - **CalDAV Server Username** — your username from htpasswd
 - **CalDAV Server Password** — the matching password
 
-Start with the plain address. Keeper asks the server where your calendars live and follows that to the collections.
+Start with the plain address. If nothing turns up, use your user collection root instead — `https://radicale.example.com/username/`, with the trailing slash. Radicale's htpasswd backend puts your password on the wire with every request, so put HTTPS in front of it.
 
-If nothing turns up, point it at your user collection root instead — `https://radicale.example.com/username/`, with the trailing slash. Radicale keeps collections directly under `/USERNAME/`, and going straight there skips the discovery step that some reverse proxy setups interfere with. Try that before assuming something is broken.
-
-Radicale's htpasswd backend uses basic authentication, which puts your password on the wire with every single request. Put HTTPS in front of it.
-
-Click **Connect**. Every calendar found is imported at once and you land in a short setup flow.
-
-Keeper keeps only collections that declare they hold events, so your task lists and address books are skipped correctly. If a calendar you expected is missing, check that the collection actually declares events in its supported component set. One created without that will be filtered out even though it holds events.
+Click **Connect**. Every calendar found is imported at once and you land in a short setup flow. Task lists and address books are skipped.
 
 ## How do you connect iCloud?
 
-Apple will not let outside apps sign in with your normal Apple password. That one opens your photos, purchases and Find My. You generate a separate app-specific password instead, which only reaches your calendar and can be cancelled on its own.
+Apple will not let outside apps sign in with your normal Apple password, which opens your photos, purchases and Find My. You generate a separate app-specific password instead, which only reaches your calendar.
 
 Keeper's connect page lists the steps, matching Apple's own [instructions](https://support.apple.com/en-us/102654):
 
@@ -95,108 +68,78 @@ Keeper's connect page lists the steps, matching Apple's own [instructions](https
 5. Label and generate the password, then copy it
 6. Paste the app-specific password below
 
-That section only appears if two-factor login is on. Apple shows the password once, so copy it before closing the box.
+That section only appears if two-factor login is on, and Apple shows the password once.
 
-Then go to **Import Calendars** and click **Connect iCloud**. The page is headed **Connect Apple Calendar**, and has two boxes:
+Then click **Connect iCloud** on **Import Calendars**. The page is headed **Connect Apple Calendar**, and has two boxes:
 
 - **Apple ID** — your Apple sign-in address
 - **App-Specific Password** — the one you just generated
 
-No server address is needed. Keeper already knows where iCloud keeps calendars.
+No server address is needed here.
 
 ## How do you tell Keeper which way events travel?
 
 Setup asks four questions, word for word:
 
 1. **Which calendars would you like to configure?** Tick the ones you want now.
-2. **Rename Your Calendars.** Radicale collections often arrive with names taken from directories, so this is more useful here than usual. Renaming only changes what you see in Keeper.
+2. **Rename Your Calendars.** Radicale collections often arrive named after directories. Renaming only changes what you see in Keeper.
 3. **Where should 'Personal' send events?** Tick iCloud, and copies start appearing on your phone.
 4. **Where should 'Personal' pull events from?** Tick iCloud here for the reverse.
 
-Both ends of this pairing can send and receive, so either can be the one events come from.
-
-Each tick is one connection. Both directions is two connections. Change any of it later from the calendar under **Calendars**, in the **Send Events to Calendars** section.
+Each tick is one connection. Change any of it later from the calendar under **Calendars**, in the **Send Events to Calendars** section.
 
 ## Will the copies carry real event titles?
 
-Check before you assume either way. It takes thirty seconds.
-
 Open the calendar under **Calendars** and find **Sync Settings**. Three switches decide what travels: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
 
-Calendars added through **Import Calendars** arrive with all three off. Both ends of this pairing behave that way, so out of the box Radicale and iCloud exchange opaque blocks rather than content.
+Calendars added through **Import Calendars** arrive with all three off, at both ends, so Radicale and iCloud exchange opaque blocks. Turn **Sync Event Name** on for real titles, shaped by the **Event Name** box, which understands `{{calendar_name}}` and `{{event_name}}`.
 
-The name on the copy comes from the **Event Name** box, which understands `{{calendar_name}}` and `{{event_name}}`. Turn **Sync Event Name** on to let real titles through.
-
-On keeper.sh this is a Pro feature — the dashboard says **Advanced sync settings are a Pro feature.** Run Keeper yourself and every user on the instance gets it.
-
-Below, **Exclusions** can drop **Exclude All Day Events**.
+On keeper.sh this is a Pro feature — the dashboard says **Advanced sync settings are a Pro feature.** Run Keeper yourself and every user on the instance gets it. Below, **Exclusions** can drop **Exclude All Day Events**.
 
 ## How fast do changes show up?
 
-Keeper reads both calendars every minute, on every plan. That never gets slower.
+Keeper reads both calendars every minute, on every plan. Getting that change onto the other calendar depends on the plan: up to thirty minutes on free, about a minute on Pro and on your own instance.
 
-Getting a change onto the other calendar depends on the plan. On free it takes up to thirty minutes. On Pro and on your own instance it is about a minute.
-
-If you are mirroring your Radicale calendar so your phone knows you are busy, thirty minutes changes nothing. If people book you through a scheduling link, it is too slow.
-
-Nothing needs to reach Keeper from outside. It checks on a timer rather than waiting to be told, so there is no callback address to expose.
+If you are mirroring Radicale so your phone knows you are busy, thirty minutes changes nothing. If people book you through a scheduling link, it is too slow.
 
 ## What does not come across?
 
-Guest lists, video call links and reminders do not travel at all. Keeper has nowhere to store them.
-
-So a copied meeting is a block of time, not a working invite. Guest lists are read for one thing only: showing you invitations you have not answered yet, so you can reply from Keeper.
+Guest lists, video call links and reminders do not travel at all, so a copied meeting is a block of time rather than a working invite. Guest lists are read only to show you invitations you have not answered yet.
 
 Keeper also looks at a fixed stretch of time — from a week ago to two years ahead. A one-off event further out is not copied. A repeating event that began before the window is still picked up, so its dates inside the window survive.
 
 ## What goes wrong, and what does it look like?
 
-**The page says "Invalid credentials".** The server was reached and rejected the sign-in. On the Radicale side, check the username and password against your htpasswd file. On the iCloud side it usually means the normal Apple password was pasted, or the app-specific one has been cancelled.
+**The page says "Invalid credentials".** The server was reached and rejected the sign-in. On the Radicale side, check the details against your htpasswd file. On the iCloud side, the normal Apple password was pasted, or the app-specific one has been cancelled.
 
-**The page says "Failed to discover calendars".** This means something different, and it is worth telling apart. Keeper never got a usable answer from that address, so the credentials were never tested. Check the address for a typo and confirm Radicale is running. If you host Keeper yourself, the private-address setting above produces this same message.
+**The page says "Failed to discover calendars".** This means something different. Keeper never got a usable answer from that address, so the credentials were never tested. Check the address for a typo, confirm Radicale is running, and if you self-host, check the private-address setting above.
 
-**The page says "No calendars found".** Your credentials worked. Keeper reached Radicale and found nothing to import at that address. This is when to try `https://radicale.example.com/username/` with the trailing slash.
+**The page says "No calendars found".** Your credentials worked, but Keeper found nothing to import at that address. This is when to try `https://radicale.example.com/username/` with the trailing slash.
 
-**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper refuses to work through a repeating series that would produce more than 10,000 dates in two years. Today that refusal stops the whole calendar, not just the one series. A calendar going completely silent, rather than losing one event, is the signature. Delete the runaway event and it catches up on its own.
+**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper refuses to work through a repeating series producing more than 10,000 dates in two years, and today that stops the whole calendar. Delete the runaway event and it catches up.
 
-**A calendar goes quiet for hours, then recovers.** After a failed request Keeper waits five minutes, then ten, then twenty, up to six hours. It backs off on purpose and comes back by itself.
+**Events disappear from iCloud that still exist in Radicale.** Keeper reads the whole calendar each round. If a proxy in front of Radicale caps how many items come back in one response, Keeper sees a shorter calendar and removes the difference.
 
-**Events disappear from iCloud that still exist in Radicale.** Keeper reads the whole calendar each round and matches it against what it already has. If something in front of Radicale caps how many items come back in one response, Keeper sees a shorter calendar and removes the difference. Radicale does not cap by default, but a restrictive proxy will.
+**There is no "sync now" button.** You wait for the next round.
 
-**You hand-edited a file and something odd happened.** Radicale stores collections as plain files. Editing them under a live sync is a poor idea — Keeper reads the result on its next round and acts on it.
-
-**There is no "sync now" button.** You wait for the next round. Removing the account and adding it again is the blunt way to start clean.
-
-## How do you tell whether it is working?
-
-The dashboard shows sync status live, so you can watch a round happen rather than guess.
-
-**View Events** lists what Keeper currently holds. That tells you which half of the problem you have. Events present there but missing in iCloud is a connection or delivery problem. Events missing there is a Radicale connection problem.
-
-Each calendar's page has a **Calendar Information** section showing its type, what it can do, and the address Keeper resolved. If discovery landed somewhere unexpected on Radicale, that is where you will see it.
+To tell which half of a problem you have, open **View Events**. Events listed there but missing in iCloud is a delivery problem. Events missing there is a Radicale problem.
 
 ## What does the free plan cover?
 
-Two calendar accounts and three connections.
+Two calendar accounts and three connections. Radicale is one account no matter how many collections it holds, and iCloud is the second, so this pairing uses both. Adding Google later means upgrading.
 
-Radicale is one account no matter how many collections it holds. iCloud is the second. So this pairing uses both, and adding Google later means upgrading.
-
-Three connections covers both directions here with one spare. There is no cap on how many calendars an account brings in.
+Three connections covers both directions with one spare, and there is no cap on how many calendars an account brings in.
 
 ## Would you rather run Keeper yourself?
 
-You already run Radicale, so this will not frighten you. For a calendar server on your own network it is often the better fit.
+You already run Radicale, so this will not frighten you, and for a calendar server on your own network it is often the better fit. Keeper is open source under AGPL-3.0. Run it yourself and every user on the instance gets Pro behaviour, with nothing held back.
 
-Keeper is open source under AGPL-3.0. Run it yourself and every user on the instance gets Pro behaviour. That means real event titles, exclusions, feed settings, unlimited accounts and connections, and updates every minute. Nothing is held back.
+It is a Docker Compose stack with Postgres and Redis behind it, documented in the [repository](https://github.com/ridafkih/keeper.sh). Running it beside Radicale is what makes `PRIVATE_RESOLUTION_WHITELIST` useful, and means you never expose Radicale at all.
 
-It is a Docker Compose stack with Postgres and Redis behind it, and the setup guide is in the [repository](https://github.com/ridafkih/keeper.sh). Running it on the same network as Radicale is what makes `PRIVATE_RESOLUTION_WHITELIST` above useful, and means you never have to expose Radicale to the internet.
+The cost is real. Another service to upgrade, another database to back up, another thing that pages you when it stops.
 
-The cost is real, though. Another service to upgrade, another database to back up, another thing that pages you when it stops. You are already carrying that for Radicale, so you know exactly what it feels like.
+## How do you cut access off?
 
-## One more thing about your passwords
+Delete the app-specific password at Apple, or delete the account under **Calendar Sources** in the dashboard.
 
-Keeper stores both passwords in a form it can read back, because this kind of calendar connection sends the password on every single request. There is no token to hide behind.
-
-They are encrypted before storage using your `ENCRYPTION_KEY`. Self-host and that key never leaves your infrastructure — which also means losing it makes the stored credentials unrecoverable.
-
-Cancelling access is deleting the app-specific password at Apple, or deleting the account under **Calendar Sources** in the dashboard, which removes it and its calendars.
+Keeper stores both passwords in a form it can read back, because this kind of connection sends the password on every request. They are encrypted first, with a key you control if you self-host.

--- a/applications/web/src/content/blog/sync-radicale-with-icloud-calendar.mdx
+++ b/applications/web/src/content/blog/sync-radicale-with-icloud-calendar.mdx
@@ -1,0 +1,133 @@
+---
+title: "How to Sync Radicale with iCloud Calendar"
+description: "A step-by-step guide to two-way syncing a self-hosted Radicale CalDAV server with iCloud Calendar using Keeper.sh, including server URLs, private network access, and known limits."
+blurb: "Radicale is a small CalDAV server that does one job well and knows nothing about the outside world. Here is how I sync it with iCloud, including the private-network setting that catches most self-hosters."
+createdAt: "2026-08-11"
+slug: "sync-radicale-with-icloud-calendar"
+updatedAt: "2026-08-11"
+tags:
+  - "radicale"
+  - "icloud"
+  - "caldav"
+  - "self-hosting"
+  - "sync"
+---
+
+Radicale is about as small as a CalDAV server gets. A Python process, a directory of files, an htpasswd file, done. That minimalism is the appeal, and it is also why it has no notion of syncing with anything else. Whatever you put in Radicale stays in Radicale.
+
+iCloud is the opposite kind of system, and it also speaks CalDAV. Since both ends talk the same protocol, this pairing is entirely credentials and mappings — no OAuth applications, no cloud console, nothing to register anywhere.
+
+This one is aimed at self-hosters, so it spends more time on the network details than the others.
+
+## Before you start
+
+- A Radicale instance reachable over HTTP or HTTPS from wherever Keeper runs
+- A Radicale username and password from your htpasswd file
+- An Apple Account with two-factor authentication enabled
+- A Keeper.sh instance, hosted or [self-hosted](https://github.com/ridafkih/keeper.sh)
+
+Only `http:` and `https:` URLs are accepted. There is no way to point Keeper at a Unix socket or a non-HTTP transport.
+
+## The private network problem
+
+Read this before anything else, because it determines whether this works at all.
+
+Most Radicale instances live on a home network — `192.168.1.x`, `10.x`, a `.local` hostname, or `localhost:5232` on the machine that runs everything. Keeper refuses to fetch URLs resolving to private or reserved addresses when `BLOCK_PRIVATE_RESOLUTION` is on, which is a deliberate defence against server-side request forgery. The bundled `compose.yaml` turns it on.
+
+So:
+
+**On hosted keeper.sh**, private addresses are blocked and you cannot change that. Your Radicale has to be reachable from the public internet — a domain with a reverse proxy in front of it, or a tunnel. There is no way around this from the dashboard, and it is not a bug.
+
+**On a self-hosted Keeper**, add the host to `PRIVATE_RESOLUTION_WHITELIST` on both the `api` and `cron` services. It takes a comma-separated list of hostnames or IPs:
+
+```
+BLOCK_PRIVATE_RESOLUTION=true
+PRIVATE_RESOLUTION_WHITELIST=192.168.1.50,radicale.local,10.0.2.12
+```
+
+The check runs against the host as written and against everything the hostname resolves to, so whitelist the exact form you are going to paste into the connect form. Restart both services afterwards.
+
+If you skip this, connecting fails with a message about the URL pointing to a private or reserved network address. That error means exactly what it says, and it is the single most common reason this setup does not work on the first try.
+
+## Connect Radicale
+
+From the dashboard, open **Import Calendars**, then choose **Connect CalDAV Server** from the bottom group. Radicale has no dedicated tile; the generic CalDAV form is the right one.
+
+Three fields:
+
+- **CalDAV Server URL** — your Radicale base URL, for example `https://radicale.example.com`
+- **CalDAV Server Username** — your Radicale username from htpasswd
+- **CalDAV Server Password** — the matching password
+
+Start with the base URL. Keeper performs standards discovery: it asks the server for the current-user principal, follows that to the calendar home set, and enumerates the collections underneath.
+
+If that turns up nothing, try your user collection root instead — `https://radicale.example.com/username/`, with the trailing slash. Radicale organises collections as direct children of `/USERNAME/`, and pointing straight at that path skips the discovery step that some reverse proxy configurations interfere with. This is the fallback worth trying before you assume something is broken.
+
+Keeper handles both basic and digest authentication and works out which one your server wants on the first request. Radicale's htpasswd backend uses basic auth, so put HTTPS in front of it — basic auth over plain HTTP puts your password on the wire in every request.
+
+Press **Connect**. Every discovered calendar is imported at once, and you land in setup.
+
+One Radicale-specific note: Keeper only keeps collections advertising support for events. Radicale's task lists and address books are correctly skipped. But if a collection you expect is missing, check that it actually declares `VEVENT` in its supported component set — a collection created without that property will be filtered out even though it holds events.
+
+## Connect iCloud
+
+iCloud needs an app-specific password. Your Apple Account password will not work over CalDAV.
+
+1. Go to [appleid.apple.com](https://appleid.apple.com) and sign in
+2. Select **App-Specific Passwords**
+3. Click the **+** next to **Passwords**
+4. Label and generate it, then copy the 16-character password
+
+Apple's own documentation is [Sign in to apps with your Apple Account using app-specific passwords](https://support.apple.com/en-us/102654). The section only appears if two-factor authentication is on.
+
+Then in Keeper, **Import Calendars → Connect iCloud**, and fill in:
+
+- **Apple ID** — your Apple sign-in address
+- **App-Specific Password** — the password you just generated
+
+No server URL is needed; Keeper knows iCloud is at `https://caldav.icloud.com/`.
+
+## Wire up the mapping
+
+Setup asks four questions:
+
+1. **Which calendars would you like to configure?**
+2. **Rename Your Calendars.** Radicale collections often arrive with directory-derived names, so this is more useful here than usual. Renaming only affects Keeper.
+3. **Where should 'Personal' send events?** Outbound.
+4. **Where should 'Personal' pull events from?** Inbound.
+
+Both CalDAV ends can pull and push, so either can be a source, a destination, or both. Two-way syncing between one Radicale calendar and one iCloud calendar is two mappings.
+
+## What actually gets synced
+
+Time, not detail. Newly connected calendars default to stripping the event name, description and location, and titling the copy after the source calendar. Both directions of this pairing behave that way, so out of the box Radicale and iCloud exchange opaque blocks rather than content.
+
+The calendar detail page has a **Sync Settings** section with **Sync Event Name**, **Sync Event Description** and **Sync Event Location** toggles, all off initially. Turning **Sync Event Name** on switches the **Event Name** template to `{{event_name}}` and passes the real title. While it is off, that template field stays editable and understands `{{event_name}}` and `{{calendar_name}}`. An **Exclusions** section can drop all-day events. On a self-hosted instance all of this is available to every user; on hosted keeper.sh it is Pro-only.
+
+New sources also join the aggregated iCal feed by default, which you can change under **iCal Link**.
+
+The sync window runs from seven days ago to two years ahead and is not configurable. One-off events outside it are skipped; recurring series whose master starts before the window are still collected.
+
+## How often it runs
+
+Ingestion runs every minute on every plan. Pushing to destinations runs every minute on self-hosted and Pro, and every thirty minutes on free.
+
+Neither end of this pairing gets incremental sync. Sync tokens and delta links are a Google and Outlook feature; CalDAV sources are refetched inside the sync window on every ingestion run and diffed against stored state. For Radicale that is usually irrelevant, since it is your own server and the calendars are small. For iCloud it means a steady stream of requests you are not in control of.
+
+Nothing needs to reach your Keeper instance from outside. It polls; there are no webhooks or push notifications to expose.
+
+## Limits and rough edges
+
+- **Self-hosting removes the tier limits.** When Keeper runs outside commercial mode, every user on the instance gets Pro behaviour: unlimited linked accounts, unlimited mappings, event filters and feed customisation. On hosted keeper.sh it is two accounts and three mappings on free, and Radicale plus iCloud uses both account slots.
+- **Credentials are stored encrypted, not hashed.** CalDAV requires replaying the password on every request, so Keeper encrypts both passwords at rest with your `ENCRYPTION_KEY` rather than one-way hashing them. Self-hosting means that key never leaves your infrastructure. It also means you are responsible for it — lose it and stored credentials become unrecoverable.
+- **Radicale's own storage is a directory of files.** If you edit files under Radicale's collection root by hand while syncing is running, Keeper will see the result on its next pass and reconcile it. That is usually what you want, but it makes hand-editing a live sync target a poor idea.
+- **Recurring events.** Keeper refuses to materialise a series expanding past ten thousand occurrences inside the two-year window, and that check currently fails the whole calendar's ingestion rather than isolating the offending series. A calendar that stops updating outright, rather than losing one event, is the signature.
+- **Response caps truncate silently.** CalDAV is refetched in full every cycle with no pagination. If a server or proxy caps how many objects come back in one response, Keeper sees a calendar that appears to have lost the remainder and removes them from the destination accordingly. Radicale does not cap by default, but it is worth knowing before you put something restrictive in front of it.
+- **Directions are separate.** Each mapping is one-way, and you set them independently.
+- **No manual resync.** There is no "sync now" control. You wait for the next cycle, or remove and re-add the account.
+
+## Checking it worked
+
+The dashboard shows live sync status over a WebSocket, so you can watch a cycle happen rather than guess. **View Events** lists what Keeper has ingested, which is the fastest way to tell an ingestion problem from a push problem: events present there but missing on the destination is a mapping or push issue, events missing there is a source connection issue.
+
+Each calendar's detail page has a **Calendar Information** section showing its type, its capabilities, and the resolved calendar URL. If discovery landed somewhere unexpected on Radicale, that URL is where you will see it.

--- a/applications/web/src/content/blog/sync-radicale-with-icloud-calendar.mdx
+++ b/applications/web/src/content/blog/sync-radicale-with-icloud-calendar.mdx
@@ -1,133 +1,198 @@
 ---
 title: "How to Sync Radicale with iCloud Calendar"
-description: "A step-by-step guide to two-way syncing a self-hosted Radicale CalDAV server with iCloud Calendar using Keeper.sh, including server URLs, private network access, and known limits."
-blurb: "Radicale is a small CalDAV server that does one job well and knows nothing about the outside world. Here is how I sync it with iCloud, including the private-network setting that catches most self-hosters."
+description: "Connect a self-hosted Radicale calendar server to iCloud with Keeper.sh: server addresses, the private-network setting that catches self-hosters, and what the copies look like."
+blurb: "Radicale keeps your calendar on your own hardware and tells nothing else about it. Here is how to get those events onto your iPhone through iCloud."
 createdAt: "2026-08-11"
 slug: "sync-radicale-with-icloud-calendar"
 updatedAt: "2026-08-11"
 tags:
   - "radicale"
   - "icloud"
-  - "caldav"
   - "self-hosting"
   - "sync"
 ---
 
-Radicale is about as small as a CalDAV server gets. A Python process, a directory of files, an htpasswd file, done. That minimalism is the appeal, and it is also why it has no notion of syncing with anything else. Whatever you put in Radicale stays in Radicale.
+You run Radicale because your calendar should live on your own hardware. Then you pick up your iPhone, and none of it is there.
 
-iCloud is the opposite kind of system, and it also speaks CalDAV. Since both ends talk the same protocol, this pairing is entirely credentials and mappings — no OAuth applications, no cloud console, nothing to register anywhere.
+Radicale has no idea anything else exists. Whatever you put in it stays in it.
 
-This one is aimed at self-hosters, so it spends more time on the network details than the others.
+Keeper signs into Radicale and iCloud and keeps copies of your events in step, so the same appointments show up in both.
 
-## Before you start
+## What does this actually do?
 
-- A Radicale instance reachable over HTTP or HTTPS from wherever Keeper runs
-- A Radicale username and password from your htpasswd file
-- An Apple Account with two-factor authentication enabled
-- A Keeper.sh instance, hosted or [self-hosted](https://github.com/ridafkih/keeper.sh)
+Add an event in Radicale and a copy appears in iCloud, which means it appears on your iPhone. Move it, the copy moves. Delete it, the copy goes.
 
-Only `http:` and `https:` URLs are accepted. There is no way to point Keeper at a Unix socket or a non-HTTP transport.
+By default the copy is a block of busy time, not a readable event. That is worth knowing before you assume your notes came along.
 
-## The private network problem
+Copies travel one way per connection. You choose Radicale to iCloud, iCloud to Radicale, or both. Both means two connections, one each way.
 
-Read this before anything else, because it determines whether this works at all.
+There is no single "two-way" switch.
 
-Most Radicale instances live on a home network — `192.168.1.x`, `10.x`, a `.local` hostname, or `localhost:5232` on the machine that runs everything. Keeper refuses to fetch URLs resolving to private or reserved addresses when `BLOCK_PRIVATE_RESOLUTION` is on, which is a deliberate defence against server-side request forgery. The bundled `compose.yaml` turns it on.
+## What you need before you start
 
-So:
+- A Radicale server reachable over HTTP or HTTPS from wherever Keeper runs
+- A username and password from your htpasswd file
+- An Apple Account with two-factor login switched on
+- An account on [keeper.sh](https://keeper.sh/register), or your own Keeper instance
 
-**On hosted keeper.sh**, private addresses are blocked and you cannot change that. Your Radicale has to be reachable from the public internet — a domain with a reverse proxy in front of it, or a tunnel. There is no way around this from the dashboard, and it is not a bug.
+Only `http:` and `https:` addresses work. There is no way to point Keeper at a Unix socket.
 
-**On a self-hosted Keeper**, add the host to `PRIVATE_RESOLUTION_WHITELIST` on both the `api` and `cron` services. It takes a comma-separated list of hostnames or IPs:
+Most of this guide describes hosted keeper.sh, because that is the quickest way to get this working even if you already run servers. Running Keeper yourself is covered at the end, and it is a perfectly good choice.
+
+## Can Keeper reach a Radicale on your home network?
+
+Read this before anything else. It decides whether the hosted route works for you at all.
+
+Most Radicale instances sit on a home network — `192.168.1.x`, a `.local` hostname, or `localhost:5232` on the box that runs everything.
+
+**On hosted keeper.sh, private addresses are refused and you cannot change that.** Your Radicale needs to be reachable from the public internet. A domain with a reverse proxy in front works, or a tunnel. If you are not willing to expose it, run Keeper yourself on the same network instead.
+
+The setting behind this is `BLOCK_PRIVATE_RESOLUTION`, which stops the server fetching anything that resolves to a private or reserved address. It is off by default in the code and in the compose file at the repository root, which only runs Postgres, Redis and Caddy. The deployment compose file at `deploy/compose.yaml` turns it on for the `api` and `cron` services, and the README documents the default as `false`.
+
+If you self-host and turn it on, `PRIVATE_RESOLUTION_WHITELIST` is the exemption list:
 
 ```
 BLOCK_PRIVATE_RESOLUTION=true
 PRIVATE_RESOLUTION_WHITELIST=192.168.1.50,radicale.local,10.0.2.12
 ```
 
-The check runs against the host as written and against everything the hostname resolves to, so whitelist the exact form you are going to paste into the connect form. Restart both services afterwards.
+Set both on `api` and `cron`, and whitelist the exact host and port you are going to paste into the form. Restart both afterwards.
 
-If you skip this, connecting fails with a message about the URL pointing to a private or reserved network address. That error means exactly what it says, and it is the single most common reason this setup does not work on the first try.
+Skip it and the connection fails with a message about the address being private or reserved. It means exactly what it says.
 
-## Connect Radicale
+## How do you connect Radicale?
 
-From the dashboard, open **Import Calendars**, then choose **Connect CalDAV Server** from the bottom group. Radicale has no dedicated tile; the generic CalDAV form is the right one.
+From the dashboard, click **Import Calendars**, then **Connect CalDAV Server** at the bottom.
 
-Three fields:
+Radicale has no button of its own. It speaks the same calendar standard as iCloud, Google and Outlook — CalDAV — so the general form is the right one.
 
-- **CalDAV Server URL** — your Radicale base URL, for example `https://radicale.example.com`
-- **CalDAV Server Username** — your Radicale username from htpasswd
+The page is headed **Connect CalDAV Server** and has three boxes:
+
+- **CalDAV Server URL** — your Radicale address, like `https://radicale.example.com`
+- **CalDAV Server Username** — your username from htpasswd
 - **CalDAV Server Password** — the matching password
 
-Start with the base URL. Keeper performs standards discovery: it asks the server for the current-user principal, follows that to the calendar home set, and enumerates the collections underneath.
+Start with the plain address. Keeper asks the server where your calendars live and follows that to the collections.
 
-If that turns up nothing, try your user collection root instead — `https://radicale.example.com/username/`, with the trailing slash. Radicale organises collections as direct children of `/USERNAME/`, and pointing straight at that path skips the discovery step that some reverse proxy configurations interfere with. This is the fallback worth trying before you assume something is broken.
+If nothing turns up, point it at your user collection root instead — `https://radicale.example.com/username/`, with the trailing slash. Radicale keeps collections directly under `/USERNAME/`, and going straight there skips the discovery step that some reverse proxy setups interfere with. Try that before assuming something is broken.
 
-Keeper handles both basic and digest authentication and works out which one your server wants on the first request. Radicale's htpasswd backend uses basic auth, so put HTTPS in front of it — basic auth over plain HTTP puts your password on the wire in every request.
+Radicale's htpasswd backend uses basic authentication, which puts your password on the wire with every single request. Put HTTPS in front of it.
 
-Press **Connect**. Every discovered calendar is imported at once, and you land in setup.
+Click **Connect**. Every calendar found is imported at once and you land in a short setup flow.
 
-One Radicale-specific note: Keeper only keeps collections advertising support for events. Radicale's task lists and address books are correctly skipped. But if a collection you expect is missing, check that it actually declares `VEVENT` in its supported component set — a collection created without that property will be filtered out even though it holds events.
+Keeper keeps only collections that declare they hold events, so your task lists and address books are skipped correctly. If a calendar you expected is missing, check that the collection actually declares events in its supported component set. One created without that will be filtered out even though it holds events.
 
-## Connect iCloud
+## How do you connect iCloud?
 
-iCloud needs an app-specific password. Your Apple Account password will not work over CalDAV.
+Apple will not let outside apps sign in with your normal Apple password. That one opens your photos, purchases and Find My. You generate a separate app-specific password instead, which only reaches your calendar and can be cancelled on its own.
 
-1. Go to [appleid.apple.com](https://appleid.apple.com) and sign in
-2. Select **App-Specific Passwords**
-3. Click the **+** next to **Passwords**
-4. Label and generate it, then copy the 16-character password
+Keeper's connect page lists the steps, matching Apple's own [instructions](https://support.apple.com/en-us/102654):
 
-Apple's own documentation is [Sign in to apps with your Apple Account using app-specific passwords](https://support.apple.com/en-us/102654). The section only appears if two-factor authentication is on.
+1. Navigate to iCloud Apple ID
+2. Sign in with your Apple ID
+3. Select "App-Specific Passwords"
+4. Click the "+" next to "Passwords"
+5. Label and generate the password, then copy it
+6. Paste the app-specific password below
 
-Then in Keeper, **Import Calendars → Connect iCloud**, and fill in:
+That section only appears if two-factor login is on. Apple shows the password once, so copy it before closing the box.
+
+Then go to **Import Calendars** and click **Connect iCloud**. The page is headed **Connect Apple Calendar**, and has two boxes:
 
 - **Apple ID** — your Apple sign-in address
-- **App-Specific Password** — the password you just generated
+- **App-Specific Password** — the one you just generated
 
-No server URL is needed; Keeper knows iCloud is at `https://caldav.icloud.com/`.
+No server address is needed. Keeper already knows where iCloud keeps calendars.
 
-## Wire up the mapping
+## How do you tell Keeper which way events travel?
 
-Setup asks four questions:
+Setup asks four questions, word for word:
 
-1. **Which calendars would you like to configure?**
-2. **Rename Your Calendars.** Radicale collections often arrive with directory-derived names, so this is more useful here than usual. Renaming only affects Keeper.
-3. **Where should 'Personal' send events?** Outbound.
-4. **Where should 'Personal' pull events from?** Inbound.
+1. **Which calendars would you like to configure?** Tick the ones you want now.
+2. **Rename Your Calendars.** Radicale collections often arrive with names taken from directories, so this is more useful here than usual. Renaming only changes what you see in Keeper.
+3. **Where should 'Personal' send events?** Tick iCloud, and copies start appearing on your phone.
+4. **Where should 'Personal' pull events from?** Tick iCloud here for the reverse.
 
-Both CalDAV ends can pull and push, so either can be a source, a destination, or both. Two-way syncing between one Radicale calendar and one iCloud calendar is two mappings.
+Both ends of this pairing can send and receive, so either can be the one events come from.
 
-## What actually gets synced
+Each tick is one connection. Both directions is two connections. Change any of it later from the calendar under **Calendars**, in the **Send Events to Calendars** section.
 
-Time, not detail. Newly connected calendars default to stripping the event name, description and location, and titling the copy after the source calendar. Both directions of this pairing behave that way, so out of the box Radicale and iCloud exchange opaque blocks rather than content.
+## Will the copies carry real event titles?
 
-The calendar detail page has a **Sync Settings** section with **Sync Event Name**, **Sync Event Description** and **Sync Event Location** toggles, all off initially. Turning **Sync Event Name** on switches the **Event Name** template to `{{event_name}}` and passes the real title. While it is off, that template field stays editable and understands `{{event_name}}` and `{{calendar_name}}`. An **Exclusions** section can drop all-day events. On a self-hosted instance all of this is available to every user; on hosted keeper.sh it is Pro-only.
+Check before you assume either way. It takes thirty seconds.
 
-New sources also join the aggregated iCal feed by default, which you can change under **iCal Link**.
+Open the calendar under **Calendars** and find **Sync Settings**. Three switches decide what travels: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
 
-The sync window runs from seven days ago to two years ahead and is not configurable. One-off events outside it are skipped; recurring series whose master starts before the window are still collected.
+Calendars added through **Import Calendars** arrive with all three off. Both ends of this pairing behave that way, so out of the box Radicale and iCloud exchange opaque blocks rather than content.
 
-## How often it runs
+The name on the copy comes from the **Event Name** box, which understands `{{calendar_name}}` and `{{event_name}}`. Turn **Sync Event Name** on to let real titles through.
 
-Ingestion runs every minute on every plan. Pushing to destinations runs every minute on self-hosted and Pro, and every thirty minutes on free.
+On keeper.sh this is a Pro feature — the dashboard says **Advanced sync settings are a Pro feature.** Run Keeper yourself and every user on the instance gets it.
 
-Neither end of this pairing gets incremental sync. Sync tokens and delta links are a Google and Outlook feature; CalDAV sources are refetched inside the sync window on every ingestion run and diffed against stored state. For Radicale that is usually irrelevant, since it is your own server and the calendars are small. For iCloud it means a steady stream of requests you are not in control of.
+Below, **Exclusions** can drop **Exclude All Day Events**.
 
-Nothing needs to reach your Keeper instance from outside. It polls; there are no webhooks or push notifications to expose.
+## How fast do changes show up?
 
-## Limits and rough edges
+Keeper reads both calendars every minute, on every plan. That never gets slower.
 
-- **Self-hosting removes the tier limits.** When Keeper runs outside commercial mode, every user on the instance gets Pro behaviour: unlimited linked accounts, unlimited mappings, event filters and feed customisation. On hosted keeper.sh it is two accounts and three mappings on free, and Radicale plus iCloud uses both account slots.
-- **Credentials are stored encrypted, not hashed.** CalDAV requires replaying the password on every request, so Keeper encrypts both passwords at rest with your `ENCRYPTION_KEY` rather than one-way hashing them. Self-hosting means that key never leaves your infrastructure. It also means you are responsible for it — lose it and stored credentials become unrecoverable.
-- **Radicale's own storage is a directory of files.** If you edit files under Radicale's collection root by hand while syncing is running, Keeper will see the result on its next pass and reconcile it. That is usually what you want, but it makes hand-editing a live sync target a poor idea.
-- **Recurring events.** Keeper refuses to materialise a series expanding past ten thousand occurrences inside the two-year window, and that check currently fails the whole calendar's ingestion rather than isolating the offending series. A calendar that stops updating outright, rather than losing one event, is the signature.
-- **Response caps truncate silently.** CalDAV is refetched in full every cycle with no pagination. If a server or proxy caps how many objects come back in one response, Keeper sees a calendar that appears to have lost the remainder and removes them from the destination accordingly. Radicale does not cap by default, but it is worth knowing before you put something restrictive in front of it.
-- **Directions are separate.** Each mapping is one-way, and you set them independently.
-- **No manual resync.** There is no "sync now" control. You wait for the next cycle, or remove and re-add the account.
+Getting a change onto the other calendar depends on the plan. On free it takes up to thirty minutes. On Pro and on your own instance it is about a minute.
 
-## Checking it worked
+If you are mirroring your Radicale calendar so your phone knows you are busy, thirty minutes changes nothing. If people book you through a scheduling link, it is too slow.
 
-The dashboard shows live sync status over a WebSocket, so you can watch a cycle happen rather than guess. **View Events** lists what Keeper has ingested, which is the fastest way to tell an ingestion problem from a push problem: events present there but missing on the destination is a mapping or push issue, events missing there is a source connection issue.
+Nothing needs to reach Keeper from outside. It checks on a timer rather than waiting to be told, so there is no callback address to expose.
 
-Each calendar's detail page has a **Calendar Information** section showing its type, its capabilities, and the resolved calendar URL. If discovery landed somewhere unexpected on Radicale, that URL is where you will see it.
+## What does not come across?
+
+Guest lists, video call links and reminders do not travel at all. Keeper has nowhere to store them.
+
+So a copied meeting is a block of time, not a working invite. Guest lists are read for one thing only: showing you invitations you have not answered yet, so you can reply from Keeper.
+
+Keeper also looks at a fixed stretch of time — from a week ago to two years ahead. A one-off event further out is not copied. A repeating event that began before the window is still picked up, so its dates inside the window survive.
+
+## What goes wrong, and what does it look like?
+
+**The page shows `401 /api/sources/caldav/discover` in red.** That is a wrong username or password, shown badly. Keeper's server does say "Invalid credentials", but the dashboard prints the status code instead of the message. On the iCloud side it usually means the normal Apple password was pasted, or the app-specific one has been cancelled.
+
+**One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper refuses to work through a repeating series that would produce more than 10,000 dates in two years. Today that refusal stops the whole calendar, not just the one series. A calendar going completely silent, rather than losing one event, is the signature. Delete the runaway event and it catches up on its own.
+
+**A calendar goes quiet for hours, then recovers.** After a failed request Keeper waits five minutes, then ten, then twenty, up to six hours. It backs off on purpose and comes back by itself.
+
+**Events disappear from iCloud that still exist in Radicale.** Keeper reads the whole calendar each round and matches it against what it already has. If something in front of Radicale caps how many items come back in one response, Keeper sees a shorter calendar and removes the difference. Radicale does not cap by default, but a restrictive proxy will.
+
+**You hand-edited a file and something odd happened.** Radicale stores collections as plain files. Editing them under a live sync is a poor idea — Keeper reads the result on its next round and acts on it.
+
+**There is no "sync now" button.** You wait for the next round. Removing the account and adding it again is the blunt way to start clean.
+
+## How do you tell whether it is working?
+
+The dashboard shows sync status live, so you can watch a round happen rather than guess.
+
+**View Events** lists what Keeper currently holds. That tells you which half of the problem you have. Events present there but missing in iCloud is a connection or delivery problem. Events missing there is a Radicale connection problem.
+
+Each calendar's page has a **Calendar Information** section showing its type, what it can do, and the address Keeper resolved. If discovery landed somewhere unexpected on Radicale, that is where you will see it.
+
+## What does the free plan cover?
+
+Two calendar accounts and three connections.
+
+Radicale is one account no matter how many collections it holds. iCloud is the second. So this pairing uses both, and adding Google later means upgrading.
+
+Three connections covers both directions here with one spare. There is no cap on how many calendars an account brings in.
+
+## Would you rather run Keeper yourself?
+
+You already run Radicale, so this will not frighten you. For a calendar server on your own network it is often the better fit.
+
+Keeper is open source under AGPL-3.0. Run it yourself and every user on the instance gets Pro behaviour. That means real event titles, exclusions, feed settings, unlimited accounts and connections, and updates every minute. Nothing is held back.
+
+It is a Docker Compose stack with Postgres and Redis behind it, and the setup guide is in the [repository](https://github.com/ridafkih/keeper.sh). Running it on the same network as Radicale is what makes `PRIVATE_RESOLUTION_WHITELIST` above useful, and means you never have to expose Radicale to the internet.
+
+The cost is real, though. Another service to upgrade, another database to back up, another thing that pages you when it stops. You are already carrying that for Radicale, so you know exactly what it feels like.
+
+## One more thing about your passwords
+
+Keeper stores both passwords in a form it can read back, because this kind of calendar connection sends the password on every single request. There is no token to hide behind.
+
+They are encrypted before storage using your `ENCRYPTION_KEY`. Self-host and that key never leaves your infrastructure — which also means losing it makes the stored credentials unrecoverable.
+
+Cancelling access is deleting the app-specific password at Apple, or deleting the account under **Calendar Sources** in the dashboard, which removes it and its calendars.

--- a/applications/web/src/content/blog/sync-radicale-with-icloud-calendar.mdx
+++ b/applications/web/src/content/blog/sync-radicale-with-icloud-calendar.mdx
@@ -58,7 +58,7 @@ PRIVATE_RESOLUTION_WHITELIST=192.168.1.50,radicale.local,10.0.2.12
 
 Set both on `api` and `cron`, and whitelist the exact host and port you are going to paste into the form. Restart both afterwards.
 
-Skip it and the connection fails with a message about the address being private or reserved. It means exactly what it says.
+Skip it and the connect page says **Failed to discover calendars**, because Keeper refused to make the request at all. It will not tell you that was the reason. The specific message about a private or reserved address only appears in the server logs, so check there before assuming Radicale is at fault.
 
 ## How do you connect Radicale?
 
@@ -151,7 +151,11 @@ Keeper also looks at a fixed stretch of time — from a week ago to two years ah
 
 ## What goes wrong, and what does it look like?
 
-**The page shows `401 /api/sources/caldav/discover` in red.** That is a wrong username or password, shown badly. Keeper's server does say "Invalid credentials", but the dashboard prints the status code instead of the message. On the iCloud side it usually means the normal Apple password was pasted, or the app-specific one has been cancelled.
+**The page says "Invalid credentials".** The server was reached and rejected the sign-in. On the Radicale side, check the username and password against your htpasswd file. On the iCloud side it usually means the normal Apple password was pasted, or the app-specific one has been cancelled.
+
+**The page says "Failed to discover calendars".** This means something different, and it is worth telling apart. Keeper never got a usable answer from that address, so the credentials were never tested. Check the address for a typo and confirm Radicale is running. If you host Keeper yourself, the private-address setting above produces this same message.
+
+**The page says "No calendars found".** Your credentials worked. Keeper reached Radicale and found nothing to import at that address. This is when to try `https://radicale.example.com/username/` with the trailing slash.
 
 **One bad repeating event freezes a whole calendar.** Not one missing event — everything stops updating. Keeper refuses to work through a repeating series that would produce more than 10,000 dates in two years. Today that refusal stops the whole calendar, not just the one series. A calendar going completely silent, rather than losing one event, is the signature. Delete the runaway event and it catches up on its own.
 


### PR DESCRIPTION
> **Merge order: this must not merge before #516 and #519.** The troubleshooting sections describe a wrong password surfacing as "Invalid credentials" and an unreachable server as "Failed to discover calendars". Both behaviours arrive with those two PRs. Merging this first would ship guides describing error messages that do not exist yet.

Four "sync X with Y" guides for the CalDAV-side pairs from #470: Nextcloud with Google, iCloud with Google, Fastmail with Outlook, and Radicale with iCloud. They are written for someone who has two calendars and a scheduling problem, not for someone who has read our source, so the median sentence runs 11-12 words, headings are the reader's question, and failure modes lead with the symptom. Hosted keeper.sh is the default path throughout, with self-hosting given its own signposted section and described honestly, including what it costs to run.

- Drops the two-way sync claim everywhere: `source_destination_mappings` has no direction column, so both directions is two connections
- Corrects `BLOCK_PRIVATE_RESOLUTION` to its real default of `false`; only `deploy/compose.yaml` sets it, on `api` and `cron`
- Fixes the plan limits to 2 linked accounts and 3 connections, and drops the invented per-account calendar limit
- States both cadences: reading runs every minute on every plan, delivery is 30 minutes on free and 1 minute on Pro
- Every UI label re-verified against source, including the iCloud tile opening a page headed **Connect Apple Calendar** and the Fastmail scope being **Calendars (CalDAV)**
- Troubleshooting distinguishes "Invalid credentials" from "Failed to discover calendars", since one means the server rejected the sign-in and the other means it was never reached
- Corrects a claim that a blocked private address names itself in the UI; it reads "Failed to discover calendars", and the specific reason only reaches the server logs
- Says plainly that attendees, conferencing links and reminders are never synced, and that attendees are only read for pending invites and RSVP
- Replaces the blanket iCal privacy claim with what to check, per #501
- Keeps the over-budget recurrence rough edge, still reproducible on the merge base, but leads with the symptom

Closes #470
