### PR TITLE
docs: comparison posts for SyncDate, SyncThemCalendars and Kalender Sync

### DIFF
--- a/applications/web/src/content/blog/keeper-sh-vs-kalender-sync.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-kalender-sync.mdx
@@ -121,7 +121,7 @@ It also changes the compliance conversation. If you run Keeper.sh on your own se
 
 It is real work, and their comparison page describes the effort accurately. You need Docker and Docker Compose, Postgres, Redis and a domain, plus your own Google and Microsoft applications, which is the fiddliest step.
 
-Most people should use hosted keeper.sh at $5 a month. Self-hosting is there when you need it, and the [repository](https://github.com/ridafkih/keeper.sh) has the full guide.
+Most people should use hosted Keeper.sh at $5 a month. Self-hosting is there when you need it, and the [repository](https://github.com/ridafkih/keeper.sh) has the full guide.
 
 ## FAQ
 

--- a/applications/web/src/content/blog/keeper-sh-vs-kalender-sync.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-kalender-sync.mdx
@@ -1,0 +1,176 @@
+---
+title: "Keeper.sh vs Kalender Sync"
+description: "An honest comparison of Keeper.sh and Kalender Sync for calendar sync, covering the AVV and EU contracting entity, the Sharings feature, German email providers, update speed, pricing, open source and self-hosting."
+blurb: "Kalender Sync signs an AVV with a named German company and we do not. They also share your availability into someone else's calendar, which we cannot do at all."
+createdAt: "2026-08-11"
+slug: "keeper-sh-vs-kalender-sync"
+updatedAt: "2026-08-11"
+tags:
+  - "calendar"
+  - "sync"
+  - "comparison"
+---
+
+Kalender Sync is a calendar syncing product from Munich. Keeper.sh does the same core job from an open-source codebase. Both keep your busy time aligned across calendars.
+
+They wrote a comparison of us first, and it was accurate and fair. It also landed one criticism we cannot argue with, so that goes near the top.
+
+## Can your legal team approve it?
+
+Kalender Sync, and it is not close.
+
+They publish an AVV, the German data processing agreement required under Article 28 of the GDPR. Their page for IT administrators offers "einen signierten AVV nach Art. 28 DSGVO" as a pre-filled PDF.
+
+It is included with their Business plan and available on request otherwise. You ask for it through their contact form.
+
+The contracting party is named and it is European. Their Impressum lists PPJ Venture Labs UG (haftungsbeschränkt), Hohenzollernstraße 30, Munich, registered as HRB 308771 at the Amtsgericht München.
+
+Keeper.sh does not publish a DPA, and does not offer a named EU contracting entity for the hosted service. Their comparison page says exactly that, and they are right.
+
+If your employer requires a signed agreement before you connect a work calendar, we fail that check outright. Kalender Sync passes it. That is the single clearest reason to pick them.
+
+They also state where the data sits: "Alle Datenbanken laufen bei Hetzner Online GmbH in Falkenstein (Sachsen)", with tokens encrypted using ChaCha20-Poly1305. They note their marketing site runs on Netlify in the United States, and they disclose that rather than glossing over it.
+
+## Can you push your availability to someone else?
+
+Kalender Sync can. Keeper.sh cannot do this at all.
+
+They call it Sharings. You create one for another person, and their site describes it as: "erstelle ein Sharing für jemand anderen. Die Person wird eingeladen, fügt es ihrem Kalender hinzu, und ab da läuft alles automatisch synchron." The other person is invited, adds it, and your blocks keep appearing in their calendar.
+
+You choose how much they see. There are three visibility levels, from availability only, through title and time, up to full details.
+
+Keeper.sh only connects calendars you own. If you want your assistant, your partner or a colleague to see your busy time inside their own calendar, we have nothing for that. Their free plan includes one Sharing.
+
+## Which calendars does each one connect?
+
+Kalender Sync's integrations page lists Google Calendar, Microsoft Outlook, Apple iCloud, Infomaniak kSuite, GMX, WEB.DE, mailbox.org, and read-only iCal feeds. They list Fastmail, Proton Calendar, Yahoo, Nextcloud and Posteo as planned rather than live.
+
+That GMX, WEB.DE and mailbox.org coverage is deliberate and useful. Those are common German consumer mailboxes, and most sync tools ignore them.
+
+Keeper.sh supports Google, Outlook, iCloud, Fastmail, and any CalDAV server you can give us an address for. Because GMX, WEB.DE and mailbox.org all speak CalDAV, you can connect them to Keeper.sh too, by entering the server details yourself rather than picking a logo.
+
+We also read iCal and ICS links, and like them, cannot write back to those.
+
+So they have Fastmail on a roadmap where we have it shipped, and we have an open CalDAV field where they have a curated list. Curated is friendlier. Open covers more.
+
+## Which one updates faster?
+
+Kalender Sync, for Google and Microsoft calendars.
+
+Google and Microsoft can notify a tool the instant an event changes, instead of the tool asking. Kalender Sync subscribes to those notifications on paid plans and markets it as "Echtzeit per Webhook". Their documentation is more precise, describing it as "nahezu sofort", nearly instant, and applying it to Google and Microsoft only.
+
+For their CalDAV-based providers, including iCloud, GMX, WEB.DE and mailbox.org, the same documentation says those are checked "alle 5 Minuten". Their free plan runs on a 30-minute interval and is limited to Google and Outlook.
+
+Keeper.sh asks on a timer for everything. We read every calendar every minute, on every plan including Free. We write copies out every 30 minutes on Free, and every minute on Pro.
+
+So for a Google calendar on a paid plan, they are faster than us. For an iCloud or mailbox.org calendar, we read every minute against their five, and our Pro plan is competitive. Neither of us publishes a latency figure in seconds.
+
+## What does each one cost?
+
+| | Keeper.sh | Kalender Sync |
+| --- | --- | --- |
+| Free plan | 2 accounts, 3 connections, per-minute reads | 2 accounts, 1 Sharing, Google and Outlook, 30-minute interval |
+| Entry paid plan | $5/month, unlimited connections | €4/month, 5 accounts, 5 syncs, 5 Sharings |
+| Higher paid plan | None | €10/month, unlimited accounts, syncs and Sharings |
+| Team plan | None | Custom, from 5 users |
+| Yearly option | Not offered | €40 and €100 per year |
+
+Their Basic plan is €4 a month, with 5 accounts, 5 syncs and 5 Sharings, or €40 a year. Business is €10 a month for unlimited accounts, syncs and Sharings, or €100 a year. All plans come with a 14-day trial of Business features and no card.
+
+Keeper.sh Pro is $5 a month with no limit on connections or accounts.
+
+At the entry tier the prices are close enough not to matter. Above five connections, we are cheaper than their Business plan. Below that, they are competitive and they include Sharings, which we do not have at any price.
+
+## What if you are buying for a company?
+
+Kalender Sync has a Team plan and we have nothing equivalent.
+
+Their pricing page lists central management of employee accounts and "SSO mit Entra ID & Google Workspace". It adds organisation-wide sync and visibility policies, plus immediate offboarding when someone leaves.
+
+The same tier covers invoiced billing and "AVV, Audit-Log, Priority-Support & persönliches Onboarding". It is quote-based from five users.
+
+Keeper.sh has no single sign-on, no admin console, no audit log and no invoicing. Keeper.sh is a tool for one person. If you are buying for a team, they built for you and we did not.
+
+## Where is Keeper.sh genuinely better?
+
+**It is open source.** Keeper.sh is AGPL-3.0 and the whole sync engine is on GitHub. Their comparison page notes this favourably.
+
+**You can run it yourself, with everything unlocked.** More below.
+
+**Every CalDAV server, not a list.** Covered above.
+
+**An API and an agent connector on the free plan.** Keeper.sh has a REST API with scoped access tokens, and an MCP server with 11 tools. An assistant can list calendars, read events, and also create, edit, delete and RSVP. Both are free, capped at 25 requests a day, and uncapped on Pro.
+
+**One feed for every calendar.** Keeper.sh gives you a single private iCal link that merges everything you have connected, readable by anything that takes a calendar feed.
+
+**Per-minute reads on the free plan.** Their free tier checks every 30 minutes and covers two providers.
+
+## One small correction
+
+Their comparison describes Keeper.sh Free as a 30-minute sync. That is right about half of the job, so it is worth splitting apart.
+
+We read your calendars every minute on every plan, including Free. The 30 minutes is how often the free plan writes the copies out. On Pro, both halves run every minute.
+
+Everything else on their page matches what we ship, including the self-hosting description and the note that our field-by-field privacy controls are more configuration work than their three visibility levels. Both of those are fair.
+
+## What Keeper.sh does not do
+
+**No signed AVV and no EU contracting entity**, as above. This is the big one.
+
+**No sharing into another person's calendar.** Also above.
+
+**One direction per connection.** Every connection in Keeper.sh runs one way. Mirroring two calendars means building two connections rather than flipping a switch.
+
+**Attendees, meeting links and reminders do not come across.** A copied block carries its time, and its details if you share them. Guests, the Meet or Teams link, and alerts stay on the original. We do read attendees for invitations you receive, so you can answer them.
+
+**Privacy settings depend on how you added the calendar.** Keeper.sh can replace titles, descriptions and locations with something generic. Whether that starts switched on depends on which screen you used, which is an inconsistency we are fixing. Check the setting rather than assuming it.
+
+**English only.** Their product and site are in German.
+
+## Running Keeper.sh yourself
+
+Self-hosting is where Keeper.sh answers the data question in its own way. Every Pro feature turns on automatically on your own instance, including per-minute writes and the uncapped API.
+
+It also changes the compliance conversation. If you run Keeper.sh on your own server, there is no processor to sign an agreement with, because nobody else is in the path. For some organisations that is a better answer than a DPA, and for others it is not acceptable at all.
+
+It is real work and their comparison page describes the effort accurately. You need Docker and Docker Compose, Postgres, Redis and a domain. You also register your own Google and Microsoft applications, which is the fiddliest step.
+
+Most people should use hosted keeper.sh at $5 a month. Self-hosting is there when you need it, and the [repository](https://github.com/ridafkih/keeper.sh) has the full guide.
+
+## FAQ
+
+### Which should I choose?
+
+Choose Kalender Sync if you need a signed AVV or an EU contracting party. It also wins if you share availability with other people, buy for a team, or want the product in German.
+
+Choose Keeper.sh if you want open source and self-hosting, need CalDAV or Fastmail, or want an API and agent access.
+
+### Can Keeper.sh connect GMX, WEB.DE or mailbox.org?
+
+Yes, through our CalDAV option. You enter the server address and credentials yourself instead of choosing a preset.
+
+### Does Keeper.sh have anything like Sharings?
+
+Not really. Our public iCal feed lets you hand someone a read-only link, but it does not push events into their calendar. It also covers all your calendars at once rather than a chosen slice.
+
+### Is Kalender Sync's article about Keeper.sh accurate?
+
+Yes, and it is generous in places. The one thing we would sharpen is the sync frequency, covered above.
+
+### Can I try both?
+
+Yes. Keeper.sh has a free plan that does not expire. Kalender Sync has a free plan and a 14-day trial of Business features without a card.
+
+## Sources
+
+Everything above about Kalender Sync comes from their own public pages, checked on the date this post was published. Quotes are in the original German:
+
+- [kalender-sync.de/preise](https://kalender-sync.de/preise/) — plans, prices and the Team tier
+- [kalender-sync.de/integrationen](https://kalender-sync.de/integrationen/) — supported and planned providers
+- [kalender-sync.de/it-admin](https://kalender-sync.de/it-admin/) — the AVV, hosting and encryption
+- [kalender-sync.de/impressum](https://kalender-sync.de/impressum/) — company details
+- [docs.kalender-sync.de/sync/how-it-works](https://docs.kalender-sync.de/sync/how-it-works/) — update intervals
+- [docs.kalender-sync.de/sharings/self-sync](https://docs.kalender-sync.de/sharings/self-sync/) — Sharings and Self-Sync
+- [kalender-sync.de/vergleich/keeper](https://kalender-sync.de/vergleich/keeper/) — their comparison with us
+
+Prices and features change. If something here is out of date, their page wins, and we would appreciate you [telling us](https://github.com/ridafkih/keeper.sh/issues).

--- a/applications/web/src/content/blog/keeper-sh-vs-kalender-sync.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-kalender-sync.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Keeper.sh vs Kalender Sync"
-description: "An honest comparison of Keeper.sh and Kalender Sync for calendar sync, covering the AVV and EU contracting entity, the Sharings feature, German email providers, update speed, pricing, open source and self-hosting."
+description: "An honest comparison of Keeper.sh and Kalender Sync, covering the AVV and EU contracting entity, Sharings, German email providers, update speed, pricing and self-hosting."
 blurb: "Kalender Sync signs an AVV with a named German company and we do not. They also share your availability into someone else's calendar, which we cannot do at all."
 createdAt: "2026-08-11"
 slug: "keeper-sh-vs-kalender-sync"
@@ -19,37 +19,31 @@ They wrote a comparison of us first, and it was accurate and fair. It also lande
 
 Kalender Sync, and it is not close.
 
-They publish an AVV, the German data processing agreement required under Article 28 of the GDPR. Their page for IT administrators offers "einen signierten AVV nach Art. 28 DSGVO" as a pre-filled PDF.
-
-It is included with their Business plan and available on request otherwise. You ask for it through their contact form.
+They publish an AVV, the German data processing agreement required under Article 28 of the GDPR. Their page for IT administrators offers "einen signierten AVV nach Art. 28 DSGVO" as a pre-filled PDF, included with the Business plan and available on request otherwise.
 
 The contracting party is named and it is European. Their Impressum lists PPJ Venture Labs UG (haftungsbeschränkt), Hohenzollernstraße 30, Munich, registered as HRB 308771 at the Amtsgericht München.
 
-Keeper.sh does not publish a DPA, and does not offer a named EU contracting entity for the hosted service. Their comparison page says exactly that, and they are right.
+They also state where the data sits: "Alle Datenbanken laufen bei Hetzner Online GmbH in Falkenstein (Sachsen)", with tokens encrypted using ChaCha20-Poly1305. Their marketing site runs on Netlify in the United States, which they disclose rather than gloss over.
 
-If your employer requires a signed agreement before you connect a work calendar, we fail that check outright. Kalender Sync passes it. That is the single clearest reason to pick them.
+Keeper.sh publishes no DPA, and offers no named EU contracting entity for the hosted service. Their comparison page says exactly that, and they are right.
 
-They also state where the data sits: "Alle Datenbanken laufen bei Hetzner Online GmbH in Falkenstein (Sachsen)", with tokens encrypted using ChaCha20-Poly1305. They note their marketing site runs on Netlify in the United States, and they disclose that rather than glossing over it.
+If your employer requires a signed agreement before you connect a work calendar, we fail that check outright. That is the single clearest reason to pick them.
 
-## Can you push your availability to someone else?
+## Can you share your busy time into someone else's calendar?
 
 Kalender Sync can. Keeper.sh cannot do this at all.
 
-They call it Sharings. You create one for another person, and their site describes it as: "erstelle ein Sharing für jemand anderen. Die Person wird eingeladen, fügt es ihrem Kalender hinzu, und ab da läuft alles automatisch synchron." The other person is invited, adds it, and your blocks keep appearing in their calendar.
+They call it Sharings. You create one for another person, and their site describes it as: "erstelle ein Sharing für jemand anderen. Die Person wird eingeladen, fügt es ihrem Kalender hinzu, und ab da läuft alles automatisch synchron."
 
-You choose how much they see. There are three visibility levels, from availability only, through title and time, up to full details.
+So the other person is invited, adds it, and your blocks keep appearing in their calendar. You pick from three visibility levels, from availability only, through title and time, up to full details.
 
-Keeper.sh only connects calendars you own. If you want your assistant, your partner or a colleague to see your busy time inside their own calendar, we have nothing for that. Their free plan includes one Sharing.
+Keeper.sh only connects calendars you own. If you want your assistant, your partner or a colleague to see your busy time inside their own calendar, we have nothing for that, at any price. Their free plan includes one Sharing.
 
 ## Which calendars does each one connect?
 
-Kalender Sync's integrations page lists Google Calendar, Microsoft Outlook, Apple iCloud, Infomaniak kSuite, GMX, WEB.DE, mailbox.org, and read-only iCal feeds. They list Fastmail, Proton Calendar, Yahoo, Nextcloud and Posteo as planned rather than live.
+Kalender Sync's integrations page lists Google Calendar, Microsoft Outlook, Apple iCloud, Infomaniak kSuite, GMX, WEB.DE, mailbox.org, and read-only iCal feeds. Fastmail, Proton Calendar, Yahoo, Nextcloud and Posteo are listed as planned rather than live. That GMX, WEB.DE and mailbox.org coverage is deliberate and useful, because those are common German consumer mailboxes that most sync tools ignore.
 
-That GMX, WEB.DE and mailbox.org coverage is deliberate and useful. Those are common German consumer mailboxes, and most sync tools ignore them.
-
-Keeper.sh supports Google, Outlook, iCloud, Fastmail, and any CalDAV server you can give us an address for. Because GMX, WEB.DE and mailbox.org all speak CalDAV, you can connect them to Keeper.sh too, by entering the server details yourself rather than picking a logo.
-
-We also read iCal and ICS links, and like them, cannot write back to those.
+Keeper.sh supports Google, Outlook, iCloud, Fastmail, and any CalDAV server you can give us an address for. Since GMX, WEB.DE and mailbox.org all speak CalDAV, you can connect them here too, by entering the server details yourself rather than picking a logo. We also read iCal and ICS links, and like them, cannot write back to those.
 
 So they have Fastmail on a roadmap where we have it shipped, and we have an open CalDAV field where they have a curated list. Curated is friendlier. Open covers more.
 
@@ -57,13 +51,13 @@ So they have Fastmail on a roadmap where we have it shipped, and we have an open
 
 Kalender Sync, for Google and Microsoft calendars.
 
-Google and Microsoft can notify a tool the instant an event changes, instead of the tool asking. Kalender Sync subscribes to those notifications on paid plans and markets it as "Echtzeit per Webhook". Their documentation is more precise, describing it as "nahezu sofort", nearly instant, and applying it to Google and Microsoft only.
+Those two providers can notify a tool the instant an event changes, instead of the tool asking. Kalender Sync subscribes to that on paid plans and markets it as "Echtzeit per Webhook". Their documentation is more precise, describing it as "nahezu sofort", nearly instant, and applying it to Google and Microsoft only.
 
-For their CalDAV-based providers, including iCloud, GMX, WEB.DE and mailbox.org, the same documentation says those are checked "alle 5 Minuten". Their free plan runs on a 30-minute interval and is limited to Google and Outlook.
+For their CalDAV-based providers, including iCloud, GMX, WEB.DE and mailbox.org, the same documentation says those are checked "alle 5 Minuten". Their free plan runs on a 30-minute interval and covers Google and Outlook only.
 
 Keeper.sh asks on a timer for everything. We read every calendar every minute, on every plan including Free. We write copies out every 30 minutes on Free, and every minute on Pro.
 
-So for a Google calendar on a paid plan, they are faster than us. For an iCloud or mailbox.org calendar, we read every minute against their five, and our Pro plan is competitive. Neither of us publishes a latency figure in seconds.
+So for a Google calendar on a paid plan, they are faster. For an iCloud or mailbox.org calendar, we read every minute against their five. Neither of us publishes a latency figure in seconds.
 
 ## What does each one cost?
 
@@ -75,19 +69,15 @@ So for a Google calendar on a paid plan, they are faster than us. For an iCloud 
 | Team plan | None | Custom, from 5 users |
 | Yearly option | Not offered | €40 and €100 per year |
 
-Their Basic plan is €4 a month, with 5 accounts, 5 syncs and 5 Sharings, or €40 a year. Business is €10 a month for unlimited accounts, syncs and Sharings, or €100 a year. All plans come with a 14-day trial of Business features and no card.
+All their plans come with a 14-day trial of Business features and no card.
 
-Keeper.sh Pro is $5 a month with no limit on connections or accounts.
-
-At the entry tier the prices are close enough not to matter. Above five connections, we are cheaper than their Business plan. Below that, they are competitive and they include Sharings, which we do not have at any price.
+At the entry tier the prices are close enough not to matter. Above five connections we are cheaper than their Business plan. Below that they are competitive, and they include Sharings, which we do not have at any price.
 
 ## What if you are buying for a company?
 
 Kalender Sync has a Team plan and we have nothing equivalent.
 
-Their pricing page lists central management of employee accounts and "SSO mit Entra ID & Google Workspace". It adds organisation-wide sync and visibility policies, plus immediate offboarding when someone leaves.
-
-The same tier covers invoiced billing and "AVV, Audit-Log, Priority-Support & persönliches Onboarding". It is quote-based from five users.
+Their pricing page lists central management of employee accounts, "SSO mit Entra ID & Google Workspace", organisation-wide policies and immediate offboarding. It adds invoiced billing and "AVV, Audit-Log, Priority-Support & persönliches Onboarding", quote-based from five users.
 
 Keeper.sh has no single sign-on, no admin console, no audit log and no invoicing. Keeper.sh is a tool for one person. If you are buying for a team, they built for you and we did not.
 
@@ -99,7 +89,7 @@ Keeper.sh has no single sign-on, no admin console, no audit log and no invoicing
 
 **Every CalDAV server, not a list.** Covered above.
 
-**An API and an agent connector on the free plan.** Keeper.sh has a REST API, and an MCP server with 11 tools. An assistant can list calendars, read events, and also create, edit, delete and RSVP. Both are free, capped at 25 requests a day, and uncapped on Pro.
+**An API and an agent connector on the free plan.** Keeper.sh has a REST API, and an MCP server with 11 tools, so an assistant can list calendars, read events, and also create, edit, delete and RSVP. Both are free, capped at 25 requests a day, and uncapped on Pro.
 
 **One feed for every calendar.** Keeper.sh gives you a single private iCal link that merges everything you have connected, readable by anything that takes a calendar feed.
 
@@ -107,23 +97,19 @@ Keeper.sh has no single sign-on, no admin console, no audit log and no invoicing
 
 ## One small correction
 
-Their comparison describes Keeper.sh Free as a 30-minute sync. That is right about half of the job, so it is worth splitting apart.
-
-We read your calendars every minute on every plan, including Free. The 30 minutes is how often the free plan writes the copies out. On Pro, both halves run every minute.
+Their comparison describes Keeper.sh Free as a 30-minute sync, which is right about half of the job. We read your calendars every minute on every plan, including Free, and the 30 minutes is how often the free plan writes the copies out. On Pro, both halves run every minute.
 
 Everything else on their page matches what we ship, including the self-hosting description and the note that our field-by-field privacy controls are more configuration work than their three visibility levels. Both of those are fair.
 
 ## What Keeper.sh does not do
 
-**No signed AVV and no EU contracting entity**, as above. This is the big one.
+**No signed AVV, no EU contracting entity, and no sharing into another person's calendar**, all above. Those are the big ones.
 
-**No sharing into another person's calendar.** Also above.
+**One direction per connection.** Mirroring two calendars means building two connections rather than flipping a switch.
 
-**One direction per connection.** Every connection in Keeper.sh runs one way. Mirroring two calendars means building two connections rather than flipping a switch.
+**Attendees, meeting links and reminders do not come across.** A copied block carries its time, plus its details if you share them, while guests, the Meet or Teams link and alerts stay on the original. We do read attendees for invitations you receive, so you can answer them.
 
-**Attendees, meeting links and reminders do not come across.** A copied block carries its time, and its details if you share them. Guests, the Meet or Teams link, and alerts stay on the original. We do read attendees for invitations you receive, so you can answer them.
-
-**Privacy settings depend on how you added the calendar.** Keeper.sh can replace titles, descriptions and locations with something generic. Whether that starts switched on depends on which screen you used, which is an inconsistency we are fixing. Check the setting rather than assuming it.
+**Showing real event details costs $5.** A connected calendar arrives anonymised: titles, descriptions and locations are replaced with something generic. Changing that is a Pro setting.
 
 **English only.** Their product and site are in German.
 
@@ -131,9 +117,9 @@ Everything else on their page matches what we ship, including the self-hosting d
 
 Self-hosting is where Keeper.sh answers the data question in its own way. Every Pro feature turns on automatically on your own instance, including per-minute writes and the uncapped API.
 
-It also changes the compliance conversation. If you run Keeper.sh on your own server, there is no processor to sign an agreement with, because nobody else is in the path. For some organisations that is a better answer than a DPA, and for others it is not acceptable at all.
+It also changes the compliance conversation. If you run Keeper.sh on your own server, there is no processor to sign an agreement with, because nobody else is in the path. For some organisations that beats a DPA, and for others it is not acceptable at all.
 
-It is real work and their comparison page describes the effort accurately. You need Docker and Docker Compose, Postgres, Redis and a domain. You also register your own Google and Microsoft applications, which is the fiddliest step.
+It is real work, and their comparison page describes the effort accurately. You need Docker and Docker Compose, Postgres, Redis and a domain, plus your own Google and Microsoft applications, which is the fiddliest step.
 
 Most people should use hosted keeper.sh at $5 a month. Self-hosting is there when you need it, and the [repository](https://github.com/ridafkih/keeper.sh) has the full guide.
 
@@ -141,21 +127,11 @@ Most people should use hosted keeper.sh at $5 a month. Self-hosting is there whe
 
 ### Which should I choose?
 
-Choose Kalender Sync if you need a signed AVV or an EU contracting party. It also wins if you share availability with other people, buy for a team, or want the product in German.
-
-Choose Keeper.sh if you want open source and self-hosting, need CalDAV or Fastmail, or want an API and agent access.
-
-### Can Keeper.sh connect GMX, WEB.DE or mailbox.org?
-
-Yes, through our CalDAV option. You enter the server address and credentials yourself instead of choosing a preset.
+Choose Kalender Sync if you need a signed AVV or an EU contracting party. It also wins if you share availability with other people, buy for a team, or want the product in German. Choose Keeper.sh if you want open source and self-hosting, need CalDAV or Fastmail, or want an API and agent access.
 
 ### Does Keeper.sh have anything like Sharings?
 
-Not really. Our public iCal feed lets you hand someone a read-only link, but it does not push events into their calendar. It also covers all your calendars at once rather than a chosen slice.
-
-### Is Kalender Sync's article about Keeper.sh accurate?
-
-Yes, and it is generous in places. The one thing we would sharpen is the sync frequency, covered above.
+Not really. Our public iCal feed lets you hand someone a read-only link, but it does not place events in their calendar. It also covers all your calendars at once rather than a chosen slice.
 
 ### Can I try both?
 

--- a/applications/web/src/content/blog/keeper-sh-vs-kalender-sync.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-kalender-sync.mdx
@@ -99,7 +99,7 @@ Keeper.sh has no single sign-on, no admin console, no audit log and no invoicing
 
 **Every CalDAV server, not a list.** Covered above.
 
-**An API and an agent connector on the free plan.** Keeper.sh has a REST API with scoped access tokens, and an MCP server with 11 tools. An assistant can list calendars, read events, and also create, edit, delete and RSVP. Both are free, capped at 25 requests a day, and uncapped on Pro.
+**An API and an agent connector on the free plan.** Keeper.sh has a REST API, and an MCP server with 11 tools. An assistant can list calendars, read events, and also create, edit, delete and RSVP. Both are free, capped at 25 requests a day, and uncapped on Pro.
 
 **One feed for every calendar.** Keeper.sh gives you a single private iCal link that merges everything you have connected, readable by anything that takes a calendar feed.
 

--- a/applications/web/src/content/blog/keeper-sh-vs-syncdate.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-syncdate.mdx
@@ -98,7 +98,7 @@ This is the option to take when your data cannot leave your control. You keep th
 
 It is real work, though. You need Docker and Docker Compose, a Postgres database, a Redis instance and a domain, plus your own Google and Microsoft applications for calendar access, which is the fiddliest part.
 
-Most people should use hosted keeper.sh and pay the $5. Self-hosting is there when you need it, and the [repository](https://github.com/ridafkih/keeper.sh) has the full setup guide.
+Most people should use hosted Keeper.sh and pay the $5. Self-hosting is there when you need it, and the [repository](https://github.com/ridafkih/keeper.sh) has the full setup guide.
 
 ## FAQ
 

--- a/applications/web/src/content/blog/keeper-sh-vs-syncdate.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-syncdate.mdx
@@ -1,0 +1,141 @@
+---
+title: "Keeper.sh vs SyncDate"
+description: "An honest comparison of Keeper.sh and SyncDate for calendar sync, covering update speed, pricing, supported calendars, open source and self-hosting, MCP servers, and where each tool is the better choice."
+blurb: "SyncDate updates in about four seconds and we poll every minute. Here is where that matters, where it doesn't, and where each of us is genuinely the better pick."
+createdAt: "2026-08-11"
+slug: "keeper-sh-vs-syncdate"
+updatedAt: "2026-08-11"
+tags:
+  - "calendar"
+  - "sync"
+  - "comparison"
+---
+
+You have calendars in more than one place. You want your busy time to show up everywhere, so nobody double-books you. Keeper.sh and SyncDate both do that job.
+
+We wrote this page because SyncDate wrote one about us first, and wrote it fairly. So this is not a hit piece. In one important area they beat us outright, and we say so before anything else.
+
+## Which one updates faster?
+
+SyncDate. This is not close, and we will not talk around it.
+
+SyncDate subscribes to push notifications from Google and Microsoft. Those providers tell SyncDate the moment an event changes, instead of SyncDate asking. Their features page puts the end-to-end result at "roughly 4 seconds for webhook-backed providers."
+
+Keeper.sh asks on a timer instead. We read your calendars every minute, on every plan, including the free one. We write the blocks out every 30 minutes on Free, and every minute on Pro.
+
+In practice a change lands on your other calendar in under two minutes on Keeper.sh Pro. On Free it can take just over half an hour. SyncDate does it in seconds.
+
+Here is when that gap actually matters. You are a consultant who moves client calls three or four times a day, and someone books you in the window you just freed up. Four seconds closes that hole and one minute might not.
+
+Here is when it doesn't. You block personal appointments onto a work calendar so colleagues stop scheduling over them. Those appointments were set days ago, so a minute is invisible.
+
+## What does each one cost?
+
+SyncDate shows annual pricing by default. Their pricing page lists Plus at "$7.42/mo" billed as "$89 billed annually", and Pro at "$14.08/mo" billed as "$169 billed annually". The intro on the same page says plans "start at $8.99/month", which suggests month-to-month billing costs more.
+
+Keeper.sh has one paid plan at $5 per month. There is no seat pricing and no higher tier.
+
+| | Keeper.sh | SyncDate |
+| --- | --- | --- |
+| Free plan | 2 linked accounts, 3 connections | 2 calendars, 2 accounts, 1 sync setup, 1-month horizon |
+| Entry paid plan | $5/month | $7.42/mo billed annually ($89/year) |
+| Higher paid plan | None | $14.08/mo billed annually ($169/year) |
+| Team plan | None | Custom, minimum 5 seats |
+
+Our free plan has no limit on calendars per account. SyncDate's free plan caps you at two calendars and one sync setup, and only looks one month ahead.
+
+## Which calendars does each one connect?
+
+Both cover the big ones. SyncDate supports Google, Outlook, CalDAV and iCal feeds, and names iCloud, Fastmail, Infomaniak, mailbox.org, Posteo and Nextcloud as CalDAV servers it works with.
+
+Keeper.sh supports Google, Outlook, iCloud, Fastmail and any CalDAV server. Those five can all read and write. We also read iCal and ICS links, but we cannot write to them, because those links are one-directional by design.
+
+That is close to a tie. Pick either on provider coverage.
+
+## Where is Keeper.sh genuinely better?
+
+**It is open source.** Keeper.sh is AGPL-3.0. You can read every line of the sync engine before you trust it with your calendar. SyncDate says plainly on their comparison page: "SYNCDATE is not open source and cannot be self-hosted."
+
+**You can run it yourself, with every paid feature unlocked.** More on that below.
+
+**It costs less.** $5 a month against $7.42 a month billed annually, and more than that month-to-month.
+
+**One calendar feed for everything.** Keeper.sh gives you a single private iCal link that combines every calendar you have connected. Paste it into anything that reads calendar feeds and you get one merged view.
+
+**An API and an agent connector on the free plan.** Keeper.sh has a REST API with scoped access tokens, and an MCP server so tools like Claude can read and change your calendars. Both work on the free plan, capped at 25 requests per day. Pro removes the cap.
+
+## A correction about our MCP server
+
+SyncDate's comparison page describes our tools as "read-focused (`list_calendars`, `get_events`, `get_event_count`, over OAuth 2.1)". We want to correct that gently, because it undersells us.
+
+Keeper.sh ships 11 MCP tools, and 4 of them write. Alongside the read tools there are `create_event`, `update_event`, `delete_event` and `rsvp_event`. An assistant connected to Keeper.sh can book, edit, cancel and reply to invitations, not just look.
+
+We do not think this was careless. Their page already carries a dated correction retracting an earlier mistake about us, which is more than most companies do. We are noting this one in the same spirit.
+
+## Where is SyncDate genuinely better?
+
+**Speed**, covered above, and it is the biggest one.
+
+**Paperwork your legal team will ask for.** SyncDate publishes a self-serve Data Processing Agreement, names DUMA DIGITAL SOLUTIONS S.R.L. as the operating company, and lists its subprocessors. If your employer needs a signed DPA before you connect a work calendar, SyncDate clears that bar and we do not.
+
+**Named infrastructure and encryption.** Their security page states hosting "with Hetzner in EU data centres (Germany and Finland)". That runs under an ISO 27001 certified management system. The same page says "OAuth tokens are encrypted at rest with AES-256-GCM."
+
+They also disclose their own gaps. They note they are "not currently SOC 2 or application-layer ISO 27001 certified."
+
+**More agent tools, including sync control.** Their MCP server has "12 tools", covering things ours does not, like triggering and pausing a sync from an assistant.
+
+One nuance if EU data residency is your reason for choosing: SyncDate's own subprocessor list includes several US-based vendors alongside the EU hosting. That is normal for a SaaS product, and they document it openly. Read the list yourself if it matters to you.
+
+## What Keeper.sh does not do
+
+We lead with the symptom, because that is how you will notice.
+
+**Your changes only travel one way per connection.** A connection in Keeper.sh runs in one direction only. If you want your work calendar in your personal one and the reverse, that is two connections, not a setting.
+
+**Attendees, meeting links and reminders do not come across.** A synced block carries its time, and its title and details if you choose to share them. Guests, the Meet or Teams link, and alerts stay on the original event. Keeper.sh does read attendees for invitations you receive, so you can see and answer them.
+
+**Privacy settings depend on how you added the calendar.** Keeper.sh can replace event titles, descriptions and locations with something generic. Whether that is on by default depends on which screen you added the calendar through, which is a real inconsistency we are fixing. Check the setting rather than assuming it.
+
+**Free plan writes are slow.** Every 30 minutes, as above.
+
+## Running Keeper.sh yourself
+
+Keeper.sh is designed to be self-hosted, and self-hosting is not a stripped-down version. Every Pro feature turns on automatically when you run your own instance, including per-minute writes and the uncapped API.
+
+This is the option to take when your data cannot leave your control. You keep the database, the tokens and the logs. Nobody else is in the path.
+
+It is real work, though, and we would rather say that than sell you a fantasy. You need Docker and Docker Compose, a Postgres database, a Redis instance and a domain. You also register your own Google and Microsoft applications to get calendar access, which is the fiddliest part.
+
+Most people should use hosted keeper.sh and pay the $5. Self-hosting is there when you need it, and the [repository](https://github.com/ridafkih/keeper.sh) has the full setup guide.
+
+## FAQ
+
+### Which should I choose?
+
+Choose SyncDate if you need updates in seconds, or if your company requires a signed DPA. Choose Keeper.sh if you want open source, self-hosting, a lower price, or an API and agent connector without paying.
+
+### Does Keeper.sh really sync every minute?
+
+We read your calendars every minute on all plans, including Free. Writing out is every 30 minutes on Free and every minute on Pro. Comparisons that call Keeper.sh a 30-minute product are describing the free plan's writes.
+
+### Can I try both?
+
+Yes. Both have free plans that need no card. Connect one calendar to each and watch how they behave for a week.
+
+### Is SyncDate's comparison page accurate?
+
+Mostly, and it is more careful than most. It concedes our open-source advantage, attributes our sync numbers to our own pricing page, marks its guesses as guesses, and publishes corrections. The MCP description above is the one thing we would change.
+
+## Sources
+
+Everything above about SyncDate comes from their own public pages, checked on the date this post was published:
+
+- [syncdate.app/pricing](https://syncdate.app/pricing) — plans, prices and free tier limits
+- [syncdate.app/features](https://syncdate.app/features) — supported calendars and the four-second figure
+- [syncdate.app/mcp](https://syncdate.app/mcp) — 12 tools
+- [syncdate.app/security](https://syncdate.app/security) — hosting, encryption and certifications
+- [syncdate.app/subprocessors](https://syncdate.app/subprocessors) — vendor list
+- [syncdate.app/dpa](https://syncdate.app/dpa) — the Data Processing Agreement
+- [syncdate.app/compare/syncdate-vs-keeper](https://syncdate.app/compare/syncdate-vs-keeper) — their comparison and correction notice
+
+Prices change. If a figure here is out of date, their page wins, and we would appreciate you [telling us](https://github.com/ridafkih/keeper.sh/issues).

--- a/applications/web/src/content/blog/keeper-sh-vs-syncdate.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-syncdate.mdx
@@ -62,7 +62,7 @@ That is close to a tie. Pick either on provider coverage.
 
 **One calendar feed for everything.** Keeper.sh gives you a single private iCal link that combines every calendar you have connected. Paste it into anything that reads calendar feeds and you get one merged view.
 
-**An API and an agent connector on the free plan.** Keeper.sh has a REST API with scoped access tokens, and an MCP server so tools like Claude can read and change your calendars. Both work on the free plan, capped at 25 requests per day. Pro removes the cap.
+**An API and an agent connector on the free plan.** Keeper.sh has a REST API, and an MCP server so tools like Claude can read and change your calendars. Both work on the free plan, capped at 25 requests per day. Pro removes the cap.
 
 ## A correction about our MCP server
 

--- a/applications/web/src/content/blog/keeper-sh-vs-syncdate.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-syncdate.mdx
@@ -11,27 +11,25 @@ tags:
   - "comparison"
 ---
 
-You have calendars in more than one place. You want your busy time to show up everywhere, so nobody double-books you. Keeper.sh and SyncDate both do that job.
+You have calendars in more than one place, and you want your busy time to show up everywhere so nobody double-books you. Keeper.sh and SyncDate both do that job.
 
-We wrote this page because SyncDate wrote one about us first, and wrote it fairly. So this is not a hit piece. In one important area they beat us outright, and we say so before anything else.
+SyncDate wrote a comparison of us first, and wrote it fairly. In one important area they beat us outright, so that goes before anything else.
 
 ## Which one updates faster?
 
 SyncDate. This is not close, and we will not talk around it.
 
-SyncDate subscribes to push notifications from Google and Microsoft. Those providers tell SyncDate the moment an event changes, instead of SyncDate asking. Their features page puts the end-to-end result at "roughly 4 seconds for webhook-backed providers."
+Google and Microsoft can tell a tool the moment an event changes. SyncDate listens for that, and their features page puts the end-to-end result at "roughly 4 seconds" for the providers that support it.
 
-Keeper.sh asks on a timer instead. We read your calendars every minute, on every plan, including the free one. We write the blocks out every 30 minutes on Free, and every minute on Pro.
+Keeper.sh asks on a timer instead. We read your calendars every minute, on every plan including Free. We write the blocks out every 30 minutes on Free, and every minute on Pro.
 
-In practice a change lands on your other calendar in under two minutes on Keeper.sh Pro. On Free it can take just over half an hour. SyncDate does it in seconds.
+So a change lands on your other calendar in under two minutes on Pro, and just over half an hour on Free.
 
-Here is when that gap actually matters. You are a consultant who moves client calls three or four times a day, and someone books you in the window you just freed up. Four seconds closes that hole and one minute might not.
-
-Here is when it doesn't. You block personal appointments onto a work calendar so colleagues stop scheduling over them. Those appointments were set days ago, so a minute is invisible.
+That gap matters if you are a consultant who moves client calls three times a day, and someone books the slot you just freed. Four seconds closes that hole and a minute might not. It is invisible if you are blocking out appointments set days ago.
 
 ## What does each one cost?
 
-SyncDate shows annual pricing by default. Their pricing page lists Plus at "$7.42/mo" billed as "$89 billed annually", and Pro at "$14.08/mo" billed as "$169 billed annually". The intro on the same page says plans "start at $8.99/month", which suggests month-to-month billing costs more.
+SyncDate shows annual pricing by default. Their pricing page lists Plus at "$7.42/mo" billed as "$89 billed annually", and Pro at "$14.08/mo" billed as "$169 billed annually". The same page says plans "start at $8.99/month", which suggests month-to-month costs more.
 
 Keeper.sh has one paid plan at $5 per month. There is no seat pricing and no higher tier.
 
@@ -42,35 +40,33 @@ Keeper.sh has one paid plan at $5 per month. There is no seat pricing and no hig
 | Higher paid plan | None | $14.08/mo billed annually ($169/year) |
 | Team plan | None | Custom, minimum 5 seats |
 
-Our free plan has no limit on calendars per account. SyncDate's free plan caps you at two calendars and one sync setup, and only looks one month ahead.
+Our free plan sets no limit on calendars per account. Theirs caps you at two calendars and one sync setup, and only looks one month ahead.
 
 ## Which calendars does each one connect?
 
 Both cover the big ones. SyncDate supports Google, Outlook, CalDAV and iCal feeds, and names iCloud, Fastmail, Infomaniak, mailbox.org, Posteo and Nextcloud as CalDAV servers it works with.
 
-Keeper.sh supports Google, Outlook, iCloud, Fastmail and any CalDAV server. Those five can all read and write. We also read iCal and ICS links, but we cannot write to them, because those links are one-directional by design.
+Keeper.sh supports Google, Outlook, iCloud, Fastmail and any CalDAV server, and can read and write all five. We also read iCal and ICS links, but cannot write to them, because those links only go one way.
 
-That is close to a tie. Pick either on provider coverage.
+Call this one a tie.
 
 ## Where is Keeper.sh genuinely better?
 
-**It is open source.** Keeper.sh is AGPL-3.0. You can read every line of the sync engine before you trust it with your calendar. SyncDate says plainly on their comparison page: "SYNCDATE is not open source and cannot be self-hosted."
+**It is open source.** Keeper.sh is AGPL-3.0, so you can read the sync engine before trusting it with your calendar. SyncDate says plainly on their comparison page: "SYNCDATE is not open source and cannot be self-hosted."
 
 **You can run it yourself, with every paid feature unlocked.** More on that below.
 
 **It costs less.** $5 a month against $7.42 a month billed annually, and more than that month-to-month.
 
-**One calendar feed for everything.** Keeper.sh gives you a single private iCal link that combines every calendar you have connected. Paste it into anything that reads calendar feeds and you get one merged view.
+**One calendar feed for everything.** Keeper.sh gives you a single private iCal link that combines every calendar you have connected. Paste it into anything that reads calendar feeds for one merged view.
 
-**An API and an agent connector on the free plan.** Keeper.sh has a REST API, and an MCP server so tools like Claude can read and change your calendars. Both work on the free plan, capped at 25 requests per day. Pro removes the cap.
+**An API and an agent connector on the free plan.** Keeper.sh has a REST API, and an MCP server so tools like Claude can read and change your calendars. Both are capped at 25 requests a day on Free, and uncapped on Pro.
 
-## A correction about our MCP server
+## One correction
 
-SyncDate's comparison page describes our tools as "read-focused (`list_calendars`, `get_events`, `get_event_count`, over OAuth 2.1)". We want to correct that gently, because it undersells us.
+Their comparison page calls our agent tools "read-focused (`list_calendars`, `get_events`, `get_event_count`, over OAuth 2.1)". We ship 11 tools and 4 of them write: `create_event`, `update_event`, `delete_event` and `rsvp_event`. An assistant connected to Keeper.sh can book, edit, cancel and reply to invitations, not just look.
 
-Keeper.sh ships 11 MCP tools, and 4 of them write. Alongside the read tools there are `create_event`, `update_event`, `delete_event` and `rsvp_event`. An assistant connected to Keeper.sh can book, edit, cancel and reply to invitations, not just look.
-
-We do not think this was careless. Their page already carries a dated correction retracting an earlier mistake about us, which is more than most companies do. We are noting this one in the same spirit.
+We do not think this was careless. Their page already carries a dated correction retracting an earlier mistake about us, which is more than most companies do.
 
 ## Where is SyncDate genuinely better?
 
@@ -78,33 +74,29 @@ We do not think this was careless. Their page already carries a dated correction
 
 **Paperwork your legal team will ask for.** SyncDate publishes a self-serve Data Processing Agreement, names DUMA DIGITAL SOLUTIONS S.R.L. as the operating company, and lists its subprocessors. If your employer needs a signed DPA before you connect a work calendar, SyncDate clears that bar and we do not.
 
-**Named infrastructure and encryption.** Their security page states hosting "with Hetzner in EU data centres (Germany and Finland)". That runs under an ISO 27001 certified management system. The same page says "OAuth tokens are encrypted at rest with AES-256-GCM."
-
-They also disclose their own gaps. They note they are "not currently SOC 2 or application-layer ISO 27001 certified."
+**Named infrastructure and encryption.** Their security page states hosting "with Hetzner in EU data centres (Germany and Finland)", running under an ISO 27001 certified management system. The same page says "OAuth tokens are encrypted at rest with AES-256-GCM."
 
 **More agent tools, including sync control.** Their MCP server has "12 tools", covering things ours does not, like triggering and pausing a sync from an assistant.
 
-One nuance if EU data residency is your reason for choosing: SyncDate's own subprocessor list includes several US-based vendors alongside the EU hosting. That is normal for a SaaS product, and they document it openly. Read the list yourself if it matters to you.
+They disclose their own gaps too, noting they are "not currently SOC 2 or application-layer ISO 27001 certified." Their subprocessor list also names several US vendors alongside the EU hosting. That is normal for a SaaS product and they document it openly, so read the list yourself if data residency is your reason for choosing.
 
 ## What Keeper.sh does not do
 
-We lead with the symptom, because that is how you will notice.
+**Your changes only travel one way per connection.** If you want your work calendar in your personal one and the reverse, that is two connections, not a setting.
 
-**Your changes only travel one way per connection.** A connection in Keeper.sh runs in one direction only. If you want your work calendar in your personal one and the reverse, that is two connections, not a setting.
+**Attendees, meeting links and reminders do not come across.** A synced block carries its time, plus its title and details if you share them, while guests, the Meet or Teams link and alerts stay on the original. We do read attendees for invitations you receive, so you can answer them.
 
-**Attendees, meeting links and reminders do not come across.** A synced block carries its time, and its title and details if you choose to share them. Guests, the Meet or Teams link, and alerts stay on the original event. Keeper.sh does read attendees for invitations you receive, so you can see and answer them.
-
-**Privacy settings depend on how you added the calendar.** Keeper.sh can replace event titles, descriptions and locations with something generic. Whether that is on by default depends on which screen you added the calendar through, which is a real inconsistency we are fixing. Check the setting rather than assuming it.
+**Showing real event details costs $5.** A connected calendar arrives anonymised: titles, descriptions and locations are replaced with something generic. Changing that is a Pro setting.
 
 **Free plan writes are slow.** Every 30 minutes, as above.
 
 ## Running Keeper.sh yourself
 
-Keeper.sh is designed to be self-hosted, and self-hosting is not a stripped-down version. Every Pro feature turns on automatically when you run your own instance, including per-minute writes and the uncapped API.
+Self-hosting Keeper.sh is not a stripped-down version. Every Pro feature turns on automatically on your own instance, including per-minute writes and the uncapped API.
 
-This is the option to take when your data cannot leave your control. You keep the database, the tokens and the logs. Nobody else is in the path.
+This is the option to take when your data cannot leave your control. You keep the database, the tokens and the logs, and nobody else is in the path.
 
-It is real work, though, and we would rather say that than sell you a fantasy. You need Docker and Docker Compose, a Postgres database, a Redis instance and a domain. You also register your own Google and Microsoft applications to get calendar access, which is the fiddliest part.
+It is real work, though. You need Docker and Docker Compose, a Postgres database, a Redis instance and a domain, plus your own Google and Microsoft applications for calendar access, which is the fiddliest part.
 
 Most people should use hosted keeper.sh and pay the $5. Self-hosting is there when you need it, and the [repository](https://github.com/ridafkih/keeper.sh) has the full setup guide.
 
@@ -121,10 +113,6 @@ We read your calendars every minute on all plans, including Free. Writing out is
 ### Can I try both?
 
 Yes. Both have free plans that need no card. Connect one calendar to each and watch how they behave for a week.
-
-### Is SyncDate's comparison page accurate?
-
-Mostly, and it is more careful than most. It concedes our open-source advantage, attributes our sync numbers to our own pricing page, marks its guesses as guesses, and publishes corrections. The MCP description above is the one thing we would change.
 
 ## Sources
 

--- a/applications/web/src/content/blog/keeper-sh-vs-syncthemcalendars.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-syncthemcalendars.mdx
@@ -15,47 +15,37 @@ You keep a work calendar and a personal one, and neither knows about the other. 
 
 They take different shapes. SyncThemCalendars is a polished, narrow product covering three providers very well. Keeper.sh is open source, covers more calendar types, and gives you an API.
 
-Here is the honest split.
-
-## Which calendars does each one connect?
-
-This is the clearest difference, so it goes first.
-
-SyncThemCalendars supports Google Calendar, Microsoft Outlook and Office 365, and Apple iCloud. Their own FAQ lists those three. We could not find any mention of generic CalDAV on their site.
-
-Keeper.sh supports Google, Outlook, iCloud, Fastmail and any CalDAV server. That last part is the difference. If your calendar lives at mailbox.org, Posteo, Nextcloud, Infomaniak or a server you run, Keeper.sh can read and write it.
-
-We also read iCal and ICS links, though we cannot write back to them. Those links are one-directional by design.
-
-So: three providers done well, against five plus anything speaking CalDAV. If your calendars are all Google, Outlook or iCloud, this difference does not affect you.
-
 ## Does either one sync both ways?
 
 SyncThemCalendars does, and this is a real advantage over us.
 
-Their two-way sync page puts it plainly. One-way copies events from one calendar to another. Two-way "mirrors both calendars", so a change on either side shows up on the other.
+Their two-way sync page puts it plainly. One-way copies events from one calendar to another. Two-way "mirrors both calendars", so a change on either side shows up on the other, and it is a per-sync setting you toggle.
 
-It is a per-sync setting you toggle.
+Keeper.sh does not work that way. Every connection runs in one direction, so mirroring two calendars means building two connections instead of flipping one switch. The end result is similar and the setup is not.
 
-Keeper.sh does not work that way. Every connection runs in one direction. To mirror two calendars you build two connections, one each way.
+## Which calendars does each one connect?
 
-The result is similar, but the setup is not. You configure twice, and you think about it twice. If you want one switch that makes two calendars mirror each other, they have it and we do not.
+SyncThemCalendars supports Google Calendar, Microsoft Outlook and Office 365, and Apple iCloud. Their own FAQ lists those three, and we could not find any mention of generic CalDAV on their site.
+
+Keeper.sh supports Google, Outlook, iCloud, Fastmail and any CalDAV server. That last part is the difference. If your calendar lives at mailbox.org, Posteo, Nextcloud, Infomaniak or a server you run, Keeper.sh can read and write it.
+
+We also read iCal and ICS links, though we cannot write back to them, because those links only go one way.
+
+If your calendars are all Google, Outlook or iCloud, none of this affects you.
 
 ## Which one updates faster?
 
-SyncThemCalendars, for Google and Outlook, and we should be clear about that.
+SyncThemCalendars, for Google and Outlook.
 
-Google and Microsoft can push a notification the instant an event changes. SyncThemCalendars subscribes to those, and their two-way sync page says "Google and Outlook notify us the moment something changes, so copies update in moments." For iCloud, the same page says they check "every few minutes."
+Google and Microsoft can notify a tool the instant an event changes. Their two-way sync page says "Google and Outlook notify us the moment something changes, so copies update in moments." For iCloud, the same page says they check "every few minutes."
 
 Keeper.sh asks on a timer rather than being told. We read every calendar every minute, on every plan including Free. We write the copies out every 30 minutes on Free, and every minute on Pro.
 
-Neither of us publishes a number in seconds. Practically: a Google change reaches its copy in moments on SyncThemCalendars, and in under two minutes on Keeper.sh Pro. For an iCloud change, the two are close.
+Neither of us publishes a number in seconds. In practice a Google change reaches its copy in moments on their side, and in under two minutes on Keeper.sh Pro. For an iCloud change, the two are close.
 
 ## What does each one cost?
 
-The pricing models are shaped differently, so read the table rather than the headline.
-
-SyncThemCalendars charges by how many syncs you run, and does not charge for connecting more calendars or accounts. Their pricing page lists three tiers, each for one user with a 14-day free trial.
+SyncThemCalendars charges by how many syncs you run, and does not charge for connecting more calendars or accounts. Their three tiers each cover one user, with a 14-day free trial.
 
 | | Keeper.sh | SyncThemCalendars |
 | --- | --- | --- |
@@ -65,53 +55,51 @@ SyncThemCalendars charges by how many syncs you run, and does not charge for con
 | Top plan | None | $17.99/month, 36 syncs |
 | Yearly option | Not offered | $47.88, $95.88, $215.88 |
 
-If you run five syncs or fewer, they are cheaper, and by a dollar. If you run more than five, we are cheaper, because $5 on Keeper.sh Pro has no connection limit at all.
+Run five syncs or fewer and they are cheaper by a dollar. Run more than five and we are cheaper, because $5 on Keeper.sh Pro has no connection limit at all.
 
-The other real difference is the free plan. Keeper.sh has one that never expires, with 2 accounts and 3 connections. SyncThemCalendars gives you 14 days and then asks for payment.
+The other real difference is the free plan. Ours never expires, with 2 accounts and 3 connections. Theirs is 14 days, and then they ask for payment.
 
 ## Where is SyncThemCalendars genuinely better?
 
-**Two-way sync in one setting**, covered above.
+**Two-way sync in one setting**, and **faster updates on Google and Outlook**, both covered above.
 
-**Faster updates on Google and Outlook**, also covered above.
+**Cheaper below five connections.** $3.99 a month against our $5.
 
-**Simpler onboarding.** They advertise "Set up your first sync in 2 minutes" across the site, and the product is built around that promise. Keeper.sh asks you to think about direction, which calendars feed which, and what to hide. That is more control and more decisions.
+**Simpler onboarding.** They advertise "Set up your first sync in 2 minutes" and the product is built around that promise. Keeper.sh asks you to think about direction, which calendars feed which, and what to hide, which is more control and more decisions.
 
-**Seven languages.** Their site and product ship in English, French, German, Japanese, Spanish, Italian and Portuguese. Keeper.sh is English only. If you would rather not work in English, that is a good reason to pick them.
+**Seven languages.** Their site and product ship in English, French, German, Japanese, Spanish, Italian and Portuguese. Keeper.sh is English only, so if you would rather not work in English, pick them.
 
-**Field-level privacy without configuration hunting.** Their pages describe it as: "Show full details, or hide title, description and location behind a 'Busy' block. You decide, per sync and per field." Keeper.sh can do the same thing, but our defaults are less consistent, which we cover below.
+**Field-level privacy without configuration hunting.** Their pages describe it as: "Show full details, or hide title, description and location behind a 'Busy' block. You decide, per sync and per field."
 
 ## Where is Keeper.sh genuinely better?
 
-**More calendar types.** CalDAV and Fastmail support, as above.
+**More calendar types.** CalDAV and Fastmail, as above.
 
 **It is open source.** Keeper.sh is AGPL-3.0. The sync engine is on GitHub and you can read it before trusting it with your calendar.
 
-**You can run it yourself.** Every paid feature is free on your own instance. See the section below.
+**You can run it yourself.** Every paid feature is free on your own instance. See below.
 
 **Unlimited connections for $5.** No counting syncs.
 
-**An API and an agent connector.** Keeper.sh has a REST API, plus an MCP server with 11 tools. Assistants like Claude can list, create, edit, delete and RSVP to events. Both run on the free plan, capped at 25 requests a day, and uncapped on Pro.
+**An API and an agent connector.** Keeper.sh has a REST API, plus an MCP server with 11 tools, so assistants like Claude can list, create, edit, delete and RSVP to events. Both run on the free plan, capped at 25 requests a day, and uncapped on Pro.
 
-**One feed for every calendar.** Keeper.sh gives you a single private iCal link combining everything you have connected. Anything that reads calendar feeds can show your whole life in one place.
+**One feed for every calendar.** Keeper.sh gives you a single private iCal link combining everything you have connected, readable by anything that takes a calendar feed.
 
 ## What about data handling?
 
-This one deserves care, because neither of us is a compliance product.
+Neither of us is a compliance product, so this deserves care.
 
-SyncThemCalendars does not publish a DPA or a security page that we could find. Their privacy policy says data is "stored and processed in United States, or where we or our partners, affiliates and third-party providers maintain facilities." That policy is dated March 2019.
+SyncThemCalendars does not publish a DPA or a security page that we could find. Their privacy policy, dated March 2019, says data is "stored and processed in United States, or where we or our partners, affiliates and third-party providers maintain facilities."
 
-Keeper.sh does not publish a DPA either. If your employer requires a signed data processing agreement before you connect a work calendar, neither of us clears that bar today.
-
-The honest answer for that situation is to self-host Keeper.sh, or to pick a vendor built for it.
+Keeper.sh does not publish a DPA either. If your employer requires a signed data processing agreement before you connect a work calendar, neither of us clears that bar today. Self-host Keeper.sh, or pick a vendor built for it.
 
 ## What Keeper.sh does not do
 
 **One direction per connection**, as above.
 
-**Attendees, meeting links and reminders do not come across.** A copied block carries its time, and its details if you share them. Guests, the Meet or Teams link, and alerts stay on the original. Keeper.sh does read attendees for invitations you receive, so you can answer them.
+**Attendees, meeting links and reminders do not come across.** A copied block carries its time, plus its details if you share them, while guests, the Meet or Teams link and alerts stay on the original. We do read attendees for invitations you receive, so you can answer them.
 
-**Privacy settings depend on how you added the calendar.** Keeper.sh can replace titles, descriptions and locations with something generic. Whether that starts switched on depends on which screen you added the calendar through, which is an inconsistency we are fixing. Check the setting instead of assuming.
+**Showing real event details costs $5.** A connected calendar arrives anonymised: titles, descriptions and locations are replaced with something generic. Changing that is a Pro setting.
 
 **Free plan writes are slow.** Every 30 minutes.
 
@@ -123,7 +111,7 @@ Keeper.sh is built to be self-hosted, and self-hosting is not a lesser version. 
 
 Take this route when the data cannot leave your control. You hold the database, the tokens and the logs, and nobody else sits in the path.
 
-It is genuine work and we would rather say so. You need Docker and Docker Compose, Postgres, Redis and a domain. You also register your own Google and Microsoft applications, which is the fiddliest step.
+It is genuine work. You need Docker and Docker Compose, Postgres, Redis and a domain, plus your own Google and Microsoft applications, which is the fiddliest step.
 
 Most people should use hosted keeper.sh at $5 a month. Self-hosting is there when you need it, and the [repository](https://github.com/ridafkih/keeper.sh) has the full guide.
 
@@ -131,19 +119,11 @@ Most people should use hosted keeper.sh at $5 a month. Self-hosting is there whe
 
 ### Which should I choose?
 
-Choose SyncThemCalendars if you want two-way sync as one switch, the fastest Google and Outlook updates, a two-minute setup, or the product in your own language. Choose Keeper.sh if you use CalDAV or Fastmail, want open source and self-hosting, run more than five connections, or want an API and agent access.
-
-### Can Keeper.sh mirror two calendars?
-
-Yes, with two connections instead of one setting. The end result is the same and the setup takes longer.
+Choose SyncThemCalendars if you want two-way sync as one switch, the fastest Google and Outlook updates, a two-minute setup, five connections or fewer, or the product in your own language. Choose Keeper.sh if you use CalDAV or Fastmail, want open source and self-hosting, run more than five connections, or want an API and agent access.
 
 ### Does Keeper.sh only sync every 30 minutes?
 
-No. We read every calendar every minute on all plans. The 30-minute figure is how often the free plan writes copies out. Pro writes every minute.
-
-### Do both hide event details?
-
-Yes. Both can replace a title, description and location with a plain busy block, chosen per connection.
+No. We read every calendar every minute on all plans. The 30-minute figure is how often the free plan writes copies out, and Pro writes every minute.
 
 ### Can I try both?
 
@@ -156,7 +136,7 @@ Everything above about SyncThemCalendars comes from their own public pages, chec
 - [syncthemcalendars.com](https://syncthemcalendars.com/) — homepage, pricing and FAQ
 - [Two-way calendar sync](https://syncthemcalendars.com/features/two-way-calendar-sync) — sync direction, update speed and privacy fields
 - [Apple iCloud calendar sync](https://syncthemcalendars.com/features/apple-icloud-calendar-sync) — iCloud checking interval
-- [Google calendar sync](https://syncthemcalendars.com/features/google-calendar-sync) — push notifications
+- [Google calendar sync](https://syncthemcalendars.com/features/google-calendar-sync) — instant updates from Google
 - [Compare](https://syncthemcalendars.com/compare) — pricing model
 - [Privacy policy](https://syncthemcalendars.com/privacy-policy) — data storage location
 

--- a/applications/web/src/content/blog/keeper-sh-vs-syncthemcalendars.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-syncthemcalendars.mdx
@@ -113,7 +113,7 @@ Take this route when the data cannot leave your control. You hold the database, 
 
 It is genuine work. You need Docker and Docker Compose, Postgres, Redis and a domain, plus your own Google and Microsoft applications, which is the fiddliest step.
 
-Most people should use hosted keeper.sh at $5 a month. Self-hosting is there when you need it, and the [repository](https://github.com/ridafkih/keeper.sh) has the full guide.
+Most people should use hosted Keeper.sh at $5 a month. Self-hosting is there when you need it, and the [repository](https://github.com/ridafkih/keeper.sh) has the full guide.
 
 ## FAQ
 

--- a/applications/web/src/content/blog/keeper-sh-vs-syncthemcalendars.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-syncthemcalendars.mdx
@@ -91,7 +91,7 @@ The other real difference is the free plan. Keeper.sh has one that never expires
 
 **Unlimited connections for $5.** No counting syncs.
 
-**An API and an agent connector.** Keeper.sh has a REST API with scoped access tokens, plus an MCP server with 11 tools. Assistants like Claude can list, create, edit, delete and RSVP to events. Both run on the free plan, capped at 25 requests a day, and uncapped on Pro.
+**An API and an agent connector.** Keeper.sh has a REST API, plus an MCP server with 11 tools. Assistants like Claude can list, create, edit, delete and RSVP to events. Both run on the free plan, capped at 25 requests a day, and uncapped on Pro.
 
 **One feed for every calendar.** Keeper.sh gives you a single private iCal link combining everything you have connected. Anything that reads calendar feeds can show your whole life in one place.
 

--- a/applications/web/src/content/blog/keeper-sh-vs-syncthemcalendars.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-syncthemcalendars.mdx
@@ -1,0 +1,163 @@
+---
+title: "Keeper.sh vs SyncThemCalendars"
+description: "An honest comparison of Keeper.sh and SyncThemCalendars for calendar sync, covering two-way sync, update speed, pricing by sync count, supported calendars, languages, open source and self-hosting."
+blurb: "SyncThemCalendars does two-way sync in one setting and we do not. Here is that trade-off in full, plus pricing, provider coverage, and where each of us wins."
+createdAt: "2026-08-11"
+slug: "keeper-sh-vs-syncthemcalendars"
+updatedAt: "2026-08-11"
+tags:
+  - "calendar"
+  - "sync"
+  - "comparison"
+---
+
+You keep a work calendar and a personal one, and neither knows about the other. Both Keeper.sh and SyncThemCalendars fix that by copying your busy time between them.
+
+They take different shapes. SyncThemCalendars is a polished, narrow product covering three providers very well. Keeper.sh is open source, covers more calendar types, and gives you an API.
+
+Here is the honest split.
+
+## Which calendars does each one connect?
+
+This is the clearest difference, so it goes first.
+
+SyncThemCalendars supports Google Calendar, Microsoft Outlook and Office 365, and Apple iCloud. Their own FAQ lists those three. We could not find any mention of generic CalDAV on their site.
+
+Keeper.sh supports Google, Outlook, iCloud, Fastmail and any CalDAV server. That last part is the difference. If your calendar lives at mailbox.org, Posteo, Nextcloud, Infomaniak or a server you run, Keeper.sh can read and write it.
+
+We also read iCal and ICS links, though we cannot write back to them. Those links are one-directional by design.
+
+So: three providers done well, against five plus anything speaking CalDAV. If your calendars are all Google, Outlook or iCloud, this difference does not affect you.
+
+## Does either one sync both ways?
+
+SyncThemCalendars does, and this is a real advantage over us.
+
+Their two-way sync page puts it plainly. One-way copies events from one calendar to another. Two-way "mirrors both calendars", so a change on either side shows up on the other.
+
+It is a per-sync setting you toggle.
+
+Keeper.sh does not work that way. Every connection runs in one direction. To mirror two calendars you build two connections, one each way.
+
+The result is similar, but the setup is not. You configure twice, and you think about it twice. If you want one switch that makes two calendars mirror each other, they have it and we do not.
+
+## Which one updates faster?
+
+SyncThemCalendars, for Google and Outlook, and we should be clear about that.
+
+Google and Microsoft can push a notification the instant an event changes. SyncThemCalendars subscribes to those, and their two-way sync page says "Google and Outlook notify us the moment something changes, so copies update in moments." For iCloud, the same page says they check "every few minutes."
+
+Keeper.sh asks on a timer rather than being told. We read every calendar every minute, on every plan including Free. We write the copies out every 30 minutes on Free, and every minute on Pro.
+
+Neither of us publishes a number in seconds. Practically: a Google change reaches its copy in moments on SyncThemCalendars, and in under two minutes on Keeper.sh Pro. For an iCloud change, the two are close.
+
+## What does each one cost?
+
+The pricing models are shaped differently, so read the table rather than the headline.
+
+SyncThemCalendars charges by how many syncs you run, and does not charge for connecting more calendars or accounts. Their pricing page lists three tiers, each for one user with a 14-day free trial.
+
+| | Keeper.sh | SyncThemCalendars |
+| --- | --- | --- |
+| Free plan | 2 linked accounts, 3 connections, no card | 14-day trial, no card |
+| Entry paid plan | $5/month, unlimited connections | $3.99/month, 5 syncs |
+| Middle plan | None | $7.99/month, 16 syncs |
+| Top plan | None | $17.99/month, 36 syncs |
+| Yearly option | Not offered | $47.88, $95.88, $215.88 |
+
+If you run five syncs or fewer, they are cheaper, and by a dollar. If you run more than five, we are cheaper, because $5 on Keeper.sh Pro has no connection limit at all.
+
+The other real difference is the free plan. Keeper.sh has one that never expires, with 2 accounts and 3 connections. SyncThemCalendars gives you 14 days and then asks for payment.
+
+## Where is SyncThemCalendars genuinely better?
+
+**Two-way sync in one setting**, covered above.
+
+**Faster updates on Google and Outlook**, also covered above.
+
+**Simpler onboarding.** They advertise "Set up your first sync in 2 minutes" across the site, and the product is built around that promise. Keeper.sh asks you to think about direction, which calendars feed which, and what to hide. That is more control and more decisions.
+
+**Seven languages.** Their site and product ship in English, French, German, Japanese, Spanish, Italian and Portuguese. Keeper.sh is English only. If you would rather not work in English, that is a good reason to pick them.
+
+**Field-level privacy without configuration hunting.** Their pages describe it as: "Show full details, or hide title, description and location behind a 'Busy' block. You decide, per sync and per field." Keeper.sh can do the same thing, but our defaults are less consistent, which we cover below.
+
+## Where is Keeper.sh genuinely better?
+
+**More calendar types.** CalDAV and Fastmail support, as above.
+
+**It is open source.** Keeper.sh is AGPL-3.0. The sync engine is on GitHub and you can read it before trusting it with your calendar.
+
+**You can run it yourself.** Every paid feature is free on your own instance. See the section below.
+
+**Unlimited connections for $5.** No counting syncs.
+
+**An API and an agent connector.** Keeper.sh has a REST API with scoped access tokens, plus an MCP server with 11 tools. Assistants like Claude can list, create, edit, delete and RSVP to events. Both run on the free plan, capped at 25 requests a day, and uncapped on Pro.
+
+**One feed for every calendar.** Keeper.sh gives you a single private iCal link combining everything you have connected. Anything that reads calendar feeds can show your whole life in one place.
+
+## What about data handling?
+
+This one deserves care, because neither of us is a compliance product.
+
+SyncThemCalendars does not publish a DPA or a security page that we could find. Their privacy policy says data is "stored and processed in United States, or where we or our partners, affiliates and third-party providers maintain facilities." That policy is dated March 2019.
+
+Keeper.sh does not publish a DPA either. If your employer requires a signed data processing agreement before you connect a work calendar, neither of us clears that bar today.
+
+The honest answer for that situation is to self-host Keeper.sh, or to pick a vendor built for it.
+
+## What Keeper.sh does not do
+
+**One direction per connection**, as above.
+
+**Attendees, meeting links and reminders do not come across.** A copied block carries its time, and its details if you share them. Guests, the Meet or Teams link, and alerts stay on the original. Keeper.sh does read attendees for invitations you receive, so you can answer them.
+
+**Privacy settings depend on how you added the calendar.** Keeper.sh can replace titles, descriptions and locations with something generic. Whether that starts switched on depends on which screen you added the calendar through, which is an inconsistency we are fixing. Check the setting instead of assuming.
+
+**Free plan writes are slow.** Every 30 minutes.
+
+**English only.**
+
+## Running Keeper.sh yourself
+
+Keeper.sh is built to be self-hosted, and self-hosting is not a lesser version. Every Pro feature switches on automatically, including per-minute writes and the uncapped API.
+
+Take this route when the data cannot leave your control. You hold the database, the tokens and the logs, and nobody else sits in the path.
+
+It is genuine work and we would rather say so. You need Docker and Docker Compose, Postgres, Redis and a domain. You also register your own Google and Microsoft applications, which is the fiddliest step.
+
+Most people should use hosted keeper.sh at $5 a month. Self-hosting is there when you need it, and the [repository](https://github.com/ridafkih/keeper.sh) has the full guide.
+
+## FAQ
+
+### Which should I choose?
+
+Choose SyncThemCalendars if you want two-way sync as one switch, the fastest Google and Outlook updates, a two-minute setup, or the product in your own language. Choose Keeper.sh if you use CalDAV or Fastmail, want open source and self-hosting, run more than five connections, or want an API and agent access.
+
+### Can Keeper.sh mirror two calendars?
+
+Yes, with two connections instead of one setting. The end result is the same and the setup takes longer.
+
+### Does Keeper.sh only sync every 30 minutes?
+
+No. We read every calendar every minute on all plans. The 30-minute figure is how often the free plan writes copies out. Pro writes every minute.
+
+### Do both hide event details?
+
+Yes. Both can replace a title, description and location with a plain busy block, chosen per connection.
+
+### Can I try both?
+
+Yes. Keeper.sh has a free plan that does not expire. SyncThemCalendars has a 14-day trial without a card.
+
+## Sources
+
+Everything above about SyncThemCalendars comes from their own public pages, checked on the date this post was published:
+
+- [syncthemcalendars.com](https://syncthemcalendars.com/) — homepage, pricing and FAQ
+- [Two-way calendar sync](https://syncthemcalendars.com/features/two-way-calendar-sync) — sync direction, update speed and privacy fields
+- [Apple iCloud calendar sync](https://syncthemcalendars.com/features/apple-icloud-calendar-sync) — iCloud checking interval
+- [Google calendar sync](https://syncthemcalendars.com/features/google-calendar-sync) — push notifications
+- [Compare](https://syncthemcalendars.com/compare) — pricing model
+- [Privacy policy](https://syncthemcalendars.com/privacy-policy) — data storage location
+
+Prices and features change. If something here is out of date, their page wins, and we would appreciate you [telling us](https://github.com/ridafkih/keeper.sh/issues).


### PR DESCRIPTION
Three comparison posts in the blog, one per competitor. Every third-party claim is quoted from that company's own public pages and cited with a URL at the bottom of each post. Each post concedes where the other product is genuinely better — SyncDate is faster, SyncThemCalendars has two-way sync and seven languages, and Kalender Sync has a signed AVV with a named EU entity plus a Sharings feature we have no answer to.

- Slugs: `keeper-sh-vs-syncdate`, `keeper-sh-vs-syncthemcalendars`, `keeper-sh-vs-kalender-sync`
- Corrects SyncDate's "read-focused" description of our MCP server: 11 tools, 4 of which write
- Corrects the "Keeper is a 30-minute product" framing: reads are every minute on all plans, writes are 30 min free / 1 min Pro
- Skipped the SyncDate CalDAV roadmap angle — their roadmap body affirms CalDAV is supported, so the "Under Review" label is not the discrepancy it looks like
- FAQs use `## FAQ` with `###` questions for the collapsible component