### PR TITLE
feat: add breadcrumb navigation to marketing subpages

### DIFF
--- a/applications/web/src/components/ui/primitives/breadcrumb.tsx
+++ b/applications/web/src/components/ui/primitives/breadcrumb.tsx
@@ -1,0 +1,41 @@
+import { Link } from "@tanstack/react-router";
+import ChevronRight from "lucide-react/dist/esm/icons/chevron-right";
+import type { BreadcrumbTrailItem } from "@/lib/seo";
+import { Text } from "./text";
+
+const crumbLink =
+  "group relative inline-flex items-center rounded-sm after:absolute after:inset-0 after:-mx-2 after:-my-3 after:content-[''] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+type BreadcrumbProps = {
+  items: BreadcrumbTrailItem[];
+  className?: string;
+};
+
+export function Breadcrumb({ items, className }: BreadcrumbProps) {
+  const currentItem = items[items.length - 1];
+  if (!currentItem) {
+    throw new Error("Breadcrumb requires at least one item");
+  }
+
+  return (
+    <nav aria-label="Breadcrumb" className={className}>
+      <ol className="flex flex-wrap items-center gap-x-2 gap-y-1 list-none">
+        {items.slice(0, -1).map((item) => (
+          <li key={item.path} className="inline-flex items-center gap-x-2">
+            <Link to={item.path} activeOptions={{ exact: true }} className={crumbLink}>
+              <Text as="span" size="sm" tone="muted" className="group-hover:text-foreground">
+                {item.name}
+              </Text>
+            </Link>
+            <ChevronRight aria-hidden="true" className="size-3.5 shrink-0 text-foreground-muted" />
+          </li>
+        ))}
+        <li aria-current="page" className="min-w-0" title={currentItem.name}>
+          <Text as="span" size="sm" tone="default" className="block max-w-56 truncate sm:max-w-none">
+            {currentItem.name}
+          </Text>
+        </li>
+      </ol>
+    </nav>
+  );
+}

--- a/applications/web/src/lib/seo.ts
+++ b/applications/web/src/lib/seo.ts
@@ -78,9 +78,13 @@ export const organizationSchema = {
   ],
 };
 
-export function breadcrumbSchema(
-  items: Array<{ name: string; path: string }>,
-) {
+export type BreadcrumbTrailItem = { name: string; path: string };
+
+export function breadcrumbTrail(...items: BreadcrumbTrailItem[]): BreadcrumbTrailItem[] {
+  return [{ name: "Home", path: "/" }, ...items];
+}
+
+export function breadcrumbSchema(items: BreadcrumbTrailItem[]) {
   return {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",

--- a/applications/web/src/routes/(marketing)/blog/$slug.tsx
+++ b/applications/web/src/routes/(marketing)/blog/$slug.tsx
@@ -6,7 +6,11 @@ import { Text } from "@/components/ui/primitives/text";
 import { NotFoundState } from "@/components/ui/shells/not-found";
 import { BlogPostCta } from "@/features/blog/components/blog-post-cta";
 import { findBlogPostBySlug, formatIsoDate } from "@/lib/blog-posts";
-import { canonicalUrl, jsonLdScript, seoMeta, blogPostingSchema, breadcrumbSchema } from "@/lib/seo";
+import { canonicalUrl, jsonLdScript, seoMeta, blogPostingSchema, breadcrumbSchema, breadcrumbTrail } from "@/lib/seo";
+import { Breadcrumb } from "@/components/ui/primitives/breadcrumb";
+
+const blogPostBreadcrumbs = (title: string, slug: string) =>
+  breadcrumbTrail({ name: "Blog", path: "/blog" }, { name: title, path: `/blog/${slug}` });
 
 export const Route = createFileRoute("/(marketing)/blog/$slug")({
   loader: ({ params }) => {
@@ -56,11 +60,7 @@ export const Route = createFileRoute("/(marketing)/blog/$slug")({
           tags: blogPost.metadata.tags,
           imagePath: blogPost.metadata.image,
         })),
-        jsonLdScript(breadcrumbSchema([
-          { name: "Home", path: "/" },
-          { name: "Blog", path: "/blog" },
-          { name: blogPost.metadata.title, path: postUrl },
-        ])),
+        jsonLdScript(breadcrumbSchema(blogPostBreadcrumbs(blogPost.metadata.title, params.slug))),
       ],
     };
   },
@@ -79,6 +79,7 @@ function BlogPostPage() {
 
   return (
     <div className="flex flex-col gap-6 py-16">
+      <Breadcrumb items={blogPostBreadcrumbs(blogPost.metadata.title, slug)} />
       <header className="flex flex-col gap-2">
         <Heading1>{blogPost.metadata.title}</Heading1>
         <div className="flex flex-col">

--- a/applications/web/src/routes/(marketing)/blog/index.tsx
+++ b/applications/web/src/routes/(marketing)/blog/index.tsx
@@ -2,7 +2,10 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { Heading1, Heading3 } from "@/components/ui/primitives/heading";
 import { Text } from "@/components/ui/primitives/text";
 import { blogPosts, formatIsoDate } from "@/lib/blog-posts";
-import { canonicalUrl, jsonLdScript, seoMeta, breadcrumbSchema, collectionPageSchema } from "@/lib/seo";
+import { canonicalUrl, jsonLdScript, seoMeta, breadcrumbSchema, breadcrumbTrail, collectionPageSchema } from "@/lib/seo";
+import { Breadcrumb } from "@/components/ui/primitives/breadcrumb";
+
+const breadcrumbs = breadcrumbTrail({ name: "Blog", path: "/blog" });
 
 const BLOG_ILLUSTRATION_STYLE = {
   backgroundImage:
@@ -19,10 +22,7 @@ export const Route = createFileRoute("/(marketing)/blog/")({
       path: "/blog",
     }),
     scripts: [
-      jsonLdScript(breadcrumbSchema([
-        { name: "Home", path: "/" },
-        { name: "Blog", path: "/blog" },
-      ])),
+      jsonLdScript(breadcrumbSchema(breadcrumbs)),
       jsonLdScript(collectionPageSchema(blogPosts)),
     ],
   }),
@@ -31,6 +31,7 @@ export const Route = createFileRoute("/(marketing)/blog/")({
 function BlogDirectoryPage() {
   return (
     <div className="flex flex-col gap-8 py-16">
+      <Breadcrumb items={breadcrumbs} />
       <header className="flex flex-col gap-1.5">
         <Heading1>Blog</Heading1>
         <Text size="base" tone="muted" className="leading-6">

--- a/applications/web/src/routes/(marketing)/privacy.tsx
+++ b/applications/web/src/routes/(marketing)/privacy.tsx
@@ -2,7 +2,10 @@ import type { PropsWithChildren } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { Heading1, Heading2, Heading3 } from "@/components/ui/primitives/heading";
 import { Text } from "@/components/ui/primitives/text";
-import { canonicalUrl, jsonLdScript, seoMeta, webPageSchema, breadcrumbSchema } from "@/lib/seo";
+import { canonicalUrl, jsonLdScript, seoMeta, webPageSchema, breadcrumbSchema, breadcrumbTrail } from "@/lib/seo";
+import { Breadcrumb } from "@/components/ui/primitives/breadcrumb";
+
+const breadcrumbs = breadcrumbTrail({ name: "Privacy Policy", path: "/privacy" });
 import { privacyPageMetadata, formatMonthYear } from "@/lib/page-metadata";
 
 export const Route = createFileRoute("/(marketing)/privacy")({
@@ -17,7 +20,7 @@ export const Route = createFileRoute("/(marketing)/privacy")({
     }),
     scripts: [
       jsonLdScript(webPageSchema("Privacy Policy", "Privacy policy for Keeper.sh, the open-source calendar syncing service.", "/privacy")),
-      jsonLdScript(breadcrumbSchema([{ name: "Home", path: "/" }, { name: "Privacy Policy", path: "/privacy" }])),
+      jsonLdScript(breadcrumbSchema(breadcrumbs)),
     ],
   }),
 });
@@ -25,6 +28,7 @@ export const Route = createFileRoute("/(marketing)/privacy")({
 function PrivacyPage() {
   return (
     <div className="flex flex-col gap-6 py-16">
+      <Breadcrumb items={breadcrumbs} />
       <div className="flex flex-col gap-1">
         <Heading1>Privacy Policy</Heading1>
         <Text size="sm" tone="muted">Last updated: {formatMonthYear(privacyPageMetadata.updatedAt)}</Text>

--- a/applications/web/src/routes/(marketing)/terms.tsx
+++ b/applications/web/src/routes/(marketing)/terms.tsx
@@ -2,7 +2,10 @@ import type { PropsWithChildren } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { Heading1, Heading2 } from "@/components/ui/primitives/heading";
 import { Text } from "@/components/ui/primitives/text";
-import { canonicalUrl, jsonLdScript, seoMeta, webPageSchema, breadcrumbSchema } from "@/lib/seo";
+import { canonicalUrl, jsonLdScript, seoMeta, webPageSchema, breadcrumbSchema, breadcrumbTrail } from "@/lib/seo";
+import { Breadcrumb } from "@/components/ui/primitives/breadcrumb";
+
+const breadcrumbs = breadcrumbTrail({ name: "Terms & Conditions", path: "/terms" });
 import { termsPageMetadata, formatMonthYear } from "@/lib/page-metadata";
 
 export const Route = createFileRoute("/(marketing)/terms")({
@@ -17,7 +20,7 @@ export const Route = createFileRoute("/(marketing)/terms")({
     }),
     scripts: [
       jsonLdScript(webPageSchema("Terms & Conditions", "Terms and conditions for using Keeper.sh, the open-source calendar syncing service.", "/terms")),
-      jsonLdScript(breadcrumbSchema([{ name: "Home", path: "/" }, { name: "Terms & Conditions", path: "/terms" }])),
+      jsonLdScript(breadcrumbSchema(breadcrumbs)),
     ],
   }),
 });
@@ -25,6 +28,7 @@ export const Route = createFileRoute("/(marketing)/terms")({
 function TermsPage() {
   return (
     <div className="flex flex-col gap-6 py-16">
+      <Breadcrumb items={breadcrumbs} />
       <div className="flex flex-col gap-1">
         <Heading1>Terms &amp; Conditions</Heading1>
         <Text size="sm" tone="muted">Last updated: {formatMonthYear(termsPageMetadata.updatedAt)}</Text>


### PR DESCRIPTION
Users landing on a subpage had no way back up the site, so this adds a `Breadcrumb` primitive and wires it into the blog index, blog post, `/privacy`, and `/terms` (not the homepage). Research across shadcn/ui, the WAI-ARIA APG, and GitHub/MDN docs sites converged on: `nav[aria-label]` + `<ol>`, separators kept out of the a11y tree entirely, and the current page marked `aria-current` rather than being a link — with the one deviation that shadcn's `role="link" aria-disabled` on the current crumb is the part a11y reviewers flag, so the current crumb here is plain non-focusable text.

- Each page builds one `breadcrumbTrail(...)` array that feeds both `<Breadcrumb items={...} />` and `breadcrumbSchema(...)`, so the visible trail and the `BreadcrumbList` JSON-LD cannot drift; `breadcrumbTrail` also prepends the Home crumb that all four pages were repeating by hand.
- Hit targets are 44px tall (WCAG 2.2 AAA / Apple HIG) via an `::after` overlay, so the visual line stays 20px and the breadcrumb reads light. Verified by hit-testing the expanded edges in a real browser; adjacent targets keep a 14px gap.
- Typography comes from `Text` (`size="sm"`); colors are `foreground-muted` for links/separators and `foreground` for the current page. Measured `foreground-muted` at 4.53:1 light and 7.63:1 dark — both pass AA, though light is close enough that these crumbs must not get the `opacity-75` treatment used elsewhere. `foreground-disabled` was rejected for separators at 1.42:1.
- TanStack's `Link` fuzzy-matches ancestors, which marked the `/blog` crumb `aria-current="page"` on post pages alongside the real current crumb; `activeOptions={{ exact: true }}` fixes it. Confirmed one `aria-current` per page.
- Long titles cap at `max-w-56` with `truncate` below `sm` and a `title` fallback, releasing at wider viewports.

Verified on a built-and-served instance at 375px and 1280px: breadcrumbs render on all four pages, links navigate, the current page is not a link, the a11y tree shows `navigation "Breadcrumb" > list > listitem`, and the separator is absent from it. Dark theme was verified from the resolved token values in the stylesheet rather than a rendered dark screenshot — the headless tool's CDP allowlist blocks `prefers-color-scheme` emulation.

`/features` and `/pricing` (#480) and the blog comparison move (#483) can adopt this by replacing their inline `breadcrumbSchema([...])` argument with a shared const and rendering `<Breadcrumb items={breadcrumbs} />` as the first child of the page wrapper.
