### PR TITLE
refactor: move the comparison article into the blog

### DIFF
--- a/applications/web/plugins/blog.ts
+++ b/applications/web/plugins/blog.ts
@@ -23,10 +23,37 @@ const blogPostMetadataSchema = type({
 
 type BlogPostMetadata = typeof blogPostMetadataSchema.infer;
 
+interface BlogPostFaqEntry {
+  answer: string;
+  question: string;
+}
+
 export interface ProcessedBlogPost {
   content: string;
+  faq: BlogPostFaqEntry[];
   metadata: BlogPostMetadata;
   slug: string;
+}
+
+const FAQ_ITEM_PATTERN = /<faq-item question="([^"]*)">([\s\S]*?)<\/faq-item>/g;
+
+function extractFaqEntries(content: string, filePath: string): BlogPostFaqEntry[] {
+  const entries = [...content.matchAll(FAQ_ITEM_PATTERN)].map((match) => ({
+    answer: match[2].trim(),
+    question: match[1].trim(),
+  }));
+
+  const incomplete = entries.find(
+    (entry) => entry.question.length === 0 || entry.answer.length === 0,
+  );
+
+  if (incomplete) {
+    throw new Error(
+      `Blog post "${filePath}" has a faq-item with an empty question or answer.`,
+    );
+  }
+
+  return entries;
 }
 
 function toIsoDate(value: string): string {
@@ -197,7 +224,7 @@ export function processBlogDirectory(
     slugCounts.set(baseSlug, seenCount + 1);
     const slug = seenCount === 0 ? baseSlug : `${baseSlug}-${seenCount + 1}`;
 
-    return { content, metadata, slug };
+    return { content, faq: extractFaqEntries(content, file), metadata, slug };
   });
 
   return posts.sort((a, b) =>

--- a/applications/web/plugins/sitemap.ts
+++ b/applications/web/plugins/sitemap.ts
@@ -61,29 +61,35 @@ function buildBlogIndexEntry(blogEntries: SitemapEntry[]): SitemapEntry {
   return { loc: `${SITE_URL}/blog`, lastmod };
 }
 
-function parseFrontmatter(raw: string): Record<string, unknown> {
-  const [, match] = raw.match(FRONTMATTER_PATTERN);
-  if (!match) return {};
-  return parseYaml(match);
+function parseFrontmatter(raw: string, file: string): Record<string, unknown> {
+  const match = raw.match(FRONTMATTER_PATTERN);
+  if (!match) {
+    throw new Error(`"${file}" is missing a YAML frontmatter block.`);
+  }
+  return parseYaml(match[1]);
 }
 
-function discoverBlogEntries(blogDir: string): SitemapEntry[] {
-  const files = readdirSync(blogDir).filter((f) => f.endsWith(".mdx"));
+function discoverContentEntries(
+  directory: string,
+  basePath: string,
+  label: string,
+): SitemapEntry[] {
+  const files = readdirSync(directory).filter((file) => file.endsWith(".mdx"));
 
   return files.map((file) => {
-    const raw = readFileSync(join(blogDir, file), "utf-8");
-    const frontmatter = parseFrontmatter(raw);
+    const raw = readFileSync(join(directory, file), "utf-8");
+    const frontmatter = parseFrontmatter(raw, file);
 
     if (typeof frontmatter.slug !== "string") {
-      throw new Error(`Blog post "${file}" is missing a slug.`);
+      throw new Error(`${label} "${file}" is missing a slug.`);
     }
 
     if (typeof frontmatter.updatedAt !== "string") {
-      throw new Error(`Blog post "${file}" is missing updatedAt.`);
+      throw new Error(`${label} "${file}" is missing updatedAt.`);
     }
 
     return {
-      loc: `${SITE_URL}/blog/${frontmatter.slug}`,
+      loc: `${SITE_URL}${basePath}/${frontmatter.slug}`,
       lastmod: frontmatter.updatedAt.slice(0, 10),
     };
   });
@@ -124,7 +130,7 @@ export function sitemapPlugin(): Plugin {
     },
 
     generateBundle() {
-      const blogEntries = discoverBlogEntries(blogDir);
+      const blogEntries = discoverContentEntries(blogDir, "/blog", "Blog post");
       const entries = [
         ...readStaticEntries(pagesFile),
         buildBlogIndexEntry(blogEntries),

--- a/applications/web/src/components/ui/primitives/markdown-component-map.ts
+++ b/applications/web/src/components/ui/primitives/markdown-component-map.ts
@@ -12,8 +12,11 @@ import {
   MarkdownParagraph,
   MarkdownRule,
   MarkdownTable,
+  MarkdownTableBody,
   MarkdownTableCell,
   MarkdownTableHeader,
+  MarkdownTableRow,
+  MarkdownTableSection,
   MarkdownUnorderedList,
 } from "./markdown-components";
 
@@ -31,7 +34,10 @@ export const markdownComponents: Components = {
   p: MarkdownParagraph,
   pre: MarkdownCodeBlock,
   table: MarkdownTable,
+  tbody: MarkdownTableBody,
   td: MarkdownTableCell,
   th: MarkdownTableHeader,
+  thead: MarkdownTableSection,
+  tr: MarkdownTableRow,
   ul: MarkdownUnorderedList,
 };

--- a/applications/web/src/components/ui/primitives/markdown-components.tsx
+++ b/applications/web/src/components/ui/primitives/markdown-components.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from "react";
+import { Children, isValidElement, type JSX, type ReactNode } from "react";
 import { Heading1, Heading2, Heading3 } from "./heading";
 import { ListItem, OrderedList, UnorderedList } from "./list";
 import { Text } from "./text";
@@ -8,8 +8,16 @@ type MarkdownElementProps<Tag extends keyof JSX.IntrinsicElements> =
   node?: unknown;
 };
 
+const SITE_ORIGIN = "https://keeper.sh";
+const HTTP_PROTOCOLS = ["http:", "https:"];
+const LABEL_COLUMN_MIN_WIDTH = "7rem";
+const COLUMN_MIN_WIDTH = "4.5rem";
+
 function isExternalHttpLink(href: string): boolean {
-  return href.startsWith("http://") || href.startsWith("https://");
+  if (!URL.canParse(href)) return false;
+
+  const url = new URL(href);
+  return HTTP_PROTOCOLS.includes(url.protocol) && url.origin !== SITE_ORIGIN;
 }
 
 export function MarkdownHeadingOne({ children }: MarkdownElementProps<"h1">) {
@@ -101,26 +109,70 @@ export function MarkdownRule() {
   return <hr className="my-6 border-interactive-border" />;
 }
 
-export function MarkdownTable({
-  children,
-}: MarkdownElementProps<"table">) {
-  return (
-    <div className="my-4 overflow-x-auto">
-      <table className="min-w-full border-collapse border border-interactive-border text-base tracking-tight text-foreground-muted">
-        {children}
-      </table>
-    </div>
-  );
-}
-
 export function MarkdownTableHeader({
   children,
 }: MarkdownElementProps<"th">) {
-  return <th className="border border-interactive-border px-2 py-1 text-left font-medium text-foreground">{children}</th>;
+  return (
+    <th className="border-interactive-border border-r border-b bg-background-elevated px-2 py-3 sm:px-3 text-left align-top font-medium text-foreground break-words">
+      {children}
+    </th>
+  );
 }
 
 export function MarkdownTableCell({
   children,
 }: MarkdownElementProps<"td">) {
-  return <td className="border border-interactive-border px-2 py-1">{children}</td>;
+  return (
+    <td className="border-interactive-border border-r border-b px-2 py-3 sm:px-3 align-top break-words">
+      {children}
+    </td>
+  );
+}
+
+export function MarkdownTableSection({
+  children,
+}: MarkdownElementProps<"thead">) {
+  return <thead className="contents">{children}</thead>;
+}
+
+export function MarkdownTableBody({
+  children,
+}: MarkdownElementProps<"tbody">) {
+  return <tbody className="contents">{children}</tbody>;
+}
+
+export function MarkdownTableRow({ children }: MarkdownElementProps<"tr">) {
+  return <tr className="contents">{children}</tr>;
+}
+
+function countHeaderCells(children: ReactNode): number {
+  return Children.toArray(children).reduce<number>((total, child) => {
+    if (!isValidElement<{ children?: ReactNode }>(child)) return total;
+    if (child.type === MarkdownTableHeader) return total + 1;
+    return total + countHeaderCells(child.props.children);
+  }, 0);
+}
+
+export function MarkdownTable({
+  children,
+}: MarkdownElementProps<"table">) {
+  const columnCount = Math.max(countHeaderCells(children), 1);
+  const gridTemplateColumns = [
+    `minmax(${LABEL_COLUMN_MIN_WIDTH}, 1.5fr)`,
+    ...Array.from(
+      { length: columnCount - 1 },
+      () => `minmax(${COLUMN_MIN_WIDTH}, 1fr)`,
+    ),
+  ].join(" ");
+
+  return (
+    <div className="my-4 overflow-x-auto rounded-2xl border border-interactive-border">
+      <table
+        className="grid w-full text-sm tracking-tight text-foreground-muted [&_tbody_tr:last-child_:is(td,th)]:border-b-0 [&_tr_:is(td,th):last-child]:border-r-0"
+        style={{ gridTemplateColumns }}
+      >
+        {children}
+      </table>
+    </div>
+  );
 }

--- a/applications/web/src/components/ui/primitives/prose.tsx
+++ b/applications/web/src/components/ui/primitives/prose.tsx
@@ -1,0 +1,23 @@
+import { Streamdown, type AllowedTags, type Components } from "streamdown";
+import { markdownComponents } from "./markdown-component-map";
+
+export function Prose({
+  children,
+  allowedTags,
+  components,
+}: {
+  children: string;
+  allowedTags?: AllowedTags;
+  components?: Components;
+}) {
+  return (
+    <article className="flex flex-col gap-2">
+      <Streamdown
+        allowedTags={allowedTags}
+        components={{ ...markdownComponents, ...components }}
+      >
+        {children}
+      </Streamdown>
+    </article>
+  );
+}

--- a/applications/web/src/components/ui/shells/layout.tsx
+++ b/applications/web/src/components/ui/shells/layout.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from "react";
 import { cn } from "@/utils/cn";
 
-const GRID_COLS = "grid grid-cols-[minmax(1rem,1fr)_minmax(auto,48rem)_minmax(1rem,1fr)]";
+const GRID_COLS = "grid grid-cols-[minmax(1rem,1fr)_minmax(0,48rem)_minmax(1rem,1fr)]";
 
 export function Layout({ children }: PropsWithChildren) {
   return (

--- a/applications/web/src/content/blog/open-source-calendar-sync.mdx
+++ b/applications/web/src/content/blog/open-source-calendar-sync.mdx
@@ -1,0 +1,154 @@
+---
+title: "Open-Source Calendar Sync Tools Compared"
+description: "The self-hostable projects people reach for when they want calendars in sync, grouped by what they actually do, with licences and release dates taken from each project's own repository."
+blurb: "Search for an open-source calendar sync tool and most of what comes back is a CalDAV server or an Android client. This sorts the projects by what they actually do."
+slug: "open-source-calendar-sync"
+createdAt: "2026-08-11"
+updatedAt: "2026-08-11"
+tags:
+  - "open-source"
+  - "self-hosting"
+  - "caldav"
+  - "sync"
+---
+
+Search for an open-source calendar sync tool and you get three unrelated kinds of software mixed together. Most of what comes back is a CalDAV server or an Android client. Neither will copy an event from your work calendar onto your personal one.
+
+This article sorts them by what they actually do.
+
+## The three categories
+
+A tool that **mirrors events between accounts** reads from one calendar account and writes into another. That is what you want if your problem is double bookings across a work and a personal calendar.
+
+A **CalDAV server** is somewhere to keep calendars you control, using the standard most calendar apps can talk to. It solves a different problem: getting off a provider, not making two of them agree.
+
+A **client or device sync agent** puts a server's calendars onto a phone or a desktop. It will not copy events between two cloud accounts either.
+
+Keeper.sh is in the first category, and this article is on Keeper.sh's own site, so read the rest with that in mind.
+
+| Project | Mirrors between accounts | Licence | Category |
+| --- | --- | --- | --- |
+| [Keeper.sh](https://github.com/ridafkih/keeper.sh) | Yes, this is the whole product | AGPL-3.0 | Mirroring |
+| [vdirsyncer](https://vdirsyncer.pimutils.org) | Yes, by pairing two remote storages | BSD 3-Clause | Mirroring |
+| [n8n](https://n8n.io) | Not out of the box, you build the workflow | Sustainable Use License v1.0 | Automation platform |
+| [Activepieces](https://www.activepieces.com) | Not out of the box, you build the flow | MIT, with `packages/ee` separately licensed | Automation platform |
+| [Radicale](https://radicale.org) | No, it is a server | GPLv3 | CalDAV server |
+| [Baïkal](https://sabre.io/baikal/) | No, it is a server | GPL-3.0 | CalDAV server |
+| [Nextcloud Calendar](https://github.com/nextcloud/calendar) | No, external calendars are read-only subscriptions | AGPL-3.0 | CalDAV server |
+| [DAVx⁵](https://www.davx5.com) | Not documented, it syncs a device to a server | GPL-3.0 | Device sync |
+| [EteSync](https://www.etesync.com) | No, it syncs its own encrypted accounts | AGPL-3.0 | Encrypted sync stack |
+
+## Mirrors events between accounts
+
+These will move an event from one calendar account into another. Two do it as a product; two give you the parts to assemble one.
+
+### Keeper.sh
+
+A hosted and self-hostable service that reads events from calendar accounts and writes busy blocks into others. Five first-class providers, plus generic CalDAV and calendar links you can subscribe to.
+
+It is AGPL-3.0, runs from published Docker images, and a self-hosted instance gets every Pro feature with no licence key. Google and Microsoft are used through their own APIs, so Keeper.sh only fetches what changed. It checks on a timer rather than being pinged: every minute in, then 30 minutes or one minute out depending on plan.
+
+### vdirsyncer
+
+A command-line tool that syncs calendars and contacts between servers and your own filesystem, under a BSD 3-Clause licence. Pairing two storages lets you connect two remote accounts directly.
+
+There is a `google_calendar` storage you sign in to, and Microsoft is not documented. There is no hosted version and no scheduler, so you run it yourself. The latest tag is v0.20.0, from a commit dated 28 August 2025.
+
+### n8n
+
+A workflow automation platform with no calendar mirroring feature. Its Google Calendar and Microsoft Outlook nodes give you the event operations to build one yourself.
+
+It is distributed under the Sustainable Use License v1.0, which is not an OSI licence. Use is limited to internal business purposes, and redistribution must be free of charge and non-commercial. Cloud tiers are Starter €20, Pro €50 and Business €667 a month billed annually.
+
+### Activepieces
+
+A workflow automation platform in the same shape as n8n, MIT licensed with the `packages/ee` directories under a separate licence. Its Google Calendar piece has event triggers and actions, and its Microsoft Outlook Calendar piece covers create, delete and list.
+
+It runs self-hosted or on Activepieces Cloud, which has a free tier, Plus at $16 and Team at $166 a month billed yearly. The latest release is 0.87.0, on 6 August 2026.
+
+## CalDAV servers you host yourself
+
+These host your calendars. None of them connects to Google Calendar or Microsoft, and none copies events between third-party accounts. They pair well with a sync tool rather than replacing one.
+
+### Radicale
+
+A small CalDAV and CardDAV server under GPLv3. It gives you somewhere to keep your own calendars.
+
+It runs as a Python server with a Docker image available, and there is no hosted version on the official site. The latest release is v3.7.8, on 6 August 2026.
+
+### Baïkal
+
+A lightweight CalDAV and CardDAV server built on sabre/dav, GPL-3.0, with a web admin interface. Same role as Radicale: a place to host calendars, not a way to copy events between accounts.
+
+It runs as a PHP server, and no hosted version is mentioned on the project page. The latest release is 0.12.1, on 5 August 2026.
+
+### Nextcloud Calendar
+
+The calendar app for a Nextcloud server, AGPL-3.0, on a CalDAV backend. Other calendars can be added as read-only subscriptions from a link, refreshed weekly, so it is a viewer of other calendars rather than a mirror.
+
+There is no documented Google or Microsoft connector. Nextcloud Enterprise starts at €71.29 per user per year from 100 users. The latest tag is v6.6.0, dated 28 July 2026.
+
+## Clients and device sync
+
+These get calendars onto your devices. They are here because they turn up in the same searches, not because they are substitutes.
+
+### DAVx⁵
+
+An Android sync adapter for CalDAV, CardDAV and WebDAV, GPL-3.0. It gets a server's calendars onto an Android phone, and its documented job is device to server rather than server to server.
+
+Google accounts work over CalDAV, which its own documentation states is not officially supported by either party. It is paid in the app stores and free on F-Droid and GitHub. The latest release is v4.5.19-ose, on 3 August 2026.
+
+### EteSync
+
+An end-to-end encrypted sync stack, AGPL-3.0, with its own server, clients and a bridge for desktop calendar apps. It syncs its own accounts across your devices rather than copying events between Google and Outlook.
+
+Hosted plans are Personal at $2 a month billed yearly and Supporter at $4 a month. The latest tag is v0.14.2, from a commit dated 13 June 2024 — worth knowing before you build on it.
+
+## Picking between them
+
+- **Want a calendar server you own?** Radicale or Baïkal, or Nextcloud if you want the rest of Nextcloud with it.
+- **Want encrypted sync across your own devices?** EteSync.
+- **Comfortable with a command line and a cron job?** vdirsyncer costs nothing to run and is a small, well-understood tool.
+- **Already running n8n or Activepieces?** Build the sync logic there rather than adding another service.
+- **Need your CalDAV calendars on Android?** DAVx⁵, alongside whatever else you use.
+
+Keeper.sh is the better fit when you want copying between accounts to work without assembling it yourself. It reaches Google and Microsoft through their own APIs rather than CalDAV workarounds, and the hosted and self-hosted versions have the same features.
+
+It writes anonymised busy blocks by default rather than full event copies. AGPL-3.0 also matters if a source available licence with use restrictions does not work for you.
+
+## What Keeper.sh does not do
+
+Keeper.sh is not a calendar server. It does not store your calendars in a way you would want to point a calendar app at, so it does not replace Radicale, Baïkal or Nextcloud. It has no mobile app and no desktop client.
+
+It checks on a timer rather than being pinged the moment something changes. Changes take up to a minute on Pro, and up to 30 minutes on the free plan, to reach the other calendar. Keeper.sh only fetches what changed on Google and Outlook, while CalDAV calendars are re-read and compared in full every cycle.
+
+Self-hosting is genuinely full-featured, with one caveat worth stating. Passkey and social login are only enabled in commercial mode, so a self-hosted instance uses email and password.
+
+## Frequently asked questions
+
+<faq>
+<faq-item question="Is n8n open source?">n8n is distributed under the Sustainable Use License version 1.0, which is not an OSI-approved open-source licence. Its terms limit use to your own internal business purposes and allow redistribution only free of charge for non-commercial purposes. The project describes itself as fair-code.</faq-item>
+
+<faq-item question="Can I self-host Keeper.sh, and do I lose features?">Yes, under AGPL-3.0, with published Docker images. Self-hosted instances get every Pro feature with no licence key. You do lose passkey and social login, which are only enabled in commercial mode, and you are responsible for running Postgres and Redis.</faq-item>
+</faq>
+
+## Sources
+
+Every third-party claim above comes from one of these pages, each checked on 11 August 2026.
+
+1. [Keeper.sh repository](https://github.com/ridafkih/keeper.sh) — AGPL-3.0 licence, Docker images, self-hosting instructions.
+2. [vdirsyncer configuration docs](https://vdirsyncer.pimutils.org/en/stable/config.html) — BSD 3-Clause licence, storage pairs, `google_calendar` storage.
+3. [vdirsyncer repository](https://github.com/pimutils/vdirsyncer) — latest tag v0.20.0, commit dated 28 August 2025.
+4. [n8n LICENSE.md](https://github.com/n8n-io/n8n/blob/master/LICENSE.md) — Sustainable Use License v1.0, internal business purposes and non-commercial distribution.
+5. [n8n documentation](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/) — Google Calendar node and Microsoft Outlook node with calendar and event operations.
+6. [n8n Cloud pricing](https://n8n.io/pricing/) — Starter, Pro, Business and Enterprise tiers.
+7. [Activepieces repository LICENSE](https://github.com/activepieces/activepieces/blob/main/LICENSE) — MIT with the `packages/ee` directories under a separate licence.
+8. [Activepieces Google Calendar piece](https://www.activepieces.com/pieces/google-calendar) — Google Calendar and Microsoft Outlook Calendar pieces, available triggers and actions.
+9. [Radicale](https://radicale.org/v3.html) — CalDAV and CardDAV server, GPLv3, release v3.7.8 on 6 August 2026.
+10. [Baïkal](https://sabre.io/baikal/) — lightweight CalDAV and CardDAV server, GPL-3.0, release 0.12.1 on 5 August 2026.
+11. [Nextcloud Calendar documentation](https://docs.nextcloud.com/server/latest/user_manual/en/groupware/calendar.html) — read-only subscription from link, refreshed weekly.
+12. [Nextcloud Calendar repository](https://github.com/nextcloud/calendar) — AGPL-3.0 licence, latest tag v6.6.0 dated 28 July 2026.
+13. [DAVx⁵](https://www.davx5.com/) — all-in-one CalDAV, CardDAV and WebDAV solution for Android, GPL-3.0, release v4.5.19-ose on 3 August 2026.
+14. [DAVx⁵ documentation](https://www.davx5.com/tested-with/google) — Google accounts work over CalDAV and are not officially supported by either party.
+15. [EteSync](https://www.etesync.com/) — end-to-end encrypted sync for contacts, calendars, tasks and notes, with a DAV bridge.
+16. [EteSync server repository](https://github.com/etesync/server) — AGPL-3.0 licence, latest tag v0.14.2 with a commit dated 13 June 2024.

--- a/applications/web/src/features/marketing/components/article-cta.tsx
+++ b/applications/web/src/features/marketing/components/article-cta.tsx
@@ -2,7 +2,7 @@ import { ButtonText, LinkButton } from "@/components/ui/primitives/button";
 import { Heading3 } from "@/components/ui/primitives/heading";
 import { Text } from "@/components/ui/primitives/text";
 
-export function BlogPostCta() {
+export function ArticleCta() {
   return (
     <aside className="overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated">
       <div className="grid grid-cols-1 sm:grid-cols-3 sm:items-stretch">

--- a/applications/web/src/features/marketing/components/markdown-faq.tsx
+++ b/applications/web/src/features/marketing/components/markdown-faq.tsx
@@ -1,0 +1,27 @@
+import type { PropsWithChildren } from "react";
+import { Collapsible } from "@/components/ui/primitives/collapsible";
+import { Text } from "@/components/ui/primitives/text";
+import { MarketingFaqItem, MarketingFaqList, MarketingFaqQuestion } from "./marketing-faq";
+
+export function MarkdownFaq({ children }: PropsWithChildren) {
+  return <MarketingFaqList>{children}</MarketingFaqList>;
+}
+
+export function MarkdownFaqItem({
+  children,
+  question,
+}: PropsWithChildren<{ question?: string }>) {
+  if (!question) {
+    throw new Error("A faq-item in markdown content is missing its question attribute.");
+  }
+
+  return (
+    <MarketingFaqItem>
+      <Collapsible trigger={<MarketingFaqQuestion>{question}</MarketingFaqQuestion>}>
+        <Text size="sm" tone="muted">
+          {children}
+        </Text>
+      </Collapsible>
+    </MarketingFaqItem>
+  );
+}

--- a/applications/web/src/lib/blog-posts.ts
+++ b/applications/web/src/lib/blog-posts.ts
@@ -12,8 +12,14 @@ export interface BlogPostMetadata {
   updatedAt: string;
 }
 
+export interface BlogPostFaqEntry {
+  answer: string;
+  question: string;
+}
+
 export interface BlogPost {
   content: string;
+  faq: BlogPostFaqEntry[];
   metadata: BlogPostMetadata;
   slug: string;
 }
@@ -22,25 +28,4 @@ export const blogPosts: BlogPost[] = processedPosts;
 
 export function findBlogPostBySlug(slug: string): BlogPost | undefined {
   return blogPosts.find((blogPost) => blogPost.slug === slug);
-}
-
-const monthNames = [
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December",
-] as const;
-
-export function formatIsoDate(isoDate: string): string {
-  const [yearPart, monthPart, dayPart] = isoDate.split("-");
-  const monthName = monthNames[Number(monthPart) - 1];
-  return `${monthName} ${Number(dayPart)}, ${yearPart}`;
 }

--- a/applications/web/src/lib/seo.ts
+++ b/applications/web/src/lib/seo.ts
@@ -110,6 +110,22 @@ export function webPageSchema(name: string, description: string, path: string) {
   };
 }
 
+export function faqPageSchema(
+  path: string,
+  questions: Array<{ question: string; answer: string }>,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "@id": `${canonicalUrl(path)}/#faqpage`,
+    mainEntity: questions.map((entry) => ({
+      "@type": "Question",
+      name: entry.question,
+      acceptedAnswer: { "@type": "Answer", text: entry.answer },
+    })),
+  };
+}
+
 export function softwareApplicationSchema() {
   return {
     "@context": "https://schema.org",

--- a/applications/web/src/routes/(marketing)/blog/$slug.tsx
+++ b/applications/web/src/routes/(marketing)/blog/$slug.tsx
@@ -1,13 +1,26 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
-import { Streamdown } from "streamdown";
+import type { AllowedTags, Components } from "streamdown";
 import { Heading1 } from "@/components/ui/primitives/heading";
-import { markdownComponents } from "@/components/ui/primitives/markdown-component-map";
+import { Prose } from "@/components/ui/primitives/prose";
+import { ExternalTextLink } from "@/components/ui/primitives/text-link";
 import { Text } from "@/components/ui/primitives/text";
 import { NotFoundState } from "@/components/ui/shells/not-found";
-import { BlogPostCta } from "@/features/blog/components/blog-post-cta";
-import { findBlogPostBySlug, formatIsoDate } from "@/lib/blog-posts";
-import { canonicalUrl, jsonLdScript, seoMeta, blogPostingSchema, breadcrumbSchema, breadcrumbTrail } from "@/lib/seo";
+import { ArticleCta } from "@/features/marketing/components/article-cta";
+import { MarkdownFaq, MarkdownFaqItem } from "@/features/marketing/components/markdown-faq";
+import { findBlogPostBySlug } from "@/lib/blog-posts";
+import { formatIsoDate } from "@/utils/date";
+import { canonicalUrl, jsonLdScript, seoMeta, blogPostingSchema, breadcrumbSchema, breadcrumbTrail, faqPageSchema } from "@/lib/seo";
 import { Breadcrumb } from "@/components/ui/primitives/breadcrumb";
+
+const MARKDOWN_FAQ_TAGS: AllowedTags = {
+  faq: [],
+  "faq-item": ["question"],
+};
+
+const MARKDOWN_FAQ_COMPONENTS = {
+  faq: MarkdownFaq,
+  "faq-item": MarkdownFaqItem,
+} as Components;
 
 const blogPostBreadcrumbs = (title: string, slug: string) =>
   breadcrumbTrail({ name: "Blog", path: "/blog" }, { name: title, path: `/blog/${slug}` });
@@ -61,6 +74,9 @@ export const Route = createFileRoute("/(marketing)/blog/$slug")({
           imagePath: blogPost.metadata.image,
         })),
         jsonLdScript(breadcrumbSchema(blogPostBreadcrumbs(blogPost.metadata.title, params.slug))),
+        ...(blogPost.faq.length > 0
+          ? [jsonLdScript(faqPageSchema(postUrl, blogPost.faq))]
+          : []),
       ],
     };
   },
@@ -85,22 +101,27 @@ function BlogPostPage() {
         <div className="flex flex-col">
           <Text size="sm" tone="muted" align="left">
             By{" "}
-            <a href="https://rida.dev" target="_blank" rel="noreferrer" className="text-foreground underline underline-offset-2">
-              Rida F'kih
-            </a>
+            <ExternalTextLink
+              align="left"
+              href="https://rida.dev"
+              rel="noopener noreferrer"
+              size="sm"
+              target="_blank"
+              tone="default"
+            >
+              Rida F&apos;kih
+            </ExternalTextLink>
             {" · "}{createdDate}
             {showUpdated && <> · Updated {updatedDate}</>}
           </Text>
         </div>
       </header>
 
-      <article className="flex flex-col gap-2">
-        <Streamdown components={markdownComponents}>
-          {blogPost.content}
-        </Streamdown>
-      </article>
+      <Prose allowedTags={MARKDOWN_FAQ_TAGS} components={MARKDOWN_FAQ_COMPONENTS}>
+        {blogPost.content}
+      </Prose>
 
-      <BlogPostCta />
+      <ArticleCta />
     </div>
   );
 }

--- a/applications/web/src/routes/(marketing)/blog/index.tsx
+++ b/applications/web/src/routes/(marketing)/blog/index.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Heading1, Heading3 } from "@/components/ui/primitives/heading";
 import { Text } from "@/components/ui/primitives/text";
-import { blogPosts, formatIsoDate } from "@/lib/blog-posts";
+import { blogPosts } from "@/lib/blog-posts";
+import { formatIsoDate } from "@/utils/date";
 import { canonicalUrl, jsonLdScript, seoMeta, breadcrumbSchema, breadcrumbTrail, collectionPageSchema } from "@/lib/seo";
 import { Breadcrumb } from "@/components/ui/primitives/breadcrumb";
 

--- a/applications/web/src/utils/date.ts
+++ b/applications/web/src/utils/date.ts
@@ -1,0 +1,20 @@
+const monthNames = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+
+export function formatIsoDate(isoDate: string): string {
+  const [yearPart, monthPart, dayPart] = isoDate.split("-");
+  const monthName = monthNames[Number(monthPart) - 1];
+  return `${monthName} ${Number(dayPart)}, ${yearPart}`;
+}


### PR DESCRIPTION
Closes #469. Reworked after review: the comparison content is blog content, so the separate `/compare` collection is gone and the roundup now lives at `/blog/open-source-calendar-sync` alongside everything else. The blog MDX pipeline gained real custom components, so FAQs render as the same collapsibles the homepage uses instead of hand-rolled markdown headings.

- Deleted `plugins/compare.ts`, `lib/compare-articles.ts`, the `compare/` route group and `compareArticleSchema`; the article is a `BlogPosting` and `/compare` now 404s. `plugins/sitemap.ts` keeps the shared `discoverContentEntries` reader and the missing-frontmatter crash fix, but discovers blog content only
- `Prose` takes `allowedTags` and `components`, so blog MDX can use `<faq>` and `<faq-item question="...">`, backed by `MarketingFaq*` and `Collapsible`
- `plugins/blog.ts` extracts the FAQ entries out of the content at build time, so `FAQPage` JSON-LD stays derived from exactly what renders
- Dropped the sixteen per-source "Checked 11 August 2026" stamps; the one statement above the Sources list covers them
- Dropped the two asides volunteering that Keeper.sh has no end-to-end encryption. EteSync's own encryption is still described accurately in the table, its section and the sources list
