### PR TITLE
docs: add iCloud/Outlook and Google/iCloud sync guides

### DIFF
--- a/applications/web/src/content/blog/sync-google-calendar-with-icloud.mdx
+++ b/applications/web/src/content/blog/sync-google-calendar-with-icloud.mdx
@@ -21,7 +21,7 @@ This guide copies your Google meetings into an iCloud calendar instead, so every
 
 ## What this actually does
 
-Keeper copies events in one direction at a time. Here, Google is where events come from and iCloud is where they land.
+Keeper.sh copies events in one direction at a time. Here, Google is where events come from and iCloud is where they land.
 
 Your work calendar is untouched, and colleagues see no difference. If you later want personal appointments blocking time at work, that is a second connection pointing the other way.
 
@@ -37,7 +37,7 @@ Apple will not let an outside app sign in with your normal Apple Account passwor
 
 Instead you generate a separate password that reaches your calendar and nothing else. You can cancel it whenever you like, without changing your real password.
 
-Keeper shows you these same steps on the connect screen, and [Apple documents them too](https://support.apple.com/en-us/102654):
+Keeper.sh shows you these same steps on the connect screen, and [Apple documents them too](https://support.apple.com/en-us/102654):
 
 1. Navigate to [appleid.apple.com](https://appleid.apple.com)
 2. Sign in with your Apple ID
@@ -55,13 +55,13 @@ From your dashboard, open **Import Calendars**, then **Connect iCloud**. The scr
 - **Apple ID** — the email address you sign in to Apple with
 - **App-Specific Password** — the one you just generated, not your usual password
 
-Press **Connect**. Keeper brings in every calendar on the account, including the "Work" one you just made. Press **Skip** at setup — the connection you want gets built from the Google side.
+Press **Connect**. Keeper.sh brings in every calendar on the account, including the "Work" one you just made. Press **Skip** at setup — the connection you want gets built from the Google side.
 
 If you see **Invalid credentials**, it is the password nearly every time. Either your normal Apple password went in by mistake, or the generated one has since been cancelled.
 
 ## Connect Google Calendar
 
-Back on **Import Calendars**, choose **Connect Google Calendar**. Keeper lists what it is about to ask Google for:
+Back on **Import Calendars**, choose **Connect Google Calendar**. Keeper.sh lists what it is about to ask Google for:
 
 - See your email address
 - View a list of your calendars
@@ -76,7 +76,7 @@ Setup now runs for your Google account.
 
 **Which calendars would you like to configure?** Tick your main work calendar. Google's primary calendar arrives named after your email address.
 
-**Rename Your Calendars.** Change it to something you will recognise, like "Work". This only affects what you see inside Keeper.
+**Rename Your Calendars.** Change it to something you will recognise, like "Work". This only affects what you see inside Keeper.sh.
 
 **Where should 'Work' send events?** Tick the iCloud calendar you created earlier. That is the connection made.
 
@@ -112,11 +112,11 @@ What lands in iCloud is a record of where your time goes, not a replacement for 
 
 ## How quickly changes show up, and how far ahead
 
-Keeper reads your calendars once a minute, on every plan, paid or not. Writing the change into iCloud is the part that differs.
+Keeper.sh reads your calendars once a minute, on every plan, paid or not. Writing the change into iCloud is the part that differs.
 
 Free writes every thirty minutes, so a meeting someone books now reaches your phone within the half hour. Pro writes every minute. If colleagues move meetings at short notice, that gap is the reason to pay.
 
-Keeper works with a window running from a week ago to two years out. A one-off booking further ahead than that will not copy yet, and starts once it comes within range.
+Keeper.sh works with a window running from a week ago to two years out. A one-off booking further ahead than that will not copy yet, and starts once it comes within range.
 
 ## What the free plan covers
 
@@ -124,7 +124,7 @@ Two connected accounts and three connections. Google is one account and iCloud t
 
 The number of calendars inside each account does not matter — a Google account with five calendars still counts as one.
 
-Work into iCloud uses one connection, leaving two spare. Tick past that and Keeper stops you and offers the upgrade rather than failing quietly.
+Work into iCloud uses one connection, leaving two spare. Tick past that and Keeper.sh stops you and offers the upgrade rather than failing quietly.
 
 ## When it stops working
 
@@ -134,11 +134,11 @@ Work into iCloud uses one connection, leaving two spare. Tick past that and Keep
 
 **Your employer disconnects the Google account.** Losing access stops the copying, and existing events stay behind in iCloud. Deleting that one iCloud calendar clears them.
 
-**A calendar goes quiet for a while, then recovers.** When Google or Apple rejects or times out a request, Keeper waits longer before trying again. Left alone, it comes back.
+**A calendar goes quiet for a while, then recovers.** When Google or Apple rejects or times out a request, Keeper.sh waits longer before trying again. Left alone, it comes back.
 
 ## Running it yourself instead
 
-Keeper is open source, and self-hosting is a real alternative rather than a lesser one. Every paid feature is included free, and your calendar data stays on hardware you control.
+Keeper.sh is open source, and self-hosting is a real alternative rather than a lesser one. Every paid feature is included free, and your calendar data stays on hardware you control.
 
 The `keeper-standalone` Docker image bundles the database, the background workers and everything else into a single container.
 

--- a/applications/web/src/content/blog/sync-google-calendar-with-icloud.mdx
+++ b/applications/web/src/content/blog/sync-google-calendar-with-icloud.mdx
@@ -1,0 +1,195 @@
+---
+title: "How to Sync Google Calendar with iCloud"
+description: "Get your Google Calendar meetings onto your iPhone, Apple Watch and Mac by syncing them into iCloud with Keeper.sh. Covers the Apple app-specific password, the exact setup screens, Google-specific event types, and what to check when sync stops."
+blurb: "You live in Apple's calendar app but work runs on Google. Here is how to get work meetings onto your iPhone and Watch without putting a work account on your personal phone."
+createdAt: "2026-08-11"
+slug: "sync-google-calendar-with-icloud"
+updatedAt: "2026-08-11"
+tags:
+  - "google-calendar"
+  - "icloud"
+  - "apple-calendar"
+  - "sync"
+  - "guides"
+---
+
+You check your day on your iPhone. Your Apple Watch taps you before meetings, and Siri knows when you are free. But work runs on Google Calendar, and none of it shows up there.
+
+The obvious fix is adding your work Google account to your iPhone. Plenty of people cannot. Work accounts are often locked down by IT, and adding one can pull in mail, contacts and device management you did not ask for.
+
+This guide takes the other route. Your Google meetings get copied into an iCloud calendar, and every Apple device you own picks them up automatically.
+
+## What this actually does
+
+Keeper copies events in one direction at a time. Here, Google is where events come from and iCloud is where they land.
+
+Your work calendar stays exactly as it is. Nothing Keeper does touches it, and colleagues see no difference.
+
+If you later want personal appointments blocking time at work, that is a second connection pointing the other way. One connection never does both.
+
+## Make a home for the meetings first
+
+Do this before anything else. In the Calendar app on your iPhone or Mac, create a new iCloud calendar and call it something like "Work".
+
+It is worth the extra minute. A calendar of its own gets its own colour, so work and personal time are distinguishable at a glance.
+
+You can also hide it with one tap at the weekend. And if you ever change jobs, deleting that one calendar removes everything at once.
+
+## Why Apple makes you generate a special password
+
+This is the step people get stuck on, so do it before you open anything else.
+
+Apple will not let an outside app sign in with your normal Apple Account password. That password opens your photos, your purchase history and Find My. Handing it to a calendar tool would hand over all of that too.
+
+Instead you generate a separate password that reaches your calendar and nothing else. You can cancel it on its own, whenever you like, without changing your real password or disturbing your other apps.
+
+Apple's own instructions are in [Sign in to apps with your Apple Account using app-specific passwords](https://support.apple.com/en-us/102654).
+
+## Generate the password
+
+Keeper shows you these same steps on the connect screen:
+
+1. Navigate to [appleid.apple.com](https://appleid.apple.com)
+2. Sign in with your Apple ID
+3. Select "App-Specific Passwords"
+4. Click the "+" next to "Passwords"
+5. Label and generate the password, then copy it
+6. Paste the app-specific password below
+
+Two things worth knowing before you start. You need two-factor authentication turned on, or the App-Specific Passwords option never appears.
+
+And Apple shows you the password exactly once. Close that box without copying it and it is gone, so generate a new one.
+
+## Connect iCloud
+
+From your dashboard, open **Import Calendars**, then **Connect iCloud**. The screen is headed **Connect Apple Calendar** and asks for two things:
+
+- **Apple ID** — the email address you sign in to Apple with
+- **App-Specific Password** — the one you just generated, not your usual password
+
+You are not asked for a server address. Keeper already knows where iCloud lives, which is why it has its own option rather than the general-purpose one at the bottom of the list.
+
+Press **Connect**. Keeper brings in every calendar on the account, including the "Work" one you just made, and moves you into setup. You can press **Skip** here, because the connection you want gets built from the Google side in a moment.
+
+If you see **Invalid credentials**, it is the password nearly every time. Either your normal Apple password went in by mistake, or the generated one has since been cancelled.
+
+## Connect Google Calendar
+
+Back on **Import Calendars**, choose **Connect Google Calendar**. Keeper lists what it is about to ask Google for before sending you anywhere:
+
+- See your email address
+- View a list of your calendars
+- View events, summaries and details
+- Add or remove calendar events
+
+Press **Connect** and finish signing in with Google.
+
+## Point Google at your iCloud calendar
+
+Setup now runs for your Google account, which is exactly what you want.
+
+First, **Which calendars would you like to configure?** Tick your main work calendar. Google's primary calendar arrives named after your email address, so look for that.
+
+Next, **Rename Your Calendars.** Change it to something you will recognise, like "Work". This only affects what you see inside Keeper.
+
+Then the question that matters: **Where should 'Work' send events?** Tick the iCloud calendar you created earlier. That is the connection made.
+
+You will also see **Where should 'Work' pull events from?** Leave this one empty. Ticking it would start copying events back into your work calendar, which is not what you are here for.
+
+Press **Next** to finish. The first copy runs immediately rather than waiting for the next scheduled round.
+
+Open Calendar on your iPhone and your meetings should be there.
+
+## Decide how much detail crosses over
+
+By default you may find the copies are deliberately vague. Keeper can carry just the time and leave titles behind, which suits a shared work calendar.
+
+For this direction you probably want the opposite. A meeting on your Watch is not much use if it does not say what it is.
+
+Open the calendar from your dashboard and find **Sync Settings**. Turn on **Sync Event Name**, and the real meeting titles come through instead of a placeholder.
+
+**Sync Event Description** and **Sync Event Location** work the same way. Location is worth having if you travel to meetings, since it gives you the address on your phone.
+
+Check these switches rather than assuming. What they start out set to depends on how the calendar was first added, and we are [fixing that inconsistency](https://github.com/ridafkih/keeper.sh/issues/501).
+
+On the hosted service these controls are part of Pro. Self-hosted installs include them for everyone.
+
+## Google's own event types
+
+Google has a few event kinds that are not really meetings, and they clutter a phone if you let them through.
+
+The **Exclusions** section gives you **Exclude Focus Time Events** and **Exclude Out of Office Events**. These two only appear for Google calendars, because no other provider has them.
+
+Turn them on if you block focus time regularly. Otherwise every protected work block reappears on your personal devices, which defeats the point.
+
+Working Location entries are always left out and have no switch. Nobody wants "In the office" occupying a day on their Apple Watch.
+
+There is also **Exclude All Day Events** if company holidays are cluttering things up.
+
+## What does not cross over
+
+Some things are deliberately left behind, and this matters more in this direction than the other.
+
+Guests are not copied, so nobody gets invited a second time or emailed by accident. That is the safe behaviour, but it does mean the copy is not a working invitation.
+
+Video call links and reminders do not travel either. You cannot join a meeting from the copy on your iPhone, so keep Google Calendar to hand for that.
+
+Think of what lands in iCloud as a reliable record of where your time goes, not a replacement for your work calendar.
+
+## How quickly changes show up
+
+Keeper checks your calendars once a minute, on every plan, paid or not.
+
+Writing the change into iCloud is the part that differs. On the free plan that happens every thirty minutes, so a meeting someone books now reaches your phone within the half hour. On Pro it happens every minute.
+
+If colleagues move meetings on short notice, that gap is the reason to pay. If your week is mostly settled by Monday, the free plan will not bother you.
+
+There is no "sync now" button, so a change will not appear the instant you go looking for it.
+
+## What gets copied, and how far ahead
+
+Keeper works with a window running from a week ago to two years out.
+
+The week behind means recently finished meetings are still accounted for. The two years ahead means a one-off booking further out than that will not copy yet.
+
+That window moves with today's date, so a distant event starts syncing once it comes within two years. Nothing is needed from you for that to happen.
+
+## What the free plan covers
+
+Two connected accounts and three connections. Google is one account and iCloud is the other, so this pairing uses both.
+
+The number of calendars inside each account does not matter. A Google account with five calendars still counts as one.
+
+Three connections is what you have to spend on directions. Work into iCloud uses one, leaving two spare for other calendars later.
+
+If you tick past that, Keeper stops you and offers the upgrade rather than failing quietly afterwards.
+
+## When it stops working
+
+**Meetings quietly stopped appearing and nothing looks broken.** This is the one that actually bites. Changing your Apple Account password cancels every app-specific password you have ever created, including this one.
+
+Apple does not warn you and sends no email. Sync simply stops. Generate a fresh password and reconnect iCloud.
+
+It hurts more in this direction, because the calendar that goes stale is the one you actually look at. If your phone seems suspiciously empty, start here.
+
+**The iCloud calendar will not accept events.** Calendars shared with you by someone else, and ones you subscribed to from a link, usually arrive read-only. Make sure you picked a calendar you created yourself.
+
+**Your employer disconnects the Google account.** Losing access to a work Google account stops the copying, and existing events stay behind in iCloud. Deleting that one iCloud calendar clears them.
+
+**A calendar goes quiet for a while, then recovers.** When Google or Apple rejects or times out a request, Keeper waits longer before trying again rather than hammering it. Left alone, it comes back.
+
+## Running it yourself instead
+
+Keeper is open source, and self-hosting is a real alternative rather than a lesser one. Every paid feature is included free, and your calendar data stays on hardware you control.
+
+For work meetings on a personal server, that appeals to a lot of people.
+
+The `keeper-standalone` Docker image is the straightforward route. It bundles the database, the background workers and everything else into a single container.
+
+Be honest about the effort, though. iCloud connects immediately, since it only needs the password you generated.
+
+Google does not. You have to create your own project in Google Cloud, set up its sign-in credentials, and supply them to your install. It is well documented but genuinely fiddly the first time.
+
+You also become the person who notices when it breaks. Nobody else is watching the logs or applying updates.
+
+If that sounds fine, the [README](https://github.com/ridafkih/keeper.sh) covers the setup. If you would rather not think about it, the hosted version is the same software with the upkeep handled.

--- a/applications/web/src/content/blog/sync-google-calendar-with-icloud.mdx
+++ b/applications/web/src/content/blog/sync-google-calendar-with-icloud.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How to Sync Google Calendar with iCloud"
-description: "Get your Google Calendar meetings onto your iPhone, Apple Watch and Mac by syncing them into iCloud with Keeper.sh. Covers the Apple app-specific password, the exact setup screens, Google-specific event types, and what to check when sync stops."
+description: "Get your Google Calendar meetings onto your iPhone, Apple Watch and Mac by syncing them into iCloud with Keeper.sh. Covers the Apple app-specific password, the exact setup screens, and what to check when sync stops."
 blurb: "You live in Apple's calendar app but work runs on Google. Here is how to get work meetings onto your iPhone and Watch without putting a work account on your personal phone."
 createdAt: "2026-08-11"
 slug: "sync-google-calendar-with-icloud"
@@ -13,41 +13,31 @@ tags:
   - "guides"
 ---
 
-You check your day on your iPhone. Your Apple Watch taps you before meetings, and Siri knows when you are free. But work runs on Google Calendar, and none of it shows up there.
+You check your day on your iPhone, and your Apple Watch taps you before meetings. But work runs on Google Calendar, and none of it shows up there.
 
-The obvious fix is adding your work Google account to your iPhone. Plenty of people cannot. Work accounts are often locked down by IT, and adding one can pull in mail, contacts and device management you did not ask for.
+The obvious fix is adding your work Google account to your iPhone. Plenty of people cannot, because IT locks those accounts down or the account drags in mail and device management too.
 
-This guide takes the other route. Your Google meetings get copied into an iCloud calendar, and every Apple device you own picks them up automatically.
+This guide copies your Google meetings into an iCloud calendar instead, so every Apple device you own picks them up.
 
 ## What this actually does
 
 Keeper copies events in one direction at a time. Here, Google is where events come from and iCloud is where they land.
 
-Your work calendar stays exactly as it is. Nothing Keeper does touches it, and colleagues see no difference.
-
-If you later want personal appointments blocking time at work, that is a second connection pointing the other way. One connection never does both.
+Your work calendar is untouched, and colleagues see no difference. If you later want personal appointments blocking time at work, that is a second connection pointing the other way.
 
 ## Make a home for the meetings first
 
-Do this before anything else. In the Calendar app on your iPhone or Mac, create a new iCloud calendar and call it something like "Work".
+In the Calendar app on your iPhone or Mac, create a new iCloud calendar and call it something like "Work".
 
-It is worth the extra minute. A calendar of its own gets its own colour, so work and personal time are distinguishable at a glance.
+It gets its own colour, you can hide it at the weekend, and deleting it later removes every copied meeting at once.
 
-You can also hide it with one tap at the weekend. And if you ever change jobs, deleting that one calendar removes everything at once.
+## Generate an Apple app-specific password
 
-## Why Apple makes you generate a special password
+Apple will not let an outside app sign in with your normal Apple Account password. That password also opens your photos, your purchase history and Find My.
 
-This is the step people get stuck on, so do it before you open anything else.
+Instead you generate a separate password that reaches your calendar and nothing else. You can cancel it whenever you like, without changing your real password.
 
-Apple will not let an outside app sign in with your normal Apple Account password. That password opens your photos, your purchase history and Find My. Handing it to a calendar tool would hand over all of that too.
-
-Instead you generate a separate password that reaches your calendar and nothing else. You can cancel it on its own, whenever you like, without changing your real password or disturbing your other apps.
-
-Apple's own instructions are in [Sign in to apps with your Apple Account using app-specific passwords](https://support.apple.com/en-us/102654).
-
-## Generate the password
-
-Keeper shows you these same steps on the connect screen:
+Keeper shows you these same steps on the connect screen, and [Apple documents them too](https://support.apple.com/en-us/102654):
 
 1. Navigate to [appleid.apple.com](https://appleid.apple.com)
 2. Sign in with your Apple ID
@@ -56,9 +46,7 @@ Keeper shows you these same steps on the connect screen:
 5. Label and generate the password, then copy it
 6. Paste the app-specific password below
 
-Two things worth knowing before you start. You need two-factor authentication turned on, or the App-Specific Passwords option never appears.
-
-And Apple shows you the password exactly once. Close that box without copying it and it is gone, so generate a new one.
+You need two-factor authentication turned on, or the App-Specific Passwords option never appears. Apple shows the password exactly once, so copy it before closing the box.
 
 ## Connect iCloud
 
@@ -67,15 +55,13 @@ From your dashboard, open **Import Calendars**, then **Connect iCloud**. The scr
 - **Apple ID** — the email address you sign in to Apple with
 - **App-Specific Password** — the one you just generated, not your usual password
 
-You are not asked for a server address. Keeper already knows where iCloud lives, which is why it has its own option rather than the general-purpose one at the bottom of the list.
-
-Press **Connect**. Keeper brings in every calendar on the account, including the "Work" one you just made, and moves you into setup. You can press **Skip** here, because the connection you want gets built from the Google side in a moment.
+Press **Connect**. Keeper brings in every calendar on the account, including the "Work" one you just made. Press **Skip** at setup — the connection you want gets built from the Google side.
 
 If you see **Invalid credentials**, it is the password nearly every time. Either your normal Apple password went in by mistake, or the generated one has since been cancelled.
 
 ## Connect Google Calendar
 
-Back on **Import Calendars**, choose **Connect Google Calendar**. Keeper lists what it is about to ask Google for before sending you anywhere:
+Back on **Import Calendars**, choose **Connect Google Calendar**. Keeper lists what it is about to ask Google for:
 
 - See your email address
 - View a list of your calendars
@@ -86,110 +72,76 @@ Press **Connect** and finish signing in with Google.
 
 ## Point Google at your iCloud calendar
 
-Setup now runs for your Google account, which is exactly what you want.
+Setup now runs for your Google account.
 
-First, **Which calendars would you like to configure?** Tick your main work calendar. Google's primary calendar arrives named after your email address, so look for that.
+**Which calendars would you like to configure?** Tick your main work calendar. Google's primary calendar arrives named after your email address.
 
-Next, **Rename Your Calendars.** Change it to something you will recognise, like "Work". This only affects what you see inside Keeper.
+**Rename Your Calendars.** Change it to something you will recognise, like "Work". This only affects what you see inside Keeper.
 
-Then the question that matters: **Where should 'Work' send events?** Tick the iCloud calendar you created earlier. That is the connection made.
+**Where should 'Work' send events?** Tick the iCloud calendar you created earlier. That is the connection made.
 
-You will also see **Where should 'Work' pull events from?** Leave this one empty. Ticking it would start copying events back into your work calendar, which is not what you are here for.
+**Where should 'Work' pull events from?** Leave this one empty. Ticking it would start copying events back into your work calendar.
 
-Press **Next** to finish. The first copy runs immediately rather than waiting for the next scheduled round.
-
-Open Calendar on your iPhone and your meetings should be there.
+Press **Next** to finish. The first copy runs immediately, so open Calendar on your iPhone and your meetings should be there.
 
 ## Decide how much detail crosses over
 
-By default you may find the copies are deliberately vague. Keeper can carry just the time and leave titles behind, which suits a shared work calendar.
+By default the copies can be deliberately vague, carrying just the time. Here you want the opposite. A meeting on your Watch is no use if it does not say what it is.
 
-For this direction you probably want the opposite. A meeting on your Watch is not much use if it does not say what it is.
+Open the calendar from your dashboard and find **Sync Settings**. Turn on **Sync Event Name** and the real meeting titles come through instead of a placeholder.
 
-Open the calendar from your dashboard and find **Sync Settings**. Turn on **Sync Event Name**, and the real meeting titles come through instead of a placeholder.
+**Sync Event Description** and **Sync Event Location** work the same way. Location is worth having if you travel to meetings, since it puts the address on your phone.
 
-**Sync Event Description** and **Sync Event Location** work the same way. Location is worth having if you travel to meetings, since it gives you the address on your phone.
+What these start out set to depends on how the calendar was added, and we are [fixing that inconsistency](https://github.com/ridafkih/keeper.sh/issues/501). Check them rather than assuming.
 
-Check these switches rather than assuming. What they start out set to depends on how the calendar was first added, and we are [fixing that inconsistency](https://github.com/ridafkih/keeper.sh/issues/501).
-
-On the hosted service these controls are part of Pro. Self-hosted installs include them for everyone.
+On the hosted service these controls are part of Pro. On free, the copy stays titled after the calendar with the details left behind. Self-hosted installs include them for everyone.
 
 ## Google's own event types
 
 Google has a few event kinds that are not really meetings, and they clutter a phone if you let them through.
 
-The **Exclusions** section gives you **Exclude Focus Time Events** and **Exclude Out of Office Events**. These two only appear for Google calendars, because no other provider has them.
+The **Exclusions** section gives you **Exclude Focus Time Events** and **Exclude Out of Office Events**. Turn them on if you block focus time regularly, or every protected work block reappears on your personal devices. There is also **Exclude All Day Events** for company holidays.
 
-Turn them on if you block focus time regularly. Otherwise every protected work block reappears on your personal devices, which defeats the point.
-
-Working Location entries are always left out and have no switch. Nobody wants "In the office" occupying a day on their Apple Watch.
-
-There is also **Exclude All Day Events** if company holidays are cluttering things up.
+Working Location entries are always left out and have no switch.
 
 ## What does not cross over
 
-Some things are deliberately left behind, and this matters more in this direction than the other.
+Guests are not copied, so nobody gets invited a second time or emailed by accident. Video call links and reminders do not travel either, so you cannot join a meeting from the copy on your iPhone.
 
-Guests are not copied, so nobody gets invited a second time or emailed by accident. That is the safe behaviour, but it does mean the copy is not a working invitation.
+What lands in iCloud is a record of where your time goes, not a replacement for your work calendar.
 
-Video call links and reminders do not travel either. You cannot join a meeting from the copy on your iPhone, so keep Google Calendar to hand for that.
+## How quickly changes show up, and how far ahead
 
-Think of what lands in iCloud as a reliable record of where your time goes, not a replacement for your work calendar.
+Keeper reads your calendars once a minute, on every plan, paid or not. Writing the change into iCloud is the part that differs.
 
-## How quickly changes show up
+Free writes every thirty minutes, so a meeting someone books now reaches your phone within the half hour. Pro writes every minute. If colleagues move meetings at short notice, that gap is the reason to pay.
 
-Keeper checks your calendars once a minute, on every plan, paid or not.
-
-Writing the change into iCloud is the part that differs. On the free plan that happens every thirty minutes, so a meeting someone books now reaches your phone within the half hour. On Pro it happens every minute.
-
-If colleagues move meetings on short notice, that gap is the reason to pay. If your week is mostly settled by Monday, the free plan will not bother you.
-
-There is no "sync now" button, so a change will not appear the instant you go looking for it.
-
-## What gets copied, and how far ahead
-
-Keeper works with a window running from a week ago to two years out.
-
-The week behind means recently finished meetings are still accounted for. The two years ahead means a one-off booking further out than that will not copy yet.
-
-That window moves with today's date, so a distant event starts syncing once it comes within two years. Nothing is needed from you for that to happen.
+Keeper works with a window running from a week ago to two years out. A one-off booking further ahead than that will not copy yet, and starts once it comes within range.
 
 ## What the free plan covers
 
-Two connected accounts and three connections. Google is one account and iCloud is the other, so this pairing uses both.
+Two connected accounts and three connections. Google is one account and iCloud the other, so this pairing uses both.
 
-The number of calendars inside each account does not matter. A Google account with five calendars still counts as one.
+The number of calendars inside each account does not matter — a Google account with five calendars still counts as one.
 
-Three connections is what you have to spend on directions. Work into iCloud uses one, leaving two spare for other calendars later.
-
-If you tick past that, Keeper stops you and offers the upgrade rather than failing quietly afterwards.
+Work into iCloud uses one connection, leaving two spare. Tick past that and Keeper stops you and offers the upgrade rather than failing quietly.
 
 ## When it stops working
 
-**Meetings quietly stopped appearing and nothing looks broken.** This is the one that actually bites. Changing your Apple Account password cancels every app-specific password you have ever created, including this one.
-
-Apple does not warn you and sends no email. Sync simply stops. Generate a fresh password and reconnect iCloud.
-
-It hurts more in this direction, because the calendar that goes stale is the one you actually look at. If your phone seems suspiciously empty, start here.
+**Meetings quietly stopped appearing and nothing looks broken.** Changing your Apple Account password silently cancels every app-specific password you have ever created, including this one. If your phone looks suspiciously empty, start here: generate a fresh password and reconnect iCloud.
 
 **The iCloud calendar will not accept events.** Calendars shared with you by someone else, and ones you subscribed to from a link, usually arrive read-only. Make sure you picked a calendar you created yourself.
 
-**Your employer disconnects the Google account.** Losing access to a work Google account stops the copying, and existing events stay behind in iCloud. Deleting that one iCloud calendar clears them.
+**Your employer disconnects the Google account.** Losing access stops the copying, and existing events stay behind in iCloud. Deleting that one iCloud calendar clears them.
 
-**A calendar goes quiet for a while, then recovers.** When Google or Apple rejects or times out a request, Keeper waits longer before trying again rather than hammering it. Left alone, it comes back.
+**A calendar goes quiet for a while, then recovers.** When Google or Apple rejects or times out a request, Keeper waits longer before trying again. Left alone, it comes back.
 
 ## Running it yourself instead
 
 Keeper is open source, and self-hosting is a real alternative rather than a lesser one. Every paid feature is included free, and your calendar data stays on hardware you control.
 
-For work meetings on a personal server, that appeals to a lot of people.
+The `keeper-standalone` Docker image bundles the database, the background workers and everything else into a single container.
 
-The `keeper-standalone` Docker image is the straightforward route. It bundles the database, the background workers and everything else into a single container.
+Be honest about the effort. iCloud connects immediately, but Google means creating your own project in Google Cloud and supplying its sign-in credentials. You also become the person who notices when it breaks.
 
-Be honest about the effort, though. iCloud connects immediately, since it only needs the password you generated.
-
-Google does not. You have to create your own project in Google Cloud, set up its sign-in credentials, and supply them to your install. It is well documented but genuinely fiddly the first time.
-
-You also become the person who notices when it breaks. Nobody else is watching the logs or applying updates.
-
-If that sounds fine, the [README](https://github.com/ridafkih/keeper.sh) covers the setup. If you would rather not think about it, the hosted version is the same software with the upkeep handled.
+The [README](https://github.com/ridafkih/keeper.sh) covers the setup. If you would rather not think about it, the hosted version is the same software with the upkeep handled.

--- a/applications/web/src/content/blog/sync-icloud-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/sync-icloud-calendar-with-outlook.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How to Sync iCloud Calendar with Outlook"
-description: "Connect your iCloud calendar to Outlook with Keeper.sh so personal commitments block time at work. Covers the Apple app-specific password, the exact setup screens, how much detail crosses over, and what to check when sync stops."
+description: "Connect your iCloud calendar to Outlook with Keeper.sh so personal commitments block time at work. Covers the Apple app-specific password, the exact setup screens, and what to check when sync stops."
 blurb: "Your dentist appointment is in iCloud and your coworkers book you in Outlook. Here is how to make one show up as busy time in the other, starting with the Apple password step everyone gets stuck on."
 createdAt: "2026-08-11"
 slug: "sync-icloud-calendar-with-outlook"
@@ -15,31 +15,23 @@ tags:
 
 Your dentist appointment is in iCloud. Your coworkers book you in Outlook. Neither calendar knows the other exists, so the 2pm you already gave away gets taken again.
 
-Apple will hand you a public read-only link to your iCloud calendar, and that is all it offers. A link someone can look at is not the same as time being blocked. This guide sets up the real thing.
-
-You will need about ten minutes. Most of it is one Apple step that trips people up, so we will do that first.
+This guide blocks that time in Outlook automatically. It takes about ten minutes, and most of that is one Apple step.
 
 ## What this actually does
 
-Keeper copies events in one direction at a time. You pick a calendar events come from, and a calendar they go to.
+Keeper copies events in one direction at a time. You pick the calendar events come from, and the calendar they go to.
 
-So "iCloud shows up in Outlook" is one connection. If you also want work meetings appearing on your iPhone, that is a second, separate connection pointing the other way.
+So "iCloud shows up in Outlook" is one connection. Work meetings appearing on your iPhone would be a second one, pointing the other way.
 
-Set up only the first one and your Outlook edits will never reach iCloud. That is the intended behaviour, not a bug.
+Set up only the first and your Outlook edits never reach iCloud. That is intended, not a bug.
 
-## Why Apple makes you generate a special password
+## First, generate an Apple app-specific password
 
-This is the step people get stuck on, so do it before you open anything else.
+Apple will not let an outside app sign in with your normal Apple Account password. That password also opens your photos, your purchase history and Find My.
 
-Apple will not let an outside app sign in with your normal Apple Account password. That password opens your photos, your purchase history and Find My. Handing it to a calendar tool would hand over all of that too.
+Instead you generate a separate password that reaches your calendar and nothing else. You can cancel it at any time without touching your real password.
 
-Instead you generate a separate password that reaches your calendar and nothing else. You can cancel it on its own, at any time, without touching your real password or your other apps.
-
-Apple's own instructions are in [Sign in to apps with your Apple Account using app-specific passwords](https://support.apple.com/en-us/102654).
-
-## Generate the password
-
-Keeper shows you these same steps on the connect screen:
+Keeper shows you these same steps on the connect screen, and [Apple documents them too](https://support.apple.com/en-us/102654):
 
 1. Navigate to [appleid.apple.com](https://appleid.apple.com)
 2. Sign in with your Apple ID
@@ -48,9 +40,7 @@ Keeper shows you these same steps on the connect screen:
 5. Label and generate the password, then copy it
 6. Paste the app-specific password below
 
-Two things worth knowing before you start. You need two-factor authentication turned on, or the App-Specific Passwords option does not appear at all.
-
-And Apple shows you the password exactly once. Close that box without copying it and you cannot get it back, so generate a new one.
+You need two-factor authentication turned on, or the App-Specific Passwords option never appears. Apple shows the password exactly once, so copy it before closing the box.
 
 ## Connect iCloud
 
@@ -59,15 +49,13 @@ From your dashboard, open **Import Calendars**, then **Connect iCloud**. The scr
 - **Apple ID** — the email address you sign in to Apple with
 - **App-Specific Password** — the one you just generated, not your usual password
 
-There is no server address to fill in. Keeper already knows where iCloud lives, which is why it gets its own option instead of the general-purpose one further down the list.
+Press **Connect**. Keeper finds the calendars on your account, brings them all in, and takes you into setup.
 
-Press **Connect**. Keeper finds the calendars on your account, brings all of them in, and takes you straight into setup.
-
-If you see **Invalid credentials**, it is the password nearly every time. Either the normal Apple password went in by mistake, or the generated one has since been cancelled.
+If you see **Invalid credentials**, it is the password nearly every time. Either your normal Apple password went in by mistake, or the generated one has since been cancelled.
 
 ## Connect Outlook
 
-Go back to **Import Calendars** and choose **Connect Outlook**. Before sending you to Microsoft, Keeper lists what it is about to ask for:
+Back on **Import Calendars**, choose **Connect Outlook**. Keeper lists what it is about to ask for:
 
 - See your email address
 - View a list of your calendars
@@ -78,77 +66,63 @@ Press **Connect** and sign in to Microsoft as normal.
 
 ## Point one calendar at the other
 
-Setup asks you a short series of questions.
+Setup asks a short series of questions.
 
-First, **Which calendars would you like to configure?** Tick the iCloud calendar you care about. You do not have to set up all of them now.
+**Which calendars would you like to configure?** Tick the iCloud calendar you care about. You do not have to set up all of them now.
 
-Next, **Rename Your Calendars.** iCloud calendars often arrive called "Home" or "Work". Renaming here only changes what you see inside Keeper.
+**Rename Your Calendars.** iCloud calendars often arrive called "Home" or "Work". Renaming here only changes what you see inside Keeper.
 
-Then the question that does the real work: **Where should 'Home' send events?** Tick your Outlook calendar. That is the connection made.
+**Where should 'Home' send events?** Tick your Outlook calendar. That is the connection made.
 
-You will also be asked **Where should 'Home' pull events from?** Leave it empty if you only want personal time showing up at work. Tick your Outlook calendar if you want work meetings appearing on your iPhone too.
+**Where should 'Home' pull events from?** Leave it empty if you only want personal time showing up at work. Tick your Outlook calendar to get work meetings on your iPhone too.
 
 Press **Next** to finish. The first copy runs immediately rather than waiting for the next scheduled round.
 
-Everything here can be changed later from the calendar's own page, under **Send Events to Calendars**.
+You can change any of this later from the calendar's own page, under **Send Events to Calendars**.
 
 ## Decide how much detail crosses over
 
-You probably do not want your colleagues reading the title of a personal appointment. Keeper can copy the time and leave everything else behind.
+You probably do not want colleagues reading the title of a personal appointment. Keeper can copy the time and leave everything else behind.
 
-Open the calendar from your dashboard and find the **Sync Settings** section. Three switches control what travels: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
+Open the calendar from your dashboard and find **Sync Settings**. Three switches control what travels: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
 
-Turn a switch off and that detail stays in iCloud. With the name switched off, the copy in Outlook is titled after the calendar it came from, so it reads as a block of busy time.
+Turn one off and that detail stays in iCloud. With the name off, the copy in Outlook is titled after the calendar it came from, so it reads as a block of busy time.
 
-Check these switches yourself before you trust the connection with anything sensitive. What they start out set to depends on how the calendar was first added, and we are [fixing that inconsistency](https://github.com/ridafkih/keeper.sh/issues/501). Look at them once and you will know where you stand.
+Check these switches before you trust the connection with anything sensitive. What they start out set to depends on how the calendar was first added, and we are [fixing that inconsistency](https://github.com/ridafkih/keeper.sh/issues/501).
 
-There is also an **Exclusions** section if you would rather all-day events stayed out of it. Birthdays and holidays otherwise arrive as day-long blocks on your work calendar.
+The **Exclusions** section keeps all-day events out, if birthdays and holidays would otherwise land on your work calendar as day-long blocks.
+
+On the hosted service both sections are part of Pro. On free, the copy stays titled after the calendar with the details left behind. Self-hosted installs include them for everyone.
 
 ## What does not cross over
 
-Some things are deliberately left behind. Guests are not copied, so nobody gets invited twice or emailed by mistake.
+Guests are not copied, so nobody gets invited twice or emailed by mistake. Meeting links and reminders stay put as well.
 
-Meeting links and reminders stay put as well. The copy in Outlook is a time block, not a second working version of the meeting.
+The copy in Outlook is a block of time, not a second working version of the meeting. If you build the Outlook-to-iCloud direction, the meeting shows on your iPhone but you cannot join the call from it.
 
-Keep that in mind for the direction from Outlook to iCloud. Your work meeting will show on your iPhone, but you will not be able to join the call from it.
+## How quickly changes show up, and how far ahead
 
-## How quickly changes show up
+Keeper reads your calendars once a minute, on every plan, paid or not. Writing the change into the other calendar is the part that differs.
 
-Keeper checks your calendars once a minute, on every plan, paid or not.
+Free writes every thirty minutes, so an appointment you add now blocks time at work within the half hour. Pro writes every minute. If you book at short notice and need coworkers to see it straight away, that gap is the reason to pay.
 
-Writing the change into the other calendar is the part that differs. On the free plan that happens every thirty minutes, so an appointment added now blocks time at work within the half hour. On Pro it happens every minute.
-
-If you tend to book things at short notice and need coworkers to see it immediately, that gap is the reason to pay. Otherwise thirty minutes is usually fine.
-
-There is no "sync now" button, so a change you just made will not appear the instant you look for it.
-
-## What gets copied, and how far ahead
-
-Keeper works with a window running from a week ago to two years out.
-
-The week behind means recently finished events are still accounted for. The two years ahead means a one-off appointment further out than that will not copy yet.
-
-That window moves with today's date, so a distant event starts syncing once it comes within two years. You do not need to do anything for that to happen.
+Keeper works with a window running from a week ago to two years out. A one-off appointment further ahead than that will not copy yet, and starts once it comes within range.
 
 ## What the free plan covers
 
-Two connected accounts and three connections. iCloud is one account and Outlook is the other, so this pairing uses both.
+Two connected accounts and three connections. iCloud is one account and Outlook the other, so this pairing uses both.
 
 The number of calendars inside each account does not matter. An iCloud account with six calendars still counts as one.
 
-Three connections is what you have to spend on directions. Personal into work uses one. Adding work into personal uses a second, leaving one spare.
-
-If you tick past that, Keeper stops you and points you at the upgrade rather than failing quietly later.
+Personal into work uses one connection. Adding work into personal uses a second, leaving one spare. Tick past that and Keeper stops you and points you at the upgrade rather than failing quietly later.
 
 ## When it stops working
 
-**Events quietly stopped appearing and nothing looks broken.** This is the one that actually bites. Changing your Apple Account password cancels every app-specific password you have ever made, including this one.
-
-Apple does not warn you and does not email you. Sync just stops. Generate a fresh password and reconnect iCloud.
+**Events quietly stopped appearing and nothing looks broken.** Changing your Apple Account password silently cancels every app-specific password you have ever made, including this one. Generate a fresh password and reconnect iCloud.
 
 **A calendar you were added to will not accept events.** Calendars shared with you by someone else, and ones you subscribed to from a link, usually arrive read-only. They work fine as the calendar events come from, and fail as the one events go to.
 
-**A calendar goes quiet for a while, then recovers.** When Apple or Microsoft rejects or times out a request, Keeper waits longer before trying again instead of hammering it. Left alone, it comes back.
+**A calendar goes quiet for a while, then recovers.** When Apple or Microsoft rejects or times out a request, Keeper waits longer before trying again. Left alone, it comes back.
 
 **An event you deleted is still there.** Check which direction you actually set up. Deleting in Outlook does nothing to iCloud unless you built that second connection.
 
@@ -156,10 +130,8 @@ Apple does not warn you and does not email you. Sync just stops. Generate a fres
 
 Keeper is open source, and self-hosting is a genuine alternative rather than a stripped-down one. Every paid feature is included free, and your calendar data stays on hardware you control.
 
-The `keeper-standalone` Docker image is the straightforward route. It bundles the database, the background workers and everything else into one container.
+The `keeper-standalone` Docker image bundles the database, the background workers and everything else into one container.
 
-Be honest with yourself about the effort, though. iCloud works immediately because it only needs the password you generated. Outlook does not — you have to register your own application with Microsoft and supply its credentials, which is fiddly the first time.
-
-You are also the one who notices when it breaks. Nobody else is watching the logs or applying updates.
+Be honest with yourself about the effort. iCloud works immediately, but Outlook means registering your own application with Microsoft and supplying its credentials. You are also the one who notices when it breaks.
 
 If that sounds fine, the [README](https://github.com/ridafkih/keeper.sh) has the setup. If you would rather not think about it, the hosted version is the same software with the maintenance handled.

--- a/applications/web/src/content/blog/sync-icloud-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/sync-icloud-calendar-with-outlook.mdx
@@ -1,0 +1,165 @@
+---
+title: "How to Sync iCloud Calendar with Outlook"
+description: "Connect your iCloud calendar to Outlook with Keeper.sh so personal commitments block time at work. Covers the Apple app-specific password, the exact setup screens, how much detail crosses over, and what to check when sync stops."
+blurb: "Your dentist appointment is in iCloud and your coworkers book you in Outlook. Here is how to make one show up as busy time in the other, starting with the Apple password step everyone gets stuck on."
+createdAt: "2026-08-11"
+slug: "sync-icloud-calendar-with-outlook"
+updatedAt: "2026-08-11"
+tags:
+  - "icloud"
+  - "apple-calendar"
+  - "outlook"
+  - "sync"
+  - "guides"
+---
+
+Your dentist appointment is in iCloud. Your coworkers book you in Outlook. Neither calendar knows the other exists, so the 2pm you already gave away gets taken again.
+
+Apple will hand you a public read-only link to your iCloud calendar, and that is all it offers. A link someone can look at is not the same as time being blocked. This guide sets up the real thing.
+
+You will need about ten minutes. Most of it is one Apple step that trips people up, so we will do that first.
+
+## What this actually does
+
+Keeper copies events in one direction at a time. You pick a calendar events come from, and a calendar they go to.
+
+So "iCloud shows up in Outlook" is one connection. If you also want work meetings appearing on your iPhone, that is a second, separate connection pointing the other way.
+
+Set up only the first one and your Outlook edits will never reach iCloud. That is the intended behaviour, not a bug.
+
+## Why Apple makes you generate a special password
+
+This is the step people get stuck on, so do it before you open anything else.
+
+Apple will not let an outside app sign in with your normal Apple Account password. That password opens your photos, your purchase history and Find My. Handing it to a calendar tool would hand over all of that too.
+
+Instead you generate a separate password that reaches your calendar and nothing else. You can cancel it on its own, at any time, without touching your real password or your other apps.
+
+Apple's own instructions are in [Sign in to apps with your Apple Account using app-specific passwords](https://support.apple.com/en-us/102654).
+
+## Generate the password
+
+Keeper shows you these same steps on the connect screen:
+
+1. Navigate to [appleid.apple.com](https://appleid.apple.com)
+2. Sign in with your Apple ID
+3. Select "App-Specific Passwords"
+4. Click the "+" next to "Passwords"
+5. Label and generate the password, then copy it
+6. Paste the app-specific password below
+
+Two things worth knowing before you start. You need two-factor authentication turned on, or the App-Specific Passwords option does not appear at all.
+
+And Apple shows you the password exactly once. Close that box without copying it and you cannot get it back, so generate a new one.
+
+## Connect iCloud
+
+From your dashboard, open **Import Calendars**, then **Connect iCloud**. The screen is headed **Connect Apple Calendar** and asks for two things:
+
+- **Apple ID** — the email address you sign in to Apple with
+- **App-Specific Password** — the one you just generated, not your usual password
+
+There is no server address to fill in. Keeper already knows where iCloud lives, which is why it gets its own option instead of the general-purpose one further down the list.
+
+Press **Connect**. Keeper finds the calendars on your account, brings all of them in, and takes you straight into setup.
+
+If you see **Invalid credentials**, it is the password nearly every time. Either the normal Apple password went in by mistake, or the generated one has since been cancelled.
+
+## Connect Outlook
+
+Go back to **Import Calendars** and choose **Connect Outlook**. Before sending you to Microsoft, Keeper lists what it is about to ask for:
+
+- See your email address
+- View a list of your calendars
+- View events, summaries and details
+- Add or remove calendar events
+
+Press **Connect** and sign in to Microsoft as normal.
+
+## Point one calendar at the other
+
+Setup asks you a short series of questions.
+
+First, **Which calendars would you like to configure?** Tick the iCloud calendar you care about. You do not have to set up all of them now.
+
+Next, **Rename Your Calendars.** iCloud calendars often arrive called "Home" or "Work". Renaming here only changes what you see inside Keeper.
+
+Then the question that does the real work: **Where should 'Home' send events?** Tick your Outlook calendar. That is the connection made.
+
+You will also be asked **Where should 'Home' pull events from?** Leave it empty if you only want personal time showing up at work. Tick your Outlook calendar if you want work meetings appearing on your iPhone too.
+
+Press **Next** to finish. The first copy runs immediately rather than waiting for the next scheduled round.
+
+Everything here can be changed later from the calendar's own page, under **Send Events to Calendars**.
+
+## Decide how much detail crosses over
+
+You probably do not want your colleagues reading the title of a personal appointment. Keeper can copy the time and leave everything else behind.
+
+Open the calendar from your dashboard and find the **Sync Settings** section. Three switches control what travels: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
+
+Turn a switch off and that detail stays in iCloud. With the name switched off, the copy in Outlook is titled after the calendar it came from, so it reads as a block of busy time.
+
+Check these switches yourself before you trust the connection with anything sensitive. What they start out set to depends on how the calendar was first added, and we are [fixing that inconsistency](https://github.com/ridafkih/keeper.sh/issues/501). Look at them once and you will know where you stand.
+
+There is also an **Exclusions** section if you would rather all-day events stayed out of it. Birthdays and holidays otherwise arrive as day-long blocks on your work calendar.
+
+## What does not cross over
+
+Some things are deliberately left behind. Guests are not copied, so nobody gets invited twice or emailed by mistake.
+
+Meeting links and reminders stay put as well. The copy in Outlook is a time block, not a second working version of the meeting.
+
+Keep that in mind for the direction from Outlook to iCloud. Your work meeting will show on your iPhone, but you will not be able to join the call from it.
+
+## How quickly changes show up
+
+Keeper checks your calendars once a minute, on every plan, paid or not.
+
+Writing the change into the other calendar is the part that differs. On the free plan that happens every thirty minutes, so an appointment added now blocks time at work within the half hour. On Pro it happens every minute.
+
+If you tend to book things at short notice and need coworkers to see it immediately, that gap is the reason to pay. Otherwise thirty minutes is usually fine.
+
+There is no "sync now" button, so a change you just made will not appear the instant you look for it.
+
+## What gets copied, and how far ahead
+
+Keeper works with a window running from a week ago to two years out.
+
+The week behind means recently finished events are still accounted for. The two years ahead means a one-off appointment further out than that will not copy yet.
+
+That window moves with today's date, so a distant event starts syncing once it comes within two years. You do not need to do anything for that to happen.
+
+## What the free plan covers
+
+Two connected accounts and three connections. iCloud is one account and Outlook is the other, so this pairing uses both.
+
+The number of calendars inside each account does not matter. An iCloud account with six calendars still counts as one.
+
+Three connections is what you have to spend on directions. Personal into work uses one. Adding work into personal uses a second, leaving one spare.
+
+If you tick past that, Keeper stops you and points you at the upgrade rather than failing quietly later.
+
+## When it stops working
+
+**Events quietly stopped appearing and nothing looks broken.** This is the one that actually bites. Changing your Apple Account password cancels every app-specific password you have ever made, including this one.
+
+Apple does not warn you and does not email you. Sync just stops. Generate a fresh password and reconnect iCloud.
+
+**A calendar you were added to will not accept events.** Calendars shared with you by someone else, and ones you subscribed to from a link, usually arrive read-only. They work fine as the calendar events come from, and fail as the one events go to.
+
+**A calendar goes quiet for a while, then recovers.** When Apple or Microsoft rejects or times out a request, Keeper waits longer before trying again instead of hammering it. Left alone, it comes back.
+
+**An event you deleted is still there.** Check which direction you actually set up. Deleting in Outlook does nothing to iCloud unless you built that second connection.
+
+## Running it yourself instead
+
+Keeper is open source, and self-hosting is a genuine alternative rather than a stripped-down one. Every paid feature is included free, and your calendar data stays on hardware you control.
+
+The `keeper-standalone` Docker image is the straightforward route. It bundles the database, the background workers and everything else into one container.
+
+Be honest with yourself about the effort, though. iCloud works immediately because it only needs the password you generated. Outlook does not — you have to register your own application with Microsoft and supply its credentials, which is fiddly the first time.
+
+You are also the one who notices when it breaks. Nobody else is watching the logs or applying updates.
+
+If that sounds fine, the [README](https://github.com/ridafkih/keeper.sh) has the setup. If you would rather not think about it, the hosted version is the same software with the maintenance handled.

--- a/applications/web/src/content/blog/sync-icloud-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/sync-icloud-calendar-with-outlook.mdx
@@ -19,7 +19,7 @@ This guide blocks that time in Outlook automatically. It takes about ten minutes
 
 ## What this actually does
 
-Keeper copies events in one direction at a time. You pick the calendar events come from, and the calendar they go to.
+Keeper.sh copies events in one direction at a time. You pick the calendar events come from, and the calendar they go to.
 
 So "iCloud shows up in Outlook" is one connection. Work meetings appearing on your iPhone would be a second one, pointing the other way.
 
@@ -31,7 +31,7 @@ Apple will not let an outside app sign in with your normal Apple Account passwor
 
 Instead you generate a separate password that reaches your calendar and nothing else. You can cancel it at any time without touching your real password.
 
-Keeper shows you these same steps on the connect screen, and [Apple documents them too](https://support.apple.com/en-us/102654):
+Keeper.sh shows you these same steps on the connect screen, and [Apple documents them too](https://support.apple.com/en-us/102654):
 
 1. Navigate to [appleid.apple.com](https://appleid.apple.com)
 2. Sign in with your Apple ID
@@ -49,13 +49,13 @@ From your dashboard, open **Import Calendars**, then **Connect iCloud**. The scr
 - **Apple ID** — the email address you sign in to Apple with
 - **App-Specific Password** — the one you just generated, not your usual password
 
-Press **Connect**. Keeper finds the calendars on your account, brings them all in, and takes you into setup.
+Press **Connect**. Keeper.sh finds the calendars on your account, brings them all in, and takes you into setup.
 
 If you see **Invalid credentials**, it is the password nearly every time. Either your normal Apple password went in by mistake, or the generated one has since been cancelled.
 
 ## Connect Outlook
 
-Back on **Import Calendars**, choose **Connect Outlook**. Keeper lists what it is about to ask for:
+Back on **Import Calendars**, choose **Connect Outlook**. Keeper.sh lists what it is about to ask for:
 
 - See your email address
 - View a list of your calendars
@@ -70,7 +70,7 @@ Setup asks a short series of questions.
 
 **Which calendars would you like to configure?** Tick the iCloud calendar you care about. You do not have to set up all of them now.
 
-**Rename Your Calendars.** iCloud calendars often arrive called "Home" or "Work". Renaming here only changes what you see inside Keeper.
+**Rename Your Calendars.** iCloud calendars often arrive called "Home" or "Work". Renaming here only changes what you see inside Keeper.sh.
 
 **Where should 'Home' send events?** Tick your Outlook calendar. That is the connection made.
 
@@ -82,7 +82,7 @@ You can change any of this later from the calendar's own page, under **Send Even
 
 ## Decide how much detail crosses over
 
-You probably do not want colleagues reading the title of a personal appointment. Keeper can copy the time and leave everything else behind.
+You probably do not want colleagues reading the title of a personal appointment. Keeper.sh can copy the time and leave everything else behind.
 
 Open the calendar from your dashboard and find **Sync Settings**. Three switches control what travels: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
 
@@ -102,11 +102,11 @@ The copy in Outlook is a block of time, not a second working version of the meet
 
 ## How quickly changes show up, and how far ahead
 
-Keeper reads your calendars once a minute, on every plan, paid or not. Writing the change into the other calendar is the part that differs.
+Keeper.sh reads your calendars once a minute, on every plan, paid or not. Writing the change into the other calendar is the part that differs.
 
 Free writes every thirty minutes, so an appointment you add now blocks time at work within the half hour. Pro writes every minute. If you book at short notice and need coworkers to see it straight away, that gap is the reason to pay.
 
-Keeper works with a window running from a week ago to two years out. A one-off appointment further ahead than that will not copy yet, and starts once it comes within range.
+Keeper.sh works with a window running from a week ago to two years out. A one-off appointment further ahead than that will not copy yet, and starts once it comes within range.
 
 ## What the free plan covers
 
@@ -114,7 +114,7 @@ Two connected accounts and three connections. iCloud is one account and Outlook 
 
 The number of calendars inside each account does not matter. An iCloud account with six calendars still counts as one.
 
-Personal into work uses one connection. Adding work into personal uses a second, leaving one spare. Tick past that and Keeper stops you and points you at the upgrade rather than failing quietly later.
+Personal into work uses one connection. Adding work into personal uses a second, leaving one spare. Tick past that and Keeper.sh stops you and points you at the upgrade rather than failing quietly later.
 
 ## When it stops working
 
@@ -122,13 +122,13 @@ Personal into work uses one connection. Adding work into personal uses a second,
 
 **A calendar you were added to will not accept events.** Calendars shared with you by someone else, and ones you subscribed to from a link, usually arrive read-only. They work fine as the calendar events come from, and fail as the one events go to.
 
-**A calendar goes quiet for a while, then recovers.** When Apple or Microsoft rejects or times out a request, Keeper waits longer before trying again. Left alone, it comes back.
+**A calendar goes quiet for a while, then recovers.** When Apple or Microsoft rejects or times out a request, Keeper.sh waits longer before trying again. Left alone, it comes back.
 
 **An event you deleted is still there.** Check which direction you actually set up. Deleting in Outlook does nothing to iCloud unless you built that second connection.
 
 ## Running it yourself instead
 
-Keeper is open source, and self-hosting is a genuine alternative rather than a stripped-down one. Every paid feature is included free, and your calendar data stays on hardware you control.
+Keeper.sh is open source, and self-hosting is a genuine alternative rather than a stripped-down one. Every paid feature is included free, and your calendar data stays on hardware you control.
 
 The `keeper-standalone` Docker image bundles the database, the background workers and everything else into one container.
 


### PR DESCRIPTION
Adds two how-to guides: iCloud to Outlook, and Google to iCloud. Both are written for readers who have two calendars and a scheduling problem, not an interest in the protocols, so they lead with what the reader sees and keep the mechanism secondary. Every UI step was verified against the connect and setup routes rather than carried over from the existing guides.

- Apple app-specific password explained by what it protects, with Apple's own docs linked, and the silent breakage on Apple password change called out as a failure mode
- Self-hosting signposted as a genuine alternative, including the honest effort cost of registering your own Google/Microsoft credentials
- No blanket privacy-default claim, per #501
- Sitemap picks both up from frontmatter; verified by building before and after (6 URLs to 8, no plugin change)