### PR TITLE
fix(web): stop dimming muted text below WCAG AA

### DIFF
--- a/applications/web/src/components/ui/primitives/input.tsx
+++ b/applications/web/src/components/ui/primitives/input.tsx
@@ -2,7 +2,7 @@ import type { ComponentPropsWithoutRef, Ref } from "react";
 import { tv, type VariantProps } from "tailwind-variants/lite";
 
 const input = tv({
-  base: "w-full rounded-xl border border-interactive-border bg-background px-4 py-2.5 text-foreground tracking-tight placeholder:text-foreground-muted disabled:opacity-50 disabled:cursor-not-allowed read-only:cursor-not-allowed read-only:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+  base: "w-full rounded-xl border border-interactive-border bg-background px-4 py-2.5 text-foreground tracking-tight placeholder:text-foreground-muted disabled:opacity-50 disabled:cursor-not-allowed read-only:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
   variants: {
     tone: {
       neutral: "",

--- a/applications/web/src/illustrations/marketing-illustration-contributors.tsx
+++ b/applications/web/src/illustrations/marketing-illustration-contributors.tsx
@@ -8,11 +8,12 @@ import CONTRIBUTORS from "@/features/marketing/contributors.json";
 const VISIBLE_COUNT = 3;
 const ROTATE_INTERVAL_MS = 1800;
 const FALLBACK_ROW_HEIGHT = 36;
+const CONTAINER_PADDING_TOP = 12;
 
 const SLOT_STYLES = [
-  { scale: 0.92, opacity: 0.35, filter: "blur(1px)" },
-  { scale: 1, opacity: 1, filter: "blur(0px)" },
-  { scale: 0.92, opacity: 0.35, filter: "blur(1px)" },
+  { scale: 0.92, filter: "blur(1px)" },
+  { scale: 1, filter: "blur(0px)" },
+  { scale: 0.92, filter: "blur(1px)" },
 ];
 
 const TRANSITION = {
@@ -75,7 +76,10 @@ export function MarketingIllustrationContributors() {
 
   return (
     <LazyMotion features={loadMotionFeatures}>
-      <div className="relative w-full pt-3 px-4" style={{ height: rowHeight * VISIBLE_COUNT + 12 }}>
+      <div
+        className="relative w-full pt-3 px-4 overflow-hidden"
+        style={{ height: rowHeight * VISIBLE_COUNT + CONTAINER_PADDING_TOP }}
+      >
         <div ref={measureRef} className="absolute inset-x-0 invisible pointer-events-none" aria-hidden="true">
           <ContributorRow contributor={CONTRIBUTORS[0]} />
         </div>
@@ -84,20 +88,17 @@ export function MarketingIllustrationContributors() {
             <m.div
               key={contributorIndex}
               initial={{
-                y: rowHeight * (VISIBLE_COUNT - 1) + (rowHeight * 2) / 3,
-                opacity: 0,
+                y: rowHeight * VISIBLE_COUNT,
                 scale: 0.7,
                 filter: "blur(3px)",
               }}
               animate={{
                 y: rowHeight * slot,
-                opacity: SLOT_STYLES[slot].opacity,
                 scale: SLOT_STYLES[slot].scale,
                 filter: SLOT_STYLES[slot].filter,
               }}
               exit={{
-                y: -(rowHeight * 2) / 3,
-                opacity: 0,
+                y: -(rowHeight + CONTAINER_PADDING_TOP),
                 scale: 0.7,
                 filter: "blur(3px)",
               }}

--- a/applications/web/src/routes/(marketing)/blog/index.tsx
+++ b/applications/web/src/routes/(marketing)/blog/index.tsx
@@ -56,7 +56,7 @@ function BlogDirectoryPage() {
                 <Heading3 as="h2" className="group-hover:text-foreground-hover">
                   {blogPost.metadata.title}
                 </Heading3>
-                <Text size="xs" tone="muted" className="opacity-75">
+                <Text size="xs" tone="muted">
                   Created {formatIsoDate(blogPost.metadata.createdAt)}
                 </Text>
                 <Text size="sm" tone="muted" className="line-clamp-3">


### PR DESCRIPTION
Lighthouse flagged muted metadata at **2.86:1** on `/` and `/blog`; both are now **4.54:1** light and **7.66:1** dark, clearing AA for 12px text. A third field of the same kind, read-only inputs at **3.68:1** light, is fixed here too. `foreground-muted` is only 4.53:1 on the page background in light, so it has no headroom left — any opacity stacked on it fails, and at the carousel's 0.35 no foreground colour exists that could pass. The dimming had to go rather than be retuned, and no new token was needed since size and cursor already carry the distinction.

- `blog/index.tsx`: dropped `opacity-75` from the post date. It still reads below the blurb at 12px vs 14px.
- `marketing-illustration-contributors.tsx`: dropped the opacity from the slot styles and the enter/exit transitions. Depth now comes from the existing scale and blur, and rows clip against an `overflow-hidden` viewport instead of fading out.
- `input.tsx`: dropped `read-only:opacity-50`, which was dimming the iCal feed URL and the one-time API token to 3.68:1 light (4.98:1 dark). Now 18.97:1 and 18.16:1, with `read-only:cursor-not-allowed` still marking the state.
- The homepage hit was the contributor carousel, not a static class — rows animate 0.35 → 1 and axe caught them mid-tween at ~0.75, which is the same 2.86 as the blog date.
- Verified with axe-core against `/`, `/blog`, blog posts, `/privacy`, `/terms`, `/login`, `/register`, `/dashboard/ical` and `/dashboard/settings/api-tokens` in both themes: zero `color-contrast` violations.

Worth a separate look, both pre-existing and both from the same lack of headroom: `foreground-muted` drops to 4.08:1 on a hovered blog card and 4.19:1 on a hovered settings row, because any surface tint at all pushes it under. Fixing that means darkening the token, which is a wider design call than this PR.
