### PR TITLE
docs: mark the sync explainer as a technical post in its title

### DIFF
--- a/applications/web/src/content/blog/how-calendar-sync-actually-works.mdx
+++ b/applications/web/src/content/blog/how-calendar-sync-actually-works.mdx
@@ -1,5 +1,5 @@
 ---
-title: "How Calendar Sync Actually Works"
+title: "How Calendar Sync Actually Works (Technical Blog Post)"
 description: "A deep explanation of calendar sync: incremental sync tokens and delta links, 410 full resyncs, deduplication, loop prevention, recurrence exceptions, all-day and timezone handling, and deletion propagation."
 blurb: "Everything I learned building a two-way calendar sync engine — sync tokens, 410 GONE, RRULE expansion across DST, loop prevention between mirrored calendars, and why deletions are the hard part."
 createdAt: "2026-08-11"


### PR DESCRIPTION
Adds "(Technical Blog Post)" to the title of `how-calendar-sync-actually-works`, so the blog index and search results signal upfront that it is a deep technical piece rather than a how-to.

- Frontmatter title only; the slug is pinned separately so the URL is unchanged
- Carries through to the H1, `<title>`, OG and Twitter titles, and the `BlogPosting` headline, which is the intent
- The footer nav label stays the shorter "How Calendar Sync Works"