### PR TITLE
feat: add find_free_time, trigger_sync and pause_sync MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Ingestion pulls from your sources into Keeper's own database once a minute, rega
 
 Pushing to destinations is what the refresh interval in the pricing table refers to. The cron service enqueues a job per destination onto a Redis-backed queue every minute for Pro and every thirty minutes for free, and the worker service reconciles the destination calendar. This is polling on our side rather than provider push notifications, so nothing needs to reach your instance from the outside.
 
+Neither half is schedule-only. `POST /api/v1/sync`, or `trigger_sync` over MCP, clears the ingest backoff so your sources are re-polled on the next pass and enqueues the push half straight away, throttled to one request per minute per user so a client cannot hammer your providers. A calendar paused with `pause_sync` is skipped by both halves until it is resumed.
+
 # Cloud Hosted
 
 I've made Keeper easy to self-host, but whether you simply want to support the project or don't want to deal with the hassle or overhead of configuring and running your own infrastructure cloud hosting is always an option.
@@ -554,6 +556,7 @@ curl https://keeper.example.com/api/v1/calendars \
 | Method   | Path                                     | Description                                                                                                                                                    |
 | -------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `GET`    | `/api/v1/calendars`                      | List connected calendars. Accepts an optional comma-delimited `provider` filter.                                                                                |
+| `PATCH`  | `/api/v1/calendars/{calendarId}`         | Pause or resume syncing for a calendar. Send `paused` as `true` to halt it in both directions without disconnecting it.                                         |
 | `GET`    | `/api/v1/calendars/{calendarId}/invites` | List invitations on a calendar that have not been responded to, within a date range.                                                                            |
 | `GET`    | `/api/v1/accounts`                       | List connected calendar accounts and how many calendars each has. Accepts an optional comma-delimited `provider` filter.                                        |
 | `GET`    | `/api/v1/events`                         | List events in a date range. Accepts `calendarId`, `availability`, and `isAllDay` filters, and `count=true` to return only a count.                             |
@@ -561,9 +564,15 @@ curl https://keeper.example.com/api/v1/calendars \
 | `GET`    | `/api/v1/events/{id}`                    | Get a single event.                                                                                                                                            |
 | `PATCH`  | `/api/v1/events/{id}`                    | Update an event's fields, or send `rsvpStatus` to respond to an invitation.                                                                                     |
 | `DELETE` | `/api/v1/events/{id}`                    | Delete an event.                                                                                                                                               |
+| `GET`    | `/api/v1/events/free-time`               | Find free slots of at least `durationMinutes` in a date range. Requires `timezone`, and accepts working-hours options.                                          |
+| `POST`   | `/api/v1/sync`                           | Trigger a sync immediately. Throttled to one request per minute per user.                                                                                      |
 | `GET`    | `/api/v1/ical`                           | Get the URL of your iCal feed.                                                                                                                                 |
 
 Range parameters `from` and `to` are ISO 8601 datetimes. If omitted, `from` defaults to now and `to` defaults to a week after `from`. A range may not exceed 732 days.
+
+`/api/v1/events/free-time` treats events marked free or working-elsewhere as non-blocking and everything else, including all-day events, as busy; pass `ignoreAllDayEvents=true` to stop all-day events blocking. `workingHoursStart` and `workingHoursEnd` are 24-hour local times such as `09:00`, and `workingDays` is a comma-delimited list where `0` is Sunday. All three are read against `timezone`, so the hours hold across daylight saving transitions.
+
+`POST /api/v1/sync` clears the ingest backoff on your sources so they are re-polled on the next pass, and enqueues a push to every destination. Exceeding the throttle returns `429` with a `Retry-After` header rather than queueing a second run.
 
 > [!NOTE]
 >
@@ -581,17 +590,20 @@ Keeper includes an optional MCP server that lets AI agents (such as Claude) acce
 | `get_event_count`     | Get the number of calendar events. Optionally scoped to a date range with `from` and `to` ISO 8601 datetimes.                                  |
 | `get_events`          | Get calendar events within a date range. Accepts ISO 8601 datetimes and an IANA timezone identifier used to localize event times.              |
 | `get_event`           | Get a single calendar event by its ID.                                                                                                         |
+| `find_free_time`      | Find open slots of at least a given duration across every synced calendar in a date range.                                                     |
 | `create_event`        | Create an event on a connected calendar. Requires a calendar ID, title, start time, and end time.                                               |
 | `update_event`        | Update an existing calendar event. Only the fields you provide are updated.                                                                    |
 | `delete_event`        | Delete a calendar event by its ID.                                                                                                             |
 | `get_pending_invites` | Get invitations on a calendar that have not been responded to within a date range.                                                             |
 | `rsvp_event`          | Respond to a calendar event invitation with `accepted`, `declined`, or `tentative`.                                                            |
 | `list_accounts`       | List all connected calendar accounts with provider information.                                                                                |
+| `trigger_sync`        | Force a sync now instead of waiting for the next scheduled run. Throttled to one request per minute.                                           |
+| `pause_sync`          | Pause or resume syncing for a single calendar without disconnecting it.                                                                        |
 | `get_ical_feed`       | Get your iCal feed URL for subscribing in other calendar apps.                                                                                 |
 
 ## Connecting an MCP Client
 
-To connect an MCP-compatible client (e.g. Claude Code, Claude Desktop), point it at your MCP server URL. The client will be guided through the OAuth consent flow to authorize read and write access to your calendar data — the toolset can create, update, delete, and RSVP to events, not just read them.
+To connect an MCP-compatible client (e.g. Claude Code, Claude Desktop), point it at your MCP server URL. The client will be guided through the OAuth consent flow to authorize read and write access to your calendar data — the toolset can create, update, delete, and RSVP to events, find open time, and pause or force a sync, not just read them.
 
 Example Claude Code MCP configuration:
 

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -58,6 +58,11 @@ export {
 } from "./core/oauth/create-source-provider";
 export { generateDeterministicEventUid, isKeeperEvent } from "./core/events/identity";
 export { inferAllDayEvent, resolveIsAllDayEvent } from "./core/events/all-day";
+export {
+  instantToWallTime,
+  resolveTimeZone,
+  wallTimeToInstant,
+} from "./ics/utils/timezone-instant";
 export { RateLimiter, type RateLimiterConfig } from "./core/utils/rate-limiter";
 export { createRedisRateLimiter, type RedisRateLimiter, type RedisRateLimiterConfig } from "./core/utils/redis-rate-limiter";
 export { allSettledWithConcurrency, type AllSettledWithConcurrencyOptions } from "./core/utils/concurrency";

--- a/services/api/src/queries/event-read-model.ts
+++ b/services/api/src/queries/event-read-model.ts
@@ -183,13 +183,12 @@ const isIncludedByFilters = (
   return true;
 };
 
-const projectSyncedEvents = (
+const materializeSyncedEvents = (
   rows: SyncedEventRow[],
   sourceMap: Map<string, SourceInfo>,
   windowStart: Date,
   windowEnd: Date,
-  filters?: KeeperEventFilters,
-): KeeperEventProjection[] => {
+): MaterializedSyncableEvent[] => {
   const events = rows.flatMap((row) => {
     const source = sourceMap.get(row.calendarId);
     if (!source) {
@@ -202,10 +201,19 @@ const projectSyncedEvents = (
   return materializeRecurrenceEvents(events, {
     end: exclusiveWindowEnd,
     start: windowStart,
-  })
+  });
+};
+
+const projectSyncedEvents = (
+  rows: SyncedEventRow[],
+  sourceMap: Map<string, SourceInfo>,
+  windowStart: Date,
+  windowEnd: Date,
+  filters?: KeeperEventFilters,
+): KeeperEventProjection[] =>
+  materializeSyncedEvents(rows, sourceMap, windowStart, windowEnd)
     .filter((occurrence) => isIncludedByFilters(occurrence, filters))
     .map((occurrence) => toSyncedProjection(occurrence));
-};
 
 const toKeeperEvent = (
   event: KeeperEventProjection,
@@ -225,6 +233,7 @@ const toKeeperEvent = (
 });
 
 export {
+  materializeSyncedEvents,
   parseEventReference,
   projectSyncedEvents,
   toKeeperEvent,

--- a/services/api/src/queries/find-free-time.ts
+++ b/services/api/src/queries/find-free-time.ts
@@ -1,0 +1,141 @@
+import { eventStatesTable, userEventsTable } from "@keeper.sh/database/schema";
+import { and, asc, eq, gte, inArray, lte } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+import type {
+  KeeperDatabase,
+  KeeperEventFilters,
+  KeeperEventRangeInput,
+  KeeperFreeTimeOptions,
+  KeeperFreeTimeResult,
+} from "@/types";
+import { findFreeSlots } from "@/utils/free-time";
+import type { TimeInterval } from "@/utils/free-time";
+import {
+  buildSyncedRangeCondition,
+  getSourcesForUser,
+  normalizeEventRange,
+} from "./get-events-in-range";
+import { materializeSyncedEvents } from "./event-read-model";
+import type { SyncedEventRow } from "./event-read-model";
+
+const EMPTY_RESULT_COUNT = 0;
+const NON_BLOCKING_AVAILABILITY = new Set(["free", "workingElsewhere"]);
+
+interface BusyCandidate {
+  availability?: string | null;
+  isAllDay?: boolean | null;
+  startTime: Date;
+  endTime: Date;
+}
+
+const isBlocking = (candidate: BusyCandidate, ignoreAllDayEvents: boolean): boolean => {
+  if (ignoreAllDayEvents && candidate.isAllDay === true) {
+    return false;
+  }
+  if (typeof candidate.availability !== "string") {
+    return true;
+  }
+  return !NON_BLOCKING_AVAILABILITY.has(candidate.availability);
+};
+
+const toBusyInterval = (candidate: BusyCandidate, range: TimeInterval): TimeInterval => ({
+  end: new Date(Math.min(candidate.endTime.getTime(), range.end.getTime())),
+  start: new Date(Math.max(candidate.startTime.getTime(), range.start.getTime())),
+});
+
+const collectBusyIntervals = async (
+  database: KeeperDatabase,
+  userId: string,
+  range: TimeInterval,
+  options: KeeperFreeTimeOptions,
+  filters?: KeeperEventFilters,
+): Promise<TimeInterval[]> => {
+  const { calendarIds, sourceMap } = await getSourcesForUser(database, userId, filters);
+
+  if (calendarIds.length === EMPTY_RESULT_COUNT) {
+    return [];
+  }
+
+  const syncedConditions: SQL[] = [inArray(eventStatesTable.calendarId, calendarIds)];
+  const syncedRangeCondition = buildSyncedRangeCondition(range.start, range.end);
+  if (syncedRangeCondition) {
+    syncedConditions.push(syncedRangeCondition);
+  }
+
+  const syncedRows: SyncedEventRow[] = await database
+    .select({
+      availability: eventStatesTable.availability,
+      calendarId: eventStatesTable.calendarId,
+      description: eventStatesTable.description,
+      endTime: eventStatesTable.endTime,
+      exceptionDates: eventStatesTable.exceptionDates,
+      id: eventStatesTable.id,
+      isAllDay: eventStatesTable.isAllDay,
+      location: eventStatesTable.location,
+      recurrenceId: eventStatesTable.recurrenceId,
+      recurrenceRule: eventStatesTable.recurrenceRule,
+      sourceEventUid: eventStatesTable.sourceEventUid,
+      startTime: eventStatesTable.startTime,
+      startTimeZone: eventStatesTable.startTimeZone,
+      title: eventStatesTable.title,
+    })
+    .from(eventStatesTable)
+    .where(and(...syncedConditions))
+    .orderBy(asc(eventStatesTable.startTime));
+
+  const userEvents = await database
+    .select({
+      availability: userEventsTable.availability,
+      endTime: userEventsTable.endTime,
+      isAllDay: userEventsTable.isAllDay,
+      startTime: userEventsTable.startTime,
+    })
+    .from(userEventsTable)
+    .where(
+      and(
+        inArray(userEventsTable.calendarId, calendarIds),
+        eq(userEventsTable.userId, userId),
+        gte(userEventsTable.endTime, range.start),
+        lte(userEventsTable.startTime, range.end),
+      ),
+    )
+    .orderBy(asc(userEventsTable.startTime));
+
+  const candidates: BusyCandidate[] = [
+    ...materializeSyncedEvents(syncedRows, sourceMap, range.start, range.end),
+    ...userEvents,
+  ];
+
+  return candidates
+    .filter((candidate) => isBlocking(candidate, options.ignoreAllDayEvents))
+    .map((candidate) => toBusyInterval(candidate, range));
+};
+
+const findFreeTime = async (
+  database: KeeperDatabase,
+  userId: string,
+  rangeInput: KeeperEventRangeInput,
+  options: KeeperFreeTimeOptions,
+  filters?: KeeperEventFilters,
+): Promise<KeeperFreeTimeResult> => {
+  const { start, end } = normalizeEventRange(rangeInput);
+  const range: TimeInterval = { end, start };
+  const busyIntervals = await collectBusyIntervals(database, userId, range, options, filters);
+
+  const slots = findFreeSlots(range, busyIntervals, {
+    durationMinutes: options.durationMinutes,
+    limit: options.limit,
+    timezone: options.timezone,
+    workingHours: options.workingHours,
+  });
+
+  return {
+    durationMinutes: options.durationMinutes,
+    from: start.toISOString(),
+    slots,
+    timezone: options.timezone,
+    to: end.toISOString(),
+  };
+};
+
+export { findFreeTime, isBlocking };

--- a/services/api/src/queries/get-events-in-range.ts
+++ b/services/api/src/queries/get-events-in-range.ts
@@ -204,4 +204,10 @@ const getEventsInRange = async (
   });
 };
 
-export { flattenSyncedEvents, getEventsInRange, normalizeEventRange };
+export {
+  buildSyncedRangeCondition,
+  flattenSyncedEvents,
+  getEventsInRange,
+  getSourcesForUser,
+  normalizeEventRange,
+};

--- a/services/api/src/read-models.ts
+++ b/services/api/src/read-models.ts
@@ -1,6 +1,7 @@
 import { getEventCount } from "./queries/get-event-count";
 import { getEvent } from "./queries/get-event";
 import { getEventsInRange, normalizeEventRange } from "./queries/get-events-in-range";
+import { findFreeTime } from "./queries/find-free-time";
 import { getSyncStatuses } from "./queries/get-sync-statuses";
 import { listDestinations } from "./queries/list-destinations";
 import { listMappings } from "./queries/list-mappings";
@@ -37,6 +38,8 @@ const createKeeperApi = (database: KeeperDatabase, options?: KeeperApiOptions): 
     getEventsInRange: (userId, range, filters) => getEventsInRange(database, userId, range, filters),
     getEvent: (userId, eventId) => getEvent(database, userId, eventId),
     getEventCount: (userId, countOptions) => getEventCount(database, userId, countOptions),
+    findFreeTime: (userId, range, freeTimeOptions, filters) =>
+      findFreeTime(database, userId, range, freeTimeOptions, filters),
     getSyncStatuses: (userId) => getSyncStatuses(database, userId),
     createEvent: (userId, input) => createEventMutation(deps, userId, input),
     updateEvent: (userId, eventId, updates) => updateEventMutation(deps, userId, eventId, updates),

--- a/services/api/src/routes/api/v1/calendars/[calendarId]/index.ts
+++ b/services/api/src/routes/api/v1/calendars/[calendarId]/index.ts
@@ -1,0 +1,32 @@
+import { isCalendarId, setCalendarPaused } from "@/utils/calendar-pause";
+import { calendarPausePatchBodySchema } from "@/utils/request-body";
+import { withV1Auth, withWideEvent } from "@/utils/middleware";
+import { ErrorResponse } from "@/utils/responses";
+import { widelog } from "@/utils/logging";
+import { database } from "@/context";
+
+const PATCH = withWideEvent(
+  withV1Auth(async ({ request, params, userId }) => {
+    const { calendarId } = params;
+    if (!isCalendarId(calendarId)) {
+      return ErrorResponse.badRequest("A valid calendar ID is required.").toResponse();
+    }
+
+    const body: unknown = await request.json().catch(() => null);
+    if (!calendarPausePatchBodySchema.allows(body)) {
+      return ErrorResponse.badRequest("'paused' must be a boolean.").toResponse();
+    }
+
+    const result = await setCalendarPaused(database, userId, calendarId, body.paused);
+    if (!result) {
+      return ErrorResponse.notFound().toResponse();
+    }
+
+    widelog.set("calendar.id", calendarId);
+    widelog.set("calendar.paused", result.paused);
+
+    return Response.json(result);
+  }),
+);
+
+export { PATCH };

--- a/services/api/src/routes/api/v1/events/free-time.ts
+++ b/services/api/src/routes/api/v1/events/free-time.ts
@@ -1,0 +1,77 @@
+import { RecurrenceMaterializationLimitError } from "@keeper.sh/calendar";
+import { normalizeDateRange, parseDateRangeParams } from "@/utils/date-range";
+import { DEFAULT_FREE_SLOTS, FreeTimeValidationError, parseWorkingHours } from "@/utils/free-time";
+import { createKeeperApi } from "@/read-models";
+import type { KeeperEventFilters, KeeperFreeTimeOptions } from "@/types";
+import { withV1Auth, withWideEvent } from "@/utils/middleware";
+import { ErrorResponse } from "@/utils/responses";
+import { database } from "@/context";
+
+const keeperApi = createKeeperApi(database);
+
+const parseLimit = (limitParam: string | null): number => {
+  if (!limitParam) {
+    return DEFAULT_FREE_SLOTS;
+  }
+  return Number(limitParam);
+};
+
+const parseFreeTimeOptions = (url: URL): KeeperFreeTimeOptions => {
+  const durationParam = url.searchParams.get("durationMinutes");
+  if (!durationParam) {
+    throw new FreeTimeValidationError("durationMinutes is required");
+  }
+
+  const timezone = url.searchParams.get("timezone");
+  if (!timezone) {
+    throw new FreeTimeValidationError("timezone is required");
+  }
+
+  return {
+    durationMinutes: Number(durationParam),
+    ignoreAllDayEvents: url.searchParams.get("ignoreAllDayEvents") === "true",
+    limit: parseLimit(url.searchParams.get("limit")),
+    timezone,
+    workingHours: parseWorkingHours(
+      url.searchParams.get("workingHoursStart"),
+      url.searchParams.get("workingHoursEnd"),
+      url.searchParams.get("workingDays"),
+    ),
+  };
+};
+
+const parseCalendarFilters = (url: URL): KeeperEventFilters | undefined => {
+  const calendarId = url.searchParams.get("calendarId");
+  if (!calendarId) {
+    return;
+  }
+  return { calendarId: calendarId.split(",").filter(Boolean) };
+};
+
+const GET = withWideEvent(
+  withV1Auth(async ({ request, userId }) => {
+    const url = new URL(request.url);
+
+    try {
+      const { from, to } = parseDateRangeParams(url);
+      const { end, start } = normalizeDateRange(from, to);
+      const options = parseFreeTimeOptions(url);
+
+      const result = await keeperApi.findFreeTime(
+        userId,
+        { from: start, to: end },
+        options,
+        parseCalendarFilters(url),
+      );
+
+      return Response.json(result);
+    } catch (error) {
+      if (error instanceof RecurrenceMaterializationLimitError || error instanceof RangeError) {
+        return ErrorResponse.badRequest(error.message).toResponse();
+      }
+      throw error;
+    }
+  }),
+);
+
+export { GET };

--- a/services/api/src/routes/api/v1/sync/index.ts
+++ b/services/api/src/routes/api/v1/sync/index.ts
@@ -1,0 +1,34 @@
+import { withV1Auth, withWideEvent } from "@/utils/middleware";
+import { ErrorResponse } from "@/utils/responses";
+import { checkAndClaimSyncTrigger } from "@/utils/sync-trigger-limit";
+import { triggerSync } from "@/utils/trigger-sync";
+import { widelog } from "@/utils/logging";
+import { premiumService, redis } from "@/context";
+
+const POST = withWideEvent(
+  withV1Auth(async ({ userId }) => {
+    const cooldown = await checkAndClaimSyncTrigger(redis, userId);
+
+    if (!cooldown.allowed) {
+      widelog.set("sync_trigger.throttled", true);
+      widelog.set("sync_trigger.retry_after_seconds", cooldown.retryAfterSeconds);
+      const throttled = ErrorResponse.tooManyRequests(
+        `A sync was already requested recently. Try again in ${cooldown.retryAfterSeconds} seconds.`,
+      ).toResponse();
+      throttled.headers.set("Retry-After", String(cooldown.retryAfterSeconds));
+      return throttled;
+    }
+
+    const plan = await premiumService.getUserPlan(userId);
+    if (!plan) {
+      throw new Error("Unable to resolve user plan for sync trigger");
+    }
+
+    const result = await triggerSync(userId, plan);
+    widelog.set("sync_trigger.sources_refreshed", result.sourcesRefreshed);
+
+    return Response.json(result);
+  }),
+);
+
+export { POST };

--- a/services/api/src/types.ts
+++ b/services/api/src/types.ts
@@ -1,4 +1,5 @@
 import type { BunSQLDatabase } from "drizzle-orm/bun-sql";
+import type { FreeSlot, WorkingHours } from "@/utils/free-time";
 
 type KeeperDatabase = BunSQLDatabase;
 
@@ -58,6 +59,32 @@ interface KeeperEvent {
   calendarName: string;
   calendarProvider: string;
   calendarUrl: string | null;
+}
+
+interface KeeperFreeTimeOptions {
+  durationMinutes: number;
+  timezone: string;
+  workingHours: WorkingHours | null;
+  ignoreAllDayEvents: boolean;
+  limit: number;
+}
+
+interface KeeperFreeTimeResult {
+  from: string;
+  to: string;
+  timezone: string;
+  durationMinutes: number;
+  slots: FreeSlot[];
+}
+
+interface KeeperSyncTriggerResult {
+  triggered: boolean;
+  sourcesRefreshed: number;
+}
+
+interface KeeperCalendarPauseResult {
+  calendarId: string;
+  paused: boolean;
 }
 
 interface KeeperSyncStatus {
@@ -148,6 +175,12 @@ interface KeeperApi {
   getEventsInRange: (userId: string, range: KeeperEventRangeInput, filters?: KeeperEventFilters) => Promise<KeeperEvent[]>;
   getEvent: (userId: string, eventId: string) => Promise<KeeperEvent | null>;
   getEventCount: (userId: string, options?: { from?: Date; to?: Date }) => Promise<number>;
+  findFreeTime: (
+    userId: string,
+    range: KeeperEventRangeInput,
+    options: KeeperFreeTimeOptions,
+    filters?: KeeperEventFilters,
+  ) => Promise<KeeperFreeTimeResult>;
   getSyncStatuses: (userId: string) => Promise<KeeperSyncStatus[]>;
   createEvent: (userId: string, input: EventInput) => Promise<EventCreateResult>;
   updateEvent: (userId: string, eventId: string, updates: EventUpdateInput) => Promise<EventActionResult>;
@@ -162,12 +195,16 @@ export type {
   EventInput,
   EventUpdateInput,
   KeeperApi,
+  KeeperCalendarPauseResult,
   KeeperDatabase,
   KeeperDestination,
   KeeperEvent,
   KeeperEventFilters,
   KeeperEventRangeInput,
+  KeeperFreeTimeOptions,
+  KeeperFreeTimeResult,
   KeeperMapping,
+  KeeperSyncTriggerResult,
   KeeperSource,
   KeeperSyncStatus,
   PendingInvite,

--- a/services/api/src/utils/calendar-pause.ts
+++ b/services/api/src/utils/calendar-pause.ts
@@ -1,0 +1,29 @@
+import { calendarsTable } from "@keeper.sh/database/schema";
+import { and, eq } from "drizzle-orm";
+import type { KeeperCalendarPauseResult, KeeperDatabase } from "@/types";
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const isCalendarId = (value: string | undefined): value is string =>
+  typeof value === "string" && UUID_PATTERN.test(value);
+
+const setCalendarPaused = async (
+  database: KeeperDatabase,
+  userId: string,
+  calendarId: string,
+  paused: boolean,
+): Promise<KeeperCalendarPauseResult | null> => {
+  const [updated] = await database
+    .update(calendarsTable)
+    .set({ disabled: paused })
+    .where(and(eq(calendarsTable.id, calendarId), eq(calendarsTable.userId, userId)))
+    .returning({ disabled: calendarsTable.disabled, id: calendarsTable.id });
+
+  if (!updated) {
+    return null;
+  }
+
+  return { calendarId: updated.id, paused: updated.disabled };
+};
+
+export { isCalendarId, setCalendarPaused };

--- a/services/api/src/utils/free-time.ts
+++ b/services/api/src/utils/free-time.ts
@@ -1,0 +1,245 @@
+import { instantToWallTime, resolveTimeZone, wallTimeToInstant } from "@keeper.sh/calendar";
+import { MS_PER_DAY } from "@keeper.sh/constants";
+
+const MS_PER_MINUTE = 60_000;
+const MINUTES_PER_HOUR = 60;
+const DAYS_PER_WEEK = 7;
+const MAX_FREE_SLOTS = 200;
+const DEFAULT_FREE_SLOTS = 50;
+const WALL_CLOCK_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+class FreeTimeValidationError extends RangeError {
+  constructor(message: string) {
+    super(message);
+    this.name = "FreeTimeValidationError";
+  }
+}
+
+interface TimeInterval {
+  start: Date;
+  end: Date;
+}
+
+interface FreeSlot {
+  start: string;
+  end: string;
+  durationMinutes: number;
+}
+
+interface WorkingHours {
+  startMinute: number;
+  endMinute: number;
+  days: number[] | null;
+}
+
+interface FreeTimeOptions {
+  durationMinutes: number;
+  timezone: string;
+  workingHours: WorkingHours | null;
+  limit: number;
+}
+
+interface MsInterval {
+  start: number;
+  end: number;
+}
+
+const parseWallClockMinute = (value: string, label: string): number => {
+  const match = WALL_CLOCK_PATTERN.exec(value);
+  if (!match) {
+    throw new FreeTimeValidationError(`${label} must be a 24-hour wall-clock time such as 09:00`);
+  }
+  return Number(match[1]) * MINUTES_PER_HOUR + Number(match[2]);
+};
+
+const parseWorkingDays = (value: string): number[] => {
+  const days = value
+    .split(",")
+    .filter(Boolean)
+    .map((day) => Number(day.trim()));
+
+  if (days.length === 0) {
+    throw new FreeTimeValidationError("workingDays must list at least one day");
+  }
+  if (days.some((day) => !Number.isInteger(day) || day < 0 || day >= DAYS_PER_WEEK)) {
+    throw new FreeTimeValidationError("workingDays must be integers from 0 (Sunday) to 6 (Saturday)");
+  }
+
+  return days;
+};
+
+const parseWorkingHours = (
+  start: string | null,
+  end: string | null,
+  days: string | null,
+): WorkingHours | null => {
+  if (!start && !end) {
+    if (days) {
+      throw new FreeTimeValidationError(
+        "workingDays requires workingHoursStart and workingHoursEnd",
+      );
+    }
+    return null;
+  }
+  if (!start || !end) {
+    throw new FreeTimeValidationError(
+      "workingHoursStart and workingHoursEnd must be provided together",
+    );
+  }
+
+  const startMinute = parseWallClockMinute(start, "workingHoursStart");
+  const endMinute = parseWallClockMinute(end, "workingHoursEnd");
+
+  if (startMinute >= endMinute) {
+    throw new FreeTimeValidationError("workingHoursStart must be before workingHoursEnd");
+  }
+
+  if (!days) {
+    return { days: null, endMinute, startMinute };
+  }
+
+  return { days: parseWorkingDays(days), endMinute, startMinute };
+};
+
+const toMsInterval = ({ start, end }: TimeInterval): MsInterval => ({
+  end: end.getTime(),
+  start: start.getTime(),
+});
+
+const mergeIntervals = (intervals: MsInterval[]): MsInterval[] => {
+  const ordered = intervals
+    .filter(({ start, end }) => end > start)
+    .toSorted((left, right) => left.start - right.start);
+  const merged: MsInterval[] = [];
+
+  for (const interval of ordered) {
+    const previous = merged.at(-1);
+    if (!previous || interval.start > previous.end) {
+      merged.push(interval);
+      continue;
+    }
+    if (interval.end > previous.end) {
+      merged.splice(-1, 1, { end: interval.end, start: previous.start });
+    }
+  }
+
+  return merged;
+};
+
+const subtractBusyFromWindow = (window: MsInterval, busy: MsInterval[]): MsInterval[] => {
+  const free: MsInterval[] = [];
+  let cursor = window.start;
+
+  for (const interval of busy) {
+    if (interval.end <= cursor || interval.start >= window.end) {
+      continue;
+    }
+    if (interval.start > cursor) {
+      free.push({ end: interval.start, start: cursor });
+    }
+    cursor = Math.min(Math.max(interval.end, cursor), window.end);
+  }
+
+  if (cursor < window.end) {
+    free.push({ end: window.end, start: cursor });
+  }
+
+  return free;
+};
+
+const buildLocalDayStarts = (range: MsInterval, timeZone: string): number[] => {
+  const startWall = instantToWallTime(new Date(range.start), timeZone);
+  const endWall = instantToWallTime(new Date(range.end), timeZone);
+  const firstDay = Date.UTC(
+    startWall.getUTCFullYear(),
+    startWall.getUTCMonth(),
+    startWall.getUTCDate(),
+  );
+  const lastDay = Date.UTC(endWall.getUTCFullYear(), endWall.getUTCMonth(), endWall.getUTCDate());
+  const dayStarts: number[] = [];
+
+  for (let day = firstDay; day <= lastDay; day += MS_PER_DAY) {
+    dayStarts.push(day);
+  }
+
+  return dayStarts;
+};
+
+const buildCandidateWindows = (
+  range: MsInterval,
+  timeZone: string,
+  workingHours: WorkingHours | null,
+): MsInterval[] => {
+  if (!workingHours) {
+    return [range];
+  }
+
+  return buildLocalDayStarts(range, timeZone)
+    .filter((dayStart) => {
+      if (!workingHours.days) {
+        return true;
+      }
+      return workingHours.days.includes(new Date(dayStart).getUTCDay());
+    })
+    .map((dayStart) => ({
+      end: wallTimeToInstant(
+        new Date(dayStart + workingHours.endMinute * MS_PER_MINUTE),
+        timeZone,
+      ).getTime(),
+      start: wallTimeToInstant(
+        new Date(dayStart + workingHours.startMinute * MS_PER_MINUTE),
+        timeZone,
+      ).getTime(),
+    }))
+    .map((window) => ({
+      end: Math.min(window.end, range.end),
+      start: Math.max(window.start, range.start),
+    }))
+    .filter((window) => window.end > window.start);
+};
+
+const toFreeSlot = (interval: MsInterval): FreeSlot => ({
+  durationMinutes: Math.floor((interval.end - interval.start) / MS_PER_MINUTE),
+  end: new Date(interval.end).toISOString(),
+  start: new Date(interval.start).toISOString(),
+});
+
+const findFreeSlots = (
+  range: TimeInterval,
+  busyIntervals: TimeInterval[],
+  options: FreeTimeOptions,
+): FreeSlot[] => {
+  if (!Number.isInteger(options.durationMinutes) || options.durationMinutes <= 0) {
+    throw new FreeTimeValidationError("durationMinutes must be a positive whole number of minutes");
+  }
+  if (!Number.isInteger(options.limit) || options.limit <= 0 || options.limit > MAX_FREE_SLOTS) {
+    throw new FreeTimeValidationError(`limit must be a whole number from 1 to ${MAX_FREE_SLOTS}`);
+  }
+
+  const timeZone = resolveTimeZone(options.timezone);
+  if (!timeZone) {
+    throw new FreeTimeValidationError("timezone must be an IANA timezone identifier");
+  }
+
+  const msRange = toMsInterval(range);
+  const busy = mergeIntervals(busyIntervals.map((interval) => toMsInterval(interval)));
+  const minimumDurationMs = options.durationMinutes * MS_PER_MINUTE;
+
+  return buildCandidateWindows(msRange, timeZone, options.workingHours)
+    .flatMap((window) => subtractBusyFromWindow(window, busy))
+    .filter((slot) => slot.end - slot.start >= minimumDurationMs)
+    .toSorted((left, right) => left.start - right.start)
+    .slice(0, options.limit)
+    .map((slot) => toFreeSlot(slot));
+};
+
+export {
+  DEFAULT_FREE_SLOTS,
+  findFreeSlots,
+  FreeTimeValidationError,
+  MAX_FREE_SLOTS,
+  mergeIntervals,
+  parseWorkingHours,
+  subtractBusyFromWindow,
+};
+export type { FreeSlot, FreeTimeOptions, TimeInterval, WorkingHours };

--- a/services/api/src/utils/request-body.ts
+++ b/services/api/src/utils/request-body.ts
@@ -59,6 +59,12 @@ const eventPatchBodySchema = type({
 });
 type EventPatchBody = typeof eventPatchBodySchema.infer;
 
+const calendarPausePatchBodySchema = type({
+  paused: "boolean",
+  "+": "reject",
+});
+type CalendarPausePatchBody = typeof calendarPausePatchBodySchema.infer;
+
 const tokenCreateBodySchema = type({
   name: "string",
   "+": "reject",
@@ -67,6 +73,7 @@ type TokenCreateBody = typeof tokenCreateBodySchema.infer;
 
 export {
   calendarIdsBodySchema,
+  calendarPausePatchBodySchema,
   sourcePatchBodySchema,
   icalSettingsPatchBodySchema,
   eventCreateBodySchema,
@@ -75,6 +82,7 @@ export {
 };
 export type {
   CalendarIdsBody,
+  CalendarPausePatchBody,
   SourcePatchBody,
   IcalSettingsPatchBody,
   EventCreateBody,

--- a/services/api/src/utils/sync-trigger-limit.ts
+++ b/services/api/src/utils/sync-trigger-limit.ts
@@ -1,0 +1,31 @@
+import type Redis from "ioredis";
+
+const SYNC_TRIGGER_COOLDOWN_SECONDS = 60;
+
+const buildCooldownKey = (userId: string): string => `sync_trigger:${userId}`;
+
+type SyncTriggerLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterSeconds: number };
+
+const checkAndClaimSyncTrigger = async (
+  redisClient: Redis,
+  userId: string,
+): Promise<SyncTriggerLimitResult> => {
+  const key = buildCooldownKey(userId);
+  const claimed = await redisClient.set(key, "1", "EX", SYNC_TRIGGER_COOLDOWN_SECONDS, "NX");
+
+  if (claimed === "OK") {
+    return { allowed: true };
+  }
+
+  const remainingSeconds = await redisClient.ttl(key);
+
+  return {
+    allowed: false,
+    retryAfterSeconds: Math.max(remainingSeconds, 1),
+  };
+};
+
+export { checkAndClaimSyncTrigger, SYNC_TRIGGER_COOLDOWN_SECONDS };
+export type { SyncTriggerLimitResult };

--- a/services/api/src/utils/trigger-sync.ts
+++ b/services/api/src/utils/trigger-sync.ts
@@ -1,0 +1,46 @@
+import type { Plan } from "@keeper.sh/data-schemas";
+import { calendarsTable } from "@keeper.sh/database/schema";
+import { and, arrayContains, eq, isNotNull } from "drizzle-orm";
+import type { KeeperSyncTriggerResult } from "@/types";
+import { enqueuePushSync } from "./enqueue-push-sync";
+
+interface TriggerSyncDependencies {
+  clearIngestBackoff: (userId: string) => Promise<number>;
+  enqueuePushSync: (userId: string, plan: Plan) => Promise<void>;
+}
+
+const runTriggerSync = async (
+  userId: string,
+  plan: Plan,
+  dependencies: TriggerSyncDependencies,
+): Promise<KeeperSyncTriggerResult> => {
+  const sourcesRefreshed = await dependencies.clearIngestBackoff(userId);
+  await dependencies.enqueuePushSync(userId, plan);
+
+  return { sourcesRefreshed, triggered: true };
+};
+
+const triggerSync = async (userId: string, plan: Plan): Promise<KeeperSyncTriggerResult> => {
+  const { database } = await import("@/context");
+
+  return runTriggerSync(userId, plan, {
+    clearIngestBackoff: async (backoffUserId) => {
+      const cleared = await database
+        .update(calendarsTable)
+        .set({ ingestNextAttemptAt: null })
+        .where(and(
+          eq(calendarsTable.userId, backoffUserId),
+          eq(calendarsTable.disabled, false),
+          arrayContains(calendarsTable.capabilities, ["pull"]),
+          isNotNull(calendarsTable.ingestNextAttemptAt),
+        ))
+        .returning({ id: calendarsTable.id });
+
+      return cleared.length;
+    },
+    enqueuePushSync,
+  });
+};
+
+export { runTriggerSync, triggerSync };
+export type { TriggerSyncDependencies };

--- a/services/api/tests/queries/find-free-time.test.ts
+++ b/services/api/tests/queries/find-free-time.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { isBlocking } from "../../src/queries/find-free-time";
+
+const candidate = (overrides: {
+  availability?: string | null;
+  isAllDay?: boolean | null;
+}) => ({
+  endTime: new Date("2026-03-02T10:00:00Z"),
+  startTime: new Date("2026-03-02T09:00:00Z"),
+  ...overrides,
+});
+
+describe("isBlocking", () => {
+  it("treats busy events as blocking", () => {
+    expect(isBlocking(candidate({ availability: "busy" }), false)).toBe(true);
+  });
+
+  it("treats out-of-office events as blocking", () => {
+    expect(isBlocking(candidate({ availability: "oof" }), false)).toBe(true);
+  });
+
+  it("treats free events as non-blocking", () => {
+    expect(isBlocking(candidate({ availability: "free" }), false)).toBe(false);
+  });
+
+  it("treats working-elsewhere events as non-blocking", () => {
+    expect(isBlocking(candidate({ availability: "workingElsewhere" }), false)).toBe(false);
+  });
+
+  it("treats an unknown availability as blocking", () => {
+    expect(isBlocking(candidate({ availability: null }), false)).toBe(true);
+    expect(isBlocking(candidate({}), false)).toBe(true);
+  });
+
+  it("blocks all-day busy events by default", () => {
+    expect(isBlocking(candidate({ availability: "busy", isAllDay: true }), false)).toBe(true);
+  });
+
+  it("ignores all-day events when asked to", () => {
+    expect(isBlocking(candidate({ availability: "busy", isAllDay: true }), true)).toBe(false);
+  });
+
+  it("still blocks timed events when all-day events are ignored", () => {
+    expect(isBlocking(candidate({ availability: "busy", isAllDay: false }), true)).toBe(true);
+  });
+
+  it("keeps free all-day events non-blocking either way", () => {
+    expect(isBlocking(candidate({ availability: "free", isAllDay: true }), false)).toBe(false);
+  });
+});

--- a/services/api/tests/utils/calendar-pause.test.ts
+++ b/services/api/tests/utils/calendar-pause.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { isCalendarId, setCalendarPaused } from "../../src/utils/calendar-pause";
+import type { KeeperDatabase } from "../../src/types";
+
+const CALENDAR_ID = "019c0000-0000-7000-8000-000000000001";
+
+interface UpdatedRow {
+  id: string;
+  disabled: boolean;
+}
+
+const createMockDatabase = (rows: UpdatedRow[]) => {
+  const state = { updates: [] as Record<string, unknown>[] };
+
+  const database = {
+    update: () => ({
+      set: (values: Record<string, unknown>) => {
+        state.updates.push(values);
+        return {
+          where: () => ({
+            returning: () => Promise.resolve(rows),
+          }),
+        };
+      },
+    }),
+  } as unknown as KeeperDatabase;
+
+  return { database, state };
+};
+
+describe("isCalendarId", () => {
+  it("accepts a UUID", () => {
+    expect(isCalendarId(CALENDAR_ID)).toBe(true);
+  });
+
+  it("rejects a non-UUID", () => {
+    expect(isCalendarId("free-time")).toBe(false);
+  });
+
+  it("rejects an empty route parameter", () => {
+    expect(isCalendarId("")).toBe(false);
+  });
+});
+
+describe("setCalendarPaused", () => {
+  it("pauses a calendar by disabling it", async () => {
+    const { database, state } = createMockDatabase([{ disabled: true, id: CALENDAR_ID }]);
+
+    const result = await setCalendarPaused(database, "user-1", CALENDAR_ID, true);
+
+    expect(state.updates).toEqual([{ disabled: true }]);
+    expect(result).toEqual({ calendarId: CALENDAR_ID, paused: true });
+  });
+
+  it("resumes a calendar by re-enabling it", async () => {
+    const { database, state } = createMockDatabase([{ disabled: false, id: CALENDAR_ID }]);
+
+    const result = await setCalendarPaused(database, "user-1", CALENDAR_ID, false);
+
+    expect(state.updates).toEqual([{ disabled: false }]);
+    expect(result).toEqual({ calendarId: CALENDAR_ID, paused: false });
+  });
+
+  it("returns null when the calendar does not belong to the user", async () => {
+    const { database } = createMockDatabase([]);
+
+    const result = await setCalendarPaused(database, "user-1", CALENDAR_ID, true);
+
+    expect(result).toBeNull();
+  });
+});

--- a/services/api/tests/utils/free-time.test.ts
+++ b/services/api/tests/utils/free-time.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_FREE_SLOTS,
+  findFreeSlots,
+  FreeTimeValidationError,
+  MAX_FREE_SLOTS,
+  mergeIntervals,
+  parseWorkingHours,
+  subtractBusyFromWindow,
+} from "../../src/utils/free-time";
+import type { FreeTimeOptions, TimeInterval } from "../../src/utils/free-time";
+
+const interval = (start: string, end: string): TimeInterval => ({
+  end: new Date(end),
+  start: new Date(start),
+});
+
+const msInterval = (start: string, end: string) => ({
+  end: new Date(end).getTime(),
+  start: new Date(start).getTime(),
+});
+
+const baseOptions = (overrides?: Partial<FreeTimeOptions>): FreeTimeOptions => ({
+  durationMinutes: 30,
+  limit: DEFAULT_FREE_SLOTS,
+  timezone: "UTC",
+  workingHours: null,
+  ...overrides,
+});
+
+describe("mergeIntervals", () => {
+  it("merges overlapping intervals", () => {
+    expect(mergeIntervals([
+      msInterval("2026-03-02T09:00:00Z", "2026-03-02T10:00:00Z"),
+      msInterval("2026-03-02T09:30:00Z", "2026-03-02T11:00:00Z"),
+    ])).toEqual([msInterval("2026-03-02T09:00:00Z", "2026-03-02T11:00:00Z")]);
+  });
+
+  it("merges intervals that touch exactly", () => {
+    expect(mergeIntervals([
+      msInterval("2026-03-02T09:00:00Z", "2026-03-02T10:00:00Z"),
+      msInterval("2026-03-02T10:00:00Z", "2026-03-02T11:00:00Z"),
+    ])).toEqual([msInterval("2026-03-02T09:00:00Z", "2026-03-02T11:00:00Z")]);
+  });
+
+  it("keeps disjoint intervals separate and sorted", () => {
+    expect(mergeIntervals([
+      msInterval("2026-03-02T14:00:00Z", "2026-03-02T15:00:00Z"),
+      msInterval("2026-03-02T09:00:00Z", "2026-03-02T10:00:00Z"),
+    ])).toEqual([
+      msInterval("2026-03-02T09:00:00Z", "2026-03-02T10:00:00Z"),
+      msInterval("2026-03-02T14:00:00Z", "2026-03-02T15:00:00Z"),
+    ]);
+  });
+
+  it("swallows intervals fully contained in an earlier one", () => {
+    expect(mergeIntervals([
+      msInterval("2026-03-02T09:00:00Z", "2026-03-02T17:00:00Z"),
+      msInterval("2026-03-02T11:00:00Z", "2026-03-02T12:00:00Z"),
+    ])).toEqual([msInterval("2026-03-02T09:00:00Z", "2026-03-02T17:00:00Z")]);
+  });
+
+  it("drops zero-length and inverted intervals", () => {
+    expect(mergeIntervals([
+      msInterval("2026-03-02T09:00:00Z", "2026-03-02T09:00:00Z"),
+      msInterval("2026-03-02T12:00:00Z", "2026-03-02T11:00:00Z"),
+    ])).toEqual([]);
+  });
+});
+
+describe("subtractBusyFromWindow", () => {
+  it("returns the whole window when nothing is busy", () => {
+    const window = msInterval("2026-03-02T09:00:00Z", "2026-03-02T17:00:00Z");
+
+    expect(subtractBusyFromWindow(window, [])).toEqual([window]);
+  });
+
+  it("splits the window around a busy block", () => {
+    expect(subtractBusyFromWindow(
+      msInterval("2026-03-02T09:00:00Z", "2026-03-02T17:00:00Z"),
+      [msInterval("2026-03-02T12:00:00Z", "2026-03-02T13:00:00Z")],
+    )).toEqual([
+      msInterval("2026-03-02T09:00:00Z", "2026-03-02T12:00:00Z"),
+      msInterval("2026-03-02T13:00:00Z", "2026-03-02T17:00:00Z"),
+    ]);
+  });
+
+  it("ignores busy blocks entirely outside the window", () => {
+    const window = msInterval("2026-03-02T09:00:00Z", "2026-03-02T17:00:00Z");
+
+    expect(subtractBusyFromWindow(window, [
+      msInterval("2026-03-02T06:00:00Z", "2026-03-02T07:00:00Z"),
+      msInterval("2026-03-02T20:00:00Z", "2026-03-02T21:00:00Z"),
+    ])).toEqual([window]);
+  });
+
+  it("clips busy blocks that straddle the window edges", () => {
+    expect(subtractBusyFromWindow(
+      msInterval("2026-03-02T09:00:00Z", "2026-03-02T17:00:00Z"),
+      [
+        msInterval("2026-03-02T08:00:00Z", "2026-03-02T10:00:00Z"),
+        msInterval("2026-03-02T16:00:00Z", "2026-03-02T19:00:00Z"),
+      ],
+    )).toEqual([msInterval("2026-03-02T10:00:00Z", "2026-03-02T16:00:00Z")]);
+  });
+
+  it("returns nothing when the window is fully busy", () => {
+    expect(subtractBusyFromWindow(
+      msInterval("2026-03-02T09:00:00Z", "2026-03-02T17:00:00Z"),
+      [msInterval("2026-03-02T08:00:00Z", "2026-03-02T18:00:00Z")],
+    )).toEqual([]);
+  });
+});
+
+describe("parseWorkingHours", () => {
+  it("returns null when no working hours are supplied", () => {
+    expect(parseWorkingHours(null, null, null)).toBeNull();
+  });
+
+  it("parses a wall-clock window into local minutes", () => {
+    expect(parseWorkingHours("09:00", "17:30", null)).toEqual({
+      days: null,
+      endMinute: 1050,
+      startMinute: 540,
+    });
+  });
+
+  it("parses working days", () => {
+    expect(parseWorkingHours("09:00", "17:00", "1,2,3,4,5")?.days).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("rejects a half-specified window", () => {
+    expect(() => parseWorkingHours("09:00", null, null)).toThrow(FreeTimeValidationError);
+  });
+
+  it("rejects working days without working hours", () => {
+    expect(() => parseWorkingHours(null, null, "1,2")).toThrow(FreeTimeValidationError);
+  });
+
+  it("rejects a malformed wall-clock time", () => {
+    expect(() => parseWorkingHours("9am", "17:00", null)).toThrow(FreeTimeValidationError);
+  });
+
+  it("rejects an end that is not after the start", () => {
+    expect(() => parseWorkingHours("17:00", "09:00", null)).toThrow(FreeTimeValidationError);
+  });
+
+  it("rejects out-of-range weekdays", () => {
+    expect(() => parseWorkingHours("09:00", "17:00", "7")).toThrow(FreeTimeValidationError);
+  });
+});
+
+describe("findFreeSlots", () => {
+  it("returns the whole range when there are no busy events", () => {
+    expect(findFreeSlots(
+      interval("2026-03-02T09:00:00Z", "2026-03-02T17:00:00Z"),
+      [],
+      baseOptions(),
+    )).toEqual([
+      {
+        durationMinutes: 480,
+        end: "2026-03-02T17:00:00.000Z",
+        start: "2026-03-02T09:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("drops gaps shorter than the requested duration", () => {
+    const slots = findFreeSlots(
+      interval("2026-03-02T09:00:00Z", "2026-03-02T17:00:00Z"),
+      [
+        interval("2026-03-02T09:00:00Z", "2026-03-02T12:00:00Z"),
+        interval("2026-03-02T12:15:00Z", "2026-03-02T17:00:00Z"),
+      ],
+      baseOptions({ durationMinutes: 30 }),
+    );
+
+    expect(slots).toEqual([]);
+  });
+
+  it("keeps a gap exactly as long as the requested duration", () => {
+    const slots = findFreeSlots(
+      interval("2026-03-02T09:00:00Z", "2026-03-02T17:00:00Z"),
+      [
+        interval("2026-03-02T09:00:00Z", "2026-03-02T12:00:00Z"),
+        interval("2026-03-02T12:30:00Z", "2026-03-02T17:00:00Z"),
+      ],
+      baseOptions({ durationMinutes: 30 }),
+    );
+
+    expect(slots).toEqual([
+      {
+        durationMinutes: 30,
+        end: "2026-03-02T12:30:00.000Z",
+        start: "2026-03-02T12:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("restricts candidates to working hours in the requested timezone", () => {
+    const slots = findFreeSlots(
+      interval("2026-03-02T00:00:00Z", "2026-03-03T00:00:00Z"),
+      [],
+      baseOptions({
+        durationMinutes: 60,
+        timezone: "America/New_York",
+        workingHours: { days: null, endMinute: 1020, startMinute: 540 },
+      }),
+    );
+
+    expect(slots).toEqual([
+      {
+        durationMinutes: 480,
+        end: "2026-03-02T22:00:00.000Z",
+        start: "2026-03-02T14:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("skips local days excluded by workingDays", () => {
+    const slots = findFreeSlots(
+      interval("2026-03-07T00:00:00Z", "2026-03-10T00:00:00Z"),
+      [],
+      baseOptions({
+        durationMinutes: 60,
+        timezone: "UTC",
+        workingHours: { days: [1], endMinute: 1020, startMinute: 540 },
+      }),
+    );
+
+    expect(slots).toEqual([
+      {
+        durationMinutes: 480,
+        end: "2026-03-09T17:00:00.000Z",
+        start: "2026-03-09T09:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("tracks the local wall clock across a daylight saving transition", () => {
+    const slots = findFreeSlots(
+      interval("2026-03-07T00:00:00Z", "2026-03-10T00:00:00Z"),
+      [],
+      baseOptions({
+        durationMinutes: 60,
+        timezone: "America/New_York",
+        workingHours: { days: null, endMinute: 1020, startMinute: 540 },
+      }),
+    );
+
+    expect(slots.map(({ start }) => start)).toEqual([
+      "2026-03-07T14:00:00.000Z",
+      "2026-03-08T13:00:00.000Z",
+      "2026-03-09T13:00:00.000Z",
+    ]);
+  });
+
+  it("clamps working-hour windows to the requested range", () => {
+    const slots = findFreeSlots(
+      interval("2026-03-02T12:00:00Z", "2026-03-02T15:00:00Z"),
+      [],
+      baseOptions({
+        durationMinutes: 30,
+        timezone: "UTC",
+        workingHours: { days: null, endMinute: 1020, startMinute: 540 },
+      }),
+    );
+
+    expect(slots).toEqual([
+      {
+        durationMinutes: 180,
+        end: "2026-03-02T15:00:00.000Z",
+        start: "2026-03-02T12:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("caps the number of returned slots at the limit", () => {
+    const slots = findFreeSlots(
+      interval("2026-03-02T00:00:00Z", "2026-03-09T00:00:00Z"),
+      [],
+      baseOptions({
+        durationMinutes: 60,
+        limit: 2,
+        workingHours: { days: null, endMinute: 1020, startMinute: 540 },
+      }),
+    );
+
+    expect(slots).toHaveLength(2);
+  });
+
+  it("rejects a non-positive duration", () => {
+    expect(() => findFreeSlots(
+      interval("2026-03-02T09:00:00Z", "2026-03-02T17:00:00Z"),
+      [],
+      baseOptions({ durationMinutes: 0 }),
+    )).toThrow(FreeTimeValidationError);
+  });
+
+  it("rejects a limit above the maximum", () => {
+    expect(() => findFreeSlots(
+      interval("2026-03-02T09:00:00Z", "2026-03-02T17:00:00Z"),
+      [],
+      baseOptions({ limit: MAX_FREE_SLOTS + 1 }),
+    )).toThrow(FreeTimeValidationError);
+  });
+
+  it("rejects a timezone that is not an IANA identifier", () => {
+    expect(() => findFreeSlots(
+      interval("2026-03-02T09:00:00Z", "2026-03-02T17:00:00Z"),
+      [],
+      baseOptions({ timezone: "Mars/Olympus_Mons" }),
+    )).toThrow(RangeError);
+  });
+});

--- a/services/api/tests/utils/sync-trigger-limit.test.ts
+++ b/services/api/tests/utils/sync-trigger-limit.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkAndClaimSyncTrigger,
+  SYNC_TRIGGER_COOLDOWN_SECONDS,
+} from "../../src/utils/sync-trigger-limit";
+
+const createMockRedis = () => {
+  const store = new Map<string, number>();
+
+  return {
+    store,
+    set: (
+      key: string,
+      _value: string,
+      _expiryFlag: string,
+      seconds: number,
+      _mode: string,
+    ): Promise<string | null> => {
+      if (store.has(key)) {
+        return Promise.resolve(null);
+      }
+      store.set(key, seconds);
+      return Promise.resolve("OK");
+    },
+    ttl: (key: string): Promise<number> => Promise.resolve(store.get(key) ?? -2),
+  };
+};
+
+describe("checkAndClaimSyncTrigger", () => {
+  it("allows the first request and claims the cooldown", async () => {
+    const redis = createMockRedis();
+
+    const result = await checkAndClaimSyncTrigger(redis as never, "user-1");
+
+    expect(result.allowed).toBe(true);
+    expect(redis.store.get("sync_trigger:user-1")).toBe(SYNC_TRIGGER_COOLDOWN_SECONDS);
+  });
+
+  it("blocks a second request inside the cooldown", async () => {
+    const redis = createMockRedis();
+    await checkAndClaimSyncTrigger(redis as never, "user-1");
+
+    const result = await checkAndClaimSyncTrigger(redis as never, "user-1");
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) {
+      throw new Error("Expected the second request to be throttled");
+    }
+    expect(result.retryAfterSeconds).toBe(SYNC_TRIGGER_COOLDOWN_SECONDS);
+  });
+
+  it("reports at least one second of remaining cooldown", async () => {
+    const redis = createMockRedis();
+    await checkAndClaimSyncTrigger(redis as never, "user-1");
+    redis.store.set("sync_trigger:user-1", 0);
+
+    const result = await checkAndClaimSyncTrigger(redis as never, "user-1");
+
+    if (result.allowed) {
+      throw new Error("Expected the second request to be throttled");
+    }
+    expect(result.retryAfterSeconds).toBe(1);
+  });
+
+  it("tracks users independently", async () => {
+    const redis = createMockRedis();
+    await checkAndClaimSyncTrigger(redis as never, "user-1");
+
+    const result = await checkAndClaimSyncTrigger(redis as never, "user-2");
+
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/services/api/tests/utils/trigger-sync.test.ts
+++ b/services/api/tests/utils/trigger-sync.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { runTriggerSync } from "../../src/utils/trigger-sync";
+import type { TriggerSyncDependencies } from "../../src/utils/trigger-sync";
+import type { Plan } from "@keeper.sh/data-schemas";
+
+interface EnqueueCall {
+  userId: string;
+  plan: Plan;
+}
+
+const createDependencies = (sourcesRefreshed = 2) => {
+  const state = {
+    backoffClearedFor: [] as string[],
+    enqueued: [] as EnqueueCall[],
+  };
+
+  const dependencies: TriggerSyncDependencies = {
+    clearIngestBackoff: (userId) => {
+      state.backoffClearedFor.push(userId);
+      return Promise.resolve(sourcesRefreshed);
+    },
+    enqueuePushSync: (userId, plan) => {
+      state.enqueued.push({ plan, userId });
+      return Promise.resolve();
+    },
+  };
+
+  return { dependencies, state };
+};
+
+describe("runTriggerSync", () => {
+  it("clears the ingest backoff and enqueues a push for the user", async () => {
+    const { dependencies, state } = createDependencies();
+
+    const result = await runTriggerSync("user-1", "pro", dependencies);
+
+    expect(state.backoffClearedFor).toEqual(["user-1"]);
+    expect(state.enqueued).toEqual([{ plan: "pro", userId: "user-1" }]);
+    expect(result).toEqual({ sourcesRefreshed: 2, triggered: true });
+  });
+
+  it("reports how many sources had their backoff cleared", async () => {
+    const { dependencies } = createDependencies(0);
+
+    const result = await runTriggerSync("user-1", "free", dependencies);
+
+    expect(result.sourcesRefreshed).toBe(0);
+    expect(result.triggered).toBe(true);
+  });
+
+  it("passes the caller's plan through to the push enqueue", async () => {
+    const { dependencies, state } = createDependencies();
+
+    await runTriggerSync("user-2", "free", dependencies);
+
+    expect(state.enqueued[0]?.plan).toBe("free");
+  });
+
+  it("propagates a failure to clear the ingest backoff without enqueuing", async () => {
+    const { state } = createDependencies();
+    const dependencies: TriggerSyncDependencies = {
+      clearIngestBackoff: () => Promise.reject(new Error("database unavailable")),
+      enqueuePushSync: (userId, plan) => {
+        state.enqueued.push({ plan, userId });
+        return Promise.resolve();
+      },
+    };
+
+    await expect(runTriggerSync("user-1", "pro", dependencies)).rejects.toThrow(
+      "database unavailable",
+    );
+    expect(state.enqueued).toEqual([]);
+  });
+
+  it("propagates a failure to enqueue the push", async () => {
+    const dependencies: TriggerSyncDependencies = {
+      clearIngestBackoff: () => Promise.resolve(1),
+      enqueuePushSync: () => Promise.reject(new Error("queue unavailable")),
+    };
+
+    await expect(runTriggerSync("user-1", "pro", dependencies)).rejects.toThrow(
+      "queue unavailable",
+    );
+  });
+});

--- a/services/mcp/src/toolset.ts
+++ b/services/mcp/src/toolset.ts
@@ -36,6 +36,33 @@ const keeperCalendarSchema = z.object({
 });
 type KeeperCalendar = z.infer<typeof keeperCalendarSchema>;
 
+const keeperFreeSlotSchema = z.object({
+  start: z.string(),
+  end: z.string(),
+  durationMinutes: z.number(),
+});
+
+const keeperFreeTimeSchema = z.object({
+  from: z.string(),
+  to: z.string(),
+  timezone: z.string(),
+  durationMinutes: z.number(),
+  slots: z.array(keeperFreeSlotSchema),
+});
+type KeeperFreeTime = z.infer<typeof keeperFreeTimeSchema>;
+
+const keeperSyncTriggerSchema = z.object({
+  triggered: z.boolean(),
+  sourcesRefreshed: z.number(),
+});
+type KeeperSyncTrigger = z.infer<typeof keeperSyncTriggerSchema>;
+
+const keeperCalendarPauseSchema = z.object({
+  calendarId: z.string(),
+  paused: z.boolean(),
+});
+type KeeperCalendarPause = z.infer<typeof keeperCalendarPauseSchema>;
+
 interface KeeperMcpToolset {
   list_calendars: KeeperMcpToolDefinition<KeeperCalendar[]>;
   get_event_count: KeeperMcpToolDefinition<{ count: number }>;
@@ -48,6 +75,9 @@ interface KeeperMcpToolset {
   rsvp_event: KeeperMcpToolDefinition<{ rsvpStatus: string } | { error: string }>;
   list_accounts: KeeperMcpToolDefinition<unknown[]>;
   get_ical_feed: KeeperMcpToolDefinition<{ url: string }>;
+  find_free_time: KeeperMcpToolDefinition<KeeperFreeTime>;
+  trigger_sync: KeeperMcpToolDefinition<KeeperSyncTrigger>;
+  pause_sync: KeeperMcpToolDefinition<KeeperCalendarPause>;
 }
 
 const isErrorResponse = (value: unknown): value is { error: string } =>
@@ -164,6 +194,52 @@ const localizeEvent = (event: KeeperEvent, timeZone: string) => ({
   ...event,
   startTime: toLocalizedTime(event.startTime, timeZone),
   endTime: toLocalizedTime(event.endTime, timeZone),
+});
+
+const FREE_TIME_OPTIONAL_PARAMS = [
+  "workingHoursStart",
+  "workingHoursEnd",
+  "workingDays",
+  "calendarId",
+  "ignoreAllDayEvents",
+  "limit",
+] as const;
+
+const toParamValue = (value: unknown): string | null => {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return null;
+};
+
+const buildFreeTimeParams = (
+  input: Record<string, unknown> & { from: string; to: string; timezone: string },
+  durationMinutes: number,
+): URLSearchParams =>
+  new URLSearchParams([
+    ["from", input.from],
+    ["to", input.to],
+    ["timezone", input.timezone],
+    ["durationMinutes", String(durationMinutes)],
+    ...FREE_TIME_OPTIONAL_PARAMS.flatMap((key) => {
+      const value = toParamValue(input[key]);
+      if (value === null) {
+        return [];
+      }
+      return [[key, value] satisfies [string, string]];
+    }),
+  ]);
+
+const localizeFreeTime = (freeTime: KeeperFreeTime): KeeperFreeTime => ({
+  ...freeTime,
+  slots: freeTime.slots.map((slot) => ({
+    ...slot,
+    start: toLocalizedTime(slot.start, freeTime.timezone),
+    end: toLocalizedTime(slot.end, freeTime.timezone),
+  })),
 });
 
 const createKeeperMcpToolset = (): KeeperMcpToolset => ({
@@ -342,7 +418,97 @@ const createKeeperMcpToolset = (): KeeperMcpToolset => ({
     description: "Get the user's iCal feed URL for subscribing in other calendar apps.",
     execute: (context) => apiFetch(context, "/api/v1/ical", z.object({ url: z.string() })),
   },
+  find_free_time: {
+    title: "Find free time",
+    description:
+      "Find open slots of at least 'durationMinutes' across every synced calendar in a date range. Events marked free or working-elsewhere never block; busy, out-of-office, and all-day events do. Optionally restrict candidates to working hours and weekdays in the given timezone. Returned slots are localized to that timezone.",
+    inputSchema: {
+      ...eventRangeSchema,
+      durationMinutes: z
+        .number()
+        .int()
+        .positive()
+        .describe("Minimum length of a usable slot, in minutes"),
+      workingHoursStart: z
+        .string()
+        .optional()
+        .describe("Local start of the working day as 24-hour HH:MM (e.g. 09:00)"),
+      workingHoursEnd: z
+        .string()
+        .optional()
+        .describe("Local end of the working day as 24-hour HH:MM (e.g. 17:00)"),
+      workingDays: z
+        .string()
+        .optional()
+        .describe("Comma-separated local weekdays to consider, 0 for Sunday through 6 for Saturday"),
+      calendarId: z
+        .string()
+        .optional()
+        .describe("Comma-separated calendar IDs to consider instead of every calendar"),
+      ignoreAllDayEvents: z
+        .boolean()
+        .optional()
+        .describe("Treat all-day events as non-blocking"),
+      limit: z.number().int().positive().optional().describe("Maximum number of slots to return"),
+    },
+    execute: async (context, input) => {
+      if (!input || !isEventRangeInput(input)) {
+        throw new Error("'from', 'to', and 'timezone' are required");
+      }
+      if (typeof input.durationMinutes !== "number") {
+        throw new TypeError("'durationMinutes' is required");
+      }
+      const params = buildFreeTimeParams(input, input.durationMinutes);
+      const freeTime = await apiFetch(
+        context,
+        `/api/v1/events/free-time?${params}`,
+        keeperFreeTimeSchema,
+      );
+      return localizeFreeTime(freeTime);
+    },
+  },
+  trigger_sync: {
+    title: "Trigger sync",
+    description:
+      "Force Keeper to sync now: clears the ingest backoff on every active source so they are polled on the next pass, and immediately enqueues a push to every destination calendar. Throttled to one request per minute per user.",
+    execute: (context) =>
+      apiFetch(context, "/api/v1/sync", keeperSyncTriggerSchema, { method: "POST" }),
+  },
+  pause_sync: {
+    title: "Pause or resume calendar sync",
+    description:
+      "Pause or resume syncing for a single calendar without disconnecting it. A paused calendar is neither polled for new events nor pushed to, in both directions, and its stored events are kept. Set paused to false to resume.",
+    inputSchema: {
+      calendarId: z.string().uuid().describe("The calendar ID returned by list_calendars"),
+      paused: z.boolean().describe("True to pause syncing, false to resume"),
+    },
+    execute: (context, input) => {
+      if (!input?.calendarId || typeof input.calendarId !== "string") {
+        throw new Error("'calendarId' is required");
+      }
+      if (typeof input.paused !== "boolean") {
+        throw new TypeError("'paused' is required");
+      }
+      return apiFetch(
+        context,
+        `/api/v1/calendars/${input.calendarId}`,
+        keeperCalendarPauseSchema,
+        {
+          method: "PATCH",
+          body: JSON.stringify({ paused: input.paused }),
+        },
+      );
+    },
+  },
 });
 
 export { createKeeperMcpToolset, normalizeTimezoneOffset, toLocalizedTime };
-export type { KeeperCalendar, KeeperMcpToolDefinition, KeeperMcpToolset, KeeperToolContext };
+export type {
+  KeeperCalendar,
+  KeeperCalendarPause,
+  KeeperFreeTime,
+  KeeperMcpToolDefinition,
+  KeeperMcpToolset,
+  KeeperSyncTrigger,
+  KeeperToolContext,
+};

--- a/services/mcp/tests/toolset.test.ts
+++ b/services/mcp/tests/toolset.test.ts
@@ -1,5 +1,53 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createKeeperMcpToolset } from "../src/toolset";
+import type { KeeperToolContext } from "../src/toolset";
+
+const context: KeeperToolContext = {
+  apiBaseUrl: "https://api.test",
+  bearerToken: "token-123",
+};
+
+interface CapturedRequest {
+  url: string;
+  method: string | null;
+  body: string | null;
+}
+
+const readBody = (body: RequestInit["body"]): string | null => {
+  if (typeof body === "string") {
+    return body;
+  }
+  return null;
+};
+
+const stubFetch = (payload: unknown): CapturedRequest[] => {
+  const requests: CapturedRequest[] = [];
+
+  vi.stubGlobal("fetch", (url: string, options?: RequestInit) => {
+    requests.push({
+      body: readBody(options?.body),
+      method: options?.method ?? null,
+      url,
+    });
+    return Promise.resolve(Response.json(payload));
+  });
+
+  return requests;
+};
+
+const freeTimePayload = {
+  durationMinutes: 30,
+  from: "2026-03-02T00:00:00.000Z",
+  slots: [
+    {
+      durationMinutes: 60,
+      end: "2026-03-02T15:00:00.000Z",
+      start: "2026-03-02T14:00:00.000Z",
+    },
+  ],
+  timezone: "America/New_York",
+  to: "2026-03-03T00:00:00.000Z",
+};
 
 describe("createKeeperMcpToolset", () => {
   it("exposes the full tool surface", () => {
@@ -8,6 +56,7 @@ describe("createKeeperMcpToolset", () => {
     expect(Object.keys(toolset).toSorted()).toEqual([
       "create_event",
       "delete_event",
+      "find_free_time",
       "get_event",
       "get_event_count",
       "get_events",
@@ -15,7 +64,9 @@ describe("createKeeperMcpToolset", () => {
       "get_pending_invites",
       "list_accounts",
       "list_calendars",
+      "pause_sync",
       "rsvp_event",
+      "trigger_sync",
       "update_event",
     ]);
   });
@@ -45,5 +96,181 @@ describe("createKeeperMcpToolset", () => {
       }
       expect(schema.safeParse(occurrenceId).success).toBe(true);
     }
+  });
+});
+
+describe("find_free_time", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards the range, timezone and duration to the free-time route", async () => {
+    const requests = stubFetch(freeTimePayload);
+
+    await createKeeperMcpToolset().find_free_time.execute(context, {
+      durationMinutes: 30,
+      from: "2026-03-02T00:00:00Z",
+      timezone: "America/New_York",
+      to: "2026-03-03T00:00:00Z",
+    });
+
+    const url = new URL(requests[0]?.url ?? "");
+    expect(url.pathname).toBe("/api/v1/events/free-time");
+    expect(url.searchParams.get("from")).toBe("2026-03-02T00:00:00Z");
+    expect(url.searchParams.get("to")).toBe("2026-03-03T00:00:00Z");
+    expect(url.searchParams.get("timezone")).toBe("America/New_York");
+    expect(url.searchParams.get("durationMinutes")).toBe("30");
+  });
+
+  it("forwards optional working-hour and filter parameters", async () => {
+    const requests = stubFetch(freeTimePayload);
+
+    await createKeeperMcpToolset().find_free_time.execute(context, {
+      calendarId: "calendar-1,calendar-2",
+      durationMinutes: 45,
+      from: "2026-03-02T00:00:00Z",
+      ignoreAllDayEvents: true,
+      limit: 5,
+      timezone: "America/New_York",
+      to: "2026-03-03T00:00:00Z",
+      workingDays: "1,2,3,4,5",
+      workingHoursEnd: "17:00",
+      workingHoursStart: "09:00",
+    });
+
+    const url = new URL(requests[0]?.url ?? "");
+    expect(url.searchParams.get("workingHoursStart")).toBe("09:00");
+    expect(url.searchParams.get("workingHoursEnd")).toBe("17:00");
+    expect(url.searchParams.get("workingDays")).toBe("1,2,3,4,5");
+    expect(url.searchParams.get("calendarId")).toBe("calendar-1,calendar-2");
+    expect(url.searchParams.get("ignoreAllDayEvents")).toBe("true");
+    expect(url.searchParams.get("limit")).toBe("5");
+  });
+
+  it("omits optional parameters that were not supplied", async () => {
+    const requests = stubFetch(freeTimePayload);
+
+    await createKeeperMcpToolset().find_free_time.execute(context, {
+      durationMinutes: 30,
+      from: "2026-03-02T00:00:00Z",
+      timezone: "America/New_York",
+      to: "2026-03-03T00:00:00Z",
+    });
+
+    const url = new URL(requests[0]?.url ?? "");
+    expect(url.searchParams.has("workingHoursStart")).toBe(false);
+    expect(url.searchParams.has("limit")).toBe(false);
+  });
+
+  it("localizes returned slots to the requested timezone", async () => {
+    stubFetch(freeTimePayload);
+
+    const result = await createKeeperMcpToolset().find_free_time.execute(context, {
+      durationMinutes: 30,
+      from: "2026-03-02T00:00:00Z",
+      timezone: "America/New_York",
+      to: "2026-03-03T00:00:00Z",
+    });
+
+    expect(result.slots).toEqual([
+      {
+        durationMinutes: 60,
+        end: "2026-03-02T10:00:00-05:00",
+        start: "2026-03-02T09:00:00-05:00",
+      },
+    ]);
+  });
+
+  it("requires a duration", async () => {
+    stubFetch(freeTimePayload);
+
+    await expect(createKeeperMcpToolset().find_free_time.execute(context, {
+      from: "2026-03-02T00:00:00Z",
+      timezone: "America/New_York",
+      to: "2026-03-03T00:00:00Z",
+    })).rejects.toThrow("'durationMinutes' is required");
+  });
+
+  it("requires the full range", async () => {
+    stubFetch(freeTimePayload);
+
+    await expect(createKeeperMcpToolset().find_free_time.execute(context, {
+      durationMinutes: 30,
+      from: "2026-03-02T00:00:00Z",
+    })).rejects.toThrow("'from', 'to', and 'timezone' are required");
+  });
+});
+
+describe("trigger_sync", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts to the sync route", async () => {
+    const requests = stubFetch({ sourcesRefreshed: 3, triggered: true });
+
+    const result = await createKeeperMcpToolset().trigger_sync.execute(context);
+
+    expect(requests[0]?.url).toBe("https://api.test/api/v1/sync");
+    expect(requests[0]?.method).toBe("POST");
+    expect(result).toEqual({ sourcesRefreshed: 3, triggered: true });
+  });
+
+  it("surfaces the throttling error from the API", async () => {
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve(Response.json(
+        { error: "A sync was already requested recently. Try again in 42 seconds." },
+        { status: 429 },
+      )));
+
+    await expect(createKeeperMcpToolset().trigger_sync.execute(context)).rejects.toThrow(
+      "Try again in 42 seconds",
+    );
+  });
+});
+
+describe("pause_sync", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("patches the calendar with the paused flag", async () => {
+    const calendarId = "019c0000-0000-7000-8000-000000000001";
+    const requests = stubFetch({ calendarId, paused: true });
+
+    const result = await createKeeperMcpToolset().pause_sync.execute(context, {
+      calendarId,
+      paused: true,
+    });
+
+    expect(requests[0]?.url).toBe(`https://api.test/api/v1/calendars/${calendarId}`);
+    expect(requests[0]?.method).toBe("PATCH");
+    expect(requests[0]?.body).toBe(JSON.stringify({ paused: true }));
+    expect(result).toEqual({ calendarId, paused: true });
+  });
+
+  it("resumes a calendar", async () => {
+    const calendarId = "019c0000-0000-7000-8000-000000000001";
+    const requests = stubFetch({ calendarId, paused: false });
+
+    await createKeeperMcpToolset().pause_sync.execute(context, { calendarId, paused: false });
+
+    expect(requests[0]?.body).toBe(JSON.stringify({ paused: false }));
+  });
+
+  it("requires a calendar ID", () => {
+    stubFetch({});
+
+    expect(
+      () => createKeeperMcpToolset().pause_sync.execute(context, { paused: true }),
+    ).toThrow("'calendarId' is required");
+  });
+
+  it("requires the paused flag", () => {
+    stubFetch({});
+
+    expect(
+      () => createKeeperMcpToolset().pause_sync.execute(context, { calendarId: "calendar-1" }),
+    ).toThrow("'paused' is required");
   });
 });


### PR DESCRIPTION
Adds the three MCP tools from #472 as thin wrappers over three new v1 API routes, all behind `withV1Auth` so they inherit the free-tier daily limit. No migration was needed: `calendars.disabled` already exists and already gates both ingest and push, so `pause_sync` just writes it — it was previously a column nothing ever set to true. Per-mapping pause is not included, since pausing a single source→destination edge would need a new column on `source_destination_mappings`.

- `GET /api/v1/events/free-time` — free slots over a range for a duration; `free`/`workingElsewhere` never block, `busy`/`oof`/unknown do, all-day events block unless `ignoreAllDayEvents=true`, optional `workingHoursStart`/`workingHoursEnd`/`workingDays` evaluated against the local wall clock so DST transitions hold the hours steady. Reuses the existing range defaults and the 732-day cap.
- `POST /api/v1/sync` — clears `ingestNextAttemptAt` on active pull sources so the 1-minute cron re-polls them, then reuses `enqueuePushSync` for the egress half rather than reimplementing it. Throttled to one per user per minute via Redis `SET NX` (same shape as `api-rate-limit.ts`), returning 429 with `Retry-After`.
- `PATCH /api/v1/calendars/{calendarId}` — `{ paused }` toggles `calendars.disabled`, halting both directions for that calendar while keeping its stored events.
- Worth a reviewer's eye: the reconnect flow in `calendar-state.ts` forces `disabled: false`, so reconnecting a calendar silently un-pauses it. That was harmless while nothing set the flag to true, but pausing is now user-reachable.
- These routes should also serve #356 (a force-resync button) and #34 (enable/disable syncing state) — both want exactly this behaviour from the web UI.
- 68 new tests covering the interval math, DST-crossing working hours, the busy/OOF/all-day rules, the cooldown, and the tool wrappers. README updated for both the MCP tool table and the REST API section.
