### PR TITLE
refactor: make a keyless configuration unrepresentable

### DIFF
--- a/packages/sync/src/resolve-provider.ts
+++ b/packages/sync/src/resolve-provider.ts
@@ -158,7 +158,7 @@ interface ResolveProviderOptions {
   userId: string;
   accountId: string;
   oauthConfig: OAuthConfig;
-  encryptionKey?: string;
+  encryptionKey: string;
   refreshLockStore?: RefreshLockStore | null;
   rateLimiter?: RedisRateLimiter;
   signal?: AbortSignal;
@@ -179,7 +179,7 @@ const resolveSyncProvider = (options: ResolveProviderOptions): Promise<CalendarS
     );
   }
 
-  if (CALDAV_PROVIDERS.has(options.provider) && options.encryptionKey) {
+  if (CALDAV_PROVIDERS.has(options.provider)) {
     return resolveCalDAVProvider(
       options.database,
       options.calendarId,

--- a/packages/sync/src/sync-user.ts
+++ b/packages/sync/src/sync-user.ts
@@ -71,7 +71,7 @@ interface SyncConfig {
   destinationCalendarId: string;
   database: BunSQLDatabase;
   redis: Redis;
-  encryptionKey?: string;
+  encryptionKey: string;
   oauthConfig: OAuthConfig;
   refreshLockStore?: RefreshLockStore | null;
   deadlineMs?: number;

--- a/services/api/src/env.ts
+++ b/services/api/src/env.ts
@@ -6,7 +6,7 @@ const schema = {
   BETTER_AUTH_URL: "string.url",
   COMMERCIAL_MODE: "boolean?",
   DATABASE_URL: "string.url",
-  ENCRYPTION_KEY: "string?",
+  ENCRYPTION_KEY: "string",
   FEEDBACK_EMAIL: "string?",
   GOOGLE_CLIENT_ID: "string?",
   GOOGLE_CLIENT_SECRET: "string?",

--- a/services/api/src/mutations/index.ts
+++ b/services/api/src/mutations/index.ts
@@ -45,7 +45,7 @@ interface MutationDependencies {
   database: KeeperDatabase;
   oauthTokenRefresher?: OAuthTokenRefresher;
   refreshLockStore?: RefreshLockStore | null;
-  encryptionKey?: string;
+  encryptionKey: string;
 }
 
 const TOKEN_REFRESH_BUFFER_MS = 60_000;
@@ -167,7 +167,7 @@ const dispatchCreateEvent = (
     return createEventViaOAuth(credentials, input, deps);
   }
 
-  if (credentials.caldav && CALDAV_PROVIDERS.has(credentials.provider) && deps.encryptionKey && credentials.calendarUrl) {
+  if (credentials.caldav && CALDAV_PROVIDERS.has(credentials.provider) && credentials.calendarUrl) {
     return createEventViaCalDAV(credentials, input, deps.encryptionKey);
   }
 
@@ -246,7 +246,7 @@ const dispatchUpdateEvent = async (
     return { success: false, error: `Unsupported OAuth provider: ${credentials.provider}` };
   }
 
-  if (credentials.caldav && CALDAV_PROVIDERS.has(credentials.provider) && deps.encryptionKey && credentials.calendarUrl) {
+  if (credentials.caldav && CALDAV_PROVIDERS.has(credentials.provider) && credentials.calendarUrl) {
     return updateCalDAVEvent(
       {
         serverUrl: credentials.caldav.serverUrl,
@@ -382,7 +382,7 @@ const deleteEventMutation = async (
           return result;
         }
       }
-    } else if (credentials.caldav && CALDAV_PROVIDERS.has(credentials.provider) && deps.encryptionKey && credentials.calendarUrl) {
+    } else if (credentials.caldav && CALDAV_PROVIDERS.has(credentials.provider) && credentials.calendarUrl) {
       const result = await deleteCalDAVEvent(
         {
           serverUrl: credentials.caldav.serverUrl,
@@ -458,7 +458,7 @@ const rsvpEventMutation = async (
     return { success: false, error: `RSVP not supported for provider: ${credentials.provider}` };
   }
 
-  if (credentials.caldav && CALDAV_PROVIDERS.has(credentials.provider) && deps.encryptionKey && credentials.calendarUrl) {
+  if (credentials.caldav && CALDAV_PROVIDERS.has(credentials.provider) && credentials.calendarUrl) {
     return rsvpCalDAVEvent(
       {
         serverUrl: credentials.caldav.serverUrl,
@@ -561,7 +561,7 @@ const fetchPendingInvitesForCalendar = (
     return fetchOAuthPendingInvites(credentials, from, to, deps);
   }
 
-  if (credentials.caldav && deps.encryptionKey) {
+  if (credentials.caldav) {
     return fetchCalDAVPendingInvites(credentials, from, to, deps.encryptionKey);
   }
 

--- a/services/api/src/read-models.ts
+++ b/services/api/src/read-models.ts
@@ -19,15 +19,15 @@ import type { KeeperApi, KeeperDatabase } from "./types";
 interface KeeperApiOptions {
   oauthTokenRefresher?: OAuthTokenRefresher;
   refreshLockStore?: RefreshLockStore | null;
-  encryptionKey?: string;
+  encryptionKey: string;
 }
 
-const createKeeperApi = (database: KeeperDatabase, options?: KeeperApiOptions): KeeperApi => {
+const createKeeperApi = (database: KeeperDatabase, options: KeeperApiOptions): KeeperApi => {
   const deps = {
     database,
-    oauthTokenRefresher: options?.oauthTokenRefresher,
-    refreshLockStore: options?.refreshLockStore,
-    encryptionKey: options?.encryptionKey,
+    oauthTokenRefresher: options.oauthTokenRefresher,
+    refreshLockStore: options.refreshLockStore,
+    encryptionKey: options.encryptionKey,
   };
 
   return {

--- a/services/api/src/routes/api/destinations/index.ts
+++ b/services/api/src/routes/api/destinations/index.ts
@@ -1,8 +1,8 @@
 import { withAuth, withWideEvent } from "@/utils/middleware";
 import { createKeeperApi } from "@/read-models";
-import { database } from "@/context";
+import { database, encryptionKey } from "@/context";
 
-const keeperApi = createKeeperApi(database);
+const keeperApi = createKeeperApi(database, { encryptionKey });
 
 export const GET = withWideEvent(
   withAuth(async ({ userId }) => {

--- a/services/api/src/routes/api/events/count.ts
+++ b/services/api/src/routes/api/events/count.ts
@@ -1,8 +1,8 @@
 import { createKeeperApi } from "@/read-models";
 import { withAuth, withWideEvent } from "@/utils/middleware";
-import { database } from "@/context";
+import { database, encryptionKey } from "@/context";
 
-const keeperApi = createKeeperApi(database);
+const keeperApi = createKeeperApi(database, { encryptionKey });
 
 export const GET = withWideEvent(
   withAuth(async ({ userId }) => {

--- a/services/api/src/routes/api/events/index.ts
+++ b/services/api/src/routes/api/events/index.ts
@@ -1,9 +1,9 @@
 import { normalizeDateRange, parseDateRangeParams } from "@/utils/date-range";
 import { createKeeperApi } from "@/read-models";
 import { withAuth, withWideEvent } from "@/utils/middleware";
-import { database } from "@/context";
+import { database, encryptionKey } from "@/context";
 
-const keeperApi = createKeeperApi(database);
+const keeperApi = createKeeperApi(database, { encryptionKey });
 
 export const GET = withWideEvent(
   withAuth(async ({ request, userId }) => {

--- a/services/api/src/routes/api/mappings/index.ts
+++ b/services/api/src/routes/api/mappings/index.ts
@@ -1,8 +1,8 @@
 import { withAuth, withWideEvent } from "@/utils/middleware";
 import { createKeeperApi } from "@/read-models";
-import { database } from "@/context";
+import { database, encryptionKey } from "@/context";
 
-const keeperApi = createKeeperApi(database);
+const keeperApi = createKeeperApi(database, { encryptionKey });
 
 export const GET = withWideEvent(
   withAuth(async ({ userId }) => {

--- a/services/api/src/routes/api/sources/index.ts
+++ b/services/api/src/routes/api/sources/index.ts
@@ -1,8 +1,8 @@
 import { withAuth, withWideEvent } from "@/utils/middleware";
-import { database } from "@/context";
+import { database, encryptionKey } from "@/context";
 import { createKeeperApi } from "@/read-models";
 
-const keeperApi = createKeeperApi(database);
+const keeperApi = createKeeperApi(database, { encryptionKey });
 
 const GET = withWideEvent(
   withAuth(async ({ userId }) =>

--- a/services/api/src/routes/api/sync/status.ts
+++ b/services/api/src/routes/api/sync/status.ts
@@ -1,8 +1,8 @@
 import { createKeeperApi } from "@/read-models";
 import { withAuth, withWideEvent } from "@/utils/middleware";
-import { database } from "@/context";
+import { database, encryptionKey } from "@/context";
 
-const keeperApi = createKeeperApi(database);
+const keeperApi = createKeeperApi(database, { encryptionKey });
 
 const GET = withWideEvent(
   withAuth(async ({ userId }) => {

--- a/services/api/src/routes/api/v1/calendars/index.ts
+++ b/services/api/src/routes/api/v1/calendars/index.ts
@@ -1,9 +1,9 @@
 import { createKeeperApi } from "@/read-models";
 import type { KeeperSource } from "@/types";
 import { withV1Auth, withWideEvent } from "@/utils/middleware";
-import { database } from "@/context";
+import { database, encryptionKey } from "@/context";
 
-const keeperApi = createKeeperApi(database);
+const keeperApi = createKeeperApi(database, { encryptionKey });
 
 const toCalendar = (source: KeeperSource) => ({
   id: source.id,

--- a/services/api/src/utils/caldav-sources.ts
+++ b/services/api/src/utils/caldav-sources.ts
@@ -86,9 +86,9 @@ const createCalDAVAccount = async (
   databaseClient: CaldavSourceDatabase,
   userId: string,
   data: CreateCalDAVSourceData,
-  resolvedEncryptionKey: string,
+  sourceEncryptionKey: string,
 ): Promise<string> => {
-  const encryptedPassword = encryptPassword(data.password, resolvedEncryptionKey);
+  const encryptedPassword = encryptPassword(data.password, sourceEncryptionKey);
 
   const [credential] = await databaseClient
     .insert(caldavCredentialsTable)
@@ -184,12 +184,6 @@ const createCalDAVSource = async (
   userId: string,
   data: CreateCalDAVSourceData,
 ): Promise<CalDAVSource> => {
-  if (!encryptionKey) {
-    throw new Error("Encryption key not configured");
-  }
-
-  const resolvedEncryptionKey = encryptionKey;
-
   const plan = await premiumService.getUserPlan(userId);
   if (!plan) {
     throw new Error("Unable to resolve user plan for sync enqueue");
@@ -234,7 +228,7 @@ const createCalDAVSource = async (
     }
 
     const accountId = existingAccount?.id ??
-      await createCalDAVAccount(tx, userId, data, resolvedEncryptionKey);
+      await createCalDAVAccount(tx, userId, data, encryptionKey);
 
     const [source] = await tx
       .insert(calendarsTable)

--- a/services/api/src/utils/caldav.ts
+++ b/services/api/src/utils/caldav.ts
@@ -90,10 +90,6 @@ const createCalDAVDestination = async (
     throw new CalDAVConnectionError(error);
   });
 
-  if (!encryptionKey) {
-    throw new Error("ENCRYPTION_KEY must be set to use CalDAV destinations");
-  }
-
   const encrypted = encryptPassword(credentials.password, encryptionKey);
   const serverHost = new URL(serverUrl).host;
   const accountId = `${credentials.username}@${serverHost}`;

--- a/services/cron/src/env.ts
+++ b/services/cron/src/env.ts
@@ -5,7 +5,7 @@ const schema = {
   BLOCK_PRIVATE_RESOLUTION: "boolean?",
   COMMERCIAL_MODE: "boolean?",
   DATABASE_URL: "string.url",
-  ENCRYPTION_KEY: "string?",
+  ENCRYPTION_KEY: "string",
   GOOGLE_CLIENT_ID: "string?",
   GOOGLE_CLIENT_SECRET: "string?",
   MICROSOFT_CLIENT_ID: "string?",

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -456,10 +456,6 @@ const ingestOAuthSources = async (): Promise<{ added: number; removed: number; e
 };
 
 const ingestCalDAVSources = async (): Promise<{ added: number; removed: number; errors: number; ingestEvents: Record<string, unknown>[] }> => {
-  if (!env.ENCRYPTION_KEY) {
-    return { added: 0, removed: 0, errors: 0, ingestEvents: [] };
-  }
-
   const encryptionKey = env.ENCRYPTION_KEY;
 
   const caldavSources = await database

--- a/services/worker/src/env.ts
+++ b/services/worker/src/env.ts
@@ -2,7 +2,7 @@ import arkenv from "arkenv";
 
 const schema = {
   DATABASE_URL: "string.url",
-  ENCRYPTION_KEY: "string?",
+  ENCRYPTION_KEY: "string",
   GOOGLE_CLIENT_ID: "string?",
   GOOGLE_CLIENT_SECRET: "string?",
   MICROSOFT_CLIENT_ID: "string?",


### PR DESCRIPTION
Must merge AFTER #507 — merging it first would break keyless deployments that #507 has not yet made impossible, since it makes `ENCRYPTION_KEY` required without #507's startup migration notice. #507 makes the key required at runtime; this removes the now-unreachable branches that handled its absence, so nobody can later "restore" keyless operation and silently reintroduce credential loss. The optionality all originates in the three env schemas, so those are tightened first and the guards then fail to typecheck rather than merely being unused.

- `services/{api,cron,worker}/src/env.ts`: `ENCRYPTION_KEY` `"string?"` → `"string"`
- `services/api/src/utils/caldav.ts` and `utils/caldav-sources.ts`: dropped the two "key not configured" throws, and the `resolvedEncryptionKey` narrowing alias with them
- `services/api/src/mutations/index.ts`: `MutationDependencies.encryptionKey` now required; dropped the four `deps.encryptionKey &&` conjuncts on the CalDAV dispatch path plus one on pending invites
- `services/api/src/read-models.ts`: `KeeperApiOptions.encryptionKey` and the `options` argument now required, so the seven read-only `createKeeperApi(database)` routes pass it through
- `packages/sync/src/{sync-user,resolve-provider}.ts`: `SyncConfig.encryptionKey` and `ResolveProviderOptions.encryptionKey` now required; dropped the `&& options.encryptionKey` conjunct
- `services/cron/src/jobs/ingest-sources.ts`: dropped the early return that skipped CalDAV ingest entirely when the key was unset

Every removed conjunct sat beside conditions that still gate the branch, so branch selection is unchanged once the key is guaranteed. #507 independently tightens the env schemas, `MutationDependencies`, `KeeperApiOptions` and `SyncConfig`; those lines will conflict and should resolve in favour of #507. README and `.env.template` updates are left to #507. `services/mcp` and `applications/web` untouched.

`bun run types`, `bun run lint` and `bun run unused` pass. `bun run test` passes except the pre-existing host-ICU-dependent Morocco VTIMEZONE test in `packages/calendar`, which this PR does not touch.
