### PR TITLE
docs: add OneCal and CalendarBridge comparison posts

### DIFF
--- a/applications/web/src/content/blog/keeper-sh-vs-calendarbridge.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-calendarbridge.mdx
@@ -1,0 +1,157 @@
+---
+title: "Keeper.sh vs CalendarBridge"
+description: "An honest comparison of Keeper.sh and CalendarBridge: which calendars each one connects, how fast changes land, what they cost, and which one fits you better."
+blurb: "CalendarBridge has mobile apps, scheduling pages, a HIPAA tier and GCC High support. Keeper.sh has CalDAV, a free tier, a flat $5 plan and code you can run yourself. Here is a straight comparison."
+createdAt: "2026-08-11"
+slug: "keeper-sh-vs-calendarbridge"
+updatedAt: "2026-08-11"
+tags:
+  - "calendar"
+  - "comparison"
+  - "sync"
+  - "calendarbridge"
+---
+
+You keep two or three calendars and you are tired of double bookings. Keeper.sh and CalendarBridge both fix that by mirroring your busy time between them.
+
+They are close on the basics and far apart on nearly everything else, and this page is an honest read on both. CalendarBridge deserves credit for one thing up front. They publish real per-calendar sync speeds on their own site instead of saying "real-time" and leaving it there, and we are aiming for that same standard here.
+
+## What each product actually is
+
+Keeper.sh mirrors busy time between calendars, and it is open source under AGPL-3.0, so you can run it on your own server.
+
+CalendarBridge does that too, and then keeps going. It adds scheduling pages, a unified calendar app, an AI scheduling assistant, and plans built for organisations where an admin manages everyone's connections.
+
+The short version is that CalendarBridge is a wider product with compliance credentials, while Keeper.sh is narrower, cheaper and open.
+
+## Which calendars can you connect?
+
+CalendarBridge connects Google Calendar, Microsoft 365 for Business, Microsoft personal accounts on outlook.com, hotmail.com, live.com and msn.com, and iCloud. They note that Microsoft 365 personal and family plans cannot be supported, because those plans do not expose a calendar over the internet.
+
+For anything else, their answer is a `.ics` link, which reads a calendar but cannot write to one.
+
+Keeper.sh connects Google, Outlook, iCloud and Fastmail, plus any CalDAV server and any public `.ics` link.
+
+The difference that matters here is CalDAV. On Nextcloud, Fastmail, Zimbra, Radicale or a server you run yourself, Keeper.sh can both read and write, where a `.ics` link only ever reads.
+
+## How fast do changes show up?
+
+CalendarBridge is real-time from Google and Microsoft calendars, and their site says changes typically reach the other calendar within a minute or two. From iCloud and `.ics` calendars, they sync every 5 to 10 minutes.
+
+Keeper.sh reads your calendars every minute on every plan, free included. Writing to the other calendar is the part that changes with your plan. On the free plan a change lands within 30 minutes, and on Pro it lands within a minute.
+
+So Keeper.sh Pro and CalendarBridge are roughly matched on Google and Microsoft calendars. On iCloud and `.ics` calendars, Keeper.sh Pro is the faster of the two. On our free plan we are slower than both, and 30 minutes is a long wait if you are booking meetings live.
+
+## What does it cost?
+
+CalendarBridge charges per month for a fixed number of calendars. Basic is $5 for 2 calendars, Premium is $10 for 5, and Pro is $40 for 8. Paying yearly takes 20% off, which makes those $4, $8 and $32 a month.
+
+Their unified calendar view is capped separately, at 4, 12 and 24 calendars depending on plan. There is no free plan listed on their pricing page, though you can start a trial without a card.
+
+Keeper.sh is free for 2 linked accounts and 3 connections, with no cap on how many calendars each account exposes. Keeper.sh Pro is $5 a month, or $42 a year, which works out to $3.50 a month.
+
+Pro removes the limits entirely, so six accounts and a dozen connections cost the same $5 as two of each. That is the sharpest contrast between the two products. On CalendarBridge more calendars means a higher tier, and on Keeper.sh it does not.
+
+## Where CalendarBridge is the better pick
+
+These advantages are real, and they are not ones we can talk our way out of.
+
+**You need an app on your phone.** CalendarBridge ships apps on the Apple App Store, Google Play and the Microsoft Store. Keeper.sh has none, so you manage it in a browser.
+
+**You need other people to book time with you.** CalendarBridge includes up to 10 scheduling pages on every plan, built for people whose availability is spread across several calendars. Keeper.sh has nothing like this and is not building it.
+
+**You handle health data.** CalendarBridge offers a HIPAA business associate agreement on its Premium and Pro plans, and states that it has been HIPAA compliant since 2022. We cannot sign a BAA.
+
+**You work in government or defence.** CalendarBridge supports Microsoft 365 Government Community Cloud High, which Keeper.sh does not and is not planning to.
+
+**Procurement will ask you for paperwork.** CalendarBridge lists a verified SOC 2 Type 1 and offers a trust centre on request, and we have neither of those today.
+
+**You are buying for a whole team.** Their group plans let an admin set up and manage everyone's connections on a single bill, with no end-user involvement. Keeper.sh has no team management at all.
+
+**You want one screen showing every calendar.** Their unified calendar app does exactly that, where Keeper.sh gives you a feed to subscribe to rather than an app to look at.
+
+## Where Keeper.sh is the better pick
+
+**Your calendar speaks CalDAV.** This is the clearest reason to choose us, because Fastmail and Nextcloud servers can be written to by Keeper.sh and only read through a link by CalendarBridge.
+
+**You want to try it for free, indefinitely.** Two accounts and three connections cost nothing and never expire, and plenty of people never need more than that.
+
+**You have a lot of calendars.** Eight calendars is $40 a month on CalendarBridge Pro and $5 a month on Keeper.sh Pro. If your setup is wide rather than complicated, that gap gets large quickly.
+
+**You want your schedule available elsewhere.** Keeper.sh publishes one iCal feed covering every calendar you opt in, subscribable from anything that reads a calendar link.
+
+**You want to automate it.** Keeper.sh has a REST API and an MCP server for AI assistants, both usable on the free plan at 25 calls a day and unmetered on Pro.
+
+**You want to read the code.** Keeper.sh is AGPL-3.0, so nothing about how your events are handled is hidden from you.
+
+## What Keeper.sh will not do for you
+
+These are the symptoms first, so you can spot your own case in them.
+
+**You invite five people and the mirrored copy has no attendees.** We do not copy attendees, video call links or reminders. Only the title, description, location, times and busy status cross over.
+
+**You change an event on the mirrored side and the change vanishes.** Each connection runs in one direction, so to keep two calendars feeding each other you set up two connections, one each way.
+
+**You want real event titles on the other calendar and the setting is locked.** Controlling what shows up there is a Pro feature, and free accounts take the default.
+
+**Your weekly standup appears as fifty separate events.** We copy each occurrence individually rather than as a repeating series.
+
+**You want scheduling pages, apps, a BAA or GCC High.** We have none of these, so read the CalendarBridge section above again.
+
+## Running Keeper.sh yourself
+
+Keeper.sh is AGPL-3.0 and built to be self-hosted, and this is a real option rather than a stripped-down teaser.
+
+Run it yourself and every Pro feature is included at no cost. There is no licence key, no seat count and no phone-home. You get unlimited accounts, unlimited connections, one-minute writes, feed customisation and event filters.
+
+Your calendar data also stays on hardware you control, which removes the part many people dislike about handing a schedule to a third party.
+
+Be honest with yourself about the work involved. You need a server, Postgres, Redis and a domain with TLS. You also register your own Google and Microsoft apps for OAuth, which takes an afternoon and involves Google's verification process.
+
+After that, upgrades, backups and uptime are yours. We ship Docker Compose files and a standalone image to keep the setup short. If that sounds like a good weekend then self-host, and if it sounds like a second job, use hosted keeper.sh for $5 a month.
+
+## FAQ
+
+### Does CalendarBridge support CalDAV?
+
+Their site lists Google, Microsoft 365 for Business, Microsoft personal accounts and iCloud, and suggests a `.ics` link for other providers. A `.ics` link can be read but never written to, while Keeper.sh connects CalDAV servers directly and can write to them.
+
+### Is CalendarBridge faster than Keeper.sh?
+
+On Google and Microsoft they are comparable to Keeper.sh Pro, with both landing changes in about a minute. On iCloud and `.ics` calendars, CalendarBridge syncs every 5 to 10 minutes where Keeper.sh Pro writes every minute. On the Keeper.sh free plan, CalendarBridge is the faster product.
+
+### Does CalendarBridge have a free plan?
+
+Their pricing page lists paid plans starting at $5 a month, and you can start a trial without a card. Keeper.sh has a permanent free tier of 2 linked accounts and 3 connections.
+
+### Can Keeper.sh sign a HIPAA BAA?
+
+No, and CalendarBridge offers a BAA on its Premium and Pro plans. If your work requires one, that is a decisive reason to choose them over us.
+
+### Does Keeper.sh have scheduling pages?
+
+No, Keeper.sh only mirrors busy time between calendars. CalendarBridge includes up to 10 scheduling pages on every one of its plans.
+
+### Does Keeper.sh sync both directions?
+
+Not in a single step, because each connection runs one way. You create two connections, one in each direction, to keep a pair of calendars feeding each other.
+
+### Can I self-host CalendarBridge?
+
+No, CalendarBridge is a hosted commercial product. Keeper.sh is AGPL-3.0 and runs on your own server with every Pro feature included.
+
+### Which one should I pick?
+
+Pick CalendarBridge if you need mobile apps, scheduling pages, a HIPAA BAA or GCC High support. Pick Keeper.sh if you need CalDAV, want a free tier, have many calendars, or want to run it yourself.
+
+## Where these facts come from
+
+Everything above about CalendarBridge comes from their own public pages, and everything about Keeper.sh comes from our code and our pricing. All of it was checked on the date this post was published, and prices and features change, so follow the links if a detail matters to your decision.
+
+- CalendarBridge supported calendars, sync speeds, apps, SOC 2 Type 1, HIPAA and GCC High: [calendarbridge.com](https://calendarbridge.com/)
+- CalendarBridge individual plans, prices, calendar counts and the HIPAA BAA tier: [calendarbridge.com/pricing-individual](https://calendarbridge.com/pricing-individual/)
+- CalendarBridge group plans and admin management: [calendarbridge.com/pricing-group](https://calendarbridge.com/pricing-group/)
+- CalendarBridge scheduling pages: [calendarbridge.com/scheduling-pages-for-people-with-multiple-calendars](https://calendarbridge.com/scheduling-pages-for-people-with-multiple-calendars/)
+- CalendarBridge security overview: [calendarbridge.com/calendarbridge-security-overview](https://calendarbridge.com/calendarbridge-security-overview/)
+- Keeper.sh plans and limits: [keeper.sh](https://www.keeper.sh/)
+- Keeper.sh code, licence and self-hosting guide: [github.com/ridafkih/keeper.sh](https://github.com/ridafkih/keeper.sh)

--- a/applications/web/src/content/blog/keeper-sh-vs-calendarbridge.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-calendarbridge.mdx
@@ -14,43 +14,31 @@ tags:
 
 You keep two or three calendars and you are tired of double bookings. Keeper.sh and CalendarBridge both fix that by mirroring your busy time between them.
 
-They are close on the basics and far apart on nearly everything else, and this page is an honest read on both. CalendarBridge deserves credit for one thing up front. They publish real per-calendar sync speeds on their own site instead of saying "real-time" and leaving it there, and we are aiming for that same standard here.
-
-## What each product actually is
-
-Keeper.sh mirrors busy time between calendars, and it is open source under AGPL-3.0, so you can run it on your own server.
-
-CalendarBridge does that too, and then keeps going. It adds scheduling pages, a unified calendar app, an AI scheduling assistant, and plans built for organisations where an admin manages everyone's connections.
-
-The short version is that CalendarBridge is a wider product with compliance credentials, while Keeper.sh is narrower, cheaper and open.
+CalendarBridge is a wider product with compliance credentials, and Keeper.sh is narrower, cheaper and open source under AGPL-3.0. They deserve credit for one thing up front: they publish real per-calendar sync speeds instead of saying "real-time" and leaving it there.
 
 ## Which calendars can you connect?
 
-CalendarBridge connects Google Calendar, Microsoft 365 for Business, Microsoft personal accounts on outlook.com, hotmail.com, live.com and msn.com, and iCloud. They note that Microsoft 365 personal and family plans cannot be supported, because those plans do not expose a calendar over the internet.
+CalendarBridge connects Google Calendar, Microsoft 365 for Business, Microsoft personal accounts on outlook.com, hotmail.com, live.com and msn.com, and iCloud. Microsoft 365 personal and family plans cannot be supported, because those plans do not expose a calendar over the internet.
 
 For anything else, their answer is a `.ics` link, which reads a calendar but cannot write to one.
 
-Keeper.sh connects Google, Outlook, iCloud and Fastmail, plus any CalDAV server and any public `.ics` link.
-
-The difference that matters here is CalDAV. On Nextcloud, Fastmail, Zimbra, Radicale or a server you run yourself, Keeper.sh can both read and write, where a `.ics` link only ever reads.
+Keeper.sh connects Google, Outlook, iCloud and Fastmail, plus any CalDAV server and any public `.ics` link. That is the difference that matters. On Nextcloud, Fastmail, Zimbra, Radicale or a server you run yourself, we can both read and write.
 
 ## How fast do changes show up?
 
 CalendarBridge is real-time from Google and Microsoft calendars, and their site says changes typically reach the other calendar within a minute or two. From iCloud and `.ics` calendars, they sync every 5 to 10 minutes.
 
-Keeper.sh reads your calendars every minute on every plan, free included. Writing to the other calendar is the part that changes with your plan. On the free plan a change lands within 30 minutes, and on Pro it lands within a minute.
+Keeper.sh reads your calendars every minute on every plan, free included. Writing to the other calendar is the part that changes with your plan: within 30 minutes on free, within a minute on Pro.
 
-So Keeper.sh Pro and CalendarBridge are roughly matched on Google and Microsoft calendars. On iCloud and `.ics` calendars, Keeper.sh Pro is the faster of the two. On our free plan we are slower than both, and 30 minutes is a long wait if you are booking meetings live.
+So Keeper.sh Pro and CalendarBridge are roughly matched on Google and Microsoft. On iCloud and `.ics` calendars we are faster. On our free plan we are slower than both, and 30 minutes is a long wait if you are booking meetings live.
 
 ## What does it cost?
 
 CalendarBridge charges per month for a fixed number of calendars. Basic is $5 for 2 calendars, Premium is $10 for 5, and Pro is $40 for 8. Paying yearly takes 20% off, which makes those $4, $8 and $32 a month.
 
-Their unified calendar view is capped separately, at 4, 12 and 24 calendars depending on plan. There is no free plan listed on their pricing page, though you can start a trial without a card.
+Their unified calendar view is capped separately, at 4, 12 and 24 calendars depending on plan. There is no free plan on their pricing page, though you can start a trial without a card.
 
-Keeper.sh is free for 2 linked accounts and 3 connections, with no cap on how many calendars each account exposes. Keeper.sh Pro is $5 a month, or $42 a year, which works out to $3.50 a month.
-
-Pro removes the limits entirely, so six accounts and a dozen connections cost the same $5 as two of each. That is the sharpest contrast between the two products. On CalendarBridge more calendars means a higher tier, and on Keeper.sh it does not.
+Keeper.sh is free for 2 linked accounts and 3 connections, with no cap on how many calendars each account exposes. Pro is $5 a month, or $42 a year, and removes the limits entirely, so six accounts and a dozen connections cost the same as two of each.
 
 ## Where CalendarBridge is the better pick
 
@@ -64,17 +52,17 @@ These advantages are real, and they are not ones we can talk our way out of.
 
 **You work in government or defence.** CalendarBridge supports Microsoft 365 Government Community Cloud High, which Keeper.sh does not and is not planning to.
 
-**Procurement will ask you for paperwork.** CalendarBridge lists a verified SOC 2 Type 1 and offers a trust centre on request, and we have neither of those today.
+**Procurement will ask you for paperwork.** CalendarBridge lists a verified SOC 2 Type 1 and offers a trust centre on request, and we have neither today.
 
 **You are buying for a whole team.** Their group plans let an admin set up and manage everyone's connections on a single bill, with no end-user involvement. Keeper.sh has no team management at all.
 
-**You want one screen showing every calendar.** Their unified calendar app does exactly that, where Keeper.sh gives you a feed to subscribe to rather than an app to look at.
+**You want one screen showing every calendar.** Their unified calendar app does exactly that, where Keeper.sh gives you a feed to subscribe to.
 
 ## Where Keeper.sh is the better pick
 
-**Your calendar speaks CalDAV.** This is the clearest reason to choose us, because Fastmail and Nextcloud servers can be written to by Keeper.sh and only read through a link by CalendarBridge.
+**Your calendar speaks CalDAV.** Fastmail and Nextcloud servers can be written to by Keeper.sh, and only read through a link by CalendarBridge.
 
-**You want to try it for free, indefinitely.** Two accounts and three connections cost nothing and never expire, and plenty of people never need more than that.
+**You want to try it for free, indefinitely.** Two accounts and three connections cost nothing and never expire, and plenty of people never need more.
 
 **You have a lot of calendars.** Eight calendars is $40 a month on CalendarBridge Pro and $5 a month on Keeper.sh Pro. If your setup is wide rather than complicated, that gap gets large quickly.
 
@@ -90,55 +78,37 @@ These are the symptoms first, so you can spot your own case in them.
 
 **You invite five people and the mirrored copy has no attendees.** We do not copy attendees, video call links or reminders. Only the title, description, location, times and busy status cross over.
 
-**You change an event on the mirrored side and the change vanishes.** Each connection runs in one direction, so to keep two calendars feeding each other you set up two connections, one each way.
+**You change an event on the mirrored side and the change vanishes.** Each connection runs in one direction, so two calendars feeding each other means two connections.
 
-**You want real event titles on the other calendar and the setting is locked.** Controlling what shows up there is a Pro feature, and free accounts take the default.
+**You want real event titles on the other calendar and the setting is locked.** A connected calendar arrives anonymised, and controlling what shows up is a Pro feature.
 
 **Your weekly standup appears as fifty separate events.** We copy each occurrence individually rather than as a repeating series.
 
-**You want scheduling pages, apps, a BAA or GCC High.** We have none of these, so read the CalendarBridge section above again.
+**You want scheduling pages, apps, a BAA or GCC High.** We have none of these.
 
 ## Running Keeper.sh yourself
 
-Keeper.sh is AGPL-3.0 and built to be self-hosted, and this is a real option rather than a stripped-down teaser.
+Keeper.sh is built to be self-hosted, and that is a real option rather than a stripped-down teaser.
 
-Run it yourself and every Pro feature is included at no cost. There is no licence key, no seat count and no phone-home. You get unlimited accounts, unlimited connections, one-minute writes, feed customisation and event filters.
+Run it yourself and every Pro feature is included at no cost. There is no licence key, no seat count and no phone-home. You get unlimited accounts and connections, one-minute writes, feed customisation and event filters, and your calendar data stays on hardware you control.
 
-Your calendar data also stays on hardware you control, which removes the part many people dislike about handing a schedule to a third party.
+Be honest with yourself about the work. You need a server, Postgres, Redis and a domain with TLS, plus your own Google and Microsoft apps for calendar access, which takes an afternoon and involves Google's verification process.
 
-Be honest with yourself about the work involved. You need a server, Postgres, Redis and a domain with TLS. You also register your own Google and Microsoft apps for OAuth, which takes an afternoon and involves Google's verification process.
-
-After that, upgrades, backups and uptime are yours. We ship Docker Compose files and a standalone image to keep the setup short. If that sounds like a good weekend then self-host, and if it sounds like a second job, use hosted keeper.sh for $5 a month.
+After that, upgrades, backups and uptime are yours. We ship Docker Compose files and a standalone image to keep the setup short. If that sounds like a second job, use hosted keeper.sh for $5 a month.
 
 ## FAQ
 
-### Does CalendarBridge support CalDAV?
-
-Their site lists Google, Microsoft 365 for Business, Microsoft personal accounts and iCloud, and suggests a `.ics` link for other providers. A `.ics` link can be read but never written to, while Keeper.sh connects CalDAV servers directly and can write to them.
-
-### Is CalendarBridge faster than Keeper.sh?
-
-On Google and Microsoft they are comparable to Keeper.sh Pro, with both landing changes in about a minute. On iCloud and `.ics` calendars, CalendarBridge syncs every 5 to 10 minutes where Keeper.sh Pro writes every minute. On the Keeper.sh free plan, CalendarBridge is the faster product.
-
-### Does CalendarBridge have a free plan?
-
-Their pricing page lists paid plans starting at $5 a month, and you can start a trial without a card. Keeper.sh has a permanent free tier of 2 linked accounts and 3 connections.
-
 ### Can Keeper.sh sign a HIPAA BAA?
 
-No, and CalendarBridge offers a BAA on its Premium and Pro plans. If your work requires one, that is a decisive reason to choose them over us.
-
-### Does Keeper.sh have scheduling pages?
-
-No, Keeper.sh only mirrors busy time between calendars. CalendarBridge includes up to 10 scheduling pages on every one of its plans.
-
-### Does Keeper.sh sync both directions?
-
-Not in a single step, because each connection runs one way. You create two connections, one in each direction, to keep a pair of calendars feeding each other.
+No, and CalendarBridge offers one on its Premium and Pro plans. If your work requires it, that is a decisive reason to choose them over us.
 
 ### Can I self-host CalendarBridge?
 
 No, CalendarBridge is a hosted commercial product. Keeper.sh is AGPL-3.0 and runs on your own server with every Pro feature included.
+
+### Does Keeper.sh sync both directions?
+
+Not in a single step, because each connection runs one way. You create two connections, one in each direction, to keep a pair of calendars feeding each other.
 
 ### Which one should I pick?
 

--- a/applications/web/src/content/blog/keeper-sh-vs-calendarbridge.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-calendarbridge.mdx
@@ -94,7 +94,7 @@ Run it yourself and every Pro feature is included at no cost. There is no licenc
 
 Be honest with yourself about the work. You need a server, Postgres, Redis and a domain with TLS, plus your own Google and Microsoft apps for calendar access, which takes an afternoon and involves Google's verification process.
 
-After that, upgrades, backups and uptime are yours. We ship Docker Compose files and a standalone image to keep the setup short. If that sounds like a second job, use hosted keeper.sh for $5 a month.
+After that, upgrades, backups and uptime are yours. We ship Docker Compose files and a standalone image to keep the setup short. If that sounds like a second job, use hosted Keeper.sh for $5 a month.
 
 ## FAQ
 

--- a/applications/web/src/content/blog/keeper-sh-vs-onecal.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-onecal.mdx
@@ -12,45 +12,33 @@ tags:
   - "onecal"
 ---
 
-You have a work calendar and a personal one, and you want your busy time to show up in both. Keeper.sh and OneCal both do that job, in noticeably different ways.
+You have a work calendar and a personal one, and you want your busy time to show up in both. Keeper.sh and OneCal both do that job, for different people.
 
-They are also built for different people, and this page lays out the differences without spin. Some of what follows is us telling you to buy the other product, and that is deliberate. If OneCal fits you better, we would rather you find that out here than after a refund request.
-
-## What each product actually is
-
-Keeper.sh keeps your busy time mirrored between calendars, and it is open source under AGPL-3.0, so you can run it on your own server.
-
-OneCal does calendar sync too, and quite a bit more. It adds booking links, a unified calendar view, phone and desktop apps, and admin tools for teams. It is a commercial product with no free plan.
-
-The short version is that OneCal is a broader scheduling suite, while Keeper.sh is a focused sync tool that connects to more kinds of calendar.
+OneCal is a broader scheduling suite with booking links, apps and admin tools. Keeper.sh is a focused sync tool, open source under AGPL-3.0, that connects to more kinds of calendar. Some of what follows is us telling you to buy the other product.
 
 ## Which calendars can you connect?
 
-OneCal connects Google Calendar, Microsoft Outlook Calendar and Apple iCloud Calendar. That is the full list on their site, with no CalDAV option and no way to pull in a plain `.ics` feed.
+OneCal connects Google Calendar, Microsoft Outlook Calendar and Apple iCloud Calendar. That is the full list on their site, with no CalDAV option and no way to add a plain `.ics` feed.
 
-Keeper.sh connects Google, Outlook, iCloud and Fastmail, plus any CalDAV server and any public `.ics` or iCal link.
+Keeper.sh connects Google, Outlook, iCloud and Fastmail, plus any CalDAV server and any public `.ics` or iCal link. If your calendar lives on Fastmail, Nextcloud, Zimbra, Radicale or your university's server, OneCal cannot see it and we can.
 
-That last part is the real gap between the two products. If your calendar lives on Fastmail, Nextcloud, Zimbra, Radicale or your university's CalDAV server, OneCal cannot see it and Keeper.sh can.
-
-One caveat on our side: an `.ics` link is read-only by nature, so Keeper.sh can read events from it but never write to it.
+One caveat on our side: an `.ics` link is read-only by nature, so Keeper.sh reads events from it but never writes to it.
 
 ## How fast do changes show up?
 
 OneCal syncs changes as they happen on Google and Outlook. For iCloud, their site says updates take up to 10 minutes to reach your other calendars.
 
-Keeper.sh works on a timer instead, reading your calendars every minute on every plan, including the free one. Writing to the other calendar is the part that changes with your plan. On the free plan a change lands within 30 minutes, and on Pro it lands within a minute.
+Keeper.sh works on a timer, reading your calendars every minute on every plan including the free one. Writing to the other calendar is the part that changes with your plan: within 30 minutes on free, within a minute on Pro.
 
-So on Google and Outlook, OneCal is faster than Keeper.sh Pro and much faster than Keeper.sh free. On iCloud the two are closer. If you book meetings back to back and need the block to appear instantly, that speed difference is worth paying for.
+So on Google and Outlook, OneCal is faster than Keeper.sh Pro and much faster than our free plan. On iCloud the two are closer. If you book meetings back to back and need the block to appear instantly, that difference is worth paying for.
 
 ## What does it cost?
 
-OneCal has no free tier, and every plan starts with a 14-day trial that needs no card.
+OneCal has no free tier, and every plan starts with a 14-day trial that needs no card. Their annual prices are $5, $10 and $25 per user per month, for 2, 5 and 50 calendars. Billed monthly, the same three plans are $6, $12 and $30 per user.
 
-Their annual prices are $5, $10 and $25 per user per month, for 2, 5 and 50 calendars. Billed monthly, the same three plans are $6, $12 and $30 per user.
+Keeper.sh is free for 2 linked accounts and 3 connections, with no limit on how many calendars each account exposes. Pro is $5 a month, or $42 a year, and it removes the account and connection limits and speeds writes up to every minute.
 
-Keeper.sh is free for 2 linked accounts and 3 connections, with no limit on how many calendars each account exposes. Keeper.sh Pro is $5 a month, or $42 a year, which works out to $3.50 a month. Pro removes the account and connection limits and speeds writes up to every minute.
-
-Note that the calendar counts are not comparable, because OneCal counts calendars while we count accounts and connections. Two Google accounts with six calendars between them is a 5-calendar OneCal plan, and fits inside the Keeper.sh free tier.
+The calendar counts are not comparable, because OneCal counts calendars and we count accounts and connections. Two Google accounts with six calendars between them is a 5-calendar OneCal plan, and fits inside the Keeper.sh free tier.
 
 ## Where OneCal is the better pick
 
@@ -64,7 +52,7 @@ These are real advantages, and no amount of feature-matching on our side changes
 
 **Your security review has teeth.** OneCal publishes a data security page, a data processing addendum and a subprocessor list, states that it is GDPR compliant, and says its SOC 2 audit is in progress. We publish none of that today.
 
-**You wanted the AI angle.** OneCal ships an MCP server with 8 tools for reading calendars and creating, updating, deleting and responding to events. We ship one too, so treat this as a tie rather than a reason to pick us.
+**You wanted the AI angle.** OneCal ships an MCP server with 8 tools for reading calendars and creating, updating, deleting and responding to events. We ship a REST API and an MCP server too, so treat this as a tie.
 
 ## Where Keeper.sh is the better pick
 
@@ -72,9 +60,9 @@ These are real advantages, and no amount of feature-matching on our side changes
 
 **You want to try it without handing over a card.** Two accounts and three connections stay free indefinitely, which is where most people with one work calendar and one personal calendar stay.
 
-**You do not want to think about per-calendar pricing.** Link an account and every calendar on it is available to you. Nothing gets more expensive because you made a new calendar this morning.
+**You do not want to think about per-calendar pricing.** Link an account and every calendar on it is available. Nothing gets more expensive because you made a new calendar this morning.
 
-**You want to pull your schedule somewhere else.** Keeper.sh gives you one iCal feed covering every calendar you opt in, subscribable from anything that reads a calendar link.
+**You want your schedule available somewhere else.** Keeper.sh gives you one iCal feed covering every calendar you opt in, subscribable from anything that reads a calendar link.
 
 **You want to read the code.** Keeper.sh is AGPL-3.0, so you can see exactly how your events are handled and file an issue when we get it wrong.
 
@@ -82,53 +70,35 @@ These are real advantages, and no amount of feature-matching on our side changes
 
 These are the symptoms, so you can recognise your own situation in them.
 
-**You invite three people to a meeting, and the copy on your other calendar has no attendees.** We do not copy attendees, and the same goes for video call links and reminders. Only the title, description, location, times and busy status cross over.
+**You invite three people to a meeting, and the copy on your other calendar has no attendees.** We do not copy attendees, video call links or reminders. Only the title, description, location, times and busy status cross over.
 
-**You edit an event on the mirrored side and your change disappears.** Each connection runs in one direction only, so if you want both calendars to feed each other, you set up two connections, one each way.
+**You edit an event on the mirrored side and your change disappears.** Each connection runs in one direction only, so two calendars feeding each other means two connections.
 
-**You want the other calendar to show real event titles, and the option is greyed out.** Choosing what shows up on the other calendar is a Pro feature, and on the free plan you take the default.
+**You want the other calendar to show real event titles, and the option is greyed out.** A connected calendar arrives anonymised, and changing what shows up is a Pro feature.
 
 **Your recurring meeting looks like a wall of separate events.** We copy each occurrence as its own event rather than as a repeating series.
 
-**You want a booking page, or an app, or single sign-on.** We have none of these, so read the OneCal section above again.
+**You want a booking page, or an app, or single sign-on.** We have none of these.
 
 ## Running Keeper.sh yourself
 
-Keeper.sh is AGPL-3.0 and designed to be self-hosted, and this is a genuine option rather than a stripped-down demo.
+Keeper.sh is designed to be self-hosted, and that is a genuine option rather than a stripped-down demo.
 
-Every Pro feature is included when you run it yourself, at no cost. There is no licence key, no seat count and no phone-home. You get unlimited accounts, unlimited connections, one-minute writes, feed customisation and event filters.
+Every Pro feature is included when you run it yourself, at no cost. There is no licence key, no seat count and no phone-home. You get unlimited accounts and connections, one-minute writes, feed customisation and event filters, and your events stay on hardware you control.
 
-Your events also stay on hardware you control, which for many people is the entire argument for not handing a calendar to a third party.
+Be realistic about the effort. You will need a server, a Postgres database, Redis and a domain with TLS. You also register your own Google and Microsoft apps for calendar access, which takes an afternoon and involves Google's verification process.
 
-Be realistic about the effort involved. You will need a server, a Postgres database, Redis and a domain with TLS. You also register your own Google and Microsoft apps for OAuth credentials, which takes an afternoon and involves Google's verification process.
-
-After that, upgrades, backups and uptime are yours forever. We ship Docker Compose files and a standalone image to keep the setup as short as we can. If that read like a fun weekend, self-hosting suits you, and if it read like a chore, use hosted keeper.sh for $5 a month.
+After that, upgrades, backups and uptime are yours forever. We ship Docker Compose files and a standalone image to keep the setup short. If that read like a chore, use hosted keeper.sh for $5 a month.
 
 ## FAQ
 
-### Does OneCal support CalDAV or ICS calendars?
+### Can I self-host OneCal?
 
-No, OneCal lists only Google Calendar, Microsoft Outlook Calendar and Apple iCloud Calendar. Keeper.sh supports those three, plus Fastmail, any CalDAV server and any public `.ics` link.
-
-### Is OneCal faster than Keeper.sh?
-
-On Google and Outlook, yes, because OneCal syncs changes as they happen. Keeper.sh writes every minute on Pro and every 30 minutes on free. On iCloud, OneCal's own site says up to 10 minutes, which puts the two products much closer together.
-
-### Does OneCal have a free plan?
-
-No, though OneCal offers a 14-day free trial on every plan with no card required, after which you pick a paid plan. Keeper.sh has a permanent free tier of 2 accounts and 3 connections.
-
-### Can I get booking links from Keeper.sh?
-
-No, Keeper.sh only mirrors busy time between calendars. If you need scheduling links for other people to book you, OneCal includes them on every plan.
+No, OneCal is a hosted commercial product with no free plan. Keeper.sh is AGPL-3.0 and can be run on your own server with every Pro feature included.
 
 ### Does Keeper.sh sync both directions?
 
 Not in one step, because each connection runs one way. You create two connections, one in each direction, to keep a pair of calendars feeding each other.
-
-### Can I self-host OneCal?
-
-No, OneCal is a hosted commercial product. Keeper.sh is AGPL-3.0 and can be run on your own server with every Pro feature included.
 
 ### Which one should I pick?
 

--- a/applications/web/src/content/blog/keeper-sh-vs-onecal.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-onecal.mdx
@@ -1,0 +1,148 @@
+---
+title: "Keeper.sh vs OneCal"
+description: "An honest comparison of Keeper.sh and OneCal: which calendars each one connects, how fast changes land, what they cost, and which one fits you better."
+blurb: "OneCal has mobile apps, booking links and single sign-on. Keeper.sh has CalDAV, ICS feeds, a free tier and an open-source codebase you can run yourself. Here is a straight comparison."
+createdAt: "2026-08-11"
+slug: "keeper-sh-vs-onecal"
+updatedAt: "2026-08-11"
+tags:
+  - "calendar"
+  - "comparison"
+  - "sync"
+  - "onecal"
+---
+
+You have a work calendar and a personal one, and you want your busy time to show up in both. Keeper.sh and OneCal both do that job, in noticeably different ways.
+
+They are also built for different people, and this page lays out the differences without spin. Some of what follows is us telling you to buy the other product, and that is deliberate. If OneCal fits you better, we would rather you find that out here than after a refund request.
+
+## What each product actually is
+
+Keeper.sh keeps your busy time mirrored between calendars, and it is open source under AGPL-3.0, so you can run it on your own server.
+
+OneCal does calendar sync too, and quite a bit more. It adds booking links, a unified calendar view, phone and desktop apps, and admin tools for teams. It is a commercial product with no free plan.
+
+The short version is that OneCal is a broader scheduling suite, while Keeper.sh is a focused sync tool that connects to more kinds of calendar.
+
+## Which calendars can you connect?
+
+OneCal connects Google Calendar, Microsoft Outlook Calendar and Apple iCloud Calendar. That is the full list on their site, with no CalDAV option and no way to pull in a plain `.ics` feed.
+
+Keeper.sh connects Google, Outlook, iCloud and Fastmail, plus any CalDAV server and any public `.ics` or iCal link.
+
+That last part is the real gap between the two products. If your calendar lives on Fastmail, Nextcloud, Zimbra, Radicale or your university's CalDAV server, OneCal cannot see it and Keeper.sh can.
+
+One caveat on our side: an `.ics` link is read-only by nature, so Keeper.sh can read events from it but never write to it.
+
+## How fast do changes show up?
+
+OneCal syncs changes as they happen on Google and Outlook. For iCloud, their site says updates take up to 10 minutes to reach your other calendars.
+
+Keeper.sh works on a timer instead, reading your calendars every minute on every plan, including the free one. Writing to the other calendar is the part that changes with your plan. On the free plan a change lands within 30 minutes, and on Pro it lands within a minute.
+
+So on Google and Outlook, OneCal is faster than Keeper.sh Pro and much faster than Keeper.sh free. On iCloud the two are closer. If you book meetings back to back and need the block to appear instantly, that speed difference is worth paying for.
+
+## What does it cost?
+
+OneCal has no free tier, and every plan starts with a 14-day trial that needs no card.
+
+Their annual prices are $5, $10 and $25 per user per month, for 2, 5 and 50 calendars. Billed monthly, the same three plans are $6, $12 and $30 per user.
+
+Keeper.sh is free for 2 linked accounts and 3 connections, with no limit on how many calendars each account exposes. Keeper.sh Pro is $5 a month, or $42 a year, which works out to $3.50 a month. Pro removes the account and connection limits and speeds writes up to every minute.
+
+Note that the calendar counts are not comparable, because OneCal counts calendars while we count accounts and connections. Two Google accounts with six calendars between them is a 5-calendar OneCal plan, and fits inside the Keeper.sh free tier.
+
+## Where OneCal is the better pick
+
+These are real advantages, and no amount of feature-matching on our side changes them.
+
+**You want a phone in your pocket that shows everything.** OneCal ships an iOS app, an Android app and a macOS app, included on every plan. Keeper.sh has no apps at all, so you manage it in a browser.
+
+**You want other people to book time with you.** OneCal includes unlimited one-on-one and collective scheduling links, with buffers, custom availability and minimum notice periods. Keeper.sh has nothing like this and is not building it.
+
+**You are buying for a team.** OneCal supports OIDC and SAML single sign-on, SCIM directory sync, audit logs and an admin dashboard for managing your team's accounts. Keeper.sh is built for one person at a time.
+
+**Your security review has teeth.** OneCal publishes a data security page, a data processing addendum and a subprocessor list, states that it is GDPR compliant, and says its SOC 2 audit is in progress. We publish none of that today.
+
+**You wanted the AI angle.** OneCal ships an MCP server with 8 tools for reading calendars and creating, updating, deleting and responding to events. We ship one too, so treat this as a tie rather than a reason to pick us.
+
+## Where Keeper.sh is the better pick
+
+**Your calendar is not Google, Outlook or iCloud.** CalDAV and `.ics` support is the clearest reason to choose us. If OneCal cannot connect your calendar, nothing else about it matters.
+
+**You want to try it without handing over a card.** Two accounts and three connections stay free indefinitely, which is where most people with one work calendar and one personal calendar stay.
+
+**You do not want to think about per-calendar pricing.** Link an account and every calendar on it is available to you. Nothing gets more expensive because you made a new calendar this morning.
+
+**You want to pull your schedule somewhere else.** Keeper.sh gives you one iCal feed covering every calendar you opt in, subscribable from anything that reads a calendar link.
+
+**You want to read the code.** Keeper.sh is AGPL-3.0, so you can see exactly how your events are handled and file an issue when we get it wrong.
+
+## What Keeper.sh will not do for you
+
+These are the symptoms, so you can recognise your own situation in them.
+
+**You invite three people to a meeting, and the copy on your other calendar has no attendees.** We do not copy attendees, and the same goes for video call links and reminders. Only the title, description, location, times and busy status cross over.
+
+**You edit an event on the mirrored side and your change disappears.** Each connection runs in one direction only, so if you want both calendars to feed each other, you set up two connections, one each way.
+
+**You want the other calendar to show real event titles, and the option is greyed out.** Choosing what shows up on the other calendar is a Pro feature, and on the free plan you take the default.
+
+**Your recurring meeting looks like a wall of separate events.** We copy each occurrence as its own event rather than as a repeating series.
+
+**You want a booking page, or an app, or single sign-on.** We have none of these, so read the OneCal section above again.
+
+## Running Keeper.sh yourself
+
+Keeper.sh is AGPL-3.0 and designed to be self-hosted, and this is a genuine option rather than a stripped-down demo.
+
+Every Pro feature is included when you run it yourself, at no cost. There is no licence key, no seat count and no phone-home. You get unlimited accounts, unlimited connections, one-minute writes, feed customisation and event filters.
+
+Your events also stay on hardware you control, which for many people is the entire argument for not handing a calendar to a third party.
+
+Be realistic about the effort involved. You will need a server, a Postgres database, Redis and a domain with TLS. You also register your own Google and Microsoft apps for OAuth credentials, which takes an afternoon and involves Google's verification process.
+
+After that, upgrades, backups and uptime are yours forever. We ship Docker Compose files and a standalone image to keep the setup as short as we can. If that read like a fun weekend, self-hosting suits you, and if it read like a chore, use hosted keeper.sh for $5 a month.
+
+## FAQ
+
+### Does OneCal support CalDAV or ICS calendars?
+
+No, OneCal lists only Google Calendar, Microsoft Outlook Calendar and Apple iCloud Calendar. Keeper.sh supports those three, plus Fastmail, any CalDAV server and any public `.ics` link.
+
+### Is OneCal faster than Keeper.sh?
+
+On Google and Outlook, yes, because OneCal syncs changes as they happen. Keeper.sh writes every minute on Pro and every 30 minutes on free. On iCloud, OneCal's own site says up to 10 minutes, which puts the two products much closer together.
+
+### Does OneCal have a free plan?
+
+No, though OneCal offers a 14-day free trial on every plan with no card required, after which you pick a paid plan. Keeper.sh has a permanent free tier of 2 accounts and 3 connections.
+
+### Can I get booking links from Keeper.sh?
+
+No, Keeper.sh only mirrors busy time between calendars. If you need scheduling links for other people to book you, OneCal includes them on every plan.
+
+### Does Keeper.sh sync both directions?
+
+Not in one step, because each connection runs one way. You create two connections, one in each direction, to keep a pair of calendars feeding each other.
+
+### Can I self-host OneCal?
+
+No, OneCal is a hosted commercial product. Keeper.sh is AGPL-3.0 and can be run on your own server with every Pro feature included.
+
+### Which one should I pick?
+
+Pick OneCal if you need mobile apps, booking links, or single sign-on for a team. Pick Keeper.sh if you need CalDAV or `.ics` calendars, want a free tier, or want to run the whole thing yourself.
+
+## Where these facts come from
+
+Everything above about OneCal comes from their own public pages, and everything about Keeper.sh comes from our code and our pricing. All of it was checked on the date this post was published, and prices and features change, so follow the links if a detail matters to your decision.
+
+- OneCal plans, prices, calendar counts, trial, apps, single sign-on, SCIM and audit logs: [onecal.io/pricing](https://www.onecal.io/pricing)
+- OneCal supported calendars and sync speed, including the iCloud figure: [onecal.io](https://www.onecal.io/)
+- OneCal mobile apps: [onecal.io/mobile-apps](https://www.onecal.io/mobile-apps)
+- OneCal booking and scheduling links: [onecal.io/scheduling-links](https://www.onecal.io/scheduling-links)
+- OneCal security posture, GDPR and SOC 2 status: [onecal.io/data-security](https://www.onecal.io/data-security)
+- OneCal MCP server and its 8 tools: [onecal.io/integrations/calendar-mcp-server](https://www.onecal.io/integrations/calendar-mcp-server)
+- Keeper.sh plans and limits: [keeper.sh](https://www.keeper.sh/)
+- Keeper.sh code, licence and self-hosting guide: [github.com/ridafkih/keeper.sh](https://github.com/ridafkih/keeper.sh)

--- a/applications/web/src/content/blog/keeper-sh-vs-onecal.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-onecal.mdx
@@ -88,7 +88,7 @@ Every Pro feature is included when you run it yourself, at no cost. There is no 
 
 Be realistic about the effort. You will need a server, a Postgres database, Redis and a domain with TLS. You also register your own Google and Microsoft apps for calendar access, which takes an afternoon and involves Google's verification process.
 
-After that, upgrades, backups and uptime are yours forever. We ship Docker Compose files and a standalone image to keep the setup short. If that read like a chore, use hosted keeper.sh for $5 a month.
+After that, upgrades, backups and uptime are yours forever. We ship Docker Compose files and a standalone image to keep the setup short. If that read like a chore, use hosted Keeper.sh for $5 a month.
 
 ## FAQ
 


### PR DESCRIPTION
Adds two comparison posts to the blog: `keeper-sh-vs-onecal` and `keeper-sh-vs-calendarbridge`. Every claim about the other product is cited to that company's own public pages, and each post states plainly where they beat us rather than only where we win. Our own numbers were checked against the code, not the marketing site.

- FAQs are `## FAQ` with `###` questions so the collapsible component converts them mechanically
- Both posts start at `##`; the page supplies the H1
- Sitemap picks both up automatically; `plugins/sitemap.ts` untouched
- `bun run types`, `bun run lint` and the web build pass; both routes serve 200 and appear in the built sitemap
