### PR TITLE
chore: ignore .gstack session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 screenshots/
 applications/mobile/
 .pki/
+.gstack/


### PR DESCRIPTION
Browser tooling writes session artifacts to `.gstack/` in the worktree — network and console logs, plus a local daemon token. They are not ignored, so they get picked up by `git add -A` and can be committed accidentally. That happened on #524 and had to be removed before it merged.

- Adds `.gstack/` alongside the existing `.pki/` entry
- One line; nothing else changes