### PR TITLE
fix(web): stop inline code styling leaking into fenced code blocks

### DIFF
--- a/applications/web/src/components/ui/primitives/markdown-components.tsx
+++ b/applications/web/src/components/ui/primitives/markdown-components.tsx
@@ -81,7 +81,7 @@ export function MarkdownCodeBlock({
   children,
 }: MarkdownElementProps<"pre">) {
   return (
-    <pre className="my-4 overflow-x-auto border border-interactive-border bg-background p-3 text-xs text-foreground">
+    <pre className="my-4 overflow-x-auto border border-interactive-border bg-background p-3 text-xs text-foreground [&_code]:rounded-none [&_code]:border-0 [&_code]:bg-transparent [&_code]:p-0 [&_code]:text-[length:inherit]">
       {children}
     </pre>
   );


### PR DESCRIPTION
Fenced code blocks render as `<pre><code>`, but the markdown component map sends every `code` element to `MarkdownInlineCode`, so the inner one picks up the inline chip treatment — border, elevated background, padding and a smaller font — inside an already-styled block. Every code block in the blog renders as a block containing an inline pill.

- Neutralises the chip styling for `code` descendants of `pre`, matching how the table components already override descendant styles
- Inline code outside a block is unaffected, since the override is scoped to `pre`
- Verified in the rendered stylesheet: each descendant rule is one class plus one type selector, so it outranks the utilities on the `code` element