### PR TITLE
fix: surface API error messages instead of status and URL

### DIFF
--- a/applications/web/src/lib/fetcher.ts
+++ b/applications/web/src/lib/fetcher.ts
@@ -2,15 +2,47 @@ export class HttpError extends Error {
   constructor(
     public readonly status: number,
     public readonly url: string,
+    public readonly serverMessage: string | null = null,
   ) {
     super(`${status} ${url}`);
     this.name = "HttpError";
   }
 }
 
+function extractServerMessage(value: unknown): string | null {
+  if (typeof value === "string") return value.trim() || null;
+  if (typeof value !== "object" || value === null) return null;
+
+  const { error, message } = value as Record<string, unknown>;
+  return extractServerMessage(error) ?? extractServerMessage(message);
+}
+
+async function readServerMessage(
+  response: Response,
+  url: string,
+): Promise<string | null> {
+  if (response.status < 400 || response.status >= 500) return null;
+
+  try {
+    const body = (await response.text()).trim();
+    if (!body.startsWith("{")) return null;
+    return extractServerMessage(JSON.parse(body));
+  } catch (error) {
+    console.error(`[fetcher] ${response.status} ${url}: unreadable error body`, error);
+    return null;
+  }
+}
+
+export async function createHttpError(
+  response: Response,
+  url: string,
+): Promise<HttpError> {
+  return new HttpError(response.status, url, await readServerMessage(response, url));
+}
+
 export async function fetcher<T>(url: string): Promise<T> {
   const response = await fetch(url, { credentials: "include" });
-  if (!response.ok) throw new HttpError(response.status, url);
+  if (!response.ok) throw await createHttpError(response, url);
   return response.json();
 }
 
@@ -19,6 +51,6 @@ export async function apiFetch(
   options: RequestInit,
 ): Promise<Response> {
   const response = await fetch(url, { credentials: "include", ...options });
-  if (!response.ok) throw new HttpError(response.status, url);
+  if (!response.ok) throw await createHttpError(response, url);
   return response;
 }

--- a/applications/web/src/router.ts
+++ b/applications/web/src/router.ts
@@ -1,6 +1,6 @@
 import { createRouter } from "@tanstack/react-router";
 import { routeTree } from "./generated/tanstack/route-tree.generated";
-import { HttpError } from "./lib/fetcher";
+import { createHttpError } from "./lib/fetcher";
 import { getPublicRuntimeConfig, getServerPublicRuntimeConfig } from "./lib/runtime-config";
 import type { PublicRuntimeConfig } from "./lib/runtime-config";
 import { hasSessionCookie } from "./lib/session-cookie";
@@ -68,7 +68,7 @@ function createJsonFetcher(
     });
 
     if (!response.ok) {
-      throw new HttpError(response.status, path);
+      throw await createHttpError(response, path);
     }
 
     return response.json();

--- a/applications/web/src/utils/errors.ts
+++ b/applications/web/src/utils/errors.ts
@@ -1,4 +1,7 @@
+import { HttpError } from "@/lib/fetcher";
+
 export function resolveErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof HttpError) return error.serverMessage ?? fallback;
   if (error instanceof Error) return error.message;
   return fallback;
 }

--- a/applications/web/tests/lib/fetcher.test.ts
+++ b/applications/web/tests/lib/fetcher.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HttpError, createHttpError } from "../../src/lib/fetcher";
+import { resolveErrorMessage } from "../../src/utils/errors";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createHttpError", () => {
+  it("surfaces the server message from the error envelope", async () => {
+    const error = await createHttpError(
+      jsonResponse(401, { error: "Invalid credentials" }),
+      "/api/sources/caldav/discover",
+    );
+
+    expect(error.status).toBe(401);
+    expect(error.url).toBe("/api/sources/caldav/discover");
+    expect(error.serverMessage).toBe("Invalid credentials");
+  });
+
+  it("surfaces a better-auth style message envelope", async () => {
+    const error = await createHttpError(
+      jsonResponse(400, { message: "Password too short", code: "PASSWORD_TOO_SHORT" }),
+      "/api/auth/sign-up/email",
+    );
+
+    expect(error.serverMessage).toBe("Password too short");
+  });
+
+  it("returns no message when the envelope carries a null error", async () => {
+    const error = await createHttpError(jsonResponse(404, { error: null }), "/api/sources");
+
+    expect(error.serverMessage).toBeNull();
+  });
+
+  it("withholds the server message for server errors", async () => {
+    const error = await createHttpError(
+      jsonResponse(500, { error: "connection to 10.0.0.4:5432 refused" }),
+      "/api/sources",
+    );
+
+    expect(error.status).toBe(500);
+    expect(error.serverMessage).toBeNull();
+  });
+
+  it("ignores empty and non-JSON bodies without reporting them", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const empty = await createHttpError(new Response("", { status: 403 }), "/api/sources");
+    const html = await createHttpError(
+      new Response("<html><body>Gateway</body></html>", { status: 429 }),
+      "/api/sources",
+    );
+
+    expect(empty.serverMessage).toBeNull();
+    expect(html.serverMessage).toBeNull();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("reports a malformed JSON body instead of throwing", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const error = await createHttpError(new Response("{oops", { status: 400 }), "/api/sources");
+
+    expect(error.serverMessage).toBeNull();
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it("reports an already-consumed body instead of throwing", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const response = jsonResponse(400, { error: "Invalid credentials" });
+    await response.text();
+
+    const error = await createHttpError(response, "/api/sources");
+
+    expect(error.serverMessage).toBeNull();
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it("keeps the status and url on the error message for diagnostics", async () => {
+    const error = await createHttpError(
+      jsonResponse(401, { error: "Invalid credentials" }),
+      "/api/sources/caldav/discover",
+    );
+
+    expect(error.message).toBe("401 /api/sources/caldav/discover");
+  });
+});
+
+describe("resolveErrorMessage", () => {
+  it("shows the server message when there is one", () => {
+    const error = new HttpError(401, "/api/sources/caldav/discover", "Invalid credentials");
+
+    expect(resolveErrorMessage(error, "Failed to discover calendars")).toBe(
+      "Invalid credentials",
+    );
+  });
+
+  it("falls back to the caller message when the server sent none", () => {
+    const error = new HttpError(500, "/api/sources/caldav/discover");
+
+    expect(resolveErrorMessage(error, "Failed to discover calendars")).toBe(
+      "Failed to discover calendars",
+    );
+  });
+
+  it("preserves the message of non-HTTP errors", () => {
+    expect(resolveErrorMessage(new Error("Network request failed"), "fallback")).toBe(
+      "Network request failed",
+    );
+  });
+
+  it("falls back for values that are not errors", () => {
+    expect(resolveErrorMessage("nope", "fallback")).toBe("fallback");
+  });
+});


### PR DESCRIPTION
Connecting a CalDAV account with a bad password showed `400 http://localhost:3999/api/sources/caldav/discover`; it now shows `Failed to discover calendars`. `apiFetch`/`fetcher` threw `HttpError` before reading the response body, and its message was built as `${status} ${url}`, so every error surface in the web app rendered a status and a URL rather than the message the API had already sent.

The client now reads the error envelope and exposes it as `HttpError.serverMessage`, which `resolveErrorMessage` prefers over the call-site fallback.

- Affects all 15 `resolveErrorMessage` call sites, not just CalDAV — auth, password reset, feedback, reports, API tokens, passkeys, account/calendar deletion, OAuth consent, and the root error boundary.
- Handles the shapes the API actually returns: `{error}` from `ErrorResponse` (94 call sites), the hand-built `{error}` 409s, `{authRequired, error}`, and better-auth `{message, code}`.
- Only 4xx pass the server message through. Those come from `ErrorResponse` helpers with author-written, user-facing strings. 5xx are withheld because uncaught exceptions fall through to Bun default handling, which serves an HTML error page with the stack trace outside production.
- Non-JSON, empty, and already-consumed bodies fall back to the caller message; a malformed JSON body is reported via `console.error` rather than swallowed, and body parsing can never throw out of the fetcher.
- `status` and `url` stay on `HttpError`, and `message` remains `${status} ${url}`, so the `__root.tsx` retry logic, the upgrade loader 401 redirect, and SWR logging are unchanged. Non-HTTP errors keep their own message.
- `router.ts` had a second copy of the same throw site for SSR loaders; it now shares the helper.

Note for whoever merges: #481 documents the old behaviour in four how-to guides, telling readers they will see `401 /api/sources/caldav/discover`. Those guides need updating once this lands.