### PR TITLE
feat(web): support per-post Open Graph images

### DIFF
--- a/applications/web/plugins/blog.ts
+++ b/applications/web/plugins/blog.ts
@@ -1,14 +1,20 @@
-import { readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 import type { Plugin } from "vite";
 import { type } from "arktype";
 import { parse as parseYaml } from "yaml";
+
+const OPEN_GRAPH_IMAGE_WIDTH = 1200;
+const OPEN_GRAPH_IMAGE_HEIGHT = 630;
+const OPEN_GRAPH_IMAGE_PATH =
+  /^\/open-graph\/[a-z0-9]+(?:-[a-z0-9]+)*\.png$/;
 
 const blogPostMetadataSchema = type({
   "+": "reject",
   blurb: "string >= 1",
   createdAt: "string.date.iso",
   description: "string >= 1",
+  "image?": OPEN_GRAPH_IMAGE_PATH,
   "slug?": /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
   tags: "string[]",
   title: "string >= 1",
@@ -90,6 +96,46 @@ function parseMetadata(value: unknown, filePath: string): BlogPostMetadata {
   };
 }
 
+const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+
+function readPngDimensions(
+  file: Buffer,
+): { height: number; width: number } | null {
+  if (file.length < 24 || !file.subarray(0, 8).equals(PNG_SIGNATURE)) {
+    return null;
+  }
+  return { height: file.readUInt32BE(20), width: file.readUInt32BE(16) };
+}
+
+function assertOpenGraphImage(
+  imagePath: string,
+  publicDir: string,
+  filePath: string,
+): void {
+  const absolutePath = join(publicDir, imagePath);
+  if (!existsSync(absolutePath)) {
+    throw new Error(
+      `Blog post "${filePath}" references an Open Graph image that does not exist at "public${imagePath}".`,
+    );
+  }
+
+  const dimensions = readPngDimensions(readFileSync(absolutePath));
+  if (!dimensions) {
+    throw new Error(
+      `Open Graph image "public${imagePath}" referenced by "${filePath}" is not a valid PNG.`,
+    );
+  }
+
+  if (
+    dimensions.width !== OPEN_GRAPH_IMAGE_WIDTH ||
+    dimensions.height !== OPEN_GRAPH_IMAGE_HEIGHT
+  ) {
+    throw new Error(
+      `Open Graph image "public${imagePath}" referenced by "${filePath}" must be ${OPEN_GRAPH_IMAGE_WIDTH}x${OPEN_GRAPH_IMAGE_HEIGHT}, but is ${dimensions.width}x${dimensions.height}.`,
+    );
+  }
+}
+
 function createSlug(title: string): string {
   return title
     .toLowerCase()
@@ -119,7 +165,10 @@ function removeRedundantLeadingHeading(
   return lines.slice(nextIndex).join("\n");
 }
 
-function processBlogDirectory(blogDir: string): ProcessedBlogPost[] {
+function processBlogDirectory(
+  blogDir: string,
+  publicDir: string,
+): ProcessedBlogPost[] {
   const files = readdirSync(blogDir)
     .filter((f) => f.endsWith(".mdx"))
     .sort();
@@ -132,6 +181,10 @@ function processBlogDirectory(blogDir: string): ProcessedBlogPost[] {
     const { content: rawContent, data } = splitFrontmatter(raw, file);
     const metadata = parseMetadata(data, file);
     const content = removeRedundantLeadingHeading(rawContent, metadata.title);
+
+    if (metadata.image) {
+      assertOpenGraphImage(metadata.image, publicDir, file);
+    }
 
     const hasCustomSlug = typeof metadata.slug === "string";
     const baseSlug = hasCustomSlug ? metadata.slug : createSlug(metadata.title);
@@ -157,12 +210,14 @@ const RESOLVED_ID = `\0${VIRTUAL_MODULE_ID}`;
 
 export function blogPlugin(): Plugin {
   let blogDir: string;
+  let publicDir: string;
 
   return {
     name: "keeper-blog",
 
     configResolved(config) {
       blogDir = resolve(config.root, "src/content/blog");
+      publicDir = config.publicDir;
     },
 
     resolveId(id) {
@@ -172,7 +227,7 @@ export function blogPlugin(): Plugin {
     load(id) {
       if (id !== RESOLVED_ID) return;
 
-      const posts = processBlogDirectory(blogDir);
+      const posts = processBlogDirectory(blogDir, publicDir);
       return `export const blogPosts = ${JSON.stringify(posts)};`;
     },
 

--- a/applications/web/src/lib/blog-posts.ts
+++ b/applications/web/src/lib/blog-posts.ts
@@ -5,6 +5,7 @@ export interface BlogPostMetadata {
   blurb: string;
   createdAt: string;
   description: string;
+  image?: string;
   slug?: string;
   tags: string[];
   title: string;

--- a/applications/web/src/lib/seo.ts
+++ b/applications/web/src/lib/seo.ts
@@ -1,5 +1,6 @@
 const SITE_URL = "https://www.keeper.sh";
 const SITE_NAME = "Keeper.sh";
+const DEFAULT_IMAGE_PATH = "/open-graph.png";
 
 export function canonicalUrl(path: string): string {
   return `${SITE_URL}${path}`;
@@ -15,16 +16,19 @@ export function seoMeta({
   path,
   type = "website",
   brandPosition = "after",
+  imagePath = DEFAULT_IMAGE_PATH,
 }: {
   title: string;
   description: string;
   path: string;
   type?: string;
   brandPosition?: "before" | "after";
+  imagePath?: string;
 }) {
   const fullTitle = brandPosition === "before"
     ? `${SITE_NAME} — ${title}`
     : `${title} · ${SITE_NAME}`;
+  const imageUrl = canonicalUrl(imagePath);
   return [
     { title: fullTitle },
     { content: description, name: "description" },
@@ -33,13 +37,13 @@ export function seoMeta({
     { content: description, property: "og:description" },
     { content: canonicalUrl(path), property: "og:url" },
     { content: SITE_NAME, property: "og:site_name" },
-    { content: `${SITE_URL}/open-graph.png`, property: "og:image" },
+    { content: imageUrl, property: "og:image" },
     { content: "1200", property: "og:image:width" },
     { content: "630", property: "og:image:height" },
     { content: "summary_large_image", name: "twitter:card" },
     { content: title, name: "twitter:title" },
     { content: description, name: "twitter:description" },
-    { content: `${SITE_URL}/open-graph.png`, name: "twitter:image" },
+    { content: imageUrl, name: "twitter:image" },
   ];
 }
 
@@ -195,6 +199,7 @@ export function blogPostingSchema(post: {
   createdAt: string;
   updatedAt: string;
   tags: string[];
+  imagePath?: string;
 }) {
   const url = canonicalUrl(`/blog/${post.slug}`);
   return {
@@ -203,7 +208,7 @@ export function blogPostingSchema(post: {
     "@id": `${url}/#blogposting`,
     headline: post.title,
     description: post.description,
-    image: `${SITE_URL}/open-graph.png`,
+    image: canonicalUrl(post.imagePath ?? DEFAULT_IMAGE_PATH),
     url,
     datePublished: post.createdAt,
     dateModified: post.updatedAt,

--- a/applications/web/src/routes/(marketing)/blog/$slug.tsx
+++ b/applications/web/src/routes/(marketing)/blog/$slug.tsx
@@ -24,6 +24,7 @@ export const Route = createFileRoute("/(marketing)/blog/$slug")({
           description: blogPost.metadata.description,
           path: postUrl,
           type: "article",
+          imagePath: blogPost.metadata.image,
         }),
         { content: blogPost.metadata.tags.join(", "), name: "keywords" },
         { content: blogPost.metadata.createdAt, property: "article:published_time" },
@@ -41,6 +42,7 @@ export const Route = createFileRoute("/(marketing)/blog/$slug")({
           createdAt: blogPost.metadata.createdAt,
           updatedAt: blogPost.metadata.updatedAt,
           tags: blogPost.metadata.tags,
+          imagePath: blogPost.metadata.image,
         })),
         jsonLdScript(breadcrumbSchema([
           { name: "Home", path: "/" },

--- a/applications/web/tests/lib/seo.test.ts
+++ b/applications/web/tests/lib/seo.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { blogPostingSchema, seoMeta } from "@/lib/seo";
+
+const GENERIC_IMAGE_URL = "https://www.keeper.sh/open-graph.png";
+
+const post = {
+  title: "How Calendar Sync Actually Works",
+  description: "A long-form explainer.",
+  slug: "how-calendar-sync-actually-works",
+  createdAt: "2026-08-01",
+  updatedAt: "2026-08-02",
+  tags: ["calendar"],
+};
+
+function findMeta(meta: ReturnType<typeof seoMeta>, key: string) {
+  return meta.find((entry) => "property" in entry && entry.property === key
+    || "name" in entry && entry.name === key);
+}
+
+describe("seoMeta", () => {
+  it("falls back to the generic share image", () => {
+    const meta = seoMeta({
+      title: "Pricing",
+      description: "Plans and pricing.",
+      path: "/pricing",
+    });
+
+    expect(findMeta(meta, "og:image")).toEqual({
+      content: GENERIC_IMAGE_URL,
+      property: "og:image",
+    });
+    expect(findMeta(meta, "twitter:image")).toEqual({
+      content: GENERIC_IMAGE_URL,
+      name: "twitter:image",
+    });
+  });
+
+  it("resolves a site-relative image path against the www host", () => {
+    const meta = seoMeta({
+      title: "Pricing",
+      description: "Plans and pricing.",
+      path: "/pricing",
+      imagePath: "/open-graph/pricing.png",
+    });
+
+    expect(findMeta(meta, "og:image")).toEqual({
+      content: "https://www.keeper.sh/open-graph/pricing.png",
+      property: "og:image",
+    });
+    expect(findMeta(meta, "twitter:image")).toEqual({
+      content: "https://www.keeper.sh/open-graph/pricing.png",
+      name: "twitter:image",
+    });
+  });
+
+  it("keeps the declared image dimensions at 1200x630", () => {
+    const meta = seoMeta({
+      title: "Pricing",
+      description: "Plans and pricing.",
+      path: "/pricing",
+      imagePath: "/open-graph/pricing.png",
+    });
+
+    expect(findMeta(meta, "og:image:width")).toEqual({
+      content: "1200",
+      property: "og:image:width",
+    });
+    expect(findMeta(meta, "og:image:height")).toEqual({
+      content: "630",
+      property: "og:image:height",
+    });
+  });
+});
+
+describe("blogPostingSchema", () => {
+  it("falls back to the generic share image", () => {
+    expect(blogPostingSchema(post).image).toBe(GENERIC_IMAGE_URL);
+  });
+
+  it("uses the post image when one is provided", () => {
+    expect(
+      blogPostingSchema({
+        ...post,
+        imagePath: "/open-graph/how-calendar-sync-actually-works.png",
+      }).image,
+    ).toBe(
+      "https://www.keeper.sh/open-graph/how-calendar-sync-actually-works.png",
+    );
+  });
+});


### PR DESCRIPTION
Blog posts can now declare their own share image via an optional `image` frontmatter field, so we can start giving posts individual Open Graph art instead of the one generic `open-graph.png` everyone shares. `seoMeta` and `blogPostingSchema` take an optional `imagePath` and fall back to the generic image, so a post without the field emits exactly what it does today. This is plumbing only — no images are added here.

- `image` must be a site-relative `/open-graph/<kebab-slug>.png`, validated by the arktype schema in `plugins/blog.ts`; the build fails loudly if the file is missing, is not a PNG, or is not 1200x630, which is the size the existing `og:image:width`/`og:image:height` tags declare.
- Images live in `applications/web/public/open-graph/`.
- Absolute URLs go through `canonicalUrl`, and the enforced leading slash means no double-slash is possible.
- `seoMeta` takes `imagePath` for any page, so `/features`, `/pricing` and the other marketing pages can opt in later without further changes; none of them pass it today.
- Verified by diffing rendered head tags before and after: only the post given a test `image` changed, and only in `og:image`, `twitter:image` and the `BlogPosting` `image`. Every other page and post is byte-identical.
