### PR TITLE
fix: normalize canonical URL joins in seo.ts

### DIFF
--- a/applications/web/src/lib/seo.ts
+++ b/applications/web/src/lib/seo.ts
@@ -3,7 +3,12 @@ const SITE_NAME = "Keeper.sh";
 const DEFAULT_IMAGE_PATH = "/open-graph.png";
 
 export function canonicalUrl(path: string): string {
-  return `${SITE_URL}${path}`;
+  return `${SITE_URL}/${path.replace(/^\/+/, "")}`;
+}
+
+function entityId(path: string, fragment: string): string {
+  const url = canonicalUrl(path);
+  return `${url.endsWith("/") ? url : `${url}/`}#${fragment}`;
 }
 
 export function jsonLdScript(data: Record<string, unknown>) {
@@ -92,7 +97,7 @@ export function webPageSchema(name: string, description: string, path: string) {
   return {
     "@context": "https://schema.org",
     "@type": "WebPage",
-    "@id": `${canonicalUrl(path)}/#webpage`,
+    "@id": entityId(path, "webpage"),
     name,
     description,
     url: canonicalUrl(path),
@@ -168,7 +173,7 @@ export function collectionPageSchema(posts: Array<{ slug: string; metadata: { ti
   return {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
-    "@id": `${SITE_URL}/blog/#collectionpage`,
+    "@id": entityId("/blog", "collectionpage"),
     name: "Blog",
     url: canonicalUrl("/blog"),
     isPartOf: { "@id": `${SITE_URL}/#website` },
@@ -205,7 +210,7 @@ export function blogPostingSchema(post: {
   return {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
-    "@id": `${url}/#blogposting`,
+    "@id": entityId(`/blog/${post.slug}`, "blogposting"),
     headline: post.title,
     description: post.description,
     image: canonicalUrl(post.imagePath ?? DEFAULT_IMAGE_PATH),

--- a/applications/web/tests/lib/seo.test.ts
+++ b/applications/web/tests/lib/seo.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { blogPostingSchema, seoMeta } from "@/lib/seo";
+import {
+  blogPostingSchema,
+  canonicalUrl,
+  collectionPageSchema,
+  seoMeta,
+  webPageSchema,
+} from "@/lib/seo";
 
 const GENERIC_IMAGE_URL = "https://www.keeper.sh/open-graph.png";
 
@@ -16,6 +22,25 @@ function findMeta(meta: ReturnType<typeof seoMeta>, key: string) {
   return meta.find((entry) => "property" in entry && entry.property === key
     || "name" in entry && entry.name === key);
 }
+
+describe("canonicalUrl", () => {
+  it("keeps the trailing slash on the homepage", () => {
+    expect(canonicalUrl("/")).toBe("https://www.keeper.sh/");
+  });
+
+  it("treats an empty path as the homepage", () => {
+    expect(canonicalUrl("")).toBe("https://www.keeper.sh/");
+  });
+
+  it("preserves nested paths verbatim", () => {
+    expect(canonicalUrl("/blog/why-keeper")).toBe("https://www.keeper.sh/blog/why-keeper");
+    expect(canonicalUrl("/pricing/")).toBe("https://www.keeper.sh/pricing/");
+  });
+
+  it("collapses duplicate leading slashes", () => {
+    expect(canonicalUrl("//pricing")).toBe("https://www.keeper.sh/pricing");
+  });
+});
 
 describe("seoMeta", () => {
   it("falls back to the generic share image", () => {
@@ -72,6 +97,19 @@ describe("seoMeta", () => {
   });
 });
 
+describe("webPageSchema", () => {
+  it("builds a fragment identifier without a double slash", () => {
+    expect(webPageSchema("Home", "Home page", "/")["@id"]).toBe("https://www.keeper.sh/#webpage");
+    expect(webPageSchema("Home", "Home page", "")["@id"]).toBe("https://www.keeper.sh/#webpage");
+  });
+
+  it("keeps the published identifier for nested pages", () => {
+    const schema = webPageSchema("Privacy Policy", "Privacy policy", "/privacy");
+    expect(schema["@id"]).toBe("https://www.keeper.sh/privacy/#webpage");
+    expect(schema.url).toBe("https://www.keeper.sh/privacy");
+  });
+});
+
 describe("blogPostingSchema", () => {
   it("falls back to the generic share image", () => {
     expect(blogPostingSchema(post).image).toBe(GENERIC_IMAGE_URL);
@@ -86,5 +124,24 @@ describe("blogPostingSchema", () => {
     ).toBe(
       "https://www.keeper.sh/open-graph/how-calendar-sync-actually-works.png",
     );
+  });
+
+  it("keeps the published identifier", () => {
+    const schema = blogPostingSchema({
+      title: "Why Keeper",
+      description: "A post",
+      slug: "why-keeper",
+      createdAt: "2026-01-01",
+      updatedAt: "2026-01-02",
+      tags: ["calendar"],
+    });
+    expect(schema["@id"]).toBe("https://www.keeper.sh/blog/why-keeper/#blogposting");
+    expect(schema.url).toBe("https://www.keeper.sh/blog/why-keeper");
+  });
+});
+
+describe("collectionPageSchema", () => {
+  it("keeps the published identifier", () => {
+    expect(collectionPageSchema([])["@id"]).toBe("https://www.keeper.sh/blog/#collectionpage");
   });
 });


### PR DESCRIPTION
`canonicalUrl` concatenated `SITE_URL` and `path` directly, so the homepage's trailing slash plus the `${canonicalUrl(path)}/#fragment` pattern used by the `@id` builders would have produced `https://www.keeper.sh//#webpage`. Dormant today because those helpers are never called with `"/"`, but it fires the moment one is. The join now goes through a normalized base plus a shared `entityId` helper, so `""`, `"/"`, `"/pricing"` and `"/pricing/"` are all safe.

- `canonicalUrl` strips leading slashes off the path before joining, which keeps `"/"` emitting `https://www.keeper.sh/` for the canonical tag and `og:url` and leaves every other current input byte-identical
- `entityId` adds the separating slash only when the base lacks one, so `webPageSchema`, `blogPostingSchema` and `collectionPageSchema` keep their published `@id` values
- rendered `<link rel="canonical">`, `og:url`, and every JSON-LD `@id`/`url` on `/`, `/blog`, both blog posts, `/privacy` and `/terms` diff clean before vs. after, as does the built `sitemap.xml`
- `plugins/sitemap.ts` builds its own URLs but from literal paths and bare frontmatter slugs, so it has no equivalent join; left alone
- added `tests/lib/seo.test.ts` covering the normalization and pinning the currently-published `@id` values