### PR TITLE
fix: reset scroll position on navigation

### DIFF
--- a/applications/web/src/router.ts
+++ b/applications/web/src/router.ts
@@ -131,7 +131,8 @@ export function createAppRouter(options: CreateAppRouterOptions = {}) {
     context: buildRouterContext(options.request, options.viteAssets),
     defaultPreload: "intent",
     routeTree,
-    scrollRestoration: false,
+    scrollRestoration: true,
+    scrollToTopSelectors: ["body"],
   });
 
   return router;

--- a/applications/web/src/routes/__root.tsx
+++ b/applications/web/src/routes/__root.tsx
@@ -1,6 +1,5 @@
-import { HeadContent, Outlet, Scripts, createRootRouteWithContext, useLocation } from "@tanstack/react-router";
+import { HeadContent, Outlet, Scripts, createRootRouteWithContext } from "@tanstack/react-router";
 import type { ErrorComponentProps } from "@tanstack/react-router";
-import { useEffect } from "react";
 import { SWRConfig } from "swr";
 import { Heading2 } from "@/components/ui/primitives/heading";
 import { Text } from "@/components/ui/primitives/text";
@@ -96,7 +95,6 @@ function RootComponent() {
       <body>
         <div id="root">
           <SWRConfig value={SWR_CONFIG}>
-            <ScrollToTopOnNavigation />
             <Outlet />
           </SWRConfig>
         </div>
@@ -108,20 +106,6 @@ function RootComponent() {
       </body>
     </html>
   );
-}
-
-function ScrollToTopOnNavigation() {
-  const location = useLocation();
-
-  useEffect(() => {
-    if (location.hash.length > 0) {
-      return;
-    }
-
-    window.scrollTo({ left: 0, top: 0, behavior: "auto" });
-  }, [location.hash, location.pathname]);
-
-  return null;
 }
 
 function ErrorFallback({ error }: ErrorComponentProps) {


### PR DESCRIPTION
Clicking a footer link from the bottom of a marketing page left the new route scrolled to the bottom. `body` is the scroll container here (`height: 100dvh; overflow-y: scroll` in `index.css`), not the viewport, so the `window.scrollTo` effect in `__root.tsx` was scrolling an element that never scrolls. TanStack Router 1.163.3 only wires up its scroll handling when `scrollRestoration` is set, so with it `false` we got neither router reset nor native restore (it still forces `history.scrollRestoration = "manual"` regardless).

- Enable `scrollRestoration` and add `scrollToTopSelectors: ["body"]` so the reset pass reaches the real scroller
- Drop the dead `ScrollToTopOnNavigation` effect
- Restoration is per history key, so back returns to the previous offset instead of the top
- Hash links are unaffected: the router scrolls the anchor into view and takes priority over the top reset, so `/#features` and `/#pricing` still work, as will the real routes from #480

Verified in a headless browser against a production build: footer nav from 8676px lands at 0, back restores 3210px exactly, `/#pricing` lands with the section at the top of the viewport, and a fresh SSR load holds at 0 across 1s of sampling with no hydration warnings.