### PR TITLE
docs: add Google/Outlook calendar sync how-to guides

### DIFF
--- a/applications/web/src/content/blog/how-to-sync-google-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/how-to-sync-google-calendar-with-outlook.mdx
@@ -16,84 +16,70 @@ Your personal life sits in Google Calendar. Your work sits in Outlook. Nobody at
 
 This guide fixes that in one direction, so your Google events start appearing in Outlook as busy time. It takes about five minutes and costs nothing.
 
-The tool doing the copying is Keeper. You can use it at [keeper.sh](https://keeper.sh), or run your own copy on your own hardware.
+The tool doing the copying is Keeper, at [keeper.sh](https://keeper.sh) or on your own hardware.
 
 ## What will my colleagues actually see?
 
-Meet Priya, a contract product designer. Her client calls, her Thursday physio appointment, and her daughter's 3pm school pickup all live in Google.
+Meet Priya, a contract product designer. Her Thursday physio appointment and her daughter's 3pm school pickup both live in Google.
 
-Once this is set up, each of those becomes an event in her work Outlook calendar at the same day, time, and length. When her project lead checks her availability, the 3pm pickup is sitting there as a blocked hour.
+Once this is set up, each becomes an event in her work Outlook calendar at the same day, time and length. When her project lead checks her availability, the 3pm pickup is a blocked hour.
 
-The title is not "Physio", because Keeper writes the name of the Google calendar instead. Priya called that calendar "Personal", so her colleagues see an hour called "Personal".
-
-That is the point of the whole exercise. Your team needs to know the hour is gone, not why you gave it away.
+The title is not "Physio". Keeper writes the name of the Google calendar instead, so colleagues see an hour called "Personal". They need to know the hour is gone, not why.
 
 ## What should I do before I start?
 
-Two things are worth doing first, and both save you undoing work later.
+**Decide where the copies land in Outlook.** They go into a real Outlook calendar, mixed in with your actual meetings. If you would rather keep them apart, make a new Outlook calendar now and call it something like "Personal (synced)".
 
-**Decide where the copies land in Outlook.** They go into a real Outlook calendar, mixed in with your actual meetings. If you would rather keep them apart, make a new calendar in Outlook now and call it something like "Personal (synced)".
-
-Make that calendar before you connect Outlook to Keeper. Keeper reads your list of Outlook calendars at the moment you connect and never re-scans it, so a calendar you create later will not show up as an option.
-
-**Have both logins ready.** You will sign in to Outlook first and then to Google.
+Make it before you connect Outlook to Keeper. Keeper reads your list of Outlook calendars at the moment you connect and never re-scans, so a calendar you create later will not appear as an option.
 
 ## How do I set it up?
 
-Sign in at [keeper.sh](https://keeper.sh) and you land on your dashboard.
-
-Connect Outlook first, because it is the calendar receiving events, and Keeper can only offer you a target it already knows about.
+Sign in at [keeper.sh](https://keeper.sh) to reach your dashboard. Connect Outlook first, because it is the calendar receiving events, and Keeper can only offer a target it already knows about.
 
 1. Choose **Import Calendars**.
 2. Choose **Connect Outlook**.
-3. A screen headed "Connect Outlook" lists what is being asked for: your email address, your list of calendars, your events and their details, and permission to add or remove events. That last one is what lets Keeper write the copies. Press **Connect**.
+3. A screen headed "Connect Outlook" lists what is being asked for: your email address, your calendars, your events and their details, and permission to add or remove events. That last one lets Keeper write the copies. Press **Connect**.
 4. Sign in to Microsoft and approve.
-5. Keeper shows "Which calendars would you like to configure?" with your Outlook calendars listed. Nothing is leaving Outlook yet, so press **Skip**.
+5. Keeper shows **Which calendars would you like to configure?**. Nothing is leaving Outlook yet, so press **Skip**.
 
 Now connect Google.
 
 6. Choose **Import Calendars** again, then **Connect Google Calendar**.
 7. Press **Connect** and sign in to Google.
-8. Keeper asks which calendars you want to configure. Tick the Google calendars you want visible at work, then press **Next**.
-9. You reach **Rename Your Calendars**, which matters more than it looks. The name you type here is what your colleagues will read as the event title, so "Personal" works and your full name does not. Press **Next**.
-10. A screen asks **"Where should 'Personal' send events?"** and lists your calendars. Tick your Outlook calendar and press **Next**.
-11. The next screen asks where this calendar should pull events *from*. Leave it empty, then press **Next** and **Finish**.
+8. Keeper asks which calendars to configure. Tick the Google calendars you want visible at work, then press **Next**.
+9. You reach **Rename Your Calendars**, which matters more than it looks. The name you type is what colleagues read as the event title, so "Personal" works and your full name does not.
+10. **Where should 'Personal' send events?** Tick your Outlook calendar and press **Next**.
+11. **Where should 'Personal' pull events from?** Leave it empty, then press **Next** and **Finish**.
 
-That last screen is the reverse direction, and you do not want it yet. Ticking anything there would start copying work meetings into your personal Google calendar.
+Step 11 is the reverse direction, and you do not want it yet. Ticking anything there would start copying work meetings into your personal Google calendar.
 
-You can change all of this later. Open **Calendars** on the dashboard, pick the Google calendar, and edit the **Send Events to Calendars** section.
+You can change all of this later. Open **Calendars** on the dashboard, pick the Google calendar, and edit **Send Events to Calendars**.
 
 ## How long before an event shows up?
 
 Keeper reads your Google calendar every minute, on every plan, so a new appointment is noticed almost immediately.
 
-Writing it into Outlook is the slower half, and it happens every 30 minutes on the free plan and every minute on Pro.
+Writing it into Outlook is the slower half: every 30 minutes on free, every minute on Pro. So on free you can book something in Google and expect it in Outlook within half an hour.
 
-In practice, on free you can book something in Google and expect it in Outlook within half an hour. If you routinely add meetings for that same morning, that gap is the reason to pay.
+If you routinely add meetings for that same morning, that gap is the reason to pay.
 
 ## Who can see what?
 
 Keeper copies the time, but whether it copies the detail is a setting you should look at rather than assume.
 
-Open the Google calendar inside Keeper and find **Sync Settings**. Three switches decide what leaves: **Sync Event Name**, **Sync Event Description**, and **Sync Event Location**.
+Open the Google calendar inside Keeper and find **Sync Settings**. Three switches decide what leaves: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
 
-Connected the way described above, all three start off. Your titles, notes, and addresses stay in Google, and Outlook gets an hour named after the calendar.
+Connected the way described above, all three start off. Your titles, notes and addresses stay in Google, and Outlook gets an hour named after the calendar.
 
-Check them anyway on every calendar you connect. Keeper does not currently start every calendar from the same position depending on how it was added, so look rather than trust a promise.
+Check them on every calendar you connect, because Keeper does not yet start every calendar from the same position. Turning them on is a Pro feature; on free the details stay hidden and cannot be released.
 
-Turning those switches on is a Pro feature. On the free plan the details stay hidden and cannot be released.
-
-One thing you will notice in Outlook is that every event Keeper creates carries a coloured category label called `keeper.sh`. That label is how Keeper recognises its own work later, so leave it alone.
+Every event Keeper creates in Outlook carries a coloured category label called `keeper.sh`. That label is how Keeper recognises its own work later, so leave it alone.
 
 ## What does not come across?
 
-Keeper copies the shape of an event rather than everything attached to it.
+Keeper carries the title or its stand-in, the description, the location, the start and end, the timezone, all-day status, busy or free, and any repeat pattern. It does not carry attendees, video call links or reminders.
 
-It carries the title or its stand-in, the description, the location, the start and end, the timezone, all-day status, whether you are busy or free, and any repeat pattern.
-
-It does not carry attendees, video call links, or reminders.
-
-So the copy in Outlook is a block of time rather than a joinable meeting. If Priya's client call has a Meet link, she still joins from Google, and nobody at work can accidentally dial into her physio appointment.
+So the copy in Outlook is a block of time rather than a joinable meeting. If Priya's client call has a Meet link, she still joins from Google, and nobody at work can dial into her physio appointment.
 
 ## Can I make it work both ways?
 
@@ -101,40 +87,32 @@ Not with one switch, no. Keeper connections point one way, deliberately, which i
 
 You can still have both directions, set up as two separate connections: Google to Outlook, and Outlook to Google. Each is configured on its own and each can hide or show different things.
 
-Do it deliberately, though. Pushing a work calendar into a personal Google calendar you share with a partner is a different privacy question from the one you just answered.
-
-The free plan allows three connections in total, so running both directions still fits comfortably.
+Do it deliberately, though. Copying a work calendar into a personal Google calendar you share with a partner is a different privacy question from the one you just answered.
 
 ## Something looks wrong. What is it?
 
-**Outlook shows a duplicate of every synced event.** You probably have both directions running and something stripped the `keeper.sh` label off Keeper's copies. Without that label Keeper no longer recognises them and treats them as real events worth copying back.
+**Outlook shows a duplicate of every synced event.** You probably have both directions running and something stripped the `keeper.sh` label off Keeper's copies. Without it Keeper no longer recognises them and treats them as real events worth copying back.
 
-**An event moved in Google but Outlook still shows the old time.** On the free plan, wait a full 30 minutes before worrying about it. If it is still wrong after that, the Google connection likely needs re-authorising, which happens after a password change or a revoked permission.
+**An event moved in Google but Outlook still shows the old time.** On free, wait a full 30 minutes. If it is still wrong, the Google connection likely needs re-authorising, which happens after a password change or a revoked permission.
 
-**A repeating appointment came across, but the one week you moved it did not.** Give it another update interval, because Keeper treats a moved instance of a repeating event as its own separate change.
+**A repeating appointment came across, but the one week you moved it did not.** Give it another update interval. Keeper treats a moved instance of a repeating event as its own separate change.
 
-**Nothing at all arrived.** Check that you actually ticked an Outlook calendar on the "Where should 'Personal' send events?" screen. An unticked box there is the most common cause, and it looks exactly like everything working slowly.
+**Nothing at all arrived.** Check that you ticked an Outlook calendar on the **Where should 'Personal' send events?** screen. An unticked box is the most common cause, and it looks exactly like everything working slowly.
 
-**A calendar you just made in Outlook is missing from the list.** Keeper read your calendars at the moment you connected the account. Remove the Outlook account in Keeper and connect it again to pick up the new one.
+**A calendar you just made in Outlook is missing from the list.** Remove the Outlook account in Keeper and connect it again to pick it up.
 
 ## Can I run this myself?
 
-Yes, and it is a genuine alternative rather than a consolation prize. Keeper is open source under AGPL-3.0, and a copy you run yourself has every Pro feature enabled at no cost.
+Yes, and it is a genuine alternative rather than a consolation prize. Keeper is open source under AGPL-3.0, and a copy you run yourself has every Pro feature at no cost, including the one-minute updates and the detail switches.
 
-That includes the one-minute updates and the switches controlling event titles and details. It also means your calendar data lives on your hardware and never touches ours.
+The honest cost is a real evening's work. You need somewhere to run Docker, a PostgreSQL database and a Redis instance, and you must register your own application with both Google and Microsoft.
 
-The honest cost is a real evening's work. You need somewhere to run Docker, a PostgreSQL database, and a Redis instance, and you must register your own application with both Google and Microsoft to make sign-in work.
-
-That last part is the fiddly bit, and it takes you through both companies' developer consoles. The [README on GitHub](https://github.com/ridafkih/keeper.sh#readme) has the full walkthrough and prepared Docker images.
-
-If that sounds like a chore, the hosted version at [keeper.sh](https://keeper.sh) is the same software with the setup already done.
+The [README on GitHub](https://github.com/ridafkih/keeper.sh#readme) has the walkthrough and prepared Docker images. If that sounds like a chore, [keeper.sh](https://keeper.sh) is the same software with the setup already done.
 
 ## What does it cost?
 
-Free covers this guide exactly: two connected accounts, being one Google and one Outlook, plus three connections between calendars.
+Free covers this guide exactly: two connected accounts, one Google and one Outlook, plus three connections between calendars. Running both directions still fits.
 
-There is no limit on how many calendars each account brings with it. If your Google account has six calendars behind it, all six are available to you.
+There is no limit on how many calendars each account brings with it. If your Google account has six calendars behind it, all six are available.
 
-Pro costs $5 a month and moves updates from every 30 minutes to every minute. It also removes both limits and unlocks the settings that decide which event details travel.
-
-Self-hosting gives you all of it in exchange for setting it up yourself.
+Pro costs $5 a month and moves updates from every 30 minutes to every minute. It also removes both limits and unlocks the settings deciding which event details travel.

--- a/applications/web/src/content/blog/how-to-sync-google-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/how-to-sync-google-calendar-with-outlook.mdx
@@ -16,7 +16,7 @@ Your personal life sits in Google Calendar. Your work sits in Outlook. Nobody at
 
 This guide fixes that in one direction, so your Google events start appearing in Outlook as busy time. It takes about five minutes and costs nothing.
 
-The tool doing the copying is Keeper, at [keeper.sh](https://keeper.sh) or on your own hardware.
+The tool doing the copying is Keeper.sh, at [keeper.sh](https://keeper.sh) or on your own hardware.
 
 ## What will my colleagues actually see?
 
@@ -24,29 +24,29 @@ Meet Priya, a contract product designer. Her Thursday physio appointment and her
 
 Once this is set up, each becomes an event in her work Outlook calendar at the same day, time and length. When her project lead checks her availability, the 3pm pickup is a blocked hour.
 
-The title is not "Physio". Keeper writes the name of the Google calendar instead, so colleagues see an hour called "Personal". They need to know the hour is gone, not why.
+The title is not "Physio". Keeper.sh writes the name of the Google calendar instead, so colleagues see an hour called "Personal". They need to know the hour is gone, not why.
 
 ## What should I do before I start?
 
 **Decide where the copies land in Outlook.** They go into a real Outlook calendar, mixed in with your actual meetings. If you would rather keep them apart, make a new Outlook calendar now and call it something like "Personal (synced)".
 
-Make it before you connect Outlook to Keeper. Keeper reads your list of Outlook calendars at the moment you connect and never re-scans, so a calendar you create later will not appear as an option.
+Make it before you connect Outlook to Keeper.sh. Keeper.sh reads your list of Outlook calendars at the moment you connect and never re-scans, so a calendar you create later will not appear as an option.
 
 ## How do I set it up?
 
-Sign in at [keeper.sh](https://keeper.sh) to reach your dashboard. Connect Outlook first, because it is the calendar receiving events, and Keeper can only offer a target it already knows about.
+Sign in at [keeper.sh](https://keeper.sh) to reach your dashboard. Connect Outlook first, because it is the calendar receiving events, and Keeper.sh can only offer a target it already knows about.
 
 1. Choose **Import Calendars**.
 2. Choose **Connect Outlook**.
-3. A screen headed "Connect Outlook" lists what is being asked for: your email address, your calendars, your events and their details, and permission to add or remove events. That last one lets Keeper write the copies. Press **Connect**.
+3. A screen headed "Connect Outlook" lists what is being asked for: your email address, your calendars, your events and their details, and permission to add or remove events. That last one lets Keeper.sh write the copies. Press **Connect**.
 4. Sign in to Microsoft and approve.
-5. Keeper shows **Which calendars would you like to configure?**. Nothing is leaving Outlook yet, so press **Skip**.
+5. Keeper.sh shows **Which calendars would you like to configure?**. Nothing is leaving Outlook yet, so press **Skip**.
 
 Now connect Google.
 
 6. Choose **Import Calendars** again, then **Connect Google Calendar**.
 7. Press **Connect** and sign in to Google.
-8. Keeper asks which calendars to configure. Tick the Google calendars you want visible at work, then press **Next**.
+8. Keeper.sh asks which calendars to configure. Tick the Google calendars you want visible at work, then press **Next**.
 9. You reach **Rename Your Calendars**, which matters more than it looks. The name you type is what colleagues read as the event title, so "Personal" works and your full name does not.
 10. **Where should 'Personal' send events?** Tick your Outlook calendar and press **Next**.
 11. **Where should 'Personal' pull events from?** Leave it empty, then press **Next** and **Finish**.
@@ -57,7 +57,7 @@ You can change all of this later. Open **Calendars** on the dashboard, pick the 
 
 ## How long before an event shows up?
 
-Keeper reads your Google calendar every minute, on every plan, so a new appointment is noticed almost immediately.
+Keeper.sh reads your Google calendar every minute, on every plan, so a new appointment is noticed almost immediately.
 
 Writing it into Outlook is the slower half: every 30 minutes on free, every minute on Pro. So on free you can book something in Google and expect it in Outlook within half an hour.
 
@@ -65,25 +65,25 @@ If you routinely add meetings for that same morning, that gap is the reason to p
 
 ## Who can see what?
 
-Keeper copies the time, but whether it copies the detail is a setting you should look at rather than assume.
+Keeper.sh copies the time, but whether it copies the detail is a setting you should look at rather than assume.
 
-Open the Google calendar inside Keeper and find **Sync Settings**. Three switches decide what leaves: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
+Open the Google calendar inside Keeper.sh and find **Sync Settings**. Three switches decide what leaves: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
 
 Connected the way described above, all three start off. Your titles, notes and addresses stay in Google, and Outlook gets an hour named after the calendar.
 
-Check them on every calendar you connect, because Keeper does not yet start every calendar from the same position. Turning them on is a Pro feature; on free the details stay hidden and cannot be released.
+Check them on every calendar you connect, because Keeper.sh does not yet start every calendar from the same position. Turning them on is a Pro feature; on free the details stay hidden and cannot be released.
 
-Every event Keeper creates in Outlook carries a coloured category label called `keeper.sh`. That label is how Keeper recognises its own work later, so leave it alone.
+Every event Keeper.sh creates in Outlook carries a coloured category label called `keeper.sh`. That label is how Keeper.sh recognises its own work later, so leave it alone.
 
 ## What does not come across?
 
-Keeper carries the title or its stand-in, the description, the location, the start and end, the timezone, all-day status, busy or free, and any repeat pattern. It does not carry attendees, video call links or reminders.
+Keeper.sh carries the title or its stand-in, the description, the location, the start and end, the timezone, all-day status, busy or free, and any repeat pattern. It does not carry attendees, video call links or reminders.
 
 So the copy in Outlook is a block of time rather than a joinable meeting. If Priya's client call has a Meet link, she still joins from Google, and nobody at work can dial into her physio appointment.
 
 ## Can I make it work both ways?
 
-Not with one switch, no. Keeper connections point one way, deliberately, which is why step 11 exists.
+Not with one switch, no. Keeper.sh connections point one way, deliberately, which is why step 11 exists.
 
 You can still have both directions, set up as two separate connections: Google to Outlook, and Outlook to Google. Each is configured on its own and each can hide or show different things.
 
@@ -91,19 +91,19 @@ Do it deliberately, though. Copying a work calendar into a personal Google calen
 
 ## Something looks wrong. What is it?
 
-**Outlook shows a duplicate of every synced event.** You probably have both directions running and something stripped the `keeper.sh` label off Keeper's copies. Without it Keeper no longer recognises them and treats them as real events worth copying back.
+**Outlook shows a duplicate of every synced event.** You probably have both directions running and something stripped the `keeper.sh` label off Keeper.sh's copies. Without it Keeper.sh no longer recognises them and treats them as real events worth copying back.
 
 **An event moved in Google but Outlook still shows the old time.** On free, wait a full 30 minutes. If it is still wrong, the Google connection likely needs re-authorising, which happens after a password change or a revoked permission.
 
-**A repeating appointment came across, but the one week you moved it did not.** Give it another update interval. Keeper treats a moved instance of a repeating event as its own separate change.
+**A repeating appointment came across, but the one week you moved it did not.** Give it another update interval. Keeper.sh treats a moved instance of a repeating event as its own separate change.
 
 **Nothing at all arrived.** Check that you ticked an Outlook calendar on the **Where should 'Personal' send events?** screen. An unticked box is the most common cause, and it looks exactly like everything working slowly.
 
-**A calendar you just made in Outlook is missing from the list.** Remove the Outlook account in Keeper and connect it again to pick it up.
+**A calendar you just made in Outlook is missing from the list.** Remove the Outlook account in Keeper.sh and connect it again to pick it up.
 
 ## Can I run this myself?
 
-Yes, and it is a genuine alternative rather than a consolation prize. Keeper is open source under AGPL-3.0, and a copy you run yourself has every Pro feature at no cost, including the one-minute updates and the detail switches.
+Yes, and it is a genuine alternative rather than a consolation prize. Keeper.sh is open source under AGPL-3.0, and a copy you run yourself has every Pro feature at no cost, including the one-minute updates and the detail switches.
 
 The honest cost is a real evening's work. You need somewhere to run Docker, a PostgreSQL database and a Redis instance, and you must register your own application with both Google and Microsoft.
 

--- a/applications/web/src/content/blog/how-to-sync-google-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/how-to-sync-google-calendar-with-outlook.mdx
@@ -1,0 +1,140 @@
+---
+title: "How to Sync Google Calendar with Outlook"
+description: "A step-by-step guide to making your Google Calendar events appear in Outlook as busy time, so colleagues stop booking over your personal commitments."
+blurb: "Your Google events do not show up in Outlook, so people book over them. Here is how to make your Google commitments appear in Outlook, what your colleagues will actually see, and how long it takes."
+createdAt: "2026-08-11"
+slug: "how-to-sync-google-calendar-with-outlook"
+updatedAt: "2026-08-11"
+tags:
+  - "google-calendar"
+  - "outlook"
+  - "how-to"
+  - "calendar-sync"
+---
+
+Your personal life sits in Google Calendar. Your work sits in Outlook. Nobody at work can see the Google side, so they book you at 2pm on a Thursday you already gave away.
+
+This guide fixes that in one direction, so your Google events start appearing in Outlook as busy time. It takes about five minutes and costs nothing.
+
+The tool doing the copying is Keeper. You can use it at [keeper.sh](https://keeper.sh), or run your own copy on your own hardware.
+
+## What will my colleagues actually see?
+
+Meet Priya, a contract product designer. Her client calls, her Thursday physio appointment, and her daughter's 3pm school pickup all live in Google.
+
+Once this is set up, each of those becomes an event in her work Outlook calendar at the same day, time, and length. When her project lead checks her availability, the 3pm pickup is sitting there as a blocked hour.
+
+The title is not "Physio", because Keeper writes the name of the Google calendar instead. Priya called that calendar "Personal", so her colleagues see an hour called "Personal".
+
+That is the point of the whole exercise. Your team needs to know the hour is gone, not why you gave it away.
+
+## What should I do before I start?
+
+Two things are worth doing first, and both save you undoing work later.
+
+**Decide where the copies land in Outlook.** They go into a real Outlook calendar, mixed in with your actual meetings. If you would rather keep them apart, make a new calendar in Outlook now and call it something like "Personal (synced)".
+
+Make that calendar before you connect Outlook to Keeper. Keeper reads your list of Outlook calendars at the moment you connect and never re-scans it, so a calendar you create later will not show up as an option.
+
+**Have both logins ready.** You will sign in to Outlook first and then to Google.
+
+## How do I set it up?
+
+Sign in at [keeper.sh](https://keeper.sh) and you land on your dashboard.
+
+Connect Outlook first, because it is the calendar receiving events, and Keeper can only offer you a target it already knows about.
+
+1. Choose **Import Calendars**.
+2. Choose **Connect Outlook**.
+3. A screen headed "Connect Outlook" lists what is being asked for: your email address, your list of calendars, your events and their details, and permission to add or remove events. That last one is what lets Keeper write the copies. Press **Connect**.
+4. Sign in to Microsoft and approve.
+5. Keeper shows "Which calendars would you like to configure?" with your Outlook calendars listed. Nothing is leaving Outlook yet, so press **Skip**.
+
+Now connect Google.
+
+6. Choose **Import Calendars** again, then **Connect Google Calendar**.
+7. Press **Connect** and sign in to Google.
+8. Keeper asks which calendars you want to configure. Tick the Google calendars you want visible at work, then press **Next**.
+9. You reach **Rename Your Calendars**, which matters more than it looks. The name you type here is what your colleagues will read as the event title, so "Personal" works and your full name does not. Press **Next**.
+10. A screen asks **"Where should 'Personal' send events?"** and lists your calendars. Tick your Outlook calendar and press **Next**.
+11. The next screen asks where this calendar should pull events *from*. Leave it empty, then press **Next** and **Finish**.
+
+That last screen is the reverse direction, and you do not want it yet. Ticking anything there would start copying work meetings into your personal Google calendar.
+
+You can change all of this later. Open **Calendars** on the dashboard, pick the Google calendar, and edit the **Send Events to Calendars** section.
+
+## How long before an event shows up?
+
+Keeper reads your Google calendar every minute, on every plan, so a new appointment is noticed almost immediately.
+
+Writing it into Outlook is the slower half, and it happens every 30 minutes on the free plan and every minute on Pro.
+
+In practice, on free you can book something in Google and expect it in Outlook within half an hour. If you routinely add meetings for that same morning, that gap is the reason to pay.
+
+## Who can see what?
+
+Keeper copies the time, but whether it copies the detail is a setting you should look at rather than assume.
+
+Open the Google calendar inside Keeper and find **Sync Settings**. Three switches decide what leaves: **Sync Event Name**, **Sync Event Description**, and **Sync Event Location**.
+
+Connected the way described above, all three start off. Your titles, notes, and addresses stay in Google, and Outlook gets an hour named after the calendar.
+
+Check them anyway on every calendar you connect. Keeper does not currently start every calendar from the same position depending on how it was added, so look rather than trust a promise.
+
+Turning those switches on is a Pro feature. On the free plan the details stay hidden and cannot be released.
+
+One thing you will notice in Outlook is that every event Keeper creates carries a coloured category label called `keeper.sh`. That label is how Keeper recognises its own work later, so leave it alone.
+
+## What does not come across?
+
+Keeper copies the shape of an event rather than everything attached to it.
+
+It carries the title or its stand-in, the description, the location, the start and end, the timezone, all-day status, whether you are busy or free, and any repeat pattern.
+
+It does not carry attendees, video call links, or reminders.
+
+So the copy in Outlook is a block of time rather than a joinable meeting. If Priya's client call has a Meet link, she still joins from Google, and nobody at work can accidentally dial into her physio appointment.
+
+## Can I make it work both ways?
+
+Not with one switch, no. Keeper connections point one way, deliberately, which is why step 11 exists.
+
+You can still have both directions, set up as two separate connections: Google to Outlook, and Outlook to Google. Each is configured on its own and each can hide or show different things.
+
+Do it deliberately, though. Pushing a work calendar into a personal Google calendar you share with a partner is a different privacy question from the one you just answered.
+
+The free plan allows three connections in total, so running both directions still fits comfortably.
+
+## Something looks wrong. What is it?
+
+**Outlook shows a duplicate of every synced event.** You probably have both directions running and something stripped the `keeper.sh` label off Keeper's copies. Without that label Keeper no longer recognises them and treats them as real events worth copying back.
+
+**An event moved in Google but Outlook still shows the old time.** On the free plan, wait a full 30 minutes before worrying about it. If it is still wrong after that, the Google connection likely needs re-authorising, which happens after a password change or a revoked permission.
+
+**A repeating appointment came across, but the one week you moved it did not.** Give it another update interval, because Keeper treats a moved instance of a repeating event as its own separate change.
+
+**Nothing at all arrived.** Check that you actually ticked an Outlook calendar on the "Where should 'Personal' send events?" screen. An unticked box there is the most common cause, and it looks exactly like everything working slowly.
+
+**A calendar you just made in Outlook is missing from the list.** Keeper read your calendars at the moment you connected the account. Remove the Outlook account in Keeper and connect it again to pick up the new one.
+
+## Can I run this myself?
+
+Yes, and it is a genuine alternative rather than a consolation prize. Keeper is open source under AGPL-3.0, and a copy you run yourself has every Pro feature enabled at no cost.
+
+That includes the one-minute updates and the switches controlling event titles and details. It also means your calendar data lives on your hardware and never touches ours.
+
+The honest cost is a real evening's work. You need somewhere to run Docker, a PostgreSQL database, and a Redis instance, and you must register your own application with both Google and Microsoft to make sign-in work.
+
+That last part is the fiddly bit, and it takes you through both companies' developer consoles. The [README on GitHub](https://github.com/ridafkih/keeper.sh#readme) has the full walkthrough and prepared Docker images.
+
+If that sounds like a chore, the hosted version at [keeper.sh](https://keeper.sh) is the same software with the setup already done.
+
+## What does it cost?
+
+Free covers this guide exactly: two connected accounts, being one Google and one Outlook, plus three connections between calendars.
+
+There is no limit on how many calendars each account brings with it. If your Google account has six calendars behind it, all six are available to you.
+
+Pro costs $5 a month and moves updates from every 30 minutes to every minute. It also removes both limits and unlocks the settings that decide which event details travel.
+
+Self-hosting gives you all of it in exchange for setting it up yourself.

--- a/applications/web/src/content/blog/how-to-sync-outlook-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/how-to-sync-outlook-calendar-with-google-calendar.mdx
@@ -1,0 +1,164 @@
+---
+title: "How to Sync Outlook Calendar with Google Calendar"
+description: "A step-by-step guide to getting your work Outlook schedule into Google Calendar, including what your household sees and how to keep meeting titles at work."
+blurb: "Your shifts and meetings live in a work Outlook account nobody at home can see. Here is how to get them into Google Calendar, how to keep the titles private, and what to do when your employer blocks it."
+createdAt: "2026-08-11"
+slug: "how-to-sync-outlook-calendar-with-google-calendar"
+updatedAt: "2026-08-11"
+tags:
+  - "outlook"
+  - "google-calendar"
+  - "how-to"
+  - "calendar-sync"
+---
+
+Your work schedule lives in Outlook. Everything else in your life runs on Google Calendar. The two never meet, so you keep agreeing to things you are not actually free for.
+
+This guide moves your Outlook schedule into Google, in one direction only. Work meetings show up at home, and nothing from your Google calendar goes back to your employer.
+
+That last part is worth saying plainly, because it is the thing people worry about. Setting this up does not expose your personal calendar to anyone at work.
+
+The tool is Keeper. Use it at [keeper.sh](https://keeper.sh), or run your own copy on your own hardware.
+
+## Why bother?
+
+Marcus is a respiratory therapist on a rotating roster, and his shifts are published to his hospital's Outlook account weeks ahead.
+
+His household runs on a Google calendar he shares with his partner. She cannot see the roster, so she books the dentist on a Tuesday he is working nights.
+
+After this, every shift appears on that shared Google calendar by itself. When the roster changes, the Google copy follows within the hour.
+
+He never retypes a shift again, and never has to remember to.
+
+## Will your employer let you?
+
+This is the first thing to find out, because it is the one part that is out of your hands.
+
+Some organisations restrict which outside applications can reach staff calendars. If yours does, the Microsoft sign-in screen stops you and says that approval is needed.
+
+You see this immediately, at the sign-in step, before anything has been connected. There is no half-finished state to clean up afterwards.
+
+Your options then are to ask IT to approve Keeper, or to run your own copy so the application is yours rather than ours. There is a section on that below.
+
+A personal Outlook.com account has no such restriction and will simply work.
+
+## Where should the copies go in Google?
+
+Do not send them into your main Google calendar. Create a separate one first and name it something like "Work shifts", then share it with whoever needs to see it.
+
+There are two reasons for that. The copies Keeper creates in Google carry no visible marker, so on a busy calendar you cannot tell them apart from events you made yourself.
+
+The second reason is simpler: a calendar of its own can be hidden with a single checkbox when the weekend starts.
+
+Create it before you connect Google to Keeper. Keeper reads your calendar list at the moment you connect and never checks again, so a calendar you add later will not appear as an option.
+
+## How do I set it up?
+
+Sign in at [keeper.sh](https://keeper.sh) to reach your dashboard.
+
+Connect Google first, because it is the calendar receiving events, and Keeper can only offer a target it already knows about.
+
+1. Choose **Import Calendars**.
+2. Choose **Connect Google Calendar**.
+3. A screen headed "Connect Google" lists what is being asked for: your email address, your list of calendars, your events and their details, and permission to add or remove events. Press **Connect**.
+4. Sign in to Google and approve.
+5. Keeper asks "Which calendars would you like to configure?". Nothing is leaving Google, so press **Skip**.
+
+Now connect the work account.
+
+6. Choose **Import Calendars**, then **Connect Outlook**.
+7. Press **Connect** and sign in with your work address. This is the step your employer might block.
+8. Keeper lists your Outlook calendars. Tick your main work calendar and press **Next**.
+9. You reach **Rename Your Calendars**. Read the next section before typing anything here, because this name can become the title of every event at home. Press **Next**.
+10. A screen asks **"Where should 'Work' send events?"**. Tick the Google calendar you made earlier and press **Next**.
+11. The next screen asks where this Outlook calendar should pull events *from*. Leave it empty, then press **Next** and **Finish**.
+
+Step 11 is the reverse direction. Ticking anything there would start copying your personal Google events onto your employer's systems.
+
+To change any of this later, open **Calendars** on the dashboard, choose the Outlook calendar, and edit **Send Events to Calendars**.
+
+## What will my partner see?
+
+This is the question that actually matters, because a shared Google calendar is being read by someone else.
+
+Keeper copies the times, but whether it copies the details is controlled by three switches you should check rather than assume.
+
+Open the Outlook calendar inside Keeper and look at **Sync Settings**, where you will find **Sync Event Name**, **Sync Event Description**, and **Sync Event Location**.
+
+Connected the way described above, all three start off. A meeting called "Redundancy consultation, R. Patel" arrives at home as a block with no title of its own, no notes, and no room number.
+
+In place of the real title, Keeper writes the name you gave the calendar back in step 9. Name it "Work" and your partner sees blocks called "Work", but name it after your employer and everyone you share with reads that instead.
+
+Check those switches on every calendar you connect. Keeper does not currently start every calendar from the same position depending on how it was added, so look rather than trust.
+
+Turning the switches on, so that real titles come through, is a Pro feature. On the free plan the details stay at work and cannot be released.
+
+## What stays behind in Outlook?
+
+Keeper copies the shape of a commitment rather than its contents.
+
+It carries the title or its stand-in, the description, the location, the start and end, the timezone, whether it is all-day, whether you are marked busy, and any repeat pattern.
+
+It does not carry attendees, Teams links, or reminders.
+
+So the Google copy is a block of time and nothing more. Your partner cannot see who else is in the meeting, and cannot accidentally join it.
+
+## Do you want the other direction too?
+
+Keeper connections run one way. That is a deliberate choice rather than a missing feature, and it is why step 11 exists.
+
+You can have both directions if you want them, set up as two separate connections, each configured on its own with its own settings.
+
+Think hard before adding the return trip. Sending personal Google events into a work Outlook account places them on your employer's systems, subject to your employer's retention and discovery rules.
+
+If you do want work to see when you are unavailable, set that direction up with the detail switches off. Colleagues then see busy hours and nothing else.
+
+The free plan covers three connections in total, so both directions fit.
+
+## Something looks wrong. What is it?
+
+**Google shows blocks with no useful title.** That is the intended behaviour rather than a fault, and the title you see is the name you gave the calendar in step 9. Rename that calendar inside Keeper and every copy updates.
+
+**Microsoft refused the sign-in.** Your workplace restricts which outside applications can reach staff calendars. Ask IT to approve it, or run your own instance so that the application registration belongs to you.
+
+**A night shift appears on the wrong day at home.** Check the timezone set on the Outlook calendar itself rather than the one on your computer. Shifts crossing midnight land on whichever day the start time falls in, and a wrong calendar timezone moves that boundary.
+
+**You deleted a copy in Google and it came back.** That is expected, because Keeper checks its copies against the original and replaces anything missing. Cancel the shift in Outlook instead, and the Google copy disappears on the next run.
+
+**The roster stopped updating.** Usually the work account needs signing in again, which happens after a password change or after IT revokes access. Reconnect the Outlook account in Keeper.
+
+**Everything vanished from Google after you left the job.** Losing access to the work account means Keeper can no longer confirm those events exist, so its copies are cleaned up. Export the Google calendar before your last day if you want to keep the history.
+
+## How current is it?
+
+Keeper reads your Outlook calendar every minute, whatever plan you are on, so a roster change is picked up almost straight away.
+
+Writing it into Google is the part that differs by plan: every 30 minutes on free, and every minute on Pro.
+
+For a roster published weeks ahead, every 30 minutes is more than enough. Pay for the faster one only if you are the person whose meetings move twice a morning.
+
+## Can I run it myself?
+
+Yes, and for a work calendar there is a specific reason to.
+
+Keeper is open source under AGPL-3.0, and running your own copy gives you every Pro feature at no cost. That includes one-minute updates and full control over which details travel.
+
+More usefully here, your own instance registers its own application with Microsoft. If your IT team will approve an internal application but not an outside service, that is the difference between this working and not working at all.
+
+Your calendar data also never leaves hardware you control, which is its own argument when the calendar belongs to an employer.
+
+The honest cost is a real evening's work. You need somewhere to run Docker, a PostgreSQL database, and a Redis instance, and you must register applications with both Google and Microsoft to make sign-in work.
+
+That last step means a trip through both companies' developer consoles. The [README on GitHub](https://github.com/ridafkih/keeper.sh#readme) covers all of it, and there are prepared Docker images.
+
+If none of that appeals, [keeper.sh](https://keeper.sh) is the same software already running.
+
+## What does it cost?
+
+Free is enough for this guide: two connected accounts, being one Outlook and one Google, plus three connections between calendars.
+
+There is no cap on the number of calendars inside an account. A work account exposing eight calendars still counts as a single connected account.
+
+Pro costs $5 a month. It moves updates from every 30 minutes to every minute, removes both limits, and unlocks the switches deciding which event details travel.
+
+Self-hosting gives you all of it in exchange for setting it up yourself.

--- a/applications/web/src/content/blog/how-to-sync-outlook-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/how-to-sync-outlook-calendar-with-google-calendar.mdx
@@ -14,64 +14,46 @@ tags:
 
 Your work schedule lives in Outlook. Everything else in your life runs on Google Calendar. The two never meet, so you keep agreeing to things you are not actually free for.
 
+Marcus is a respiratory therapist whose rotating roster is published to his hospital's Outlook account. His partner cannot see it, so she books the dentist on a Tuesday he is working nights.
+
 This guide moves your Outlook schedule into Google, in one direction only. Work meetings show up at home, and nothing from your Google calendar goes back to your employer.
 
-That last part is worth saying plainly, because it is the thing people worry about. Setting this up does not expose your personal calendar to anyone at work.
-
-The tool is Keeper. Use it at [keeper.sh](https://keeper.sh), or run your own copy on your own hardware.
-
-## Why bother?
-
-Marcus is a respiratory therapist on a rotating roster, and his shifts are published to his hospital's Outlook account weeks ahead.
-
-His household runs on a Google calendar he shares with his partner. She cannot see the roster, so she books the dentist on a Tuesday he is working nights.
-
-After this, every shift appears on that shared Google calendar by itself. When the roster changes, the Google copy follows within the hour.
-
-He never retypes a shift again, and never has to remember to.
+The tool is Keeper, at [keeper.sh](https://keeper.sh) or on your own hardware.
 
 ## Will your employer let you?
 
-This is the first thing to find out, because it is the one part that is out of your hands.
+Find this out first, because it is the one part out of your hands.
 
-Some organisations restrict which outside applications can reach staff calendars. If yours does, the Microsoft sign-in screen stops you and says that approval is needed.
+Some organisations restrict which outside applications can reach staff calendars. If yours does, the Microsoft sign-in screen stops you and says approval is needed, before anything is connected.
 
-You see this immediately, at the sign-in step, before anything has been connected. There is no half-finished state to clean up afterwards.
-
-Your options then are to ask IT to approve Keeper, or to run your own copy so the application is yours rather than ours. There is a section on that below.
-
-A personal Outlook.com account has no such restriction and will simply work.
+Ask IT to approve Keeper, or run your own copy so the application is yours rather than ours. A personal Outlook.com account has no such restriction.
 
 ## Where should the copies go in Google?
 
-Do not send them into your main Google calendar. Create a separate one first and name it something like "Work shifts", then share it with whoever needs to see it.
+Do not send them into your main Google calendar. Create a separate one first, name it something like "Work shifts", then share it with whoever needs to see it.
 
-There are two reasons for that. The copies Keeper creates in Google carry no visible marker, so on a busy calendar you cannot tell them apart from events you made yourself.
+The copies carry no visible marker, so on a busy calendar you cannot tell them apart from events you made yourself. A calendar of its own also hides with a single checkbox when the weekend starts.
 
-The second reason is simpler: a calendar of its own can be hidden with a single checkbox when the weekend starts.
-
-Create it before you connect Google to Keeper. Keeper reads your calendar list at the moment you connect and never checks again, so a calendar you add later will not appear as an option.
+Create it before you connect Google to Keeper, which reads your calendar list at the moment you connect and never checks again.
 
 ## How do I set it up?
 
-Sign in at [keeper.sh](https://keeper.sh) to reach your dashboard.
-
-Connect Google first, because it is the calendar receiving events, and Keeper can only offer a target it already knows about.
+Sign in at [keeper.sh](https://keeper.sh) to reach your dashboard. Connect Google first, because it is the calendar receiving events, and Keeper can only offer a target it already knows about.
 
 1. Choose **Import Calendars**.
 2. Choose **Connect Google Calendar**.
-3. A screen headed "Connect Google" lists what is being asked for: your email address, your list of calendars, your events and their details, and permission to add or remove events. Press **Connect**.
+3. A screen headed "Connect Google" lists what is being asked for: your email address, your calendars, your events and their details, and permission to add or remove events. Press **Connect**.
 4. Sign in to Google and approve.
-5. Keeper asks "Which calendars would you like to configure?". Nothing is leaving Google, so press **Skip**.
+5. Keeper asks **Which calendars would you like to configure?**. Nothing is leaving Google, so press **Skip**.
 
 Now connect the work account.
 
 6. Choose **Import Calendars**, then **Connect Outlook**.
 7. Press **Connect** and sign in with your work address. This is the step your employer might block.
 8. Keeper lists your Outlook calendars. Tick your main work calendar and press **Next**.
-9. You reach **Rename Your Calendars**. Read the next section before typing anything here, because this name can become the title of every event at home. Press **Next**.
-10. A screen asks **"Where should 'Work' send events?"**. Tick the Google calendar you made earlier and press **Next**.
-11. The next screen asks where this Outlook calendar should pull events *from*. Leave it empty, then press **Next** and **Finish**.
+9. You reach **Rename Your Calendars**. Read the next section before typing anything, because this name can become the title of every event at home.
+10. **Where should 'Work' send events?** Tick the Google calendar you made earlier and press **Next**.
+11. **Where should 'Work' pull events from?** Leave it empty, then press **Next** and **Finish**.
 
 Step 11 is the reverse direction. Ticking anything there would start copying your personal Google events onto your employer's systems.
 
@@ -79,86 +61,62 @@ To change any of this later, open **Calendars** on the dashboard, choose the Out
 
 ## What will my partner see?
 
-This is the question that actually matters, because a shared Google calendar is being read by someone else.
+Open the Outlook calendar inside Keeper and look at **Sync Settings**, where you will find **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
 
-Keeper copies the times, but whether it copies the details is controlled by three switches you should check rather than assume.
+Connected the way described above, all three start off. A meeting called "Redundancy consultation, R. Patel" arrives at home as a block with no title, no notes and no room number.
 
-Open the Outlook calendar inside Keeper and look at **Sync Settings**, where you will find **Sync Event Name**, **Sync Event Description**, and **Sync Event Location**.
+In place of the real title, Keeper writes the name you gave the calendar in step 9. Name it "Work" and your partner sees blocks called "Work"; name it after your employer and everyone you share with reads that.
 
-Connected the way described above, all three start off. A meeting called "Redundancy consultation, R. Patel" arrives at home as a block with no title of its own, no notes, and no room number.
-
-In place of the real title, Keeper writes the name you gave the calendar back in step 9. Name it "Work" and your partner sees blocks called "Work", but name it after your employer and everyone you share with reads that instead.
-
-Check those switches on every calendar you connect. Keeper does not currently start every calendar from the same position depending on how it was added, so look rather than trust.
-
-Turning the switches on, so that real titles come through, is a Pro feature. On the free plan the details stay at work and cannot be released.
+Check those switches on every calendar you connect, because Keeper does not yet start every calendar from the same position. Turning them on is a Pro feature; on free the details stay at work and cannot be released.
 
 ## What stays behind in Outlook?
 
-Keeper copies the shape of a commitment rather than its contents.
-
-It carries the title or its stand-in, the description, the location, the start and end, the timezone, whether it is all-day, whether you are marked busy, and any repeat pattern.
-
-It does not carry attendees, Teams links, or reminders.
+Keeper carries the title or its stand-in, the description, the location, the start and end, the timezone, all-day status, whether you are marked busy, and any repeat pattern. It does not carry attendees, Teams links or reminders.
 
 So the Google copy is a block of time and nothing more. Your partner cannot see who else is in the meeting, and cannot accidentally join it.
 
 ## Do you want the other direction too?
 
-Keeper connections run one way. That is a deliberate choice rather than a missing feature, and it is why step 11 exists.
-
-You can have both directions if you want them, set up as two separate connections, each configured on its own with its own settings.
+Keeper connections run one way, which is why step 11 exists. You can have both directions, set up as two separate connections, each configured on its own.
 
 Think hard before adding the return trip. Sending personal Google events into a work Outlook account places them on your employer's systems, subject to your employer's retention and discovery rules.
 
 If you do want work to see when you are unavailable, set that direction up with the detail switches off. Colleagues then see busy hours and nothing else.
 
-The free plan covers three connections in total, so both directions fit.
-
 ## Something looks wrong. What is it?
 
-**Google shows blocks with no useful title.** That is the intended behaviour rather than a fault, and the title you see is the name you gave the calendar in step 9. Rename that calendar inside Keeper and every copy updates.
+**Google shows blocks with no useful title.** That is intended rather than a fault, and the title is the name you gave the calendar in step 9. Rename that calendar inside Keeper and every copy updates.
 
-**Microsoft refused the sign-in.** Your workplace restricts which outside applications can reach staff calendars. Ask IT to approve it, or run your own instance so that the application registration belongs to you.
+**Microsoft refused the sign-in.** Your workplace restricts which outside applications can reach staff calendars. Ask IT to approve it, or run your own instance so the application registration belongs to you.
 
-**A night shift appears on the wrong day at home.** Check the timezone set on the Outlook calendar itself rather than the one on your computer. Shifts crossing midnight land on whichever day the start time falls in, and a wrong calendar timezone moves that boundary.
+**A night shift appears on the wrong day at home.** Check the timezone set on the Outlook calendar itself, not the one on your computer. Shifts crossing midnight land on whichever day the start time falls in.
 
-**You deleted a copy in Google and it came back.** That is expected, because Keeper checks its copies against the original and replaces anything missing. Cancel the shift in Outlook instead, and the Google copy disappears on the next run.
+**You deleted a copy in Google and it came back.** Keeper replaces anything missing from its copies. Cancel the shift in Outlook instead, and the Google copy disappears on the next run.
 
-**The roster stopped updating.** Usually the work account needs signing in again, which happens after a password change or after IT revokes access. Reconnect the Outlook account in Keeper.
+**The roster stopped updating.** Usually the work account needs signing in again, after a password change or after IT revokes access.
 
-**Everything vanished from Google after you left the job.** Losing access to the work account means Keeper can no longer confirm those events exist, so its copies are cleaned up. Export the Google calendar before your last day if you want to keep the history.
+**Everything vanished from Google after you left the job.** Losing access to the work account means Keeper can no longer confirm those events exist, so its copies are cleaned up. Export the Google calendar before your last day if you want the history.
 
 ## How current is it?
 
-Keeper reads your Outlook calendar every minute, whatever plan you are on, so a roster change is picked up almost straight away.
+Keeper reads your Outlook calendar every minute, whatever plan you are on, so a roster change is picked up almost straight away. Writing it into Google differs by plan: every 30 minutes on free, every minute on Pro.
 
-Writing it into Google is the part that differs by plan: every 30 minutes on free, and every minute on Pro.
-
-For a roster published weeks ahead, every 30 minutes is more than enough. Pay for the faster one only if you are the person whose meetings move twice a morning.
+For a roster published weeks ahead, every 30 minutes is more than enough. Pay for the faster one only if your meetings move twice a morning.
 
 ## Can I run it myself?
 
-Yes, and for a work calendar there is a specific reason to.
+Yes, and for a work calendar there is a specific reason to. Keeper is open source under AGPL-3.0, and your own copy gives you every Pro feature at no cost.
 
-Keeper is open source under AGPL-3.0, and running your own copy gives you every Pro feature at no cost. That includes one-minute updates and full control over which details travel.
+Your own instance also registers its own application with Microsoft. If your IT team will approve an internal application but not an outside service, that is the difference between this working and not working at all.
 
-More usefully here, your own instance registers its own application with Microsoft. If your IT team will approve an internal application but not an outside service, that is the difference between this working and not working at all.
+The honest cost is a real evening's work: somewhere to run Docker, a PostgreSQL database, a Redis instance, and your own application registered with both Google and Microsoft.
 
-Your calendar data also never leaves hardware you control, which is its own argument when the calendar belongs to an employer.
-
-The honest cost is a real evening's work. You need somewhere to run Docker, a PostgreSQL database, and a Redis instance, and you must register applications with both Google and Microsoft to make sign-in work.
-
-That last step means a trip through both companies' developer consoles. The [README on GitHub](https://github.com/ridafkih/keeper.sh#readme) covers all of it, and there are prepared Docker images.
-
-If none of that appeals, [keeper.sh](https://keeper.sh) is the same software already running.
+The [README on GitHub](https://github.com/ridafkih/keeper.sh#readme) covers all of it. If none of that appeals, [keeper.sh](https://keeper.sh) is the same software already running.
 
 ## What does it cost?
 
-Free is enough for this guide: two connected accounts, being one Outlook and one Google, plus three connections between calendars.
+Free is enough for this guide: two connected accounts, one Outlook and one Google, plus three connections between calendars. Both directions still fit.
 
-There is no cap on the number of calendars inside an account. A work account exposing eight calendars still counts as a single connected account.
+There is no cap on calendars inside an account. A work account exposing eight calendars still counts as one.
 
 Pro costs $5 a month. It moves updates from every 30 minutes to every minute, removes both limits, and unlocks the switches deciding which event details travel.
-
-Self-hosting gives you all of it in exchange for setting it up yourself.

--- a/applications/web/src/content/blog/how-to-sync-outlook-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/how-to-sync-outlook-calendar-with-google-calendar.mdx
@@ -18,7 +18,7 @@ Marcus is a respiratory therapist whose rotating roster is published to his hosp
 
 This guide moves your Outlook schedule into Google, in one direction only. Work meetings show up at home, and nothing from your Google calendar goes back to your employer.
 
-The tool is Keeper, at [keeper.sh](https://keeper.sh) or on your own hardware.
+The tool is Keeper.sh, at [keeper.sh](https://keeper.sh) or on your own hardware.
 
 ## Will your employer let you?
 
@@ -26,7 +26,7 @@ Find this out first, because it is the one part out of your hands.
 
 Some organisations restrict which outside applications can reach staff calendars. If yours does, the Microsoft sign-in screen stops you and says approval is needed, before anything is connected.
 
-Ask IT to approve Keeper, or run your own copy so the application is yours rather than ours. A personal Outlook.com account has no such restriction.
+Ask IT to approve Keeper.sh, or run your own copy so the application is yours rather than ours. A personal Outlook.com account has no such restriction.
 
 ## Where should the copies go in Google?
 
@@ -34,23 +34,23 @@ Do not send them into your main Google calendar. Create a separate one first, na
 
 The copies carry no visible marker, so on a busy calendar you cannot tell them apart from events you made yourself. A calendar of its own also hides with a single checkbox when the weekend starts.
 
-Create it before you connect Google to Keeper, which reads your calendar list at the moment you connect and never checks again.
+Create it before you connect Google to Keeper.sh, which reads your calendar list at the moment you connect and never checks again.
 
 ## How do I set it up?
 
-Sign in at [keeper.sh](https://keeper.sh) to reach your dashboard. Connect Google first, because it is the calendar receiving events, and Keeper can only offer a target it already knows about.
+Sign in at [keeper.sh](https://keeper.sh) to reach your dashboard. Connect Google first, because it is the calendar receiving events, and Keeper.sh can only offer a target it already knows about.
 
 1. Choose **Import Calendars**.
 2. Choose **Connect Google Calendar**.
 3. A screen headed "Connect Google" lists what is being asked for: your email address, your calendars, your events and their details, and permission to add or remove events. Press **Connect**.
 4. Sign in to Google and approve.
-5. Keeper asks **Which calendars would you like to configure?**. Nothing is leaving Google, so press **Skip**.
+5. Keeper.sh asks **Which calendars would you like to configure?**. Nothing is leaving Google, so press **Skip**.
 
 Now connect the work account.
 
 6. Choose **Import Calendars**, then **Connect Outlook**.
 7. Press **Connect** and sign in with your work address. This is the step your employer might block.
-8. Keeper lists your Outlook calendars. Tick your main work calendar and press **Next**.
+8. Keeper.sh lists your Outlook calendars. Tick your main work calendar and press **Next**.
 9. You reach **Rename Your Calendars**. Read the next section before typing anything, because this name can become the title of every event at home.
 10. **Where should 'Work' send events?** Tick the Google calendar you made earlier and press **Next**.
 11. **Where should 'Work' pull events from?** Leave it empty, then press **Next** and **Finish**.
@@ -61,23 +61,23 @@ To change any of this later, open **Calendars** on the dashboard, choose the Out
 
 ## What will my partner see?
 
-Open the Outlook calendar inside Keeper and look at **Sync Settings**, where you will find **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
+Open the Outlook calendar inside Keeper.sh and look at **Sync Settings**, where you will find **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
 
 Connected the way described above, all three start off. A meeting called "Redundancy consultation, R. Patel" arrives at home as a block with no title, no notes and no room number.
 
-In place of the real title, Keeper writes the name you gave the calendar in step 9. Name it "Work" and your partner sees blocks called "Work"; name it after your employer and everyone you share with reads that.
+In place of the real title, Keeper.sh writes the name you gave the calendar in step 9. Name it "Work" and your partner sees blocks called "Work"; name it after your employer and everyone you share with reads that.
 
-Check those switches on every calendar you connect, because Keeper does not yet start every calendar from the same position. Turning them on is a Pro feature; on free the details stay at work and cannot be released.
+Check those switches on every calendar you connect, because Keeper.sh does not yet start every calendar from the same position. Turning them on is a Pro feature; on free the details stay at work and cannot be released.
 
 ## What stays behind in Outlook?
 
-Keeper carries the title or its stand-in, the description, the location, the start and end, the timezone, all-day status, whether you are marked busy, and any repeat pattern. It does not carry attendees, Teams links or reminders.
+Keeper.sh carries the title or its stand-in, the description, the location, the start and end, the timezone, all-day status, whether you are marked busy, and any repeat pattern. It does not carry attendees, Teams links or reminders.
 
 So the Google copy is a block of time and nothing more. Your partner cannot see who else is in the meeting, and cannot accidentally join it.
 
 ## Do you want the other direction too?
 
-Keeper connections run one way, which is why step 11 exists. You can have both directions, set up as two separate connections, each configured on its own.
+Keeper.sh connections run one way, which is why step 11 exists. You can have both directions, set up as two separate connections, each configured on its own.
 
 Think hard before adding the return trip. Sending personal Google events into a work Outlook account places them on your employer's systems, subject to your employer's retention and discovery rules.
 
@@ -85,27 +85,27 @@ If you do want work to see when you are unavailable, set that direction up with 
 
 ## Something looks wrong. What is it?
 
-**Google shows blocks with no useful title.** That is intended rather than a fault, and the title is the name you gave the calendar in step 9. Rename that calendar inside Keeper and every copy updates.
+**Google shows blocks with no useful title.** That is intended rather than a fault, and the title is the name you gave the calendar in step 9. Rename that calendar inside Keeper.sh and every copy updates.
 
 **Microsoft refused the sign-in.** Your workplace restricts which outside applications can reach staff calendars. Ask IT to approve it, or run your own instance so the application registration belongs to you.
 
 **A night shift appears on the wrong day at home.** Check the timezone set on the Outlook calendar itself, not the one on your computer. Shifts crossing midnight land on whichever day the start time falls in.
 
-**You deleted a copy in Google and it came back.** Keeper replaces anything missing from its copies. Cancel the shift in Outlook instead, and the Google copy disappears on the next run.
+**You deleted a copy in Google and it came back.** Keeper.sh replaces anything missing from its copies. Cancel the shift in Outlook instead, and the Google copy disappears on the next run.
 
 **The roster stopped updating.** Usually the work account needs signing in again, after a password change or after IT revokes access.
 
-**Everything vanished from Google after you left the job.** Losing access to the work account means Keeper can no longer confirm those events exist, so its copies are cleaned up. Export the Google calendar before your last day if you want the history.
+**Everything vanished from Google after you left the job.** Losing access to the work account means Keeper.sh can no longer confirm those events exist, so its copies are cleaned up. Export the Google calendar before your last day if you want the history.
 
 ## How current is it?
 
-Keeper reads your Outlook calendar every minute, whatever plan you are on, so a roster change is picked up almost straight away. Writing it into Google differs by plan: every 30 minutes on free, every minute on Pro.
+Keeper.sh reads your Outlook calendar every minute, whatever plan you are on, so a roster change is picked up almost straight away. Writing it into Google differs by plan: every 30 minutes on free, every minute on Pro.
 
 For a roster published weeks ahead, every 30 minutes is more than enough. Pay for the faster one only if your meetings move twice a morning.
 
 ## Can I run it myself?
 
-Yes, and for a work calendar there is a specific reason to. Keeper is open source under AGPL-3.0, and your own copy gives you every Pro feature at no cost.
+Yes, and for a work calendar there is a specific reason to. Keeper.sh is open source under AGPL-3.0, and your own copy gives you every Pro feature at no cost.
 
 Your own instance also registers its own application with Microsoft. If your IT team will approve an internal application but not an outside service, that is the difference between this working and not working at all.
 


### PR DESCRIPTION
Adds the two head-term how-to guides for Google/Outlook calendar sync. They are separate articles because the search intent differs by direction, and they share no structure, scenario, or failure modes. Written for a reader who has never heard of ICS, CalDAV, or sync tokens, so the banned-jargon list is enforced throughout.

- `/blog/how-to-sync-google-calendar-with-outlook` — personal Google into work Outlook; leads on what colleagues see
- `/blog/how-to-sync-outlook-calendar-with-google-calendar` — work Outlook into a shared Google calendar; leads on employer restrictions and what a partner sees
- Every UI step walked against the real connect flow and setup wizard; button labels and screen copy match what ships
- Directional connections only, never described as two-way; free limits stated as 2 accounts / 3 connections
- Cadence stated honestly: read every minute on all plans, written out every 30 minutes on free and every minute on Pro
- Avoids a blanket "private by default" claim per #501; tells the reader to check Sync Settings per calendar
- Self-hosting gets its own section as a real alternative, including the honest setup cost
- Sitemap auto-discovery confirmed by building before and after (6 URLs to 8); both pages render at 200