### PR TITLE
docs: add Fastmail-to-Google and Nextcloud-to-Outlook sync guides

### DIFF
--- a/applications/web/src/content/blog/sync-fastmail-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/sync-fastmail-calendar-with-google-calendar.mdx
@@ -14,7 +14,7 @@ tags:
 
 Your dentist appointment lives on Fastmail. Your meetings live on Google Calendar. Neither one knows the other exists.
 
-So a colleague books you at 3pm, and you were already busy at 3pm. Keeper fixes that by copying events from one calendar onto the other.
+So a colleague books you at 3pm, and you were already busy at 3pm. Keeper.sh fixes that by copying events from one calendar onto the other.
 
 ## What will this actually do?
 
@@ -28,16 +28,16 @@ Want it both ways? Set up a second connection pointing the other way.
 
 Fastmail refuses to let outside apps sign in with your account password. That one password reaches your mail, your files, your contacts and your billing.
 
-Instead you generate a separate password just for Keeper. You can delete it on its own later, and your account password keeps working.
+Instead you generate a separate password just for Keeper.sh. You can delete it on its own later, and your account password keeps working.
 
 1. Open [Fastmail's app password settings](https://www.fastmail.com/settings/security/devicekeys).
 2. Click **Manage app password and access**.
 3. Click **New app password**. Fastmail may ask you to confirm your account password.
-4. Give it a name you will recognise in six months, like "Keeper".
+4. Give it a name you will recognise in six months, like "Keeper.sh".
 5. Under **Access**, choose **Calendars (CalDAV)**.
 6. Click **Generate password** and copy what appears.
 
-Step five is worth slowing down for. **Calendars (CalDAV)** is the narrowest option that still works, so the password reaches your calendars and nothing else. The default also covers mail and contacts, which Keeper has no use for.
+Step five is worth slowing down for. **Calendars (CalDAV)** is the narrowest option that still works, so the password reaches your calendars and nothing else. The default also covers mail and contacts, which Keeper.sh has no use for.
 
 Fastmail shows the password once. If you lose it, delete it and generate another.
 
@@ -50,25 +50,25 @@ Two boxes appear:
 - **Fastmail Email Address** — the full address you sign in with, domain included
 - **App-Specific Password** — the one you just generated
 
-Click **Connect**. Keeper finds every calendar on the account and brings them all in at once. Your task lists stay behind.
+Click **Connect**. Keeper.sh finds every calendar on the account and brings them all in at once. Your task lists stay behind.
 
 ## How do you connect Google Calendar?
 
-Return to **Import Calendars** and choose **Connect Google Calendar**. Keeper shows what it is about to ask Google for:
+Return to **Import Calendars** and choose **Connect Google Calendar**. Keeper.sh shows what it is about to ask Google for:
 
 - See your email address
 - View a list of your calendars
 - View events, summaries and details
 - Add or remove calendar events
 
-Click **Connect** and finish Google's own permission screen. You sign in to Google directly, so Keeper never sees that password.
+Click **Connect** and finish Google's own permission screen. You sign in to Google directly, so Keeper.sh never sees that password.
 
 ## Which calendar sends to which?
 
 Connecting an account drops you into a short setup of four screens.
 
 1. **Which calendars would you like to configure?** Tick the ones you care about now. Everything was already brought in.
-2. **Rename Your Calendars.** Fastmail tends to call yours "Calendar" and Google uses your email address. Renaming here changes only what you see inside Keeper.
+2. **Rename Your Calendars.** Fastmail tends to call yours "Calendar" and Google uses your email address. Renaming here changes only what you see inside Keeper.sh.
 3. **Where should 'Calendar' send events?** Pick the calendars that should receive copies.
 4. **Where should 'Calendar' pull events from?** The same question in reverse.
 
@@ -86,7 +86,7 @@ With **Sync Event Name** off, the copy is titled after the calendar it came from
 
 Turn it on and the real title goes through. The **Event Name** box also accepts `{{event_name}}` and `{{calendar_name}}`, so you can word the placeholder yourself.
 
-Below that, **Exclusions** can drop all-day events. Both sections are Pro on keeper.sh and included for everyone on a self-hosted install.
+Below that, **Exclusions** can drop all-day events. Both sections are Pro on Keeper.sh and included for everyone on a self-hosted install.
 
 ## What does not come across?
 
@@ -99,11 +99,11 @@ Time and text, and little else. None of the following reaches the copy:
 
 What does travel: the title, description, location, start and end, the time zone, whether it repeats, and whether it shows you as busy or free.
 
-Keeper does read the guest list on your own calendars, separately from all this. That powers its pending-invite list and lets you RSVP, and it is never written into a copied event.
+Keeper.sh does read the guest list on your own calendars, separately from all this. That powers its pending-invite list and lets you RSVP, and it is never written into a copied event.
 
 ## How quickly do changes show up?
 
-Keeper reads both calendars every minute, on every plan. That half never slows down.
+Keeper.sh reads both calendars every minute, on every plan. That half never slows down.
 
 Writing the change onto the other calendar is the part that differs. Free does that every 30 minutes, Pro every minute.
 
@@ -111,7 +111,7 @@ If you are blocking out evenings so work sees you as busy, 30 minutes is invisib
 
 ## How far ahead does it look?
 
-Keeper covers a week back to two years ahead. A one-off booking further out than that is not copied until it drifts into range.
+Keeper.sh covers a week back to two years ahead. A one-off booking further out than that is not copied until it drifts into range.
 
 Repeating events get more room. A weekly series that began years ago still has its upcoming occurrences copied.
 
@@ -119,13 +119,13 @@ Repeating events get more room. A weekly series that began years ago still has i
 
 **Connecting Fastmail fails with a short error mentioning 401.** Fastmail rejected the password. Either your account password went in instead of the app password, or that app password does not cover calendars.
 
-**Keeper says "No calendars found".** It reached Fastmail but saw nothing it could use. An app password scoped to **Files (WebDAV)** or **Mail (IMAP/POP/SMTP)** does exactly this, so generate a new one set to **Calendars (CalDAV)**.
+**Keeper.sh says "No calendars found".** It reached Fastmail but saw nothing it could use. An app password scoped to **Files (WebDAV)** or **Mail (IMAP/POP/SMTP)** does exactly this, so generate a new one set to **Calendars (CalDAV)**.
 
 **Events arrive on Google titled after the calendar.** That is **Sync Event Name** switched off. Turn it on under **Sync Settings**.
 
 **Changes you make in Google never reach Fastmail.** You built one connection and it points one way. Add a second going back.
 
-**An entire calendar stops updating, not just one event.** Usually a repeating event with a runaway rule. Keeper will not expand a series past ten thousand occurrences inside its two-year window, and hitting that stops the calendar it belongs to.
+**An entire calendar stops updating, not just one event.** Usually a repeating event with a runaway rule. Keeper.sh will not expand a series past ten thousand occurrences inside its two-year window, and hitting that stops the calendar it belongs to.
 
 ## What does the free plan cover?
 
@@ -137,7 +137,7 @@ Three connections covers Fastmail to Google, Google back to Fastmail, and one sp
 
 ## Would you rather run it yourself?
 
-Keeper is open source under AGPL-3.0, and self-hosting is a genuine option rather than a cut-down one. Every Pro feature comes with it: one-minute updates, unlimited accounts, unlimited connections, **Sync Settings** and **Exclusions**.
+Keeper.sh is open source under AGPL-3.0, and self-hosting is a genuine option rather than a cut-down one. Every Pro feature comes with it: one-minute updates, unlimited accounts, unlimited connections, **Sync Settings** and **Exclusions**.
 
 It is more work, and you should know how much before starting:
 

--- a/applications/web/src/content/blog/sync-fastmail-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/sync-fastmail-calendar-with-google-calendar.mdx
@@ -1,0 +1,157 @@
+---
+title: "How to Sync Fastmail Calendar with Google Calendar"
+description: "Put your Fastmail events on your Google calendar so nobody books over them. Covers the Fastmail app password, both connection screens, how much detail crosses over, and what never does."
+blurb: "Your dentist appointment is on Fastmail and your meetings are on Google, and neither one knows the other exists. Here is how to fix that in about ten minutes."
+createdAt: "2026-08-11"
+slug: "sync-fastmail-calendar-with-google-calendar"
+updatedAt: "2026-08-11"
+tags:
+  - "fastmail"
+  - "google-calendar"
+  - "sync"
+  - "calendar"
+---
+
+Your dentist appointment lives on Fastmail. Your meetings live on Google Calendar. Neither one knows the other exists.
+
+So a colleague books you at 3pm, and you were already busy at 3pm. Keeper fixes that by copying events from one calendar onto the other.
+
+This guide sets it up start to finish. It also says plainly what never crosses over.
+
+## What will this actually do?
+
+Your Fastmail events appear on your Google calendar. Move one on Fastmail and the copy moves with it. Delete it and the copy goes too.
+
+That is a connection, and it runs in one direction only. Fastmail sending to Google does not mean Google sends back.
+
+Want it both ways? Set up a second connection pointing the other way. The first one carries on unchanged.
+
+## Why won't Fastmail take your normal password?
+
+Fastmail refuses to let outside apps sign in with your account password. That one password reaches your mail, your files, your contacts and your billing.
+
+Instead you generate a separate password just for Keeper. You can delete it on its own later, and your account password keeps working.
+
+1. Sign in to Fastmail and open **Settings**, then **Privacy & Security**.
+2. Find **Connected apps & API tokens** and click **Manage app passwords and access**.
+3. Click **New app password**. Fastmail may ask you to confirm your account password.
+4. Pick a name you will recognise in six months. **Custom...** lets you type "Keeper".
+5. Choose an access option that includes calendars.
+6. Click **Generate password** and copy what appears.
+
+Fastmail's access list currently reads **Mail, Contacts & Calendars** and **Files (WebDAV)**. Choose the first — it is the one covering calendars. If your account offers a narrower calendars-only option instead, take that one, because it hands over less.
+
+Fastmail shows the password once and never again. If you lose it, delete it and generate another.
+
+## How do you connect Fastmail?
+
+Sign in at [keeper.sh](https://keeper.sh/register) and open **Import Calendars** from your dashboard. Choose **Connect Fastmail**.
+
+Two boxes appear:
+
+- **Fastmail Email Address** — the full address you sign in with, domain included
+- **App-Specific Password** — the one you just generated
+
+You are never asked for a server address. Keeper already knows where Fastmail keeps calendars, which is why Fastmail gets its own button rather than the generic one.
+
+Click **Connect**. Keeper finds every calendar on the account and brings them all in at once. Your task lists stay behind.
+
+## How do you connect Google Calendar?
+
+Return to **Import Calendars** and choose **Connect Google Calendar**. Keeper shows what it is about to ask Google for before sending you anywhere:
+
+- See your email address
+- View a list of your calendars
+- View events, summaries and details
+- Add or remove calendar events
+
+Click **Connect** and finish Google's own permission screen. You sign in to Google directly, so Keeper never sees that password.
+
+## Which calendar sends to which?
+
+Connecting an account drops you into a short setup of four screens.
+
+1. **Which calendars would you like to configure?** Tick the ones you care about now. Everything was already brought in.
+2. **Rename Your Calendars.** Fastmail tends to call yours "Calendar" and Google uses your email address. Renaming here changes only what you see inside Keeper.
+3. **Where should 'Calendar' send events?** Pick the calendars that should receive copies.
+4. **Where should 'Calendar' pull events from?** The same question in reverse.
+
+For Fastmail into Google you only need screen three. Choose your Google calendar there and the connection exists.
+
+You can change any of this later. Open a calendar from your dashboard and use **Send Events to Calendars**.
+
+## How much of the event crosses over?
+
+Settle this before you trust it with anything private. Open the calendar in your dashboard and find **Sync Settings**.
+
+Three switches live there: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
+
+With **Sync Event Name** off, the copy is titled after the calendar it came from. Your 3pm arrives on Google as a block called "Personal", not "Therapy".
+
+Turn it on and the real title goes through. The **Event Name** box also accepts `{{event_name}}` and `{{calendar_name}}`, so you can word the placeholder yourself.
+
+Below that, **Exclusions** can drop all-day events. Both sections are Pro on keeper.sh and included for everyone on a self-hosted install.
+
+Check these switches on every calendar you connect, rather than assuming what they are set to.
+
+## What does not come across?
+
+Time and text, and little else. None of the following reaches the copy:
+
+- **Guests.** The copy has no attendees, so nobody receives an invitation from it.
+- **Meeting links.** Google Meet, Teams and Zoom joins are not carried over.
+- **Alerts.** Reminders do not travel, so Google applies its own defaults instead.
+- **Colours, attachments and categories.** None of these are copied.
+
+What does travel: the title, description, location, start and end, the time zone, whether it repeats, and whether it shows you as busy or free.
+
+Keeper does read the guest list on your own calendars, separately from all this. That is what powers its pending-invite list and lets you RSVP. It is never written into a copied event.
+
+## How quickly do changes show up?
+
+Keeper reads both calendars every minute, on every plan. That half never slows down.
+
+Writing the change onto the other calendar is the part that differs. Free does that every 30 minutes. Pro does it every minute.
+
+If you are blocking out evenings so work sees you as busy, 30 minutes is invisible. If people book you through a scheduling link, half an hour is long enough to get double-booked. Pay for the speed only if you will notice it.
+
+## How far ahead does it look?
+
+Keeper covers a week back to two years ahead. A one-off booking further out than that is not copied until it drifts into range.
+
+Repeating events get more room. A weekly series that began years ago still has its upcoming occurrences copied.
+
+## Why isn't it working?
+
+**Connecting Fastmail fails with a short error mentioning 401.** Fastmail rejected the password. Either your account password went in instead of the app password, or that app password does not cover calendars.
+
+**Keeper says "No calendars found".** It reached Fastmail but saw nothing it could use. An app password limited to **Files (WebDAV)** produces exactly this.
+
+**Events arrive on Google titled after the calendar.** That is **Sync Event Name** switched off. Turn it on under **Sync Settings**.
+
+**Changes you make in Google never reach Fastmail.** You built one connection and it points one way. Add a second going back.
+
+**An entire calendar stops updating, not just one event.** Usually a repeating event with a runaway rule. Keeper will not expand a series past ten thousand occurrences inside its two-year window, and hitting that stops the calendar it belongs to. Look for something set to repeat every minute, often imported from elsewhere.
+
+## What does the free plan cover?
+
+Two calendar accounts and three connections.
+
+Fastmail counts as one account however many calendars it holds, and Google is the second. So this pairing uses your account allowance exactly, and adding iCloud later means upgrading.
+
+Nothing caps the calendars inside an account. Ten Fastmail calendars still count as one.
+
+Three connections covers Fastmail to Google, Google back to Fastmail, and one spare.
+
+## Would you rather run it yourself?
+
+Keeper is open source under AGPL-3.0, and self-hosting is a genuine option rather than a cut-down one. Every Pro feature comes with it: one-minute updates, unlimited accounts, unlimited connections, **Sync Settings** and **Exclusions**.
+
+It is more work, and you should know how much before starting:
+
+- A server, a domain and a certificate
+- Docker and Docker Compose, alongside Postgres and Redis
+- Your own Google OAuth client, because Google issues credentials per application. Fastmail needs nothing of the sort — a username and a password is the whole story.
+- Backups, updates, and being the person who gets paged when it stops at 2am
+
+The [README](https://github.com/ridafkih/keeper.sh) covers a single-container setup and a full Compose file. If that reads like a decent evening, self-host it. If it reads like a chore, [keeper.sh](https://keeper.sh/register) does the same job and funds the project.

--- a/applications/web/src/content/blog/sync-fastmail-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/sync-fastmail-calendar-with-google-calendar.mdx
@@ -32,16 +32,18 @@ Fastmail refuses to let outside apps sign in with your account password. That on
 
 Instead you generate a separate password just for Keeper. You can delete it on its own later, and your account password keeps working.
 
-1. Sign in to Fastmail and open **Settings**, then **Privacy & Security**.
-2. Find **Connected apps & API tokens** and click **Manage app passwords and access**.
+1. Open [Fastmail's app password settings](https://www.fastmail.com/settings/security/devicekeys).
+2. Click **Manage app password and access**.
 3. Click **New app password**. Fastmail may ask you to confirm your account password.
-4. Pick a name you will recognise in six months. **Custom...** lets you type "Keeper".
-5. Choose an access option that includes calendars.
+4. Give it a name you will recognise in six months, like "Keeper".
+5. Under **Access**, choose **Calendars (CalDAV)**.
 6. Click **Generate password** and copy what appears.
 
-Fastmail's access list currently reads **Mail, Contacts & Calendars** and **Files (WebDAV)**. Choose the first — it is the one covering calendars. If your account offers a narrower calendars-only option instead, take that one, because it hands over less.
+Step five is the one worth slowing down for. **Calendars (CalDAV)** is the narrowest option that still does the job, so the password you hand Keeper reaches your calendars and nothing else.
 
-Fastmail shows the password once and never again. If you lose it, delete it and generate another.
+The default is broader. It covers mail and contacts as well, which Keeper has no use for. Pick the narrow one and a leaked password cannot read your inbox.
+
+Fastmail shows the password once. If you lose it, delete it and generate another.
 
 ## How do you connect Fastmail?
 
@@ -125,7 +127,7 @@ Repeating events get more room. A weekly series that began years ago still has i
 
 **Connecting Fastmail fails with a short error mentioning 401.** Fastmail rejected the password. Either your account password went in instead of the app password, or that app password does not cover calendars.
 
-**Keeper says "No calendars found".** It reached Fastmail but saw nothing it could use. An app password limited to **Files (WebDAV)** produces exactly this.
+**Keeper says "No calendars found".** It reached Fastmail but saw nothing it could use. An app password scoped to something other than calendars does exactly this — **Files (WebDAV)** and **Mail (IMAP/POP/SMTP)** are the usual slips. Generate a new one set to **Calendars (CalDAV)**.
 
 **Events arrive on Google titled after the calendar.** That is **Sync Event Name** switched off. Turn it on under **Sync Settings**.
 

--- a/applications/web/src/content/blog/sync-fastmail-calendar-with-google-calendar.mdx
+++ b/applications/web/src/content/blog/sync-fastmail-calendar-with-google-calendar.mdx
@@ -16,15 +16,13 @@ Your dentist appointment lives on Fastmail. Your meetings live on Google Calenda
 
 So a colleague books you at 3pm, and you were already busy at 3pm. Keeper fixes that by copying events from one calendar onto the other.
 
-This guide sets it up start to finish. It also says plainly what never crosses over.
-
 ## What will this actually do?
 
 Your Fastmail events appear on your Google calendar. Move one on Fastmail and the copy moves with it. Delete it and the copy goes too.
 
 That is a connection, and it runs in one direction only. Fastmail sending to Google does not mean Google sends back.
 
-Want it both ways? Set up a second connection pointing the other way. The first one carries on unchanged.
+Want it both ways? Set up a second connection pointing the other way.
 
 ## Why won't Fastmail take your normal password?
 
@@ -39,9 +37,7 @@ Instead you generate a separate password just for Keeper. You can delete it on i
 5. Under **Access**, choose **Calendars (CalDAV)**.
 6. Click **Generate password** and copy what appears.
 
-Step five is the one worth slowing down for. **Calendars (CalDAV)** is the narrowest option that still does the job, so the password you hand Keeper reaches your calendars and nothing else.
-
-The default is broader. It covers mail and contacts as well, which Keeper has no use for. Pick the narrow one and a leaked password cannot read your inbox.
+Step five is worth slowing down for. **Calendars (CalDAV)** is the narrowest option that still works, so the password reaches your calendars and nothing else. The default also covers mail and contacts, which Keeper has no use for.
 
 Fastmail shows the password once. If you lose it, delete it and generate another.
 
@@ -54,13 +50,11 @@ Two boxes appear:
 - **Fastmail Email Address** — the full address you sign in with, domain included
 - **App-Specific Password** — the one you just generated
 
-You are never asked for a server address. Keeper already knows where Fastmail keeps calendars, which is why Fastmail gets its own button rather than the generic one.
-
 Click **Connect**. Keeper finds every calendar on the account and brings them all in at once. Your task lists stay behind.
 
 ## How do you connect Google Calendar?
 
-Return to **Import Calendars** and choose **Connect Google Calendar**. Keeper shows what it is about to ask Google for before sending you anywhere:
+Return to **Import Calendars** and choose **Connect Google Calendar**. Keeper shows what it is about to ask Google for:
 
 - See your email address
 - View a list of your calendars
@@ -94,8 +88,6 @@ Turn it on and the real title goes through. The **Event Name** box also accepts 
 
 Below that, **Exclusions** can drop all-day events. Both sections are Pro on keeper.sh and included for everyone on a self-hosted install.
 
-Check these switches on every calendar you connect, rather than assuming what they are set to.
-
 ## What does not come across?
 
 Time and text, and little else. None of the following reaches the copy:
@@ -107,15 +99,15 @@ Time and text, and little else. None of the following reaches the copy:
 
 What does travel: the title, description, location, start and end, the time zone, whether it repeats, and whether it shows you as busy or free.
 
-Keeper does read the guest list on your own calendars, separately from all this. That is what powers its pending-invite list and lets you RSVP. It is never written into a copied event.
+Keeper does read the guest list on your own calendars, separately from all this. That powers its pending-invite list and lets you RSVP, and it is never written into a copied event.
 
 ## How quickly do changes show up?
 
 Keeper reads both calendars every minute, on every plan. That half never slows down.
 
-Writing the change onto the other calendar is the part that differs. Free does that every 30 minutes. Pro does it every minute.
+Writing the change onto the other calendar is the part that differs. Free does that every 30 minutes, Pro every minute.
 
-If you are blocking out evenings so work sees you as busy, 30 minutes is invisible. If people book you through a scheduling link, half an hour is long enough to get double-booked. Pay for the speed only if you will notice it.
+If you are blocking out evenings so work sees you as busy, 30 minutes is invisible. If people book you through a scheduling link, half an hour is long enough to get double-booked.
 
 ## How far ahead does it look?
 
@@ -127,19 +119,17 @@ Repeating events get more room. A weekly series that began years ago still has i
 
 **Connecting Fastmail fails with a short error mentioning 401.** Fastmail rejected the password. Either your account password went in instead of the app password, or that app password does not cover calendars.
 
-**Keeper says "No calendars found".** It reached Fastmail but saw nothing it could use. An app password scoped to something other than calendars does exactly this — **Files (WebDAV)** and **Mail (IMAP/POP/SMTP)** are the usual slips. Generate a new one set to **Calendars (CalDAV)**.
+**Keeper says "No calendars found".** It reached Fastmail but saw nothing it could use. An app password scoped to **Files (WebDAV)** or **Mail (IMAP/POP/SMTP)** does exactly this, so generate a new one set to **Calendars (CalDAV)**.
 
 **Events arrive on Google titled after the calendar.** That is **Sync Event Name** switched off. Turn it on under **Sync Settings**.
 
 **Changes you make in Google never reach Fastmail.** You built one connection and it points one way. Add a second going back.
 
-**An entire calendar stops updating, not just one event.** Usually a repeating event with a runaway rule. Keeper will not expand a series past ten thousand occurrences inside its two-year window, and hitting that stops the calendar it belongs to. Look for something set to repeat every minute, often imported from elsewhere.
+**An entire calendar stops updating, not just one event.** Usually a repeating event with a runaway rule. Keeper will not expand a series past ten thousand occurrences inside its two-year window, and hitting that stops the calendar it belongs to.
 
 ## What does the free plan cover?
 
-Two calendar accounts and three connections.
-
-Fastmail counts as one account however many calendars it holds, and Google is the second. So this pairing uses your account allowance exactly, and adding iCloud later means upgrading.
+Two calendar accounts and three connections. Fastmail is one account and Google the second, so this pairing uses your account allowance exactly.
 
 Nothing caps the calendars inside an account. Ten Fastmail calendars still count as one.
 
@@ -156,4 +146,4 @@ It is more work, and you should know how much before starting:
 - Your own Google OAuth client, because Google issues credentials per application. Fastmail needs nothing of the sort — a username and a password is the whole story.
 - Backups, updates, and being the person who gets paged when it stops at 2am
 
-The [README](https://github.com/ridafkih/keeper.sh) covers a single-container setup and a full Compose file. If that reads like a decent evening, self-host it. If it reads like a chore, [keeper.sh](https://keeper.sh/register) does the same job and funds the project.
+The [README](https://github.com/ridafkih/keeper.sh) covers a single-container setup and a full Compose file. If that reads like a chore, [keeper.sh](https://keeper.sh/register) does the same job and funds the project.

--- a/applications/web/src/content/blog/sync-nextcloud-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/sync-nextcloud-calendar-with-outlook.mdx
@@ -15,17 +15,13 @@ tags:
 
 You run Nextcloud because your calendar should belong to you. Then work hands you Outlook, and your two calendars stop speaking.
 
-The usual result is a personal calendar nobody at work can see, and a work calendar that books straight over your Saturday. Keeper copies events from one onto the other so the busy blocks line up.
-
-You already run a server, so this guide goes into the URLs and the failure modes properly.
+The result is a personal calendar nobody at work can see, and a work calendar that books straight over your Saturday. Keeper copies events from one onto the other so the busy blocks line up.
 
 ## What will this actually do?
 
 Your Nextcloud events appear on your Outlook calendar. Move one in Nextcloud and the copy moves. Delete it and the copy goes.
 
-That is a connection, and it runs in one direction only. Nextcloud sending to Outlook does not mean Outlook sends back.
-
-Want both directions? Build a second connection the other way. Each one is separate, and each counts separately.
+That is a connection, and it runs in one direction only. Want both directions? Build a second connection the other way, which counts separately.
 
 ## What do you need before you start?
 
@@ -35,13 +31,11 @@ Want both directions? Build a second connection the other way. Each one is separ
 - An Outlook or Microsoft 365 account
 - An account on [keeper.sh](https://keeper.sh/register)
 
-That last one is the easy path, and the rest of this guide assumes it. If you would rather run Keeper on your own box too, there is a section at the end.
-
 One thing worth settling early: hosted keeper.sh has to reach your Nextcloud over the public internet. A Nextcloud on `192.168.1.50` or `nextcloud.local` is not reachable, and no setting on your account changes that. Self-hosting Keeper is the answer for a LAN-only instance.
 
 ## How do you connect Nextcloud?
 
-Open **Import Calendars** from your dashboard and choose **Connect CalDAV Server** from the bottom group. Nextcloud has no button of its own and does not need one. It speaks the CalDAV standard, the same one Keeper uses for iCloud and Fastmail.
+Open **Import Calendars** from your dashboard and choose **Connect CalDAV Server** from the bottom group. Nextcloud has no button of its own and does not need one, because it speaks the same CalDAV standard Keeper uses for iCloud.
 
 Three fields:
 
@@ -49,32 +43,26 @@ Three fields:
 - **CalDAV Server Username** — your Nextcloud username, not your email address unless they match
 - **CalDAV Server Password** — your password, or an app password
 
-Paste the base URL. Keeper walks the rest itself. It checks `/.well-known/caldav`, follows any redirect, asks the server who you are, then follows that to your calendar home and lists what it finds.
-
-So you do not need to dig out the `remote.php/dav/calendars/username/` path.
-
-Both basic and digest authentication work, and Keeper negotiates which one without asking you.
+Paste the base URL and Keeper finds your calendars from there. You do not need to dig out the `remote.php/dav/calendars/username/` path.
 
 ### Get an app password
 
-Use one even without two-factor. It is revocable on its own, and it never reaches your Nextcloud login session.
+Use one even without two-factor, because it is revocable on its own.
 
-In Nextcloud, open **Settings → Security**, find **Devices & sessions**, name the app and create the password. With two-factor turned on this stops being optional — Nextcloud rejects your login password over CalDAV entirely.
+In Nextcloud, open **Settings → Security**, find **Devices & sessions**, name the app and create the password. With two-factor turned on this stops being optional, because Nextcloud rejects your login password over CalDAV entirely.
 
-Click **Connect**. Keeper imports every calendar it discovers on the account at once, then drops you into setup. There is no "choose which ones" step first; the choosing happens after.
+Click **Connect**. Keeper imports every calendar it discovers, then drops you into setup.
 
 ## How do you connect Outlook?
 
-Back on **Import Calendars** there are two Microsoft buttons. **Connect Outlook** is for personal accounts. **Connect Microsoft 365** is for work and school accounts. Pick the one matching the account you are signing into.
-
-Either way, Keeper lists what it will ask Microsoft for before redirecting you:
+Back on **Import Calendars**, **Connect Outlook** is for personal accounts and **Connect Microsoft 365** is for work and school accounts. Either way, Keeper lists what it will ask Microsoft for:
 
 - See your email address
 - View a list of your calendars
 - View events, summaries and details
 - Add or remove calendar events
 
-Click **Connect** and complete Microsoft's consent screen. On a managed work tenant an administrator may need to approve the app first. That is your employer's policy, and nothing in Keeper can route around it.
+Click **Connect** and complete Microsoft's consent screen. On a managed work tenant an administrator may need to approve the app first, and nothing in Keeper can route around that.
 
 ## Which calendar sends to which?
 
@@ -87,21 +75,17 @@ Setup is four screens.
 
 For Nextcloud into Outlook you need screen three. Pick your Outlook calendar and the connection exists.
 
-Everything is editable afterwards. Open a calendar from your dashboard and use **Send Events to Calendars**.
+Everything is editable afterwards from a calendar's page, under **Send Events to Calendars**.
 
 ## How much of the event crosses over?
 
-Decide this deliberately, because one end of this pairing is your employer's system. Open the calendar in your dashboard and find **Sync Settings**.
-
-Three switches: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
+Decide this deliberately, because one end of this pairing is your employer's system. Open the calendar in your dashboard and find **Sync Settings**, which holds **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
 
 With **Sync Event Name** off, the copy is titled after the calendar it came from. A consultant's appointment reaches Outlook as a block called "Personal", not as its real name.
 
 Turn it on and the true title goes through. The **Event Name** box accepts `{{event_name}}` and `{{calendar_name}}`, so you can word the placeholder however you like.
 
 **Exclusions** below can drop all-day events. Both sections are Pro on keeper.sh and included for everyone self-hosting.
-
-Check these switches on each calendar you connect rather than assuming what they are set to.
 
 ## What does not come across?
 
@@ -114,80 +98,58 @@ Time and text, and little else. None of this reaches the copy:
 
 What does travel: the title, description, location, start and end, the time zone, whether it repeats, and whether it shows you as busy or free.
 
-Keeper does read the guest list on your own calendars, separately. That drives its pending-invite list and lets you RSVP. It never lands in a copied event.
+## How quickly, and how far ahead?
 
-## What is that keeper.sh category on my Outlook events?
-
-Keeper tags every event it creates in Outlook with a category named `keeper.sh`. Microsoft does not let outside apps set their own event identifiers, so this tag is how Keeper recognises its own work later.
-
-It is visible in Outlook, which some people dislike. It also matters practically: strip that category off an event by hand and Keeper stops recognising it. The event becomes a leftover it can no longer update or clean up.
-
-The tag is what keeps events from looping back, too. Outlook events carrying it are skipped when Outlook is the calendar sending events.
-
-## How quickly do changes show up?
-
-Keeper reads both calendars every minute, on every plan.
-
-Writing the change onto the other calendar is what differs. Free does it every 30 minutes. Pro does it every minute.
+Keeper reads both calendars every minute, on every plan. Writing the change onto the other calendar is what differs: free does it every 30 minutes, Pro every minute.
 
 If you are mirroring personal commitments so work sees you as busy, 30 minutes changes nothing you will notice. If people book you through a scheduling link, half an hour is enough to get double-booked.
 
-Worth knowing about the reading half. Microsoft tells Keeper only what changed since last time, so a large Outlook calendar stays cheap to check.
+Keeper covers a week back to two years ahead. A one-off event further out is not copied until it drifts into range, though a repeating series that began before the window still has its upcoming occurrences copied.
 
-Nextcloud gets refetched in full each cycle and compared against what Keeper stored. Correct either way, but a very large Nextcloud calendar does more work per cycle.
-
-## How far ahead does it look?
-
-A week back to two years ahead. A one-off event further out is not copied until it drifts into range.
-
-Repeating events get more room. A series whose first occurrence predates the window is still collected, so its upcoming occurrences survive.
+Every event Keeper creates in Outlook carries a category named `keeper.sh`. That tag is how Keeper recognises its own work later, so leave it alone.
 
 ## Why isn't it working?
 
 **Connecting fails with a short error mentioning 401.** Nextcloud rejected the credentials. With two-factor enabled this is almost always the login password being used where an app password is required.
 
-**Keeper says "No calendars found".** It authenticated but nothing survived filtering. Keeper keeps only collections that advertise support for `VEVENT`, which correctly skips task lists and contacts. A server that omits the supported-components property entirely reports nothing at all, and some reverse proxy configurations strip it from PROPFIND responses.
+**Keeper says "No calendars found".** It authenticated, but Keeper keeps only collections advertising support for `VEVENT`, and some reverse proxies strip that property from PROPFIND responses.
 
-**Nextcloud is unreachable and you self-host Keeper.** The deployment Compose file sets `BLOCK_PRIVATE_RESOLUTION=true`, which refuses to fetch anything resolving to a private or reserved address. Add your host to `PRIVATE_RESOLUTION_WHITELIST`. On hosted keeper.sh you cannot change this, so the instance has to be publicly reachable.
+**Nextcloud is unreachable and you self-host Keeper.** The deployment Compose file sets `BLOCK_PRIVATE_RESOLUTION=true`, which refuses anything resolving to a private address. Add your host to `PRIVATE_RESOLUTION_WHITELIST`.
 
-**Microsoft consent fails outright on a work account.** Managed tenants can block third-party calendar apps. You need an administrator to approve it; there is no way around a tenant policy.
+**Microsoft consent fails outright on a work account.** Managed tenants can block third-party calendar apps, and you need an administrator to approve it.
 
 **Events arrive on Outlook titled after the calendar.** **Sync Event Name** is off. Turn it on in **Sync Settings**.
 
 **Changes in Outlook never reach Nextcloud.** One connection, one direction. Add a second going back.
 
-**An entire calendar stops updating, not one event.** Usually a repeating event with a runaway rule. Keeper will not expand a series past ten thousand occurrences in the two-year window, and hitting that stops the calendar it belongs to. Look for something repeating every minute, generally imported from elsewhere.
+**An entire calendar stops updating, not one event.** Usually a repeating event with a runaway rule. Keeper will not expand a series past ten thousand occurrences in the two-year window, and hitting that stops the calendar it belongs to.
 
-**Events vanish from Outlook that still exist in Nextcloud.** Nextcloud is refetched in full each cycle. So a proxy that silently caps objects per response looks like a calendar that really lost them. Nextcloud sets no such cap itself, but an aggressive response limit in front of it does.
+**Events vanish from Outlook that still exist in Nextcloud.** Keeper refetches Nextcloud in full each cycle, so a proxy that silently caps objects per response looks like a calendar that really lost them.
 
 ## What does the free plan cover?
 
-Two calendar accounts and three connections.
+Two calendar accounts and three connections. Nextcloud is one account and Microsoft the second, so this pairing uses the whole account allowance.
 
-Nextcloud is one account however many calendars it exposes, and Microsoft is the second. So this pairing uses the whole account allowance.
-
-Nothing caps calendars inside an account. Twelve Nextcloud calendars still count as one.
-
-Three connections covers Nextcloud to Outlook, Outlook back to Nextcloud, and one spare.
+Nothing caps calendars inside an account — twelve Nextcloud calendars still count as one. Three connections covers Nextcloud to Outlook, Outlook back to Nextcloud, and one spare.
 
 ## Where are my Nextcloud credentials kept?
 
-Encrypted at rest with a configurable key before storage. CalDAV replays the password on every request, so there is no token exchange to hide behind. Keeper needs it in a reversible form, and would rather say so than imply otherwise.
+Encrypted at rest with a configurable key. CalDAV replays the password on every request, so Keeper needs it in a reversible form and would rather say so than imply otherwise.
 
-Revoking is either end. Delete the app password in Nextcloud, or open the account in Keeper and use **Delete Account**, which removes the account and all its calendars.
+Revoking works from either end: delete the app password in Nextcloud, or open the account in Keeper and use **Delete Account**.
 
 ## Would you rather run Keeper yourself too?
 
 Running Nextcloud does not mean you want another service to babysit, so this is a real choice rather than the obvious one.
 
-If you do want it, self-hosting Keeper is not a downgrade. It is AGPL-3.0 and every Pro feature is included: one-minute updates, unlimited accounts, unlimited connections, **Sync Settings** and **Exclusions**. It also removes the public-reachability problem, since Keeper can then sit on the same network as your Nextcloud.
+Self-hosting is not a downgrade. It is AGPL-3.0 with every Pro feature included, and it removes the public-reachability problem, since Keeper can then sit on the same network as your Nextcloud.
 
 The honest costs:
 
 - Another server, domain and certificate to keep alive
 - Docker and Docker Compose, plus Postgres and Redis
-- Your own Microsoft OAuth app registered in Azure, with scopes `Calendars.ReadWrite`, `User.Read` and `offline_access`. Nextcloud needs no such registration — CalDAV is a username and a password.
-- `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY` generated and kept safe, because losing the second one loses your stored credentials
+- Your own Microsoft OAuth app registered in Azure, with scopes `Calendars.ReadWrite`, `User.Read` and `offline_access`
+- `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY` kept safe, because losing the second loses your stored credentials
 - Backups, updates, and being the person who gets paged when it stops
 
-The [README](https://github.com/ridafkih/keeper.sh) has a single-container setup and a full Compose file. If none of that is new to you, self-host it. If you would rather not own another thing, [keeper.sh](https://keeper.sh/register) runs it and funds the project.
+The [README](https://github.com/ridafkih/keeper.sh) has a single-container setup and a full Compose file. If you would rather not own another thing, [keeper.sh](https://keeper.sh/register) runs it and funds the project.

--- a/applications/web/src/content/blog/sync-nextcloud-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/sync-nextcloud-calendar-with-outlook.mdx
@@ -1,0 +1,195 @@
+---
+title: "How to Sync Nextcloud Calendar with Outlook"
+description: "Get your Nextcloud events onto an Outlook or Microsoft 365 calendar. Covers the URL to paste, app passwords and two-factor, tenant consent, how much detail crosses over, and what never does."
+blurb: "You run Nextcloud because your calendar should be yours. Then work hands you Outlook, and the two stop speaking. Here is how to bridge them, and where the sharp edges are."
+createdAt: "2026-08-11"
+slug: "sync-nextcloud-calendar-with-outlook"
+updatedAt: "2026-08-11"
+tags:
+  - "nextcloud"
+  - "outlook"
+  - "sync"
+  - "calendar"
+  - "self-hosting"
+---
+
+You run Nextcloud because your calendar should belong to you. Then work hands you Outlook, and your two calendars stop speaking.
+
+The usual result is a personal calendar nobody at work can see, and a work calendar that books straight over your Saturday. Keeper copies events from one onto the other so the busy blocks line up.
+
+You already run a server, so this guide goes into the URLs and the failure modes properly.
+
+## What will this actually do?
+
+Your Nextcloud events appear on your Outlook calendar. Move one in Nextcloud and the copy moves. Delete it and the copy goes.
+
+That is a connection, and it runs in one direction only. Nextcloud sending to Outlook does not mean Outlook sends back.
+
+Want both directions? Build a second connection the other way. Each one is separate, and each counts separately.
+
+## What do you need before you start?
+
+- A Nextcloud instance reachable over HTTPS from wherever Keeper runs
+- Your Nextcloud username, which is often not your email address
+- An app password if you have two-factor enabled, and ideally even if you do not
+- An Outlook or Microsoft 365 account
+- An account on [keeper.sh](https://keeper.sh/register)
+
+That last one is the easy path, and the rest of this guide assumes it. If you would rather run Keeper on your own box too, there is a section at the end.
+
+One thing worth settling early: hosted keeper.sh has to reach your Nextcloud over the public internet. A Nextcloud on `192.168.1.50` or `nextcloud.local` is not reachable, and no setting on your account changes that. Self-hosting Keeper is the answer for a LAN-only instance.
+
+## How do you connect Nextcloud?
+
+Open **Import Calendars** from your dashboard and choose **Connect CalDAV Server** from the bottom group. Nextcloud has no button of its own and does not need one. It speaks the CalDAV standard, the same one Keeper uses for iCloud and Fastmail.
+
+Three fields:
+
+- **CalDAV Server URL** — your Nextcloud base URL, for example `https://cloud.example.com`
+- **CalDAV Server Username** — your Nextcloud username, not your email address unless they match
+- **CalDAV Server Password** — your password, or an app password
+
+Paste the base URL. Keeper walks the rest itself. It checks `/.well-known/caldav`, follows any redirect, asks the server who you are, then follows that to your calendar home and lists what it finds.
+
+So you do not need to dig out the `remote.php/dav/calendars/username/` path.
+
+Both basic and digest authentication work, and Keeper negotiates which one without asking you.
+
+### Get an app password
+
+Use one even without two-factor. It is revocable on its own, and it never reaches your Nextcloud login session.
+
+In Nextcloud, open **Settings → Security**, find **Devices & sessions**, name the app and create the password. With two-factor turned on this stops being optional — Nextcloud rejects your login password over CalDAV entirely.
+
+Click **Connect**. Keeper imports every calendar it discovers on the account at once, then drops you into setup. There is no "choose which ones" step first; the choosing happens after.
+
+## How do you connect Outlook?
+
+Back on **Import Calendars** there are two Microsoft buttons. **Connect Outlook** is for personal accounts. **Connect Microsoft 365** is for work and school accounts. Pick the one matching the account you are signing into.
+
+Either way, Keeper lists what it will ask Microsoft for before redirecting you:
+
+- See your email address
+- View a list of your calendars
+- View events, summaries and details
+- Add or remove calendar events
+
+Click **Connect** and complete Microsoft's consent screen. On a managed work tenant an administrator may need to approve the app first. That is your employer's policy, and nothing in Keeper can route around it.
+
+## Which calendar sends to which?
+
+Setup is four screens.
+
+1. **Which calendars would you like to configure?** Tick what you want to set up now. Everything was already imported.
+2. **Rename Your Calendars.** Nextcloud defaults to names like "Personal". Renaming here is local to Keeper and does not touch the calendar on your server.
+3. **Where should 'Personal' send events?** Pick the calendars that should receive copies.
+4. **Where should 'Personal' pull events from?** The same question in reverse.
+
+For Nextcloud into Outlook you need screen three. Pick your Outlook calendar and the connection exists.
+
+Everything is editable afterwards. Open a calendar from your dashboard and use **Send Events to Calendars**.
+
+## How much of the event crosses over?
+
+Decide this deliberately, because one end of this pairing is your employer's system. Open the calendar in your dashboard and find **Sync Settings**.
+
+Three switches: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
+
+With **Sync Event Name** off, the copy is titled after the calendar it came from. A consultant's appointment reaches Outlook as a block called "Personal", not as its real name.
+
+Turn it on and the true title goes through. The **Event Name** box accepts `{{event_name}}` and `{{calendar_name}}`, so you can word the placeholder however you like.
+
+**Exclusions** below can drop all-day events. Both sections are Pro on keeper.sh and included for everyone self-hosting.
+
+Check these switches on each calendar you connect rather than assuming what they are set to.
+
+## What does not come across?
+
+Time and text, and little else. None of this reaches the copy:
+
+- **Guests.** The copy has no attendees, so nobody gets an invitation from it.
+- **Meeting links.** Teams, Meet and Zoom joins are not carried over.
+- **Alerts.** Reminders do not travel, so Outlook applies its own defaults.
+- **Colours, attachments and categories from your side.** Not copied.
+
+What does travel: the title, description, location, start and end, the time zone, whether it repeats, and whether it shows you as busy or free.
+
+Keeper does read the guest list on your own calendars, separately. That drives its pending-invite list and lets you RSVP. It never lands in a copied event.
+
+## What is that keeper.sh category on my Outlook events?
+
+Keeper tags every event it creates in Outlook with a category named `keeper.sh`. Microsoft does not let outside apps set their own event identifiers, so this tag is how Keeper recognises its own work later.
+
+It is visible in Outlook, which some people dislike. It also matters practically: strip that category off an event by hand and Keeper stops recognising it. The event becomes a leftover it can no longer update or clean up.
+
+The tag is what keeps events from looping back, too. Outlook events carrying it are skipped when Outlook is the calendar sending events.
+
+## How quickly do changes show up?
+
+Keeper reads both calendars every minute, on every plan.
+
+Writing the change onto the other calendar is what differs. Free does it every 30 minutes. Pro does it every minute.
+
+If you are mirroring personal commitments so work sees you as busy, 30 minutes changes nothing you will notice. If people book you through a scheduling link, half an hour is enough to get double-booked.
+
+Worth knowing about the reading half. Microsoft tells Keeper only what changed since last time, so a large Outlook calendar stays cheap to check.
+
+Nextcloud gets refetched in full each cycle and compared against what Keeper stored. Correct either way, but a very large Nextcloud calendar does more work per cycle.
+
+## How far ahead does it look?
+
+A week back to two years ahead. A one-off event further out is not copied until it drifts into range.
+
+Repeating events get more room. A series whose first occurrence predates the window is still collected, so its upcoming occurrences survive.
+
+## Why isn't it working?
+
+**Connecting fails with a short error mentioning 401.** Nextcloud rejected the credentials. With two-factor enabled this is almost always the login password being used where an app password is required.
+
+**Keeper says "No calendars found".** It authenticated but nothing survived filtering. Keeper keeps only collections that advertise support for `VEVENT`, which correctly skips task lists and contacts. A server that omits the supported-components property entirely reports nothing at all, and some reverse proxy configurations strip it from PROPFIND responses.
+
+**Nextcloud is unreachable and you self-host Keeper.** The deployment Compose file sets `BLOCK_PRIVATE_RESOLUTION=true`, which refuses to fetch anything resolving to a private or reserved address. Add your host to `PRIVATE_RESOLUTION_WHITELIST`. On hosted keeper.sh you cannot change this, so the instance has to be publicly reachable.
+
+**Microsoft consent fails outright on a work account.** Managed tenants can block third-party calendar apps. You need an administrator to approve it; there is no way around a tenant policy.
+
+**Events arrive on Outlook titled after the calendar.** **Sync Event Name** is off. Turn it on in **Sync Settings**.
+
+**Changes in Outlook never reach Nextcloud.** One connection, one direction. Add a second going back.
+
+**An entire calendar stops updating, not one event.** Usually a repeating event with a runaway rule. Keeper will not expand a series past ten thousand occurrences in the two-year window, and hitting that stops the calendar it belongs to. Look for something repeating every minute, generally imported from elsewhere.
+
+**Events vanish from Outlook that still exist in Nextcloud.** Nextcloud is refetched in full each cycle. So a proxy that silently caps objects per response looks like a calendar that really lost them. Nextcloud sets no such cap itself, but an aggressive response limit in front of it does.
+
+**A recurring Outlook meeting arrives in Nextcloud as one event.** That is a known gap in how Microsoft series survive the trip, not a misconfiguration on your side.
+
+## What does the free plan cover?
+
+Two calendar accounts and three connections.
+
+Nextcloud is one account however many calendars it exposes, and Microsoft is the second. So this pairing uses the whole account allowance.
+
+Nothing caps calendars inside an account. Twelve Nextcloud calendars still count as one.
+
+Three connections covers Nextcloud to Outlook, Outlook back to Nextcloud, and one spare.
+
+## Where are my Nextcloud credentials kept?
+
+Encrypted at rest with a configurable key before storage. CalDAV replays the password on every request, so there is no token exchange to hide behind. Keeper needs it in a reversible form, and would rather say so than imply otherwise.
+
+Revoking is either end. Delete the app password in Nextcloud, or open the account in Keeper and use **Delete Account**, which removes the account and all its calendars.
+
+## Would you rather run Keeper yourself too?
+
+Running Nextcloud does not mean you want another service to babysit, so this is a real choice rather than the obvious one.
+
+If you do want it, self-hosting Keeper is not a downgrade. It is AGPL-3.0 and every Pro feature is included: one-minute updates, unlimited accounts, unlimited connections, **Sync Settings** and **Exclusions**. It also removes the public-reachability problem, since Keeper can then sit on the same network as your Nextcloud.
+
+The honest costs:
+
+- Another server, domain and certificate to keep alive
+- Docker and Docker Compose, plus Postgres and Redis
+- Your own Microsoft OAuth app registered in Azure, with scopes `Calendars.ReadWrite`, `User.Read` and `offline_access`. Nextcloud needs no such registration — CalDAV is a username and a password.
+- `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY` generated and kept safe, because losing the second one loses your stored credentials
+- Backups, updates, and being the person who gets paged when it stops
+
+The [README](https://github.com/ridafkih/keeper.sh) has a single-container setup and a full Compose file. If none of that is new to you, self-host it. If you would rather not own another thing, [keeper.sh](https://keeper.sh/register) runs it and funds the project.

--- a/applications/web/src/content/blog/sync-nextcloud-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/sync-nextcloud-calendar-with-outlook.mdx
@@ -15,7 +15,7 @@ tags:
 
 You run Nextcloud because your calendar should belong to you. Then work hands you Outlook, and your two calendars stop speaking.
 
-The result is a personal calendar nobody at work can see, and a work calendar that books straight over your Saturday. Keeper copies events from one onto the other so the busy blocks line up.
+The result is a personal calendar nobody at work can see, and a work calendar that books straight over your Saturday. Keeper.sh copies events from one onto the other so the busy blocks line up.
 
 ## What will this actually do?
 
@@ -25,17 +25,17 @@ That is a connection, and it runs in one direction only. Want both directions? B
 
 ## What do you need before you start?
 
-- A Nextcloud instance reachable over HTTPS from wherever Keeper runs
+- A Nextcloud instance reachable over HTTPS from wherever Keeper.sh runs
 - Your Nextcloud username, which is often not your email address
 - An app password if you have two-factor enabled, and ideally even if you do not
 - An Outlook or Microsoft 365 account
 - An account on [keeper.sh](https://keeper.sh/register)
 
-One thing worth settling early: hosted keeper.sh has to reach your Nextcloud over the public internet. A Nextcloud on `192.168.1.50` or `nextcloud.local` is not reachable, and no setting on your account changes that. Self-hosting Keeper is the answer for a LAN-only instance.
+One thing worth settling early: hosted Keeper.sh has to reach your Nextcloud over the public internet. A Nextcloud on `192.168.1.50` or `nextcloud.local` is not reachable, and no setting on your account changes that. Self-hosting Keeper.sh is the answer for a LAN-only instance.
 
 ## How do you connect Nextcloud?
 
-Open **Import Calendars** from your dashboard and choose **Connect CalDAV Server** from the bottom group. Nextcloud has no button of its own and does not need one, because it speaks the same CalDAV standard Keeper uses for iCloud.
+Open **Import Calendars** from your dashboard and choose **Connect CalDAV Server** from the bottom group. Nextcloud has no button of its own and does not need one, because it speaks the same CalDAV standard Keeper.sh uses for iCloud.
 
 Three fields:
 
@@ -43,7 +43,7 @@ Three fields:
 - **CalDAV Server Username** — your Nextcloud username, not your email address unless they match
 - **CalDAV Server Password** — your password, or an app password
 
-Paste the base URL and Keeper finds your calendars from there. You do not need to dig out the `remote.php/dav/calendars/username/` path.
+Paste the base URL and Keeper.sh finds your calendars from there. You do not need to dig out the `remote.php/dav/calendars/username/` path.
 
 ### Get an app password
 
@@ -51,25 +51,25 @@ Use one even without two-factor, because it is revocable on its own.
 
 In Nextcloud, open **Settings → Security**, find **Devices & sessions**, name the app and create the password. With two-factor turned on this stops being optional, because Nextcloud rejects your login password over CalDAV entirely.
 
-Click **Connect**. Keeper imports every calendar it discovers, then drops you into setup.
+Click **Connect**. Keeper.sh imports every calendar it discovers, then drops you into setup.
 
 ## How do you connect Outlook?
 
-Back on **Import Calendars**, **Connect Outlook** is for personal accounts and **Connect Microsoft 365** is for work and school accounts. Either way, Keeper lists what it will ask Microsoft for:
+Back on **Import Calendars**, **Connect Outlook** is for personal accounts and **Connect Microsoft 365** is for work and school accounts. Either way, Keeper.sh lists what it will ask Microsoft for:
 
 - See your email address
 - View a list of your calendars
 - View events, summaries and details
 - Add or remove calendar events
 
-Click **Connect** and complete Microsoft's consent screen. On a managed work tenant an administrator may need to approve the app first, and nothing in Keeper can route around that.
+Click **Connect** and complete Microsoft's consent screen. On a managed work tenant an administrator may need to approve the app first, and nothing in Keeper.sh can route around that.
 
 ## Which calendar sends to which?
 
 Setup is four screens.
 
 1. **Which calendars would you like to configure?** Tick what you want to set up now. Everything was already imported.
-2. **Rename Your Calendars.** Nextcloud defaults to names like "Personal". Renaming here is local to Keeper and does not touch the calendar on your server.
+2. **Rename Your Calendars.** Nextcloud defaults to names like "Personal". Renaming here is local to Keeper.sh and does not touch the calendar on your server.
 3. **Where should 'Personal' send events?** Pick the calendars that should receive copies.
 4. **Where should 'Personal' pull events from?** The same question in reverse.
 
@@ -85,7 +85,7 @@ With **Sync Event Name** off, the copy is titled after the calendar it came from
 
 Turn it on and the true title goes through. The **Event Name** box accepts `{{event_name}}` and `{{calendar_name}}`, so you can word the placeholder however you like.
 
-**Exclusions** below can drop all-day events. Both sections are Pro on keeper.sh and included for everyone self-hosting.
+**Exclusions** below can drop all-day events. Both sections are Pro on Keeper.sh and included for everyone self-hosting.
 
 ## What does not come across?
 
@@ -100,21 +100,21 @@ What does travel: the title, description, location, start and end, the time zone
 
 ## How quickly, and how far ahead?
 
-Keeper reads both calendars every minute, on every plan. Writing the change onto the other calendar is what differs: free does it every 30 minutes, Pro every minute.
+Keeper.sh reads both calendars every minute, on every plan. Writing the change onto the other calendar is what differs: free does it every 30 minutes, Pro every minute.
 
 If you are mirroring personal commitments so work sees you as busy, 30 minutes changes nothing you will notice. If people book you through a scheduling link, half an hour is enough to get double-booked.
 
-Keeper covers a week back to two years ahead. A one-off event further out is not copied until it drifts into range, though a repeating series that began before the window still has its upcoming occurrences copied.
+Keeper.sh covers a week back to two years ahead. A one-off event further out is not copied until it drifts into range, though a repeating series that began before the window still has its upcoming occurrences copied.
 
-Every event Keeper creates in Outlook carries a category named `keeper.sh`. That tag is how Keeper recognises its own work later, so leave it alone.
+Every event Keeper.sh creates in Outlook carries a category named `keeper.sh`. That tag is how Keeper.sh recognises its own work later, so leave it alone.
 
 ## Why isn't it working?
 
 **Connecting fails with a short error mentioning 401.** Nextcloud rejected the credentials. With two-factor enabled this is almost always the login password being used where an app password is required.
 
-**Keeper says "No calendars found".** It authenticated, but Keeper keeps only collections advertising support for `VEVENT`, and some reverse proxies strip that property from PROPFIND responses.
+**Keeper.sh says "No calendars found".** It authenticated, but Keeper.sh keeps only collections advertising support for `VEVENT`, and some reverse proxies strip that property from PROPFIND responses.
 
-**Nextcloud is unreachable and you self-host Keeper.** The deployment Compose file sets `BLOCK_PRIVATE_RESOLUTION=true`, which refuses anything resolving to a private address. Add your host to `PRIVATE_RESOLUTION_WHITELIST`.
+**Nextcloud is unreachable and you self-host Keeper.sh.** The deployment Compose file sets `BLOCK_PRIVATE_RESOLUTION=true`, which refuses anything resolving to a private address. Add your host to `PRIVATE_RESOLUTION_WHITELIST`.
 
 **Microsoft consent fails outright on a work account.** Managed tenants can block third-party calendar apps, and you need an administrator to approve it.
 
@@ -122,9 +122,9 @@ Every event Keeper creates in Outlook carries a category named `keeper.sh`. That
 
 **Changes in Outlook never reach Nextcloud.** One connection, one direction. Add a second going back.
 
-**An entire calendar stops updating, not one event.** Usually a repeating event with a runaway rule. Keeper will not expand a series past ten thousand occurrences in the two-year window, and hitting that stops the calendar it belongs to.
+**An entire calendar stops updating, not one event.** Usually a repeating event with a runaway rule. Keeper.sh will not expand a series past ten thousand occurrences in the two-year window, and hitting that stops the calendar it belongs to.
 
-**Events vanish from Outlook that still exist in Nextcloud.** Keeper refetches Nextcloud in full each cycle, so a proxy that silently caps objects per response looks like a calendar that really lost them.
+**Events vanish from Outlook that still exist in Nextcloud.** Keeper.sh refetches Nextcloud in full each cycle, so a proxy that silently caps objects per response looks like a calendar that really lost them.
 
 ## What does the free plan cover?
 
@@ -134,15 +134,15 @@ Nothing caps calendars inside an account — twelve Nextcloud calendars still co
 
 ## Where are my Nextcloud credentials kept?
 
-Encrypted at rest with a configurable key. CalDAV replays the password on every request, so Keeper needs it in a reversible form and would rather say so than imply otherwise.
+Encrypted at rest with a configurable key. CalDAV replays the password on every request, so Keeper.sh needs it in a reversible form and would rather say so than imply otherwise.
 
-Revoking works from either end: delete the app password in Nextcloud, or open the account in Keeper and use **Delete Account**.
+Revoking works from either end: delete the app password in Nextcloud, or open the account in Keeper.sh and use **Delete Account**.
 
-## Would you rather run Keeper yourself too?
+## Would you rather run Keeper.sh yourself too?
 
 Running Nextcloud does not mean you want another service to babysit, so this is a real choice rather than the obvious one.
 
-Self-hosting is not a downgrade. It is AGPL-3.0 with every Pro feature included, and it removes the public-reachability problem, since Keeper can then sit on the same network as your Nextcloud.
+Self-hosting is not a downgrade. It is AGPL-3.0 with every Pro feature included, and it removes the public-reachability problem, since Keeper.sh can then sit on the same network as your Nextcloud.
 
 The honest costs:
 

--- a/applications/web/src/content/blog/sync-nextcloud-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/sync-nextcloud-calendar-with-outlook.mdx
@@ -160,8 +160,6 @@ Repeating events get more room. A series whose first occurrence predates the win
 
 **Events vanish from Outlook that still exist in Nextcloud.** Nextcloud is refetched in full each cycle. So a proxy that silently caps objects per response looks like a calendar that really lost them. Nextcloud sets no such cap itself, but an aggressive response limit in front of it does.
 
-**A recurring Outlook meeting arrives in Nextcloud as one event.** That is a known gap in how Microsoft series survive the trip, not a misconfiguration on your side.
-
 ## What does the free plan cover?
 
 Two calendar accounts and three connections.


### PR DESCRIPTION
Two how-to guides for the provider pairs we don't cover yet: Fastmail to Google Calendar and Nextcloud to Outlook. Both follow the marketing-voice register rather than the existing pair guides — question-shaped headings, symptom-first failure modes, hosted keeper.sh as the default path with self-hosting signposted separately and costed honestly.

Every UI step, field label and setup question was checked against the connect routes and the setup flow rather than copied from the older guides, which corrects a few things: the tiles are "Connect Fastmail" / "Connect CalDAV Server" under the Import Calendars nav item, and a rejected CalDAV credential surfaces as a raw "401 ..." string, not "Invalid credentials".

- Free tier stated as 2 accounts / 3 connections, no per-account calendar limit
- Reads every minute on all plans; writes every 30 min free, every minute Pro
- Explicitly lists what never crosses: guests, meeting links, reminders, colours
- No blanket privacy-default claim, per #501 — both guides tell the reader to check Sync Settings
- Fastmail app password scope written so either the current "Mail, Contacts & Calendars" UI or a narrower calendars-only option works
