### PR TITLE
docs: add Reclaim.ai and Morgen comparison posts

### DIFF
--- a/applications/web/src/content/blog/keeper-sh-vs-morgen.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-morgen.mdx
@@ -1,0 +1,178 @@
+---
+title: "Keeper.sh vs Morgen"
+description: "An honest comparison of Keeper.sh and Morgen for blocking time across work and personal calendars, covering how often each one writes, where your data lives, and native apps."
+blurb: "Morgen has the better calendar app, native apps on five platforms, and Swiss hosting. It copies busy time between calendars once a day at 6pm. That gap is the whole comparison."
+createdAt: "2026-08-11"
+updatedAt: "2026-08-11"
+slug: "keeper-sh-vs-morgen"
+tags:
+  - "comparison"
+  - "morgen"
+  - "calendar"
+  - "sync"
+---
+
+Morgen is a calendar app you install and live in. It shows all your calendars together, plans your day, and pulls in tasks from tools like Notion and Todoist.
+
+Keeper.sh is not a calendar app at all. It runs in the background and keeps busy time visible across the calendars you already use.
+
+Both can block out your personal events on your work calendar. They do it very differently, and the difference is timing.
+
+## How often does each one block out your time?
+
+This is the main reason to read this page, so it goes first.
+
+Morgen's Calendar Propagation workflow "will run daily at 6:00 pm" and covers "the upcoming 14 days" ([Morgen's guide](https://www.morgen.so/guides/how-to-use-morgens-calendar-propagation-workflow)). It runs in one direction, from one calendar to another.
+
+The same guide is upfront about the consequence. When an event is cancelled or moved, "there will be a lag as the workflow runs daily at 6pm".
+
+So a meeting you accept at 9am is not blocked elsewhere until that evening. Anything more than two weeks out is not blocked at all until the day gets close enough.
+
+Keeper reads your calendars every minute, on every plan. It writes copies out every minute on Pro, and every 30 minutes on the free plan.
+
+It also reaches much further ahead. Keeper covers the next two years and the past week, rather than only the next fortnight.
+
+Say you book a dentist appointment at 9am, for 2pm the same day. Your work calendar still looks free at 2pm all morning, because the workflow has not run yet.
+
+That is the case for us over Morgen, and honestly it is the only one that really matters.
+
+## Which calendars can each one connect?
+
+Morgen has the broader list, and it is not close on the task side.
+
+Morgen connects Google Calendar, Outlook Calendar, Apple Calendar, Fastmail, generic CalDAV, and subscription feeds ([integrations](https://www.morgen.so/integrations)). It also connects Notion, Todoist, Obsidian, ClickUp, Linear, Apple Reminders, and more.
+
+Keeper connects Google, Outlook, iCloud, Fastmail, and any CalDAV server. It reads public ICS links but cannot write to them, and it connects no task tools at all.
+
+For calendars specifically, the two lists are close to equal. There is one limit worth noting on Morgen's side. Their own guide says Calendar Propagation supports "Outlook, Google, iCloud, and Fastmail Calendars", which is narrower than the calendars Morgen can display.
+
+## What does a blocked-out copy look like?
+
+Morgen writes a plain placeholder instead of the event. Copies appear as "Private Event (from Morgen)" with no details listed, so you check the original calendar for specifics.
+
+That is a good default to have. Nothing leaks, and you never have to think about it.
+
+Keeper copies the real title, description, and location by default. You can switch each of those off per calendar and swap the title for fixed text or the calendar's name.
+
+Being straight about it: our defaults are less private than Morgen's, and our privacy controls are a Pro feature. On our free plan, a copied event carries its original title.
+
+If you want a quiet blocker and nothing else, Morgen's default does that out of the box.
+
+## Which one has better filtering?
+
+Morgen does, and it is not a close call.
+
+Their guide describes a "Nerd Mode" that lets you add custom filters on things like business hours, event tags, and whether an event has invitees. It also lets you choose between copying every event or only events marked busy.
+
+Keeper's controls are noticeably coarser than that. You can exclude event names, descriptions, and locations, plus all-day events, focus time, and out-of-office blocks. Those are per-calendar switches rather than a real filter language.
+
+If you want fine-grained rules about which events get blocked, Morgen is ahead of us today.
+
+## Where does your calendar data live?
+
+Morgen is meaningfully better here, and it is worth saying loudly.
+
+Their FAQ states: "We do not store your calendar data in the cloud. Instead, our servers act as a proxy, transmitting data as needed to your devices without persisting it" ([Morgen FAQ](https://www.morgen.so/faq)). The same page describes them as a Swiss company, subject to Swiss privacy law.
+
+Their privacy policy adds that "Our data centers are located in Switzerland or in the European Union, while some partners are located in the United States" ([privacy policy](https://www.morgen.so/privacy)).
+
+Keeper works differently, and it has to. We keep a copy of your events in our own database.
+
+That copy is exactly what makes minute-level timing possible. We can only spot a change in under a minute if we know what your calendar looked like a minute ago.
+
+It is a real trade, not a detail. If you would rather no service held a copy of your events, Morgen's design suits you better. If you want that copy on a server you own, see the self-hosting section below.
+
+## What apps does each one have?
+
+Morgen wins this one outright, with nothing to argue about.
+
+Morgen ships desktop apps for macOS 12 and above, Windows 10 and above, and Linux on x86 64-bit ([downloads](https://platform.morgen.so/download)). There are iOS and Android apps too, though the download page says to set up your account on desktop first.
+
+Keeper is a web app you open in a browser. There is no desktop app and no mobile app.
+
+You do not really sit in Keeper, so this matters less than it sounds. But if you want a calendar client on your laptop, we do not have one and Morgen does.
+
+## What does each one cost?
+
+Morgen Pro is $30 a month, or $15 a month billed annually ([pricing](https://www.morgen.so/pricing)). Team plans are $25 per seat monthly, or $10 per seat billed annually, with a minimum of two seats.
+
+There is no free tier at all. Morgen offers a 14-day trial with no credit card, and a 30-day money-back guarantee.
+
+Keeper is $0 or $5 a month, flat, for one person.
+
+The prices are not really comparable, and pretending otherwise would be unfair. Morgen is a full calendar client you sit in all day. Keeper is plumbing you set up once and then forget about.
+
+Paying $15 a month for an app you open thirty times a day is reasonable. Paying that much for background blocking alone probably is not.
+
+## Can you use both?
+
+Yes, and for some people this is the right answer.
+
+Run Morgen as your calendar app, for the interface, the task tools, and the native apps. Run Keeper underneath for the blocking, so your availability is right within a minute instead of after 6pm.
+
+The two do not conflict, because Morgen reads your calendars and Keeper writes to them.
+
+## Can you run Keeper yourself?
+
+Yes, and this is where the data question gets a different answer.
+
+The whole codebase is on [GitHub](https://github.com/ridafkih/keeper.sh) under AGPL-3.0, with Docker images for a quick first deployment. Self-hosting turns on every Pro feature at no cost, deliberately.
+
+That means the copy of your events sits in a database you own, on hardware you chose. For some people, that settles the privacy question entirely.
+
+It is also genuine work, and worth knowing before you start. You need a host, a Postgres database, and Redis. You register your own OAuth credentials with Google and Microsoft, which takes an afternoon the first time.
+
+Upgrades, backups, and uptime are yours after that. Most people should use hosted keeper.sh and pay the $5 instead.
+
+## So which should you pick?
+
+Pick Morgen if you want a calendar app you actually enjoy opening every morning. Pick Morgen if you need native desktop apps, and especially if you are on Linux.
+
+Pick Morgen if EU or Swiss hosting matters, or if you want your tasks and calendar in one place. Pick Morgen if once-a-day blocking is fine for the way you work.
+
+Pick Keeper if a stale calendar has already got you double-booked more than once. Pick Keeper if you need your time blocked further out than the next two weeks.
+
+Pick Keeper if $5 a month is the right size for a background job. Pick Keeper if you would rather run the whole thing on your own server.
+
+If you are not sure, ask one question. Has anyone booked over you because your other calendar looked free? If the answer is no, Morgen's timing will not bother you.
+
+## FAQ
+
+### How often does Morgen block out my events?
+
+Once a day. Morgen's guide states that the Calendar Propagation workflow runs daily at 6:00 pm and covers the upcoming 14 days.
+
+Keeper reads every minute, and writes every minute on Pro or every 30 minutes on the free plan.
+
+### Does Keeper have a desktop or mobile app?
+
+No. Keeper is a web app you configure in a browser, and it runs on its own after that.
+
+Morgen has native apps for macOS, Windows, Linux, iOS, and Android.
+
+### Does Morgen store my calendar in the cloud?
+
+Their FAQ says it does not, and describes their servers as a proxy that does not keep your data. Keeper does store a copy, which is what makes minute-level timing possible.
+
+### Can Keeper sync in both directions?
+
+Only by setting up two connections, one pointing each way, because each connection moves events one way.
+
+Morgen's Calendar Propagation runs in one direction per workflow too.
+
+### Does Keeper copy attendees or video call links?
+
+No. A copied event carries its title, description, location, times, and busy or free status.
+
+Attendees, meeting links, and reminders are never copied across. Keeper does read attendees, so you can see pending invites and RSVP from the API.
+
+## Sources
+
+Every claim about Morgen above comes from Morgen's own public pages, linked inline. Those pages were reviewed on the publication date of this post, and Morgen may have changed since.
+
+- [Morgen pricing](https://www.morgen.so/pricing)
+- [Morgen integrations](https://www.morgen.so/integrations)
+- [How to use Morgen's Calendar Propagation workflow](https://www.morgen.so/guides/how-to-use-morgens-calendar-propagation-workflow)
+- [Morgen FAQ](https://www.morgen.so/faq)
+- [Morgen privacy policy](https://www.morgen.so/privacy)
+- [Morgen downloads](https://platform.morgen.so/download)

--- a/applications/web/src/content/blog/keeper-sh-vs-morgen.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-morgen.mdx
@@ -50,13 +50,15 @@ For calendars specifically, the two lists are close to equal. There is one limit
 
 Morgen writes a plain placeholder instead of the event. Copies appear as "Private Event (from Morgen)" with no details listed, so you check the original calendar for specifics.
 
-That is a good default to have. Nothing leaks, and you never have to think about it.
+Keeper does much the same thing, with one difference. A calendar you connect is copied out under the name of the calendar it came from, with the description and location stripped.
 
-Keeper copies the real title, description, and location by default. You can switch each of those off per calendar and swap the title for fixed text or the calendar's name.
+So every Morgen copy reads "Private Event (from Morgen)". Ours read "Personal", or "Family", or whatever you named the calendar.
 
-Being straight about it: our defaults are less private than Morgen's, and our privacy controls are a Pro feature. On our free plan, a copied event carries its original title.
+That cuts both ways. Ours tell you a bit more at a glance, but a calendar name travels with every copy, so a revealing name is worth renaming.
 
-If you want a quiet blocker and nothing else, Morgen's default does that out of the box.
+Changing what shows through is a Pro feature on our side. Free users keep the anonymised default, which is usually the one they wanted.
+
+Those defaults are applied when you connect a calendar, rather than enforced forever afterwards. A Pro user can turn detail back on.
 
 ## Which one has better filtering?
 
@@ -64,7 +66,7 @@ Morgen does, and it is not a close call.
 
 Their guide describes a "Nerd Mode" that lets you add custom filters on things like business hours, event tags, and whether an event has invitees. It also lets you choose between copying every event or only events marked busy.
 
-Keeper's controls are noticeably coarser than that. You can exclude event names, descriptions, and locations, plus all-day events, focus time, and out-of-office blocks. Those are per-calendar switches rather than a real filter language.
+Keeper's controls are noticeably coarser than that. You can let event names, descriptions, and locations back through, and exclude all-day events, focus time, or out-of-office blocks. Those are per-calendar switches rather than a real filter language.
 
 If you want fine-grained rules about which events get blocked, Morgen is ahead of us today.
 
@@ -162,7 +164,7 @@ Morgen's Calendar Propagation runs in one direction per workflow too.
 
 ### Does Keeper copy attendees or video call links?
 
-No. A copied event carries its title, description, location, times, and busy or free status.
+No. A copy carries the times, the busy or free status, and whatever detail your settings let through.
 
 Attendees, meeting links, and reminders are never copied across. Keeper does read attendees, so you can see pending invites and RSVP from the API.
 

--- a/applications/web/src/content/blog/keeper-sh-vs-morgen.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-morgen.mdx
@@ -24,7 +24,7 @@ Morgen's Calendar Propagation workflow "will run daily at 6:00 pm" and covers "t
 
 Say you book a dentist appointment at 9am, for 2pm the same day. Your work calendar still looks free at 2pm all morning, because the workflow has not run yet. Anything more than two weeks out is not blocked at all until the day gets close.
 
-Keeper reads your calendars every minute, on every plan. It writes copies out every minute on Pro, and every 30 minutes on the free plan. It also covers the next two years and the past week, rather than only the next fortnight.
+Keeper.sh reads your calendars every minute, on every plan. It writes copies out every minute on Pro, and every 30 minutes on the free plan. It also covers the next two years and the past week, rather than only the next fortnight.
 
 That is the case for us over Morgen, and honestly it is the only one that really matters.
 
@@ -34,7 +34,7 @@ Morgen has the broader list, and it is not close on the task side.
 
 Morgen connects Google Calendar, Outlook Calendar, Apple Calendar, Fastmail, generic CalDAV, and subscription feeds ([integrations](https://www.morgen.so/integrations)). It also connects Notion, Todoist, Obsidian, ClickUp, Linear, Apple Reminders, and more.
 
-Keeper connects Google, Outlook, iCloud, Fastmail, and any CalDAV server. It reads public ICS links but cannot write to them, and it connects no task tools at all.
+Keeper.sh connects Google, Outlook, iCloud, Fastmail, and any CalDAV server. It reads public ICS links but cannot write to them, and it connects no task tools at all.
 
 For calendars specifically, the two lists are close to equal. There is one limit worth noting on Morgen's side. Their guide says the blocking workflow supports "Outlook, Google, iCloud, and Fastmail Calendars", which is narrower than the calendars Morgen can display.
 
@@ -42,7 +42,7 @@ For calendars specifically, the two lists are close to equal. There is one limit
 
 Morgen writes a plain placeholder instead of the event. Copies appear as "Private Event (from Morgen)" with no details listed, so you check the original calendar for specifics.
 
-Keeper does much the same, with one difference. A calendar you connect is copied out under the name of the calendar it came from, with the description and location stripped.
+Keeper.sh does much the same, with one difference. A calendar you connect is copied out under the name of the calendar it came from, with the description and location stripped.
 
 So where a Morgen copy reads "Private Event", ours reads "Personal", or "Family", or whatever you named the calendar.
 
@@ -56,7 +56,7 @@ Morgen does, and it is not a close call.
 
 Their guide describes a "Nerd Mode" that lets you add custom filters on things like business hours, event tags, and whether an event has invitees. It also lets you choose between copying every event or only events marked busy.
 
-Keeper's controls are coarser. You can let event names, descriptions, and locations back through, and exclude all-day events, focus time, or out-of-office blocks. Those are per-calendar switches rather than a real filter language.
+Keeper.sh's controls are coarser. You can let event names, descriptions, and locations back through, and exclude all-day events, focus time, or out-of-office blocks. Those are per-calendar switches rather than a real filter language.
 
 ## Where does your calendar data live?
 
@@ -66,7 +66,7 @@ Their FAQ states: "We do not store your calendar data in the cloud. Instead, our
 
 Their privacy policy adds that "Our data centers are located in Switzerland or in the European Union, while some partners are located in the United States" ([privacy policy](https://www.morgen.so/privacy)).
 
-Keeper works differently, and it has to. We keep a copy of your events in our own database. That copy is exactly what makes minute-level timing possible.
+Keeper.sh works differently, and it has to. We keep a copy of your events in our own database. That copy is exactly what makes minute-level timing possible.
 
 It is a real trade, not a detail. If you would rather no service held a copy of your events, Morgen's design suits you better. If you want that copy on a server you own, see the self-hosting section below.
 
@@ -76,9 +76,9 @@ Morgen wins this one outright.
 
 Morgen ships desktop apps for macOS 12 and above, Windows 10 and above, and Linux on x86 64-bit ([downloads](https://platform.morgen.so/download)). There are iOS and Android apps too, though the download page says to set up your account on desktop first.
 
-Keeper is a web app you open in a browser, with no desktop or mobile app.
+Keeper.sh is a web app you open in a browser, with no desktop or mobile app.
 
-You do not really sit in Keeper, so this matters less than it sounds. But if you want a calendar client on your laptop, we do not have one.
+You do not really sit in Keeper.sh, so this matters less than it sounds. But if you want a calendar client on your laptop, we do not have one.
 
 ## What does each one cost?
 
@@ -86,17 +86,17 @@ Morgen Pro is $30 a month, or $15 a month billed annually ([pricing](https://www
 
 There is no free tier at all. Morgen offers a 14-day trial with no credit card, and a 30-day money-back guarantee.
 
-Keeper is $0 or $5 a month, flat, for one person. The free plan covers two linked accounts and three connections, and Pro removes both limits.
+Keeper.sh is $0 or $5 a month, flat, for one person. The free plan covers two linked accounts and three connections, and Pro removes both limits.
 
-The prices are not really comparable. Morgen is a full calendar client you sit in all day. Keeper is plumbing you set up once and then forget about.
+The prices are not really comparable. Morgen is a full calendar client you sit in all day. Keeper.sh is plumbing you set up once and then forget about.
 
 ## Can you use both?
 
 Yes, and for some people this is the right answer.
 
-Run Morgen as your calendar app, for the interface, the task tools, and the native apps. Run Keeper underneath for the blocking, so your availability is right within a minute instead of after 6pm. The two do not conflict, because Morgen reads your calendars and Keeper writes to them.
+Run Morgen as your calendar app, for the interface, the task tools, and the native apps. Run Keeper.sh underneath for the blocking, so your availability is right within a minute instead of after 6pm. The two do not conflict, because Morgen reads your calendars and Keeper.sh writes to them.
 
-## Can you run Keeper yourself?
+## Can you run Keeper.sh yourself?
 
 Yes, and this is where the data question gets a different answer.
 
@@ -106,7 +106,7 @@ That means the copy of your events sits in a database you own, on hardware you c
 
 It is also genuine work. You need a host, a Postgres database, and Redis. You register your own Google and Microsoft credentials, which takes an afternoon the first time.
 
-Upgrades, backups, and uptime are yours after that. Most people should use hosted keeper.sh and pay the $5 instead.
+Upgrades, backups, and uptime are yours after that. Most people should use hosted Keeper.sh and pay the $5 instead.
 
 ## So which should you pick?
 
@@ -114,9 +114,9 @@ Pick Morgen if you want a calendar app you enjoy opening every morning. Pick Mor
 
 Pick Morgen if EU or Swiss hosting matters, or if you want your tasks and calendar in one place.
 
-Pick Keeper if a stale calendar has already got you double-booked. Pick Keeper if you need your time blocked further out than the next two weeks.
+Pick Keeper.sh if a stale calendar has already got you double-booked. Pick Keeper.sh if you need your time blocked further out than the next two weeks.
 
-Pick Keeper if $5 a month is the right size for a background job, or if you would rather run the whole thing on your own server.
+Pick Keeper.sh if $5 a month is the right size for a background job, or if you would rather run the whole thing on your own server.
 
 If you are not sure, ask one question. Has anyone booked over you because your other calendar looked free? If the answer is no, Morgen's timing will not bother you.
 
@@ -124,17 +124,17 @@ If you are not sure, ask one question. Has anyone booked over you because your o
 
 ### How often does Morgen block out my events?
 
-Once a day. Morgen's guide states that the workflow runs daily at 6:00 pm and covers the upcoming 14 days. Keeper reads every minute, and writes every minute on Pro or every 30 minutes on the free plan.
+Once a day. Morgen's guide states that the workflow runs daily at 6:00 pm and covers the upcoming 14 days. Keeper.sh reads every minute, and writes every minute on Pro or every 30 minutes on the free plan.
 
-### Can Keeper sync in both directions?
+### Can Keeper.sh sync in both directions?
 
 Only by setting up two connections, one pointing each way, because each connection moves events one way. Morgen's Calendar Propagation runs in one direction per workflow too.
 
-### Does Keeper copy attendees or video call links?
+### Does Keeper.sh copy attendees or video call links?
 
 No. A copy carries the times, the busy or free status, and whatever detail your settings let through.
 
-Attendees, meeting links, and reminders are never copied across. Keeper does read attendees, so you can see pending invites and RSVP.
+Attendees, meeting links, and reminders are never copied across. Keeper.sh does read attendees, so you can see pending invites and RSVP.
 
 ## Sources
 

--- a/applications/web/src/content/blog/keeper-sh-vs-morgen.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-morgen.mdx
@@ -12,27 +12,19 @@ tags:
   - "sync"
 ---
 
-Morgen is a calendar app you install and live in. It shows all your calendars together, plans your day, and pulls in tasks from tools like Notion and Todoist.
+Morgen is a calendar app you install and live in. It shows all your calendars together, plans your day, and brings in tasks from tools like Notion and Todoist.
 
-Keeper.sh is not a calendar app at all. It runs in the background and keeps busy time visible across the calendars you already use.
-
-Both can block out your personal events on your work calendar. They do it very differently, and the difference is timing.
+Keeper.sh is not a calendar app at all. It runs in the background and keeps busy time visible across the calendars you already use. Both can block out your personal events on your work calendar, and the difference is timing.
 
 ## How often does each one block out your time?
 
 This is the main reason to read this page, so it goes first.
 
-Morgen's Calendar Propagation workflow "will run daily at 6:00 pm" and covers "the upcoming 14 days" ([Morgen's guide](https://www.morgen.so/guides/how-to-use-morgens-calendar-propagation-workflow)). It runs in one direction, from one calendar to another.
+Morgen's Calendar Propagation workflow "will run daily at 6:00 pm" and covers "the upcoming 14 days" ([Morgen's guide](https://www.morgen.so/guides/how-to-use-morgens-calendar-propagation-workflow)). The same guide is upfront about the consequence. When an event is cancelled or moved, "there will be a lag as the workflow runs daily at 6pm".
 
-The same guide is upfront about the consequence. When an event is cancelled or moved, "there will be a lag as the workflow runs daily at 6pm".
+Say you book a dentist appointment at 9am, for 2pm the same day. Your work calendar still looks free at 2pm all morning, because the workflow has not run yet. Anything more than two weeks out is not blocked at all until the day gets close.
 
-So a meeting you accept at 9am is not blocked elsewhere until that evening. Anything more than two weeks out is not blocked at all until the day gets close enough.
-
-Keeper reads your calendars every minute, on every plan. It writes copies out every minute on Pro, and every 30 minutes on the free plan.
-
-It also reaches much further ahead. Keeper covers the next two years and the past week, rather than only the next fortnight.
-
-Say you book a dentist appointment at 9am, for 2pm the same day. Your work calendar still looks free at 2pm all morning, because the workflow has not run yet.
+Keeper reads your calendars every minute, on every plan. It writes copies out every minute on Pro, and every 30 minutes on the free plan. It also covers the next two years and the past week, rather than only the next fortnight.
 
 That is the case for us over Morgen, and honestly it is the only one that really matters.
 
@@ -44,21 +36,19 @@ Morgen connects Google Calendar, Outlook Calendar, Apple Calendar, Fastmail, gen
 
 Keeper connects Google, Outlook, iCloud, Fastmail, and any CalDAV server. It reads public ICS links but cannot write to them, and it connects no task tools at all.
 
-For calendars specifically, the two lists are close to equal. There is one limit worth noting on Morgen's side. Their own guide says Calendar Propagation supports "Outlook, Google, iCloud, and Fastmail Calendars", which is narrower than the calendars Morgen can display.
+For calendars specifically, the two lists are close to equal. There is one limit worth noting on Morgen's side. Their guide says the blocking workflow supports "Outlook, Google, iCloud, and Fastmail Calendars", which is narrower than the calendars Morgen can display.
 
 ## What does a blocked-out copy look like?
 
 Morgen writes a plain placeholder instead of the event. Copies appear as "Private Event (from Morgen)" with no details listed, so you check the original calendar for specifics.
 
-Keeper does much the same thing, with one difference. A calendar you connect is copied out under the name of the calendar it came from, with the description and location stripped.
+Keeper does much the same, with one difference. A calendar you connect is copied out under the name of the calendar it came from, with the description and location stripped.
 
-So every Morgen copy reads "Private Event (from Morgen)". Ours read "Personal", or "Family", or whatever you named the calendar.
+So where a Morgen copy reads "Private Event", ours reads "Personal", or "Family", or whatever you named the calendar.
 
-That cuts both ways. Ours tell you a bit more at a glance, but a calendar name travels with every copy, so a revealing name is worth renaming.
+That cuts both ways. Ours tell you a bit more at a glance. But a calendar name travels with every copy, so a revealing name is worth renaming.
 
 Changing what shows through is a Pro feature on our side. Free users keep the anonymised default, which is usually the one they wanted.
-
-Those defaults are applied when you connect a calendar, rather than enforced forever afterwards. A Pro user can turn detail back on.
 
 ## Which one has better filtering?
 
@@ -66,9 +56,7 @@ Morgen does, and it is not a close call.
 
 Their guide describes a "Nerd Mode" that lets you add custom filters on things like business hours, event tags, and whether an event has invitees. It also lets you choose between copying every event or only events marked busy.
 
-Keeper's controls are noticeably coarser than that. You can let event names, descriptions, and locations back through, and exclude all-day events, focus time, or out-of-office blocks. Those are per-calendar switches rather than a real filter language.
-
-If you want fine-grained rules about which events get blocked, Morgen is ahead of us today.
+Keeper's controls are coarser. You can let event names, descriptions, and locations back through, and exclude all-day events, focus time, or out-of-office blocks. Those are per-calendar switches rather than a real filter language.
 
 ## Where does your calendar data live?
 
@@ -78,21 +66,19 @@ Their FAQ states: "We do not store your calendar data in the cloud. Instead, our
 
 Their privacy policy adds that "Our data centers are located in Switzerland or in the European Union, while some partners are located in the United States" ([privacy policy](https://www.morgen.so/privacy)).
 
-Keeper works differently, and it has to. We keep a copy of your events in our own database.
-
-That copy is exactly what makes minute-level timing possible. We can only spot a change in under a minute if we know what your calendar looked like a minute ago.
+Keeper works differently, and it has to. We keep a copy of your events in our own database. That copy is exactly what makes minute-level timing possible.
 
 It is a real trade, not a detail. If you would rather no service held a copy of your events, Morgen's design suits you better. If you want that copy on a server you own, see the self-hosting section below.
 
 ## What apps does each one have?
 
-Morgen wins this one outright, with nothing to argue about.
+Morgen wins this one outright.
 
 Morgen ships desktop apps for macOS 12 and above, Windows 10 and above, and Linux on x86 64-bit ([downloads](https://platform.morgen.so/download)). There are iOS and Android apps too, though the download page says to set up your account on desktop first.
 
-Keeper is a web app you open in a browser. There is no desktop app and no mobile app.
+Keeper is a web app you open in a browser, with no desktop or mobile app.
 
-You do not really sit in Keeper, so this matters less than it sounds. But if you want a calendar client on your laptop, we do not have one and Morgen does.
+You do not really sit in Keeper, so this matters less than it sounds. But if you want a calendar client on your laptop, we do not have one.
 
 ## What does each one cost?
 
@@ -100,19 +86,15 @@ Morgen Pro is $30 a month, or $15 a month billed annually ([pricing](https://www
 
 There is no free tier at all. Morgen offers a 14-day trial with no credit card, and a 30-day money-back guarantee.
 
-Keeper is $0 or $5 a month, flat, for one person.
+Keeper is $0 or $5 a month, flat, for one person. The free plan covers two linked accounts and three connections, and Pro removes both limits.
 
-The prices are not really comparable, and pretending otherwise would be unfair. Morgen is a full calendar client you sit in all day. Keeper is plumbing you set up once and then forget about.
-
-Paying $15 a month for an app you open thirty times a day is reasonable. Paying that much for background blocking alone probably is not.
+The prices are not really comparable. Morgen is a full calendar client you sit in all day. Keeper is plumbing you set up once and then forget about.
 
 ## Can you use both?
 
 Yes, and for some people this is the right answer.
 
-Run Morgen as your calendar app, for the interface, the task tools, and the native apps. Run Keeper underneath for the blocking, so your availability is right within a minute instead of after 6pm.
-
-The two do not conflict, because Morgen reads your calendars and Keeper writes to them.
+Run Morgen as your calendar app, for the interface, the task tools, and the native apps. Run Keeper underneath for the blocking, so your availability is right within a minute instead of after 6pm. The two do not conflict, because Morgen reads your calendars and Keeper writes to them.
 
 ## Can you run Keeper yourself?
 
@@ -122,19 +104,19 @@ The whole codebase is on [GitHub](https://github.com/ridafkih/keeper.sh) under A
 
 That means the copy of your events sits in a database you own, on hardware you chose. For some people, that settles the privacy question entirely.
 
-It is also genuine work, and worth knowing before you start. You need a host, a Postgres database, and Redis. You register your own OAuth credentials with Google and Microsoft, which takes an afternoon the first time.
+It is also genuine work. You need a host, a Postgres database, and Redis. You register your own Google and Microsoft credentials, which takes an afternoon the first time.
 
 Upgrades, backups, and uptime are yours after that. Most people should use hosted keeper.sh and pay the $5 instead.
 
 ## So which should you pick?
 
-Pick Morgen if you want a calendar app you actually enjoy opening every morning. Pick Morgen if you need native desktop apps, and especially if you are on Linux.
+Pick Morgen if you want a calendar app you enjoy opening every morning. Pick Morgen if you need native desktop apps, and especially if you are on Linux.
 
-Pick Morgen if EU or Swiss hosting matters, or if you want your tasks and calendar in one place. Pick Morgen if once-a-day blocking is fine for the way you work.
+Pick Morgen if EU or Swiss hosting matters, or if you want your tasks and calendar in one place.
 
-Pick Keeper if a stale calendar has already got you double-booked more than once. Pick Keeper if you need your time blocked further out than the next two weeks.
+Pick Keeper if a stale calendar has already got you double-booked. Pick Keeper if you need your time blocked further out than the next two weeks.
 
-Pick Keeper if $5 a month is the right size for a background job. Pick Keeper if you would rather run the whole thing on your own server.
+Pick Keeper if $5 a month is the right size for a background job, or if you would rather run the whole thing on your own server.
 
 If you are not sure, ask one question. Has anyone booked over you because your other calendar looked free? If the answer is no, Morgen's timing will not bother you.
 
@@ -142,31 +124,17 @@ If you are not sure, ask one question. Has anyone booked over you because your o
 
 ### How often does Morgen block out my events?
 
-Once a day. Morgen's guide states that the Calendar Propagation workflow runs daily at 6:00 pm and covers the upcoming 14 days.
-
-Keeper reads every minute, and writes every minute on Pro or every 30 minutes on the free plan.
-
-### Does Keeper have a desktop or mobile app?
-
-No. Keeper is a web app you configure in a browser, and it runs on its own after that.
-
-Morgen has native apps for macOS, Windows, Linux, iOS, and Android.
-
-### Does Morgen store my calendar in the cloud?
-
-Their FAQ says it does not, and describes their servers as a proxy that does not keep your data. Keeper does store a copy, which is what makes minute-level timing possible.
+Once a day. Morgen's guide states that the workflow runs daily at 6:00 pm and covers the upcoming 14 days. Keeper reads every minute, and writes every minute on Pro or every 30 minutes on the free plan.
 
 ### Can Keeper sync in both directions?
 
-Only by setting up two connections, one pointing each way, because each connection moves events one way.
-
-Morgen's Calendar Propagation runs in one direction per workflow too.
+Only by setting up two connections, one pointing each way, because each connection moves events one way. Morgen's Calendar Propagation runs in one direction per workflow too.
 
 ### Does Keeper copy attendees or video call links?
 
 No. A copy carries the times, the busy or free status, and whatever detail your settings let through.
 
-Attendees, meeting links, and reminders are never copied across. Keeper does read attendees, so you can see pending invites and RSVP from the API.
+Attendees, meeting links, and reminders are never copied across. Keeper does read attendees, so you can see pending invites and RSVP.
 
 ## Sources
 

--- a/applications/web/src/content/blog/keeper-sh-vs-reclaim-ai.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-reclaim-ai.mdx
@@ -1,0 +1,186 @@
+---
+title: "Keeper.sh vs Reclaim.ai"
+description: "An honest comparison of Keeper.sh and Reclaim.ai for keeping work and personal calendars in sync, including when Reclaim's free plan is the better answer."
+blurb: "Reclaim's free plan already mirrors one work calendar into one personal calendar, forever, at no cost. Here is when that is enough, and when you need something that reaches iCloud and CalDAV."
+createdAt: "2026-08-11"
+updatedAt: "2026-08-11"
+slug: "keeper-sh-vs-reclaim-ai"
+tags:
+  - "comparison"
+  - "reclaim"
+  - "calendar"
+  - "sync"
+---
+
+Reclaim.ai is an AI scheduling assistant. It plans your tasks, defends your focus time, and copies events between calendars.
+
+Keeper.sh does one of those things, and it does it across more calendar providers than Reclaim can reach.
+
+That difference decides most of this comparison. This page tries to be straight about where each tool wins, including the parts where we lose.
+
+## Should you just use Reclaim's free plan?
+
+For a lot of people, yes.
+
+Reclaim's Lite plan is free forever, and it includes one calendar sync and two connected calendars, per their [pricing page](https://reclaim.ai/pricing).
+
+That is exactly the job most people come to us for. One work calendar, one personal calendar, copied so nobody double-books you.
+
+Picture a Gmail account and a Google Workspace account. You want personal events to show up as busy at work. Reclaim Lite does that at $0, and we would charge you $5 a month.
+
+If that is your situation, use Reclaim, because we would rather say so than take your money.
+
+The free plan runs out in two places. It runs out when you need a third calendar involved, and it runs out when either calendar is not Google or Outlook.
+
+## Which calendars can each one connect?
+
+This is the sharpest split between the two products.
+
+Reclaim's Calendar Sync covers Google and Outlook. Their help centre says it "is only supported for calendars connected to a Google Calendar or Microsoft Outlook account" ([Calendar Sync overview](https://help.reclaim.ai/en/articles/3600762-calendar-sync-overview-keep-multiple-schedules-in-sync)).
+
+The same article suggests sharing an iCloud calendar into Google as a workaround, and notes this may cause delays.
+
+Keeper connects to Google, Outlook, iCloud, Fastmail, and any CalDAV server. It also reads public ICS links, though it cannot write events back to those.
+
+So if your personal calendar lives on iCloud, Reclaim cannot reach it directly. Same if it lives on a Nextcloud or Radicale server you run yourself.
+
+That is the single most common reason people end up with us.
+
+## How fast do copies appear?
+
+Reclaim says its copies are immediate, and their product page states: "Updates happen instantly—not on a timer or slow refresh" ([AI Calendar Sync](https://reclaim.ai/features/calendar-sync)).
+
+Keeper runs on timers, and we would rather admit that than dress it up as something else.
+
+We read your calendars every minute, on every plan. We write copies out every minute on Pro, and every 30 minutes on the free plan.
+
+So a new meeting lands on your other calendar in about a minute if you pay us. On the free plan, it can take half an hour.
+
+If you need a personal event blocked at work within seconds, Reclaim is faster. That is a genuine advantage and we are not going to argue with it.
+
+We do reach further out in time. Keeper covers the next two years plus the last week, rather than only the weeks immediately ahead of you.
+
+## Do both tools create duplicate events?
+
+Yes, both of them do, and neither of us pretends otherwise.
+
+Reclaim's help centre puts it plainly. Calendar Sync "has to create copies by design, because without those copies, your colleagues viewing the destination calendar wouldn't see time from the source calendar as blocked" ([handling duplicates](https://help.reclaim.ai/en/articles/3639940-how-to-handle-duplicate-events-from-calendar-sync)).
+
+The same is true of Keeper, for the same reason. A copy is the only thing another person's calendar can actually see.
+
+Both tools also copy in one direction at a time. Reclaim tells you to "set up two sync policies" when you want both ways ([syncing in multiple directions](https://help.reclaim.ai/en/articles/3654852-using-calendar-sync-to-sync-calendars-in-multiple-directions)).
+
+Keeper works the same way, with two connections, one pointing each way. Neither of us does true two-way sync, and you should be suspicious of anyone who claims to.
+
+## What does a copied event look like?
+
+Reclaim gives you a set of visibility choices on each policy. You can pick a Personal, Work, or Travel Commitment, "Busy for all", or two levels of detail sharing ([sync policies](https://help.reclaim.ai/en/articles/6326844-creating-and-customizing-your-calendar-sync-policies)).
+
+You can also keep single events out by adding `#nosync` to the description ([using #nosync](https://help.reclaim.ai/en/articles/3639946-using-nosync-to-prevent-events-from-being-synced)). Their policy settings include a "Sync outside of working hours?" toggle and three separate rules for all-day events.
+
+Keeper copies the real title, description, and location by default. You can switch each of those off per calendar, and replace the title with fixed text or with the calendar's name.
+
+Here is the honest part: those controls sit behind Pro. On our free plan, a copied event carries its original title.
+
+Reclaim's visibility choices are available on Lite, at no cost. If privacy on a free plan is what you need, they beat us outright.
+
+Reclaim's filtering is also further along than ours. Working-hours filters, all-day rules, and a per-event keyword are more than we ship today.
+
+## What does each one cost?
+
+Reclaim's paid tiers are listed at $10, $15, and $22 per seat per month for Starter, Business, and Enterprise ([pricing](https://reclaim.ai/pricing)). Enterprise is where SSO and SCIM user provisioning live.
+
+Keeper is $0 or $5 a month, flat, for one person.
+
+Our free plan gives you two linked accounts and three connections between calendars. There is no limit on how many calendars each account exposes.
+
+Pro removes both limits. It also drops the write interval to a minute and unlocks the title and detail controls.
+
+We have no team plan, no seats, no SSO, and no SCIM. If you are buying this for a company, Reclaim is built for that and we are not.
+
+## What Reclaim does that Keeper does not
+
+Most of Reclaim's product, honestly.
+
+It schedules tasks into open time, defends focus blocks, and adds buffer time around meetings. It builds recurring habits into your week, and offers scheduling links, a planner, and time tracking.
+
+None of that exists in Keeper, and none of it is on our list. We move events between calendars, and that is the whole product.
+
+Reclaim is also part of Dropbox, which its own site states ([about Reclaim](https://reclaim.ai/about)). If a larger company behind the product matters to your procurement team, that is worth weighing.
+
+## What Keeper does that Reclaim does not
+
+Keeper talks to iCloud, Fastmail, and CalDAV servers directly, with no shared-calendar workaround sitting in the middle.
+
+It publishes one iCal feed covering every calendar you pick. You hand that link to anyone who needs your availability, and event names show as "Busy" unless you change that.
+
+It has a REST API and an MCP server, both usable on the free plan at 25 calls a day.
+
+It costs $5 a month for a person, rather than a price per seat.
+
+And it is open source under AGPL-3.0, so you can read every line of code that touches your calendar.
+
+## Can you run Keeper yourself?
+
+Yes, and it is a real option rather than a token gesture.
+
+The whole codebase is on [GitHub](https://github.com/ridafkih/keeper.sh) under AGPL-3.0, with Docker images to make a first deployment quick.
+
+Self-hosting turns on every Pro feature at no cost, and that is deliberate. We are not going to hold the good parts back from people running our code on their own hardware.
+
+It is also genuine work, and worth knowing that before you start. You need somewhere to run it, a Postgres database, and Redis. You register your own OAuth credentials with Google and Microsoft, which takes an afternoon the first time.
+
+After that, upgrades, backups, and uptime are yours to own.
+
+Most people should use hosted keeper.sh and pay the $5. Run it yourself if you want your calendar data on hardware you control, or you simply enjoy this kind of thing.
+
+## So which should you pick?
+
+Pick Reclaim if you are on Google or Outlook only, and one free calendar sync covers you. Pick Reclaim if you want AI scheduling, focus time, and task planning. Pick Reclaim if you are buying seats for a team that needs SSO.
+
+Pick Keeper if any calendar you care about is on iCloud, Fastmail, or CalDAV. Pick Keeper if you want more than three calendars involved for a flat $5. Pick Keeper if you want an aggregated availability feed, an API, or the source code.
+
+Plenty of people should pick Reclaim. We would rather you work that out on this page than a month after paying us.
+
+## FAQ
+
+### Can Reclaim sync my iCloud calendar?
+
+Not directly. Their documentation limits Calendar Sync to calendars connected to a Google or Microsoft Outlook account, and suggests sharing iCloud into Google as a workaround.
+
+Keeper connects to iCloud directly, using an app-specific password you generate in your Apple account.
+
+### Is Keeper's free plan enough for me?
+
+It is enough for two linked accounts and three connections between calendars. Copies are written out every 30 minutes rather than every minute.
+
+The catch is that copied events keep their real title on the free plan, because masking titles is a Pro feature.
+
+### Do I need two connections to sync both ways?
+
+Yes, because each connection moves events in one direction only.
+
+Work into personal and personal into work is two connections. Reclaim works the same way, using two of its sync policies.
+
+### Does Keeper copy attendees or video call links?
+
+No. A copied event carries its title, description, location, times, and busy or free status.
+
+Attendees, meeting links, and reminders are never copied across. Keeper does read attendees, so you can see pending invites and RSVP from the API.
+
+### Can I use both tools together?
+
+Yes, though most people will not need to. Reclaim can handle scheduling on your Google and Outlook calendars while Keeper covers an iCloud or CalDAV calendar it cannot reach.
+
+## Sources
+
+Every claim about Reclaim.ai above comes from Reclaim's own public pages, linked inline. Those pages were reviewed on the publication date of this post, and Reclaim may have changed since.
+
+- [Reclaim pricing](https://reclaim.ai/pricing)
+- [AI Calendar Sync](https://reclaim.ai/features/calendar-sync)
+- [Calendar Sync overview](https://help.reclaim.ai/en/articles/3600762-calendar-sync-overview-keep-multiple-schedules-in-sync)
+- [Creating and customizing Calendar Sync policies](https://help.reclaim.ai/en/articles/6326844-creating-and-customizing-your-calendar-sync-policies)
+- [Syncing calendars in multiple directions](https://help.reclaim.ai/en/articles/3654852-using-calendar-sync-to-sync-calendars-in-multiple-directions)
+- [Using #nosync](https://help.reclaim.ai/en/articles/3639946-using-nosync-to-prevent-events-from-being-synced)
+- [Handling duplicate events](https://help.reclaim.ai/en/articles/3639940-how-to-handle-duplicate-events-from-calendar-sync)
+- [About Reclaim](https://reclaim.ai/about)

--- a/applications/web/src/content/blog/keeper-sh-vs-reclaim-ai.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-reclaim-ai.mdx
@@ -14,7 +14,7 @@ tags:
 
 Reclaim.ai is an AI scheduling assistant. It plans your tasks, defends your focus time, and copies events between calendars.
 
-Keeper does one of those things, across more calendar providers than Reclaim can reach. That difference decides most of this comparison, including the parts where we lose.
+Keeper.sh does one of those things, across more calendar providers than Reclaim can reach. That difference decides most of this comparison, including the parts where we lose.
 
 ## Should you just use Reclaim's free plan?
 
@@ -36,7 +36,7 @@ This is the sharpest split between the two products.
 
 Reclaim's Calendar Sync covers Google and Outlook. Their help centre says it "is only supported for calendars connected to a Google Calendar or Microsoft Outlook account" ([Calendar Sync overview](https://help.reclaim.ai/en/articles/3600762-calendar-sync-overview-keep-multiple-schedules-in-sync)). The same article suggests sharing an iCloud calendar into Google as a workaround, and notes this may cause delays.
 
-Keeper connects to Google, Outlook, iCloud, Fastmail, and any CalDAV server. It also reads public ICS links, though it cannot write events back to those.
+Keeper.sh connects to Google, Outlook, iCloud, Fastmail, and any CalDAV server. It also reads public ICS links, though it cannot write events back to those.
 
 So if your personal calendar lives on iCloud, or on a Nextcloud or Radicale server you run yourself, Reclaim cannot reach it directly. That is the single most common reason people end up with us.
 
@@ -44,21 +44,21 @@ So if your personal calendar lives on iCloud, or on a Nextcloud or Radicale serv
 
 Reclaim says its copies are immediate, and their product page states: "Updates happen instantly—not on a timer or slow refresh" ([AI Calendar Sync](https://reclaim.ai/features/calendar-sync)).
 
-Keeper runs on timers, and we would rather admit that than dress it up. We read your calendars every minute, on every plan. We write copies out every minute on Pro, and every 30 minutes on the free plan.
+Keeper.sh runs on timers, and we would rather admit that than dress it up. We read your calendars every minute, on every plan. We write copies out every minute on Pro, and every 30 minutes on the free plan.
 
 So a new meeting lands on your other calendar in about a minute if you pay us. On the free plan it can take half an hour.
 
 If you need a personal event blocked at work within seconds, Reclaim is faster. That is a genuine advantage and we are not going to argue with it.
 
-We do reach further out in time. Keeper covers the next two years plus the last week, rather than only the weeks immediately ahead of you.
+We do reach further out in time. Keeper.sh covers the next two years plus the last week, rather than only the weeks immediately ahead of you.
 
 ## Do both tools create duplicate events?
 
 Yes, both of them do, and neither of us pretends otherwise.
 
-Reclaim's help centre puts it plainly. Calendar Sync "has to create copies by design, because without those copies, your colleagues viewing the destination calendar wouldn't see time from the source calendar as blocked" ([handling duplicates](https://help.reclaim.ai/en/articles/3639940-how-to-handle-duplicate-events-from-calendar-sync)). The same is true of Keeper, because a copy is the only thing another person's calendar can see.
+Reclaim's help centre puts it plainly. Calendar Sync "has to create copies by design, because without those copies, your colleagues viewing the destination calendar wouldn't see time from the source calendar as blocked" ([handling duplicates](https://help.reclaim.ai/en/articles/3639940-how-to-handle-duplicate-events-from-calendar-sync)). The same is true of Keeper.sh, because a copy is the only thing another person's calendar can see.
 
-Both tools also copy in one direction at a time. Reclaim tells you to "set up two sync policies" when you want both ways ([syncing in multiple directions](https://help.reclaim.ai/en/articles/3654852-using-calendar-sync-to-sync-calendars-in-multiple-directions)). Keeper wants two connections, one pointing each way.
+Both tools also copy in one direction at a time. Reclaim tells you to "set up two sync policies" when you want both ways ([syncing in multiple directions](https://help.reclaim.ai/en/articles/3654852-using-calendar-sync-to-sync-calendars-in-multiple-directions)). Keeper.sh wants two connections, one pointing each way.
 
 Neither of us does two-way sync, and you should be suspicious of anyone who claims to.
 
@@ -68,7 +68,7 @@ Reclaim gives you a set of visibility choices on each policy. You can pick a Per
 
 You can also keep single events out by adding `#nosync` to the description ([using #nosync](https://help.reclaim.ai/en/articles/3639946-using-nosync-to-prevent-events-from-being-synced)). Their policy settings include a "Sync outside of working hours?" toggle and three separate rules for all-day events.
 
-Keeper anonymises copies by default. A calendar you connect is copied out under the name of the calendar it came from, with the description and location stripped.
+Keeper.sh anonymises copies by default. A calendar you connect is copied out under the name of the calendar it came from, with the description and location stripped.
 
 So a dentist appointment on a calendar you called "Personal" shows up at work as "Personal". Right day, right time, no detail.
 
@@ -80,23 +80,23 @@ Their filtering is further along than ours too. Working-hours filters, all-day r
 
 Reclaim's paid tiers are listed at $10, $15, and $22 per seat per month for Starter, Business, and Enterprise ([pricing](https://reclaim.ai/pricing)). Enterprise is where SSO and SCIM user provisioning live. None of those tiers add a calendar provider, so paying more does not get you iCloud or CalDAV.
 
-Keeper is $0 or $5 a month, flat, for one person. Our free plan gives you two linked accounts and three connections, with no limit on how many calendars each account exposes.
+Keeper.sh is $0 or $5 a month, flat, for one person. Our free plan gives you two linked accounts and three connections, with no limit on how many calendars each account exposes.
 
 Pro removes both limits. It also drops the write interval to a minute, and lets you change what shows through on a copy.
 
 We have no team plan, no seats, no SSO, and no SCIM. If you are buying this for a company, Reclaim is built for that and we are not.
 
-## What Reclaim does that Keeper does not
+## What Reclaim does that Keeper.sh does not
 
 Most of Reclaim's product, honestly.
 
-It schedules tasks into open time, defends focus blocks, and adds buffer time around meetings. It builds recurring habits into your week, and offers scheduling links, a planner, and time tracking. None of that exists in Keeper, and none of it is on our list.
+It schedules tasks into open time, defends focus blocks, and adds buffer time around meetings. It builds recurring habits into your week, and offers scheduling links, a planner, and time tracking. None of that exists in Keeper.sh, and none of it is on our list.
 
 Reclaim is also part of Dropbox, which its own site states ([about Reclaim](https://reclaim.ai/about)). If a larger company behind the product matters to your procurement team, that is worth weighing.
 
-## What Keeper does that Reclaim does not
+## What Keeper.sh does that Reclaim does not
 
-Keeper talks to iCloud, Fastmail, and CalDAV servers directly, with no shared-calendar workaround in the middle.
+Keeper.sh talks to iCloud, Fastmail, and CalDAV servers directly, with no shared-calendar workaround in the middle.
 
 It publishes one iCal feed covering every calendar you pick. Hand that link to anyone who needs your availability, and event names show as "Busy" unless you change that.
 
@@ -104,7 +104,7 @@ It has a REST API and an MCP server, both usable on the free plan at 25 calls a 
 
 And it is open source under AGPL-3.0, so you can read every line of code that touches your calendar.
 
-## Can you run Keeper yourself?
+## Can you run Keeper.sh yourself?
 
 Yes, and it is a real option rather than a token gesture. The whole codebase is on [GitHub](https://github.com/ridafkih/keeper.sh) under AGPL-3.0, with Docker images to make a first deployment quick.
 
@@ -114,13 +114,13 @@ It is genuine work, though. You need somewhere to run it, a Postgres database, a
 
 After that, upgrades, backups, and uptime are yours to own.
 
-Most people should use hosted keeper.sh and pay the $5. Run it yourself if you want your calendar data on hardware you control.
+Most people should use hosted Keeper.sh and pay the $5. Run it yourself if you want your calendar data on hardware you control.
 
 ## So which should you pick?
 
 Pick Reclaim if both calendars are Google or Outlook and one free sync covers you. Pick Reclaim if you want AI scheduling and task planning, or if you are buying seats for a team that needs SSO.
 
-Pick Keeper if any calendar you care about is on iCloud, Fastmail, or CalDAV. Pick Keeper if you want more than three calendars involved for a flat $5. Pick Keeper if you want an availability feed, an API, or the source code.
+Pick Keeper.sh if any calendar you care about is on iCloud, Fastmail, or CalDAV. Pick Keeper.sh if you want more than three calendars involved for a flat $5. Pick Keeper.sh if you want an availability feed, an API, or the source code.
 
 Plenty of people should pick Reclaim. We would rather you work that out on this page than a month after paying us.
 
@@ -128,17 +128,17 @@ Plenty of people should pick Reclaim. We would rather you work that out on this 
 
 ### Can Reclaim sync my iCloud calendar?
 
-Not directly, on any plan. Their documentation limits Calendar Sync to calendars connected to a Google or Microsoft Outlook account, and suggests sharing iCloud into Google as a workaround. Keeper connects to iCloud directly, using an app-specific password you generate in your Apple account.
+Not directly, on any plan. Their documentation limits Calendar Sync to calendars connected to a Google or Microsoft Outlook account, and suggests sharing iCloud into Google as a workaround. Keeper.sh connects to iCloud directly, using an app-specific password you generate in your Apple account.
 
-### Does Keeper copy attendees or video call links?
+### Does Keeper.sh copy attendees or video call links?
 
 No. A copy carries the times, the busy or free status, and whatever detail your settings let through.
 
-Attendees, meeting links, and reminders are never copied across. Keeper does read attendees, so you can see pending invites and RSVP.
+Attendees, meeting links, and reminders are never copied across. Keeper.sh does read attendees, so you can see pending invites and RSVP.
 
 ### Can I use both tools together?
 
-Yes, though most people will not need to. Reclaim can handle scheduling on your Google and Outlook calendars while Keeper covers an iCloud or CalDAV calendar it cannot reach.
+Yes, though most people will not need to. Reclaim can handle scheduling on your Google and Outlook calendars while Keeper.sh covers an iCloud or CalDAV calendar it cannot reach.
 
 ## Sources
 

--- a/applications/web/src/content/blog/keeper-sh-vs-reclaim-ai.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-reclaim-ai.mdx
@@ -78,11 +78,15 @@ Reclaim gives you a set of visibility choices on each policy. You can pick a Per
 
 You can also keep single events out by adding `#nosync` to the description ([using #nosync](https://help.reclaim.ai/en/articles/3639946-using-nosync-to-prevent-events-from-being-synced)). Their policy settings include a "Sync outside of working hours?" toggle and three separate rules for all-day events.
 
-Keeper copies the real title, description, and location by default. You can switch each of those off per calendar, and replace the title with fixed text or with the calendar's name.
+Keeper anonymises copies by default. A calendar you connect is copied out under the name of the calendar it came from, with the description and location stripped.
 
-Here is the honest part: those controls sit behind Pro. On our free plan, a copied event carries its original title.
+So a dentist appointment on a calendar you called "Personal" shows up at work as "Personal". Right day, right time, no detail.
 
-Reclaim's visibility choices are available on Lite, at no cost. If privacy on a free plan is what you need, they beat us outright.
+Here is the honest part: changing that is a Pro feature. Turning event names, descriptions, or locations back on needs a paid plan.
+
+Those defaults are applied when you connect a calendar, rather than enforced forever afterwards. A Pro user can turn detail back on, and we do not stop them.
+
+Reclaim gives you that choice for free. Their visibility levels sit on every policy including Lite, so you pick per policy instead of accepting one default.
 
 Reclaim's filtering is also further along than ours. Working-hours filters, all-day rules, and a per-event keyword are more than we ship today.
 
@@ -94,7 +98,7 @@ Keeper is $0 or $5 a month, flat, for one person.
 
 Our free plan gives you two linked accounts and three connections between calendars. There is no limit on how many calendars each account exposes.
 
-Pro removes both limits. It also drops the write interval to a minute and unlocks the title and detail controls.
+Pro removes both limits. It also drops the write interval to a minute, and lets you change what shows through on a copy.
 
 We have no team plan, no seats, no SSO, and no SCIM. If you are buying this for a company, Reclaim is built for that and we are not.
 
@@ -154,7 +158,7 @@ Keeper connects to iCloud directly, using an app-specific password you generate 
 
 It is enough for two linked accounts and three connections between calendars. Copies are written out every 30 minutes rather than every minute.
 
-The catch is that copied events keep their real title on the free plan, because masking titles is a Pro feature.
+Copies are anonymised by default, which is what most people want anyway. The catch is that changing what shows through is a Pro feature.
 
 ### Do I need two connections to sync both ways?
 
@@ -164,7 +168,7 @@ Work into personal and personal into work is two connections. Reclaim works the 
 
 ### Does Keeper copy attendees or video call links?
 
-No. A copied event carries its title, description, location, times, and busy or free status.
+No. A copy carries the times, the busy or free status, and whatever detail your settings let through.
 
 Attendees, meeting links, and reminders are never copied across. Keeper does read attendees, so you can see pending invites and RSVP from the API.
 

--- a/applications/web/src/content/blog/keeper-sh-vs-reclaim-ai.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-reclaim-ai.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Keeper.sh vs Reclaim.ai"
 description: "An honest comparison of Keeper.sh and Reclaim.ai for keeping work and personal calendars in sync, including when Reclaim's free plan is the better answer."
-blurb: "Reclaim's free plan already mirrors one work calendar into one personal calendar, forever, at no cost. Here is when that is enough, and when you need something that reaches iCloud and CalDAV."
+blurb: "Reclaim's free plan covers one sync between two Google or Outlook calendars, at no cost. Here is when that is enough, and when you need something that reaches iCloud and CalDAV."
 createdAt: "2026-08-11"
 updatedAt: "2026-08-11"
 slug: "keeper-sh-vs-reclaim-ai"
@@ -14,47 +14,39 @@ tags:
 
 Reclaim.ai is an AI scheduling assistant. It plans your tasks, defends your focus time, and copies events between calendars.
 
-Keeper.sh does one of those things, and it does it across more calendar providers than Reclaim can reach.
-
-That difference decides most of this comparison. This page tries to be straight about where each tool wins, including the parts where we lose.
+Keeper does one of those things, across more calendar providers than Reclaim can reach. That difference decides most of this comparison, including the parts where we lose.
 
 ## Should you just use Reclaim's free plan?
 
-For a lot of people, yes.
+Sometimes, and we would rather say so than take your money.
 
-Reclaim's Lite plan is free forever, and it includes one calendar sync and two connected calendars, per their [pricing page](https://reclaim.ai/pricing).
+Reclaim's Lite plan is free and includes one Calendar Sync and two connected calendars, per their [pricing page](https://reclaim.ai/pricing). Picture a Gmail account and a Google Workspace account, with personal events showing as busy at work. Lite does that at $0, and we would charge you $5 a month.
 
-That is exactly the job most people come to us for. One work calendar, one personal calendar, copied so nobody double-books you.
+That offer is narrower than it first looks. Reclaim supports Google and Outlook only, on every tier including the paid ones.
 
-Picture a Gmail account and a Google Workspace account. You want personal events to show up as busy at work. Reclaim Lite does that at $0, and we would charge you $5 a month.
+So if either calendar lives on iCloud, Fastmail, Nextcloud, Radicale or another CalDAV server, Reclaim cannot connect it. The same goes for a public ICS feed.
 
-If that is your situation, use Reclaim, because we would rather say so than take your money.
+The counts are not comparable either. Reclaim's free plan is one sync between two calendars. Ours is two linked accounts and three connections, and one account can expose many calendars.
 
-The free plan runs out in two places. It runs out when you need a third calendar involved, and it runs out when either calendar is not Google or Outlook.
+So the rule is simple. If you are on Google and Outlook only and need exactly one connection, use Reclaim Lite. Anything wider than that and the free plan runs out.
 
 ## Which calendars can each one connect?
 
 This is the sharpest split between the two products.
 
-Reclaim's Calendar Sync covers Google and Outlook. Their help centre says it "is only supported for calendars connected to a Google Calendar or Microsoft Outlook account" ([Calendar Sync overview](https://help.reclaim.ai/en/articles/3600762-calendar-sync-overview-keep-multiple-schedules-in-sync)).
-
-The same article suggests sharing an iCloud calendar into Google as a workaround, and notes this may cause delays.
+Reclaim's Calendar Sync covers Google and Outlook. Their help centre says it "is only supported for calendars connected to a Google Calendar or Microsoft Outlook account" ([Calendar Sync overview](https://help.reclaim.ai/en/articles/3600762-calendar-sync-overview-keep-multiple-schedules-in-sync)). The same article suggests sharing an iCloud calendar into Google as a workaround, and notes this may cause delays.
 
 Keeper connects to Google, Outlook, iCloud, Fastmail, and any CalDAV server. It also reads public ICS links, though it cannot write events back to those.
 
-So if your personal calendar lives on iCloud, Reclaim cannot reach it directly. Same if it lives on a Nextcloud or Radicale server you run yourself.
-
-That is the single most common reason people end up with us.
+So if your personal calendar lives on iCloud, or on a Nextcloud or Radicale server you run yourself, Reclaim cannot reach it directly. That is the single most common reason people end up with us.
 
 ## How fast do copies appear?
 
 Reclaim says its copies are immediate, and their product page states: "Updates happen instantly—not on a timer or slow refresh" ([AI Calendar Sync](https://reclaim.ai/features/calendar-sync)).
 
-Keeper runs on timers, and we would rather admit that than dress it up as something else.
+Keeper runs on timers, and we would rather admit that than dress it up. We read your calendars every minute, on every plan. We write copies out every minute on Pro, and every 30 minutes on the free plan.
 
-We read your calendars every minute, on every plan. We write copies out every minute on Pro, and every 30 minutes on the free plan.
-
-So a new meeting lands on your other calendar in about a minute if you pay us. On the free plan, it can take half an hour.
+So a new meeting lands on your other calendar in about a minute if you pay us. On the free plan it can take half an hour.
 
 If you need a personal event blocked at work within seconds, Reclaim is faster. That is a genuine advantage and we are not going to argue with it.
 
@@ -64,13 +56,11 @@ We do reach further out in time. Keeper covers the next two years plus the last 
 
 Yes, both of them do, and neither of us pretends otherwise.
 
-Reclaim's help centre puts it plainly. Calendar Sync "has to create copies by design, because without those copies, your colleagues viewing the destination calendar wouldn't see time from the source calendar as blocked" ([handling duplicates](https://help.reclaim.ai/en/articles/3639940-how-to-handle-duplicate-events-from-calendar-sync)).
+Reclaim's help centre puts it plainly. Calendar Sync "has to create copies by design, because without those copies, your colleagues viewing the destination calendar wouldn't see time from the source calendar as blocked" ([handling duplicates](https://help.reclaim.ai/en/articles/3639940-how-to-handle-duplicate-events-from-calendar-sync)). The same is true of Keeper, because a copy is the only thing another person's calendar can see.
 
-The same is true of Keeper, for the same reason. A copy is the only thing another person's calendar can actually see.
+Both tools also copy in one direction at a time. Reclaim tells you to "set up two sync policies" when you want both ways ([syncing in multiple directions](https://help.reclaim.ai/en/articles/3654852-using-calendar-sync-to-sync-calendars-in-multiple-directions)). Keeper wants two connections, one pointing each way.
 
-Both tools also copy in one direction at a time. Reclaim tells you to "set up two sync policies" when you want both ways ([syncing in multiple directions](https://help.reclaim.ai/en/articles/3654852-using-calendar-sync-to-sync-calendars-in-multiple-directions)).
-
-Keeper works the same way, with two connections, one pointing each way. Neither of us does true two-way sync, and you should be suspicious of anyone who claims to.
+Neither of us does two-way sync, and you should be suspicious of anyone who claims to.
 
 ## What does a copied event look like?
 
@@ -82,21 +72,15 @@ Keeper anonymises copies by default. A calendar you connect is copied out under 
 
 So a dentist appointment on a calendar you called "Personal" shows up at work as "Personal". Right day, right time, no detail.
 
-Here is the honest part: changing that is a Pro feature. Turning event names, descriptions, or locations back on needs a paid plan.
+Here is the honest part: changing that is a Pro feature. Reclaim gives you the same choice for free, on every policy including Lite.
 
-Those defaults are applied when you connect a calendar, rather than enforced forever afterwards. A Pro user can turn detail back on, and we do not stop them.
-
-Reclaim gives you that choice for free. Their visibility levels sit on every policy including Lite, so you pick per policy instead of accepting one default.
-
-Reclaim's filtering is also further along than ours. Working-hours filters, all-day rules, and a per-event keyword are more than we ship today.
+Their filtering is further along than ours too. Working-hours filters, all-day rules, and a per-event keyword are more than we ship today.
 
 ## What does each one cost?
 
-Reclaim's paid tiers are listed at $10, $15, and $22 per seat per month for Starter, Business, and Enterprise ([pricing](https://reclaim.ai/pricing)). Enterprise is where SSO and SCIM user provisioning live.
+Reclaim's paid tiers are listed at $10, $15, and $22 per seat per month for Starter, Business, and Enterprise ([pricing](https://reclaim.ai/pricing)). Enterprise is where SSO and SCIM user provisioning live. None of those tiers add a calendar provider, so paying more does not get you iCloud or CalDAV.
 
-Keeper is $0 or $5 a month, flat, for one person.
-
-Our free plan gives you two linked accounts and three connections between calendars. There is no limit on how many calendars each account exposes.
+Keeper is $0 or $5 a month, flat, for one person. Our free plan gives you two linked accounts and three connections, with no limit on how many calendars each account exposes.
 
 Pro removes both limits. It also drops the write interval to a minute, and lets you change what shows through on a copy.
 
@@ -106,43 +90,37 @@ We have no team plan, no seats, no SSO, and no SCIM. If you are buying this for 
 
 Most of Reclaim's product, honestly.
 
-It schedules tasks into open time, defends focus blocks, and adds buffer time around meetings. It builds recurring habits into your week, and offers scheduling links, a planner, and time tracking.
-
-None of that exists in Keeper, and none of it is on our list. We move events between calendars, and that is the whole product.
+It schedules tasks into open time, defends focus blocks, and adds buffer time around meetings. It builds recurring habits into your week, and offers scheduling links, a planner, and time tracking. None of that exists in Keeper, and none of it is on our list.
 
 Reclaim is also part of Dropbox, which its own site states ([about Reclaim](https://reclaim.ai/about)). If a larger company behind the product matters to your procurement team, that is worth weighing.
 
 ## What Keeper does that Reclaim does not
 
-Keeper talks to iCloud, Fastmail, and CalDAV servers directly, with no shared-calendar workaround sitting in the middle.
+Keeper talks to iCloud, Fastmail, and CalDAV servers directly, with no shared-calendar workaround in the middle.
 
-It publishes one iCal feed covering every calendar you pick. You hand that link to anyone who needs your availability, and event names show as "Busy" unless you change that.
+It publishes one iCal feed covering every calendar you pick. Hand that link to anyone who needs your availability, and event names show as "Busy" unless you change that.
 
-It has a REST API and an MCP server, both usable on the free plan at 25 calls a day.
-
-It costs $5 a month for a person, rather than a price per seat.
+It has a REST API and an MCP server, both usable on the free plan at 25 calls a day. It costs $5 a month for a person, rather than a price per seat.
 
 And it is open source under AGPL-3.0, so you can read every line of code that touches your calendar.
 
 ## Can you run Keeper yourself?
 
-Yes, and it is a real option rather than a token gesture.
-
-The whole codebase is on [GitHub](https://github.com/ridafkih/keeper.sh) under AGPL-3.0, with Docker images to make a first deployment quick.
+Yes, and it is a real option rather than a token gesture. The whole codebase is on [GitHub](https://github.com/ridafkih/keeper.sh) under AGPL-3.0, with Docker images to make a first deployment quick.
 
 Self-hosting turns on every Pro feature at no cost, and that is deliberate. We are not going to hold the good parts back from people running our code on their own hardware.
 
-It is also genuine work, and worth knowing that before you start. You need somewhere to run it, a Postgres database, and Redis. You register your own OAuth credentials with Google and Microsoft, which takes an afternoon the first time.
+It is genuine work, though. You need somewhere to run it, a Postgres database, and Redis. You also register your own Google and Microsoft credentials, which takes an afternoon the first time.
 
 After that, upgrades, backups, and uptime are yours to own.
 
-Most people should use hosted keeper.sh and pay the $5. Run it yourself if you want your calendar data on hardware you control, or you simply enjoy this kind of thing.
+Most people should use hosted keeper.sh and pay the $5. Run it yourself if you want your calendar data on hardware you control.
 
 ## So which should you pick?
 
-Pick Reclaim if you are on Google or Outlook only, and one free calendar sync covers you. Pick Reclaim if you want AI scheduling, focus time, and task planning. Pick Reclaim if you are buying seats for a team that needs SSO.
+Pick Reclaim if both calendars are Google or Outlook and one free sync covers you. Pick Reclaim if you want AI scheduling and task planning, or if you are buying seats for a team that needs SSO.
 
-Pick Keeper if any calendar you care about is on iCloud, Fastmail, or CalDAV. Pick Keeper if you want more than three calendars involved for a flat $5. Pick Keeper if you want an aggregated availability feed, an API, or the source code.
+Pick Keeper if any calendar you care about is on iCloud, Fastmail, or CalDAV. Pick Keeper if you want more than three calendars involved for a flat $5. Pick Keeper if you want an availability feed, an API, or the source code.
 
 Plenty of people should pick Reclaim. We would rather you work that out on this page than a month after paying us.
 
@@ -150,27 +128,13 @@ Plenty of people should pick Reclaim. We would rather you work that out on this 
 
 ### Can Reclaim sync my iCloud calendar?
 
-Not directly. Their documentation limits Calendar Sync to calendars connected to a Google or Microsoft Outlook account, and suggests sharing iCloud into Google as a workaround.
-
-Keeper connects to iCloud directly, using an app-specific password you generate in your Apple account.
-
-### Is Keeper's free plan enough for me?
-
-It is enough for two linked accounts and three connections between calendars. Copies are written out every 30 minutes rather than every minute.
-
-Copies are anonymised by default, which is what most people want anyway. The catch is that changing what shows through is a Pro feature.
-
-### Do I need two connections to sync both ways?
-
-Yes, because each connection moves events in one direction only.
-
-Work into personal and personal into work is two connections. Reclaim works the same way, using two of its sync policies.
+Not directly, on any plan. Their documentation limits Calendar Sync to calendars connected to a Google or Microsoft Outlook account, and suggests sharing iCloud into Google as a workaround. Keeper connects to iCloud directly, using an app-specific password you generate in your Apple account.
 
 ### Does Keeper copy attendees or video call links?
 
 No. A copy carries the times, the busy or free status, and whatever detail your settings let through.
 
-Attendees, meeting links, and reminders are never copied across. Keeper does read attendees, so you can see pending invites and RSVP from the API.
+Attendees, meeting links, and reminders are never copied across. Keeper does read attendees, so you can see pending invites and RSVP.
 
 ### Can I use both tools together?
 


### PR DESCRIPTION
Two comparison posts in the blog: `keeper-sh-vs-reclaim-ai` and `keeper-sh-vs-morgen`. Every third-party claim is sourced inline from the competitor's own public pages, with one freshness note per post rather than a stamp per link. Both concede the cases where the other product is the better buy.

- Reclaim post leads with the concession that their free Lite tier does our core job at $0 forever on Google/Outlook, and that their privacy controls are free where ours are Pro.
- Morgen post concedes their native apps, filter DSL, Swiss/EU hosting, and their stated policy of not storing calendar data; our case is the 6pm-daily vs per-minute timing gap.
- Our side states read every minute on all plans, writes every 30 min free and every minute on Pro, no two-way sync, and no attendee/conferencing/reminder copying.
- Self-hosting gets its own section in each, described honestly including the setup effort.
- `bun run types` and `bun run lint` pass; both pages render 200 from a production build and appear in the built sitemap.
