### PR TITLE
fix: return invalid credentials for failed CalDAV discovery auth

### DIFF
--- a/packages/calendar/src/providers/caldav/index.ts
+++ b/packages/calendar/src/providers/caldav/index.ts
@@ -5,7 +5,7 @@ export { createCalDAVSyncProvider, type CalDAVSyncProviderConfig } from "./desti
 export { createCalDAVSourceProvider } from "./source/provider";
 export { createCalDAVSourceService } from "./source/sync";
 
-export { CalDAVClient, createCalDAVClient } from "./shared/client";
+export { CalDAVAuthenticationError, CalDAVClient, createCalDAVClient } from "./shared/client";
 export { eventToICalString, parseICalToRemoteEvent, parseICalToRemoteEvents } from "./shared/ics";
 
 export type {

--- a/packages/calendar/src/providers/caldav/shared/client.ts
+++ b/packages/calendar/src/providers/caldav/shared/client.ts
@@ -1,3 +1,4 @@
+import { HTTP_STATUS } from "@keeper.sh/constants";
 import { createDAVClient } from "tsdav";
 import { createSafeFetch } from "../../../utils/safe-fetch";
 import { createDigestAwareFetch } from "./digest-fetch";
@@ -22,6 +23,15 @@ class CalDAVHttpError extends Error {
     this.name = "CalDAVHttpError";
     this.operation = operation;
     this.status = response.status;
+  }
+}
+
+class CalDAVAuthenticationError extends Error {
+  readonly status = HTTP_STATUS.UNAUTHORIZED;
+
+  constructor(cause: unknown) {
+    super("Invalid credentials", { cause });
+    this.name = "CalDAVAuthenticationError";
   }
 }
 
@@ -60,6 +70,7 @@ class CalDAVClient {
   private config: CalDAVClientConfig;
   private safeFetchOptions?: SafeFetchOptions;
   private resolvedAuthMethod: (() => CalDAVAuthMethod | null) | null = null;
+  private lastResponseStatus: (() => number | null) | null = null;
 
   constructor(config: CalDAVClientConfig, safeFetchOptions?: SafeFetchOptions) {
     this.config = config;
@@ -73,12 +84,13 @@ class CalDAVClient {
   private async getClient(): Promise<DAVClientInstance> {
     if (!this.client) {
       const safeFetch = createSafeFetch(this.safeFetchOptions);
-      const { fetch: digestAwareFetch, getResolvedMethod } = createDigestAwareFetch({
+      const { fetch: digestAwareFetch, getLastResponseStatus, getResolvedMethod } = createDigestAwareFetch({
         credentials: this.config.credentials,
         baseFetch: safeFetch,
         knownAuthMethod: this.config.authMethod,
       });
       this.resolvedAuthMethod = getResolvedMethod;
+      this.lastResponseStatus = getLastResponseStatus;
       this.client = await createDAVClient({
         authMethod: "Custom",
         authFunction: () => Promise.resolve({}),
@@ -91,9 +103,22 @@ class CalDAVClient {
     return this.client;
   }
 
+  private async mapAuthenticationFailure<Result>(operation: () => Promise<Result>): Promise<Result> {
+    try {
+      return await operation();
+    } catch (error) {
+      if (this.lastResponseStatus?.() === HTTP_STATUS.UNAUTHORIZED) {
+        throw new CalDAVAuthenticationError(error);
+      }
+      throw error;
+    }
+  }
+
   async discoverCalendars(): Promise<CalendarInfo[]> {
-    const client = await this.getClient();
-    const calendars = await client.fetchCalendars();
+    const calendars = await this.mapAuthenticationFailure(async () => {
+      const client = await this.getClient();
+      return client.fetchCalendars();
+    });
 
     return calendars
       .filter(({ components }) => components?.includes("VEVENT"))
@@ -175,18 +200,18 @@ class CalDAVClient {
     return objects[0] ?? null;
   }
 
-  async fetchCalendarObjects(params: {
+  fetchCalendarObjects(params: {
     calendarUrl: string;
     timeRange?: { start: string; end: string };
   }): Promise<CalendarObject[]> {
-    const client = await this.getClient();
+    return this.mapAuthenticationFailure(async () => {
+      const client = await this.getClient();
 
-    const objects = await client.fetchCalendarObjects({
-      calendar: { url: params.calendarUrl },
-      ...(params.timeRange && { timeRange: params.timeRange }),
+      return client.fetchCalendarObjects({
+        calendar: { url: params.calendarUrl },
+        ...(params.timeRange && { timeRange: params.timeRange }),
+      });
     });
-
-    return objects;
   }
 
   private static ensureTrailingSlash(url: string): string {
@@ -206,4 +231,10 @@ class CalDAVClient {
 const createCalDAVClient = (config: CalDAVClientConfig, safeFetchOptions?: SafeFetchOptions): CalDAVClient =>
   new CalDAVClient(config, safeFetchOptions);
 
-export { CalDAVClient, CalDAVCreateConflictError, CalDAVHttpError, createCalDAVClient };
+export {
+  CalDAVAuthenticationError,
+  CalDAVClient,
+  CalDAVCreateConflictError,
+  CalDAVHttpError,
+  createCalDAVClient,
+};

--- a/packages/calendar/src/providers/caldav/shared/digest-fetch.ts
+++ b/packages/calendar/src/providers/caldav/shared/digest-fetch.ts
@@ -48,6 +48,7 @@ interface DigestAwareFetchOptions {
 interface DigestAwareFetchResult {
   fetch: FetchFunction;
   getResolvedMethod: () => CalDAVAuthMethod | null;
+  getLastResponseStatus: () => number | null;
 }
 
 const createDigestAwareFetch = (options: DigestAwareFetchOptions): DigestAwareFetchResult => {
@@ -59,9 +60,12 @@ const createDigestAwareFetch = (options: DigestAwareFetchOptions): DigestAwareFe
     fetch: baseFetch,
   });
 
-  const state: { method: AuthMethod } = { method: knownAuthMethod ?? "unknown" };
+  const state: { method: AuthMethod; lastResponseStatus: number | null } = {
+    method: knownAuthMethod ?? "unknown",
+    lastResponseStatus: null,
+  };
 
-  const performFetch: FetchFunction = async (input, init) => {
+  const authenticatedFetch: FetchFunction = async (input, init) => {
     if (state.method === "digest") {
       return digestClient.fetch(input, init);
     }
@@ -89,6 +93,12 @@ const createDigestAwareFetch = (options: DigestAwareFetchOptions): DigestAwareFe
     return digestClient.fetch(input, init);
   };
 
+  const performFetch: FetchFunction = async (input, init) => {
+    const response = await authenticatedFetch(input, init);
+    state.lastResponseStatus = response.status;
+    return response;
+  };
+
   const getResolvedMethod = (): CalDAVAuthMethod | null => {
     if (state.method === "unknown") {
       return null;
@@ -96,7 +106,9 @@ const createDigestAwareFetch = (options: DigestAwareFetchOptions): DigestAwareFe
     return state.method;
   };
 
-  return { fetch: performFetch, getResolvedMethod };
+  const getLastResponseStatus = (): number | null => state.lastResponseStatus;
+
+  return { fetch: performFetch, getLastResponseStatus, getResolvedMethod };
 };
 
 type CalDAVAuthMethod = "basic" | "digest";

--- a/packages/calendar/tests/providers/caldav/shared/client-authentication.test.ts
+++ b/packages/calendar/tests/providers/caldav/shared/client-authentication.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CalDAVAuthenticationError,
+  CalDAVClient,
+} from "../../../../src/providers/caldav/shared/client";
+
+const fetchMocks = vi.hoisted(() => ({
+  safeFetch: vi.fn(),
+}));
+
+vi.mock("../../../../src/utils/safe-fetch", () => ({
+  createSafeFetch: () => fetchMocks.safeFetch,
+}));
+
+const unauthorizedResponse = (): Response =>
+  new Response("", { status: 401, statusText: "Unauthorized" });
+
+const captureRejection = async (operation: () => Promise<unknown>): Promise<unknown> => {
+  try {
+    await operation();
+  } catch (error) {
+    return error;
+  }
+
+  throw new Error("expected the operation to reject");
+};
+
+const createClient = () =>
+  new CalDAVClient({
+    credentials: { password: "wrong-password", username: "user" },
+    serverUrl: "https://caldav.example.com",
+  });
+
+describe("CalDAVClient authentication failures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws a typed authentication error when the server answers 401", async () => {
+    fetchMocks.safeFetch.mockImplementation(() => Promise.resolve(unauthorizedResponse()));
+
+    await expect(createClient().discoverCalendars()).rejects.toBeInstanceOf(CalDAVAuthenticationError);
+  });
+
+  it("carries a 401 status the caller can branch on without reading the message", async () => {
+    fetchMocks.safeFetch.mockImplementation(() => Promise.resolve(unauthorizedResponse()));
+
+    const error = await captureRejection(() => createClient().discoverCalendars());
+
+    expect(error).toMatchObject({ name: "CalDAVAuthenticationError", status: 401 });
+    expect((error as CalDAVAuthenticationError).cause).toBeInstanceOf(Error);
+  });
+
+  it("leaves non-authentication failures untouched", async () => {
+    fetchMocks.safeFetch.mockImplementation(() =>
+      Promise.resolve(new Response("", { status: 500, statusText: "Server Error" })));
+
+    const error = await captureRejection(() => createClient().discoverCalendars());
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(CalDAVAuthenticationError);
+  });
+});

--- a/services/api/src/routes/api/sources/caldav/discover-route.ts
+++ b/services/api/src/routes/api/sources/caldav/discover-route.ts
@@ -1,0 +1,51 @@
+import { CalDAVAuthenticationError } from "@keeper.sh/calendar/caldav";
+import { ErrorResponse } from "@/utils/responses";
+import { widelog } from "@/utils/logging";
+import type { CalendarInfo } from "@keeper.sh/calendar/caldav";
+
+interface CalDAVDiscoverCredentials {
+  serverUrl: string;
+  username: string;
+  password: string;
+}
+
+interface CalDAVDiscoverResult {
+  calendars: CalendarInfo[];
+  authMethod: string;
+}
+
+interface CalDAVDiscoverRouteContext {
+  body: unknown;
+}
+
+interface CalDAVDiscoverRouteDependencies {
+  parseDiscoverBody: (body: unknown) => CalDAVDiscoverCredentials;
+  discoverCalendars: (credentials: CalDAVDiscoverCredentials) => Promise<CalDAVDiscoverResult>;
+}
+
+const handleCalDAVDiscoverRoute = async (
+  context: CalDAVDiscoverRouteContext,
+  dependencies: CalDAVDiscoverRouteDependencies,
+): Promise<Response> => {
+  try {
+    const credentials = dependencies.parseDiscoverBody(context.body);
+    const { calendars, authMethod } = await dependencies.discoverCalendars(credentials);
+
+    return Response.json({ calendars, authMethod });
+  } catch (error) {
+    if (error instanceof CalDAVAuthenticationError) {
+      widelog.errorFields(error, { slug: "caldav-auth-failed" });
+      return ErrorResponse.unauthorized("Invalid credentials").toResponse();
+    }
+
+    widelog.errorFields(error, { slug: "caldav-connection-failed" });
+    return ErrorResponse.badRequest("Failed to discover calendars").toResponse();
+  }
+};
+
+export { handleCalDAVDiscoverRoute };
+export type {
+  CalDAVDiscoverCredentials,
+  CalDAVDiscoverResult,
+  CalDAVDiscoverRouteDependencies,
+};

--- a/services/api/src/routes/api/sources/caldav/discover.ts
+++ b/services/api/src/routes/api/sources/caldav/discover.ts
@@ -1,38 +1,34 @@
 import { caldavDiscoverSourceSchema } from "@keeper.sh/data-schemas";
 import { createCalDAVClient } from "@keeper.sh/calendar/caldav";
+import { handleCalDAVDiscoverRoute } from "./discover-route";
 import { withAuth, withWideEvent } from "@/utils/middleware";
-import { ErrorResponse } from "@/utils/responses";
 import { safeFetchOptions } from "@/utils/safe-fetch-options";
-import { widelog } from "@/utils/logging";
+import type { CalDAVDiscoverCredentials, CalDAVDiscoverResult } from "./discover-route";
+
+const discoverCalendars = async (
+  credentials: CalDAVDiscoverCredentials,
+): Promise<CalDAVDiscoverResult> => {
+  const client = createCalDAVClient({
+    credentials: {
+      password: credentials.password,
+      username: credentials.username,
+    },
+    serverUrl: credentials.serverUrl,
+  }, safeFetchOptions);
+
+  const calendars = await client.discoverCalendars();
+
+  return { authMethod: client.getResolvedAuthMethod() ?? "basic", calendars };
+};
 
 const POST = withWideEvent(
   withAuth(async ({ request }) => {
     const body = await request.json();
 
-    try {
-      const { serverUrl, username, password } = caldavDiscoverSourceSchema.assert(body);
-
-      const client = createCalDAVClient({
-        credentials: {
-          password,
-          username,
-        },
-        serverUrl,
-      }, safeFetchOptions);
-
-      const calendars = await client.discoverCalendars();
-      const authMethod = client.getResolvedAuthMethod() ?? "basic";
-
-      return Response.json({ calendars, authMethod });
-    } catch (error) {
-      if (error instanceof Error && error.message.includes("401")) {
-        widelog.errorFields(error, { slug: "caldav-auth-failed" });
-        return ErrorResponse.unauthorized("Invalid credentials").toResponse();
-      }
-
-      widelog.errorFields(error, { slug: "caldav-connection-failed" });
-      return ErrorResponse.badRequest("Failed to discover calendars").toResponse();
-    }
+    return handleCalDAVDiscoverRoute({ body }, {
+      discoverCalendars,
+      parseDiscoverBody: (value) => caldavDiscoverSourceSchema.assert(value),
+    });
   }),
 );
 

--- a/services/api/tests/routes/api/sources/caldav/discover-route.test.ts
+++ b/services/api/tests/routes/api/sources/caldav/discover-route.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { CalDAVAuthenticationError } from "@keeper.sh/calendar/caldav";
+import { handleCalDAVDiscoverRoute } from "../../../../../src/routes/api/sources/caldav/discover-route";
+import type {
+  CalDAVDiscoverCredentials,
+  CalDAVDiscoverRouteDependencies,
+} from "../../../../../src/routes/api/sources/caldav/discover-route";
+
+const readJson = (response: Response): Promise<unknown> => response.json();
+
+const credentials: CalDAVDiscoverCredentials = {
+  password: "hunter2",
+  serverUrl: "https://caldav.example.com",
+  username: "user",
+};
+
+const createDependencies = (
+  overrides: Partial<CalDAVDiscoverRouteDependencies> = {},
+): CalDAVDiscoverRouteDependencies => ({
+  discoverCalendars: () => Promise.resolve({ authMethod: "basic", calendars: [] }),
+  parseDiscoverBody: () => credentials,
+  ...overrides,
+});
+
+describe("handleCalDAVDiscoverRoute", () => {
+  it("returns discovered calendars and the resolved auth method", async () => {
+    const receivedCredentials: CalDAVDiscoverCredentials[] = [];
+
+    const response = await handleCalDAVDiscoverRoute({ body: credentials }, createDependencies({
+      discoverCalendars: (value) => {
+        receivedCredentials.push(value);
+        return Promise.resolve({
+          authMethod: "digest",
+          calendars: [{ ctag: "ctag-1", displayName: "Personal", url: "https://caldav.example.com/personal/" }],
+        });
+      },
+    }));
+
+    expect(response.status).toBe(200);
+    expect(receivedCredentials).toEqual([credentials]);
+    expect(await readJson(response)).toEqual({
+      authMethod: "digest",
+      calendars: [{ ctag: "ctag-1", displayName: "Personal", url: "https://caldav.example.com/personal/" }],
+    });
+  });
+
+  it("maps an authentication failure to 401 with invalid credentials", async () => {
+    const response = await handleCalDAVDiscoverRoute({ body: credentials }, createDependencies({
+      discoverCalendars: () => Promise.reject(new CalDAVAuthenticationError(new Error("Invalid credentials"))),
+    }));
+
+    expect(response.status).toBe(401);
+    expect(await readJson(response)).toEqual({ error: "Invalid credentials" });
+  });
+
+  it("maps other discovery failures to 400", async () => {
+    const response = await handleCalDAVDiscoverRoute({ body: credentials }, createDependencies({
+      discoverCalendars: () => Promise.reject(new Error("getaddrinfo ENOTFOUND caldav.example.com")),
+    }));
+
+    expect(response.status).toBe(400);
+    expect(await readJson(response)).toEqual({ error: "Failed to discover calendars" });
+  });
+
+  it("maps invalid request bodies to 400", async () => {
+    const response = await handleCalDAVDiscoverRoute({ body: {} }, createDependencies({
+      parseDiscoverBody: () => {
+        throw new Error("serverUrl must be a string");
+      },
+    }));
+
+    expect(response.status).toBe(400);
+    expect(await readJson(response)).toEqual({ error: "Failed to discover calendars" });
+  });
+});


### PR DESCRIPTION
A wrong CalDAV password used to return `400 {"error":"Failed to discover calendars"}`; it now returns `401 {"error":"Invalid credentials"}`. The route branched on `error.message.includes("401")`, but tsdav throws `Error("Invalid credentials")` with no status code in the message, so that branch was unreachable and every auth failure fell through to the generic 400. Rather than matching the new string, the CalDAV client now observes the HTTP status at the fetch layer — where the real response is — and raises a typed `CalDAVAuthenticationError` the route branches on, so a tsdav error-text change cannot silently break it again.

- `createDigestAwareFetch` exposes the last response status; `CalDAVClient` maps a failure that follows a 401 to `CalDAVAuthenticationError` (message `Invalid credentials`, `status` 401), which the existing `isCalDAVAuthenticationError` classifier still recognises for the cron reauth path
- discover handler extracted to `discover-route.ts` with injected dependencies, matching the `ics/source-routes.ts` convention, plus tests for the 401, 400 and success paths
- new calendar test drives real tsdav over a stubbed 401 fetch, so the mechanism is covered end to end rather than by asserting on a message
- verified against a live CalDAV server (caldav.fastmail.com) with a deliberately wrong password on the full local stack: 400 "Failed to discover calendars" before, 401 "Invalid credentials" after; an unreachable host still returns the 400
- the four how-to guides in #481 document the old 400 text and will need updating once this and #516 land