### PR TITLE
fix: give light-theme elevated surfaces the same separation as dark

### DIFF
--- a/applications/web/src/features/blog/components/blog-post-cta.tsx
+++ b/applications/web/src/features/blog/components/blog-post-cta.tsx
@@ -4,7 +4,7 @@ import { Text } from "@/components/ui/primitives/text";
 
 export function BlogPostCta() {
   return (
-    <aside className="overflow-hidden rounded-2xl border border-interactive-border bg-background-elevated">
+    <aside className="overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated">
       <div className="grid grid-cols-1 sm:grid-cols-3 sm:items-stretch">
         <div className="flex flex-col gap-3 p-5 md:p-6 sm:col-span-2">
           <Heading3 as="h2" className="mb-0 mt-0">

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -67,7 +67,7 @@ html {
     transparent 40%
   );
   --ui-background-elevated: var(--color-white);
-  --ui-border-elevated: var(--color-neutral-200);
+  --ui-border-elevated: var(--color-neutral-300);
   --ui-background-inverse-hover: var(--color-neutral-800);
   --ui-background-hover: color-mix(
     in srgb,


### PR DESCRIPTION
Light theme set `--ui-border-elevated` to neutral-200 while `--ui-interactive-border` was neutral-300; dark theme sets both to neutral-800. That split is why elevated surfaces read flat in light and fine in dark, since the white-on-neutral-50 fill carries almost nothing on its own. Aligning light with the convention dark already uses fixes every elevated surface at the token level, and because no background changes, every text contrast ratio is unchanged.

- `--ui-border-elevated`: neutral-200 -> neutral-300 (light only; dark untouched)
- Elevated border vs page: 1.21:1 -> 1.42:1 in light, against 1.31:1 in dark
- Elevated fill vs page stays 1.04:1 light / 1.10:1 dark, so the border now carries elevation
- `foreground-muted` on page holds at 4.53:1 and `foreground` at 18.96:1 — darkening `--ui-background` instead would have dropped muted to 4.34:1, under AA
- `blog-post-cta` used `border-interactive-border` to compensate for the weak elevated border; switched to `border-border-elevated` (identical computed value in both themes)
- Dark-theme screenshots byte-identical before and after