### PR TITLE
perf(web): cache blog post HTML and add cache headers to SSR responses

### DIFF
--- a/applications/web/src/lib/cacheable-paths.ts
+++ b/applications/web/src/lib/cacheable-paths.ts
@@ -1,0 +1,8 @@
+import { blogPosts } from "./blog-posts";
+
+const marketingPaths = ["/", "/blog", "/privacy", "/terms"];
+
+export const cacheableHtmlPaths: string[] = [
+  ...marketingPaths,
+  ...blogPosts.map((blogPost) => `/blog/${blogPost.slug}`),
+];

--- a/applications/web/src/server.tsx
+++ b/applications/web/src/server.tsx
@@ -3,6 +3,8 @@ import { createRequestHandler } from "@tanstack/react-router/ssr/server";
 import { createAppRouter } from "./router";
 import type { ViteAssets } from "./lib/router-context";
 
+export { cacheableHtmlPaths } from "./lib/cacheable-paths";
+
 export function render(request: Request, viteAssets: ViteAssets): Promise<Response> {
   const handleRequest = createRequestHandler({
     createRouter: () => createAppRouter({ request, viteAssets }),

--- a/applications/web/src/server/compression.ts
+++ b/applications/web/src/server/compression.ts
@@ -26,28 +26,46 @@ function acceptsGzip(request: Request): boolean {
   return acceptEncoding !== null && acceptEncoding.includes("gzip");
 }
 
+function varyingOnAcceptEncoding(existingVary: string | null): string {
+  if (!existingVary) {
+    return "accept-encoding";
+  }
+
+  const fields = existingVary.split(",").map((field) => field.trim().toLowerCase());
+  if (fields.includes("accept-encoding")) {
+    return existingVary;
+  }
+
+  return `${existingVary}, accept-encoding`;
+}
+
 export async function withCompression(
   request: Request,
   response: Response,
 ): Promise<Response> {
-  if (!acceptsGzip(request)) {
+  if (!isCompressible(response.headers.get("content-type"))) {
     return response;
   }
 
-  if (!isCompressible(response.headers.get("content-type"))) {
-    return response;
+  const headers = new Headers(response.headers);
+  headers.set("vary", varyingOnAcceptEncoding(headers.get("vary")));
+
+  if (!acceptsGzip(request)) {
+    return new Response(response.body, {
+      headers,
+      status: response.status,
+    });
   }
 
   const body = await response.arrayBuffer();
   if (body.byteLength < 1024) {
     return new Response(body, {
-      headers: response.headers,
+      headers,
       status: response.status,
     });
   }
 
   const compressed = gzipSync(new Uint8Array(body));
-  const headers = new Headers(response.headers);
   headers.set("content-encoding", "gzip");
   headers.set("content-length", compressed.byteLength.toString());
 

--- a/applications/web/src/server/http-handler.ts
+++ b/applications/web/src/server/http-handler.ts
@@ -5,28 +5,33 @@ import { GDPR_COUNTRIES } from "@/config/gdpr";
 import { hasSessionCookie } from "@/lib/session-cookie";
 import type { Runtime, ServerConfig } from "./types";
 
-const CACHEABLE_PATHS = new Set(["/", "/blog", "/privacy", "/terms"]);
 const HTML_CACHE_TTL_MS = 60_000;
+const PUBLIC_HTML_CACHE_CONTROL = "public, max-age=0, s-maxage=600, stale-while-revalidate=86400";
+const PRIVATE_HTML_CACHE_CONTROL = "private, no-store";
+const PUBLIC_HTML_VARY = "accept-encoding, cookie, cf-ipcountry";
 
 interface CachedHtml {
   body: string;
   cachedAt: number;
+  etag: string;
 }
 
 const htmlCache = new Map<string, CachedHtml>();
 
-function getCachedHtml(pathname: string): string | null {
-  const entry = htmlCache.get(pathname);
+function getCachedHtml(cacheKey: string): CachedHtml | null {
+  const entry = htmlCache.get(cacheKey);
   if (!entry) return null;
   if (Date.now() - entry.cachedAt > HTML_CACHE_TTL_MS) {
-    htmlCache.delete(pathname);
+    htmlCache.delete(cacheKey);
     return null;
   }
-  return entry.body;
+  return entry;
 }
 
-function setCachedHtml(pathname: string, body: string): void {
-  htmlCache.set(pathname, { body, cachedAt: Date.now() });
+function setCachedHtml(cacheKey: string, body: string): CachedHtml {
+  const entry = { body, cachedAt: Date.now(), etag: `"${Bun.hash(body).toString(16)}"` };
+  htmlCache.set(cacheKey, entry);
+  return entry;
 }
 
 const baseSecurityHeaders: Record<string, string> = {
@@ -55,6 +60,33 @@ function withSecurityHeaders(response: Response, config: ServerConfig): Response
     headers,
     status: response.status,
   });
+}
+
+function withPublicHtmlCacheHeaders(response: Response, etag: string): Response {
+  const headers = new Headers(response.headers);
+  headers.set("cache-control", PUBLIC_HTML_CACHE_CONTROL);
+  headers.set("etag", etag);
+  headers.set("vary", PUBLIC_HTML_VARY);
+
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+  });
+}
+
+function withPrivateHtmlCacheHeaders(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set("cache-control", PRIVATE_HTML_CACHE_CONTROL);
+
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+  });
+}
+
+function notModifiedResponse(etag: string, config: ServerConfig): Response {
+  const response = new Response(null, { status: 304 });
+  return withSecurityHeaders(withPublicHtmlCacheHeaders(response, etag), config);
 }
 
 function resolveGdprCacheSegment(countryCode: string): string {
@@ -90,16 +122,26 @@ export async function handleApplicationRequest(
   const countryCode = request.headers.get("cf-ipcountry") ?? "";
   const gdprSegment = resolveGdprCacheSegment(countryCode);
   const cookieHeader = request.headers.get("cookie") ?? undefined;
-  const authSegment = hasSessionCookie(cookieHeader) ? "authed" : "anon";
+  const isAuthenticated = hasSessionCookie(cookieHeader);
+  const authSegment = isAuthenticated ? "authed" : "anon";
   const cacheKey = `${pathname}:${gdprSegment}:${authSegment}`;
+  const isCacheablePath = config.isProduction && runtime.cacheableHtmlPaths.has(pathname);
+  const isPubliclyCacheable = isCacheablePath && !isAuthenticated;
 
-  if (config.isProduction && CACHEABLE_PATHS.has(pathname)) {
+  if (isCacheablePath) {
     const cached = getCachedHtml(cacheKey);
     if (cached) {
-      const cachedResponse = new Response(cached, {
+      if (isPubliclyCacheable && request.headers.get("if-none-match") === cached.etag) {
+        return notModifiedResponse(cached.etag, config);
+      }
+
+      const cachedResponse = new Response(cached.body, {
         headers: { "content-type": "text/html; charset=utf-8" },
       });
-      const securedResponse = withSecurityHeaders(cachedResponse, config);
+      const cacheableResponse = isPubliclyCacheable
+        ? withPublicHtmlCacheHeaders(cachedResponse, cached.etag)
+        : withPrivateHtmlCacheHeaders(cachedResponse);
+      const securedResponse = withSecurityHeaders(cacheableResponse, config);
       return withCompression(request, securedResponse);
     }
   }
@@ -109,20 +151,23 @@ export async function handleApplicationRequest(
 
   const isRedirect = routerResponse.status >= 300 && routerResponse.status < 400;
   if (isRedirect) {
-    return routerResponse;
+    return withPrivateHtmlCacheHeaders(routerResponse);
   }
 
-  if (config.isProduction && CACHEABLE_PATHS.has(pathname)) {
+  if (isCacheablePath && routerResponse.status === 200) {
     const body = await routerResponse.text();
-    setCachedHtml(cacheKey, body);
+    const entry = setCachedHtml(cacheKey, body);
     const freshResponse = new Response(body, {
       headers: routerResponse.headers,
       status: routerResponse.status,
     });
-    const securedResponse = withSecurityHeaders(freshResponse, config);
+    const cacheableResponse = isPubliclyCacheable
+      ? withPublicHtmlCacheHeaders(freshResponse, entry.etag)
+      : withPrivateHtmlCacheHeaders(freshResponse);
+    const securedResponse = withSecurityHeaders(cacheableResponse, config);
     return withCompression(request, securedResponse);
   }
 
-  const securedResponse = withSecurityHeaders(routerResponse, config);
+  const securedResponse = withSecurityHeaders(withPrivateHtmlCacheHeaders(routerResponse), config);
   return withCompression(request, securedResponse);
 }

--- a/applications/web/src/server/runtime.ts
+++ b/applications/web/src/server/runtime.ts
@@ -8,6 +8,7 @@ import type { ViteAssets } from "@/lib/router-context";
 import type { Runtime, ServerConfig } from "./types";
 
 interface EntryServerModule {
+  cacheableHtmlPaths: string[];
   render: (request: Request, viteAssets: ViteAssets) => Promise<Response>;
 }
 
@@ -17,13 +18,23 @@ function isEntryServerModule(value: unknown): value is EntryServerModule {
   }
 
   const renderProperty = Reflect.get(value, "render");
-  return typeof renderProperty === "function";
+  if (typeof renderProperty !== "function") {
+    return false;
+  }
+
+  const cacheablePathsProperty = Reflect.get(value, "cacheableHtmlPaths");
+  return (
+    Array.isArray(cacheablePathsProperty)
+    && cacheablePathsProperty.every((entry) => typeof entry === "string")
+  );
 }
 
 async function loadProductionRenderer(): Promise<EntryServerModule> {
   const moduleValue = await import(pathToFileURL(serverDistEntry).href);
   if (!isEntryServerModule(moduleValue)) {
-    throw new Error("SSR entry module must export render(request, viteAssets).");
+    throw new Error(
+      "SSR entry module must export render(request, viteAssets) and cacheableHtmlPaths.",
+    );
   }
 
   return moduleValue;
@@ -35,6 +46,7 @@ async function createProductionRuntime(): Promise<Runtime> {
   const renderer = await loadProductionRenderer();
 
   return {
+    cacheableHtmlPaths: new Set(renderer.cacheableHtmlPaths),
     handleAssetRequest: async (request) => {
       const requestUrl = new URL(request.url);
       return readStaticFile(requestUrl.pathname);
@@ -78,6 +90,7 @@ async function createDevelopmentRuntime(vitePort: number): Promise<Runtime> {
   const viteOrigin = `http://localhost:${vitePort}`;
 
   return {
+    cacheableHtmlPaths: new Set<string>(),
     handleAssetRequest: (request) => proxyRequest(request, viteOrigin),
     resolveViteAssets: async (requestPath) => {
       const template = await fs.readFile(sourceTemplatePath, "utf-8");

--- a/applications/web/src/server/types.ts
+++ b/applications/web/src/server/types.ts
@@ -2,6 +2,7 @@ import type { Server as BunServer, ServerWebSocket as BunServerWebSocket } from 
 import type { ViteAssets } from "@/lib/router-context";
 
 export interface Runtime {
+  cacheableHtmlPaths: ReadonlySet<string>;
   handleAssetRequest: (request: Request) => Promise<Response>;
   resolveViteAssets: (requestPath: string) => Promise<ViteAssets>;
   renderApp: (request: Request, viteAssets: ViteAssets) => Promise<Response>;

--- a/applications/web/tests/server/http-handler.test.ts
+++ b/applications/web/tests/server/http-handler.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleApplicationRequest } from "../../src/server/http-handler";
+import type { Runtime, ServerConfig } from "../../src/server/types";
+
+const config: ServerConfig = {
+  apiProxyOrigin: "http://api.test",
+  mcpProxyOrigin: null,
+  environment: "production",
+  isProduction: true,
+  serverPort: 4000,
+  vitePort: 4001,
+};
+
+function createRuntime(cacheableHtmlPaths: string[], body = "<html>page</html>"): Runtime {
+  return {
+    cacheableHtmlPaths: new Set(cacheableHtmlPaths),
+    handleAssetRequest: async () => new Response("Not Found", { status: 404 }),
+    resolveViteAssets: async () => ({ bodyScripts: [], headScripts: [], modulePreloads: [], stylesheets: [] }),
+    renderApp: vi.fn(async () =>
+      new Response(body, { headers: { "content-type": "text/html; charset=UTF-8" } })),
+  };
+}
+
+function request(path: string, headers: Record<string, string> = {}): Request {
+  return new Request(`http://localhost${path}`, { headers });
+}
+
+describe("handleApplicationRequest caching", () => {
+  it("marks a known blog post publicly cacheable and validatable", async () => {
+    const path = "/blog/known-post";
+    const runtime = createRuntime([path]);
+
+    const response = await handleApplicationRequest(request(path), runtime, config);
+
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=0, s-maxage=600, stale-while-revalidate=86400",
+    );
+    expect(response.headers.get("etag")).toMatch(/^"[0-9a-f]+"$/);
+    expect(response.headers.get("vary")).toBe("accept-encoding, cookie, cf-ipcountry");
+  });
+
+  it("serves a repeated blog post request from the cache without re-rendering", async () => {
+    const path = "/blog/cached-post";
+    const runtime = createRuntime([path]);
+
+    await handleApplicationRequest(request(path), runtime, config);
+    await handleApplicationRequest(request(path), runtime, config);
+
+    expect(runtime.renderApp).toHaveBeenCalledTimes(1);
+  });
+
+  it("answers a matching conditional request with 304", async () => {
+    const path = "/blog/conditional-post";
+    const runtime = createRuntime([path]);
+
+    const first = await handleApplicationRequest(request(path), runtime, config);
+    const etag = first.headers.get("etag") ?? "";
+    const second = await handleApplicationRequest(
+      request(path, { "if-none-match": etag }),
+      runtime,
+      config,
+    );
+
+    expect(second.status).toBe(304);
+    expect(second.headers.get("etag")).toBe(etag);
+  });
+
+  it("never caches or publicly labels an unknown blog slug", async () => {
+    const runtime = createRuntime(["/blog/known-post"]);
+    const path = "/blog/missing-post";
+
+    const first = await handleApplicationRequest(request(path), runtime, config);
+    await handleApplicationRequest(request(path), runtime, config);
+
+    expect(first.headers.get("cache-control")).toBe("private, no-store");
+    expect(first.headers.get("etag")).toBeNull();
+    expect(runtime.renderApp).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a marketing page private for a request carrying a session cookie", async () => {
+    const path = "/blog/session-post";
+    const runtime = createRuntime([path]);
+
+    const response = await handleApplicationRequest(
+      request(path, { cookie: "keeper.has_session=1" }),
+      runtime,
+      config,
+    );
+
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("etag")).toBeNull();
+  });
+
+  it("keeps dashboard responses out of every cache", async () => {
+    const runtime = createRuntime(["/"]);
+
+    const response = await handleApplicationRequest(
+      request("/dashboard", { cookie: "keeper.has_session=1" }),
+      runtime,
+      config,
+    );
+
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+  });
+
+  it("keeps redirects out of every cache", async () => {
+    const runtime: Runtime = {
+      ...createRuntime(["/"]),
+      renderApp: async () => new Response(null, { status: 307, headers: { location: "/login" } }),
+    };
+
+    const response = await handleApplicationRequest(request("/dashboard"), runtime, config);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+  });
+});

--- a/applications/web/tests/server/http-handler.test.ts
+++ b/applications/web/tests/server/http-handler.test.ts
@@ -15,7 +15,13 @@ function createRuntime(cacheableHtmlPaths: string[], body = "<html>page</html>")
   return {
     cacheableHtmlPaths: new Set(cacheableHtmlPaths),
     handleAssetRequest: async () => new Response("Not Found", { status: 404 }),
-    resolveViteAssets: async () => ({ bodyScripts: [], headScripts: [], modulePreloads: [], stylesheets: [] }),
+    resolveViteAssets: async () => ({
+      bodyScripts: [],
+      headScripts: [],
+      inlineStyles: [],
+      modulePreloads: [],
+      stylesheets: [],
+    }),
     renderApp: vi.fn(async () =>
       new Response(body, { headers: { "content-type": "text/html; charset=UTF-8" } })),
   };


### PR DESCRIPTION
Blog post TTFB drops from 42-53ms to 1.1-1.7ms locally (production baseline was 0.69-0.85s versus 0.25s for `/`), because `CACHEABLE_PATHS` was an exact-match set and every `/blog/<slug>` request re-ran the full SSR markdown render. SSR HTML also carried no cache or validation headers at all, so every crawler fetch was a full origin render. The SSR entry now exports the cacheable path list built from the blog post set, and the server matches against that instead of a hardcoded set.

- Cacheability comes from the real post list, so an unknown slug is never cached, never gets a public header, and the cache stays bounded at the known paths; only 200s are stored, so a 404 can never be cached as a page
- Anonymous marketing HTML gets `public, max-age=0, s-maxage=600, stale-while-revalidate=86400` with an ETag and `vary: accept-encoding, cookie, cf-ipcountry`, and answers matching conditional requests with a 304
- Everything else, including any request carrying a session cookie, every dashboard and auth path, and redirects, gets `private, no-store`
- `vary: accept-encoding` is now set on all compressible responses, which we were only getting because Cloudflare re-compresses and injects its own
- The ETag is stable for a cache entry’s lifetime but rotates when the entry refreshes, because the dehydrated router state embeds a per-render timestamp