### PR TITLE
docs: use the full Keeper.sh name in marketing copy

### DIFF
--- a/applications/web/public/llms-full.txt
+++ b/applications/web/public/llms-full.txt
@@ -21,13 +21,13 @@ Keeper.sh uses a pull-compare-push architecture. On each sync cycle:
 Core sync operations:
 - **Add**: Source event with no mapping on destination gets created
 - **Delete**: Mapping exists but source event is gone — destination event gets removed
-- **Cleanup**: Keeper-created events with no mapping are cleaned up
+- **Cleanup**: Keeper.sh-created events with no mapping are cleaned up
 
-Events created by Keeper are tagged with a `@keeper.sh` suffix on their remote UID. For Outlook (which doesn't support custom UIDs), a `"keeper.sh"` category is used instead.
+Events created by Keeper.sh are tagged with a `@keeper.sh` suffix on their remote UID. For Outlook (which doesn't support custom UIDs), a `"keeper.sh"` category is used instead.
 
 Race conditions are prevented using Redis-backed generation counters. If two syncs target the same calendar simultaneously, the later one backs off.
 
-For Google and Outlook, Keeper uses incremental sync tokens — only fetching what changed since the last sync, making cycles fast even for calendars with thousands of events.
+For Google and Outlook, Keeper.sh uses incremental sync tokens — only fetching what changed since the last sync, making cycles fast even for calendars with thousands of events.
 
 ### Supported Providers
 
@@ -56,7 +56,7 @@ Per-source calendar settings:
 
 ### iCal Feed
 
-Keeper generates a unique, token-authenticated URL combining events from selected source calendars. Subscribable from any calendar app supporting iCal (Apple Calendar, Thunderbird, etc.). Respects all privacy settings.
+Keeper.sh generates a unique, token-authenticated URL combining events from selected source calendars. Subscribable from any calendar app supporting iCal (Apple Calendar, Thunderbird, etc.). Respects all privacy settings.
 
 ### Source and Destination Mappings
 
@@ -88,17 +88,17 @@ Google Calendar and Outlook require OAuth app setup (Google Cloud / Azure). CalD
 
 ## MCP (Model Context Protocol)
 
-Keeper includes an optional MCP server that gives AI agents (such as Claude) read-only access to calendar data. The server authenticates via OAuth 2.1 with a user consent flow and is proxied through the web service at `/mcp`.
+Keeper.sh includes an optional MCP server that gives AI agents (such as Claude) read-only access to calendar data. The server authenticates via OAuth 2.1 with a user consent flow and is proxied through the web service at `/mcp`.
 
 ### Available Tools
 
-- **list_calendars** — List all calendars connected to Keeper, including provider name and account
+- **list_calendars** — List all calendars connected to Keeper.sh, including provider name and account
 - **get_events** — Get calendar events within a date range (ISO 8601 datetimes + IANA timezone)
 - **get_event_count** — Get the total number of synced calendar events
 
 ### Connecting
 
-Point any MCP-compatible client at the `/mcp` endpoint of a Keeper instance. The client will be guided through the OAuth consent flow to authorize read access.
+Point any MCP-compatible client at the `/mcp` endpoint of a Keeper.sh instance. The client will be guided through the OAuth consent flow to authorize read access.
 
 MCP is fully optional — all related environment variables are optional across every service. Existing deployments are unaffected when upgrading.
 

--- a/applications/web/src/content/blog/introducing-keeper-blog.mdx
+++ b/applications/web/src/content/blog/introducing-keeper-blog.mdx
@@ -41,13 +41,13 @@ The core logic is straightforward:
 
 - **Add:** If a source event has no corresponding mapping on the destination, it gets created
 - **Delete:** If a mapping exists but the source event no longer does, the destination event gets removed
-- **Cleanup:** Any Keeper-created events with no mapping are cleaned up for consistency
+- **Cleanup:** Any Keeper.sh-created events with no mapping are cleaned up for consistency
 
-Events created by Keeper are tagged with a `@keeper.sh` suffix on their remote UID so they can be identified later. For platforms like Outlook that don't support custom UIDs, we use a `"keeper.sh"` category instead.
+Events created by Keeper.sh are tagged with a `@keeper.sh` suffix on their remote UID so they can be identified later. For platforms like Outlook that don't support custom UIDs, we use a `"keeper.sh"` category instead.
 
 To prevent race conditions, each sync operation acquires a Redis-backed generation counter. If two syncs try to run on the same calendar at the same time, the later one backs off. This keeps things consistent without requiring heavy locking.
 
-For Google and Outlook, Keeper uses incremental sync tokens. Instead of re-fetching every event on each cycle, it asks the provider for only what changed since the last sync. This makes regular sync cycles fast and lightweight, even for calendars with thousands of events.
+For Google and Outlook, Keeper.sh uses incremental sync tokens. Instead of re-fetching every event on each cycle, it asks the provider for only what changed since the last sync. This makes regular sync cycles fast and lightweight, even for calendars with thousands of events.
 
 ## What Keeper.sh supports
 
@@ -63,7 +63,7 @@ Keeper.sh works with six calendar providers across two authentication mechanisms
 - **Generic CalDAV** — any CalDAV-compatible server with username/password auth
 - **iCal/ICS feeds** — read-only public URL-based calendars
 
-Each calendar in Keeper has a capability flag: "pull" means it can be used as a source (read events from), and "push" means it can be used as a destination (write events to). iCal feeds, for example, are pull-only since they're read-only by nature. OAuth and CalDAV calendars support both.
+Each calendar in Keeper.sh has a capability flag: "pull" means it can be used as a source (read events from), and "push" means it can be used as a destination (write events to). iCal feeds, for example, are pull-only since they're read-only by nature. OAuth and CalDAV calendars support both.
 
 ## Privacy controls
 
@@ -81,7 +81,7 @@ These same controls apply to the iCal feed. When you generate your aggregated fe
 
 ## The iCal feed
 
-One of the features I use most is the aggregated iCal feed. Keeper generates a unique, token-authenticated URL that combines events from all your selected source calendars into a single feed. You can subscribe to it from any calendar app that supports iCal — Apple Calendar, Thunderbird, or any CalDAV client.
+One of the features I use most is the aggregated iCal feed. Keeper.sh generates a unique, token-authenticated URL that combines events from all your selected source calendars into a single feed. You can subscribe to it from any calendar app that supports iCal — Apple Calendar, Thunderbird, or any CalDAV client.
 
 The feed respects all your privacy settings. If you've chosen to exclude event titles, the feed shows "Busy" blocks. If you've included titles and locations, those show up too. It's the same event data, just served as a subscribable feed instead of pushed to a specific calendar.
 
@@ -89,7 +89,7 @@ This is especially useful for sharing availability externally. Instead of giving
 
 ## Source and destination mappings
 
-The mapping model is what makes Keeper flexible. You connect calendar accounts, then configure which calendars are sources and which are destinations. A single source can push to multiple destinations, and a single destination can receive from multiple sources.
+The mapping model is what makes Keeper.sh flexible. You connect calendar accounts, then configure which calendars are sources and which are destinations. A single source can push to multiple destinations, and a single destination can receive from multiple sources.
 
 The setup flow walks you through it:
 
@@ -139,11 +139,11 @@ The [`compose.yaml` setup in the README](https://github.com/ridafkih/keeper.sh/b
 
 A few decisions that shaped the architecture:
 
-**CalDAV as the universal protocol.** Rather than building custom integrations for every provider, Keeper treats CalDAV (RFC 4791) as the common layer for FastMail, iCloud, and any standards-compliant server. This means adding a new CalDAV provider is mostly a configuration change, not new code.
+**CalDAV as the universal protocol.** Rather than building custom integrations for every provider, Keeper.sh treats CalDAV (RFC 4791) as the common layer for FastMail, iCloud, and any standards-compliant server. This means adding a new CalDAV provider is mostly a configuration change, not new code.
 
 **Encrypted credentials at rest.** CalDAV passwords and OAuth tokens are encrypted before storage using a configurable encryption key. OAuth tokens include refresh token rotation, so sessions stay valid without storing long-lived credentials.
 
-**Content hashing for iCal feeds.** When pulling from iCal/ICS URLs, Keeper hashes the response content and skips processing if nothing changed. This avoids redundant work when feeds haven't been updated and keeps snapshots for 6 hours in case something goes wrong.
+**Content hashing for iCal feeds.** When pulling from iCal/ICS URLs, Keeper.sh hashes the response content and skips processing if nothing changed. This avoids redundant work when feeds haven't been updated and keeps snapshots for 6 hours in case something goes wrong.
 
 **Real-time sync status.** The API server runs a WebSocket endpoint that broadcasts sync progress to the dashboard. You can watch events get pulled, compared, and pushed in real time rather than wondering if a sync cycle actually ran.
 

--- a/applications/web/src/routes/(marketing)/index.tsx
+++ b/applications/web/src/routes/(marketing)/index.tsx
@@ -173,7 +173,7 @@ const HOW_IT_WORKS_STEPS: HowItWorksStep[] = [
   {
     title: 'Configure sync rules',
     description:
-      'Choose which calendars to sync and how events should appear. Keeper handles the rest automatically.',
+      'Choose which calendars to sync and how events should appear. Keeper.sh handles the rest automatically.',
   },
   {
     title: 'Stay in sync',
@@ -192,12 +192,12 @@ const FAQ_ITEMS: FaqItem[] = [
   {
     question: 'Can I use ICS or iCal links as a source?',
     answer:
-      'Yes. Any publicly accessible ICS or iCal link can be used as a calendar source in Keeper. This means you can pull events from services that only offer read-only calendar feeds.',
+      'Yes. Any publicly accessible ICS or iCal link can be used as a calendar source in Keeper.sh. This means you can pull events from services that only offer read-only calendar feeds.',
   },
   {
     question: 'Which calendar providers does Keeper.sh support?',
     answer:
-      'Keeper.sh works with Google Calendar, Microsoft Outlook, Apple iCloud, FastMail, and any provider that supports CalDAV or ICS feeds. If your calendar supports one of these protocols, it will work with Keeper.',
+      'Keeper.sh works with Google Calendar, Microsoft Outlook, Apple iCloud, FastMail, and any provider that supports CalDAV or ICS feeds. If your calendar supports one of these protocols, it will work with Keeper.sh.',
   },
   {
     question: 'Can I self-host Keeper.sh?',


### PR DESCRIPTION
Marketing copy on main now says "Keeper.sh" everywhere instead of bare "Keeper", which collides with the password manager of the same name and costs us brand-search clarity. Covers the founder post, the homepage FAQ and feature copy, and llms-full.txt.

- 18 occurrences changed across `introducing-keeper-blog.mdx`, `(marketing)/index.tsx` and `public/llms-full.txt`
- Left as-is: the `@keeper.sh` UID suffix, the `"keeper.sh"` Outlook category, and the `keeper-web`/`keeper-api`/`keeper-cron`/`keeper-mcp` image names
- `how-calendar-sync-actually-works.mdx`, `privacy.tsx`, `terms.tsx` and `llms.txt` were already correct