### PR TITLE
fix(web): only cache marketing HTML rendered for anonymous requests

### DIFF
--- a/applications/web/src/server/http-handler.ts
+++ b/applications/web/src/server/http-handler.ts
@@ -145,16 +145,14 @@ export async function handleApplicationRequest(
     return withPrivateHtmlCacheHeaders(routerResponse);
   }
 
-  if (isCacheablePath && routerResponse.status === 200) {
+  if (isPubliclyCacheable && routerResponse.status === 200) {
     const body = await routerResponse.text();
     const entry = setCachedHtml(cacheKey, body);
     const freshResponse = new Response(body, {
       headers: routerResponse.headers,
       status: routerResponse.status,
     });
-    const cacheableResponse = isPubliclyCacheable
-      ? withPublicHtmlCacheHeaders(freshResponse, entry.etag)
-      : withPrivateHtmlCacheHeaders(freshResponse);
+    const cacheableResponse = withPublicHtmlCacheHeaders(freshResponse, entry.etag);
     const securedResponse = withSecurityHeaders(cacheableResponse, config);
     return withCompression(request, securedResponse);
   }

--- a/applications/web/tests/server/http-handler.test.ts
+++ b/applications/web/tests/server/http-handler.test.ts
@@ -27,6 +27,19 @@ function createRuntime(cacheableHtmlPaths: string[], body = "<html>page</html>")
   };
 }
 
+function createCountingRuntime(cacheableHtmlPaths: string[]): Runtime {
+  let renderCount = 0;
+  return {
+    ...createRuntime(cacheableHtmlPaths),
+    renderApp: vi.fn(async () => {
+      renderCount += 1;
+      return new Response(`<html>render ${renderCount}</html>`, {
+        headers: { "content-type": "text/html; charset=UTF-8" },
+      });
+    }),
+  };
+}
+
 function request(path: string, headers: Record<string, string> = {}): Request {
   return new Request(`http://localhost${path}`, { headers });
 }
@@ -123,6 +136,39 @@ describe("handleApplicationRequest caching", () => {
 
     expect(response.headers.get("cache-control")).toBe("private, no-store");
     expect(response.headers.get("etag")).toBeNull();
+  });
+
+  it("never lets a signed-in render reach the shared cache", async () => {
+    const path = "/blog/authenticated-first-post";
+    const runtime = createCountingRuntime([path]);
+
+    const authenticated = await handleApplicationRequest(
+      request(path, { cookie: "keeper.has_session=1" }),
+      runtime,
+      config,
+    );
+    const anonymous = await handleApplicationRequest(request(path), runtime, config);
+
+    expect(await authenticated.text()).toBe("<html>render 1</html>");
+    expect(await anonymous.text()).toBe("<html>render 2</html>");
+    expect(runtime.renderApp).toHaveBeenCalledTimes(2);
+  });
+
+  it("serves an anonymous render to a later signed-in visitor", async () => {
+    const path = "/blog/anonymous-first-post";
+    const runtime = createCountingRuntime([path]);
+
+    await handleApplicationRequest(request(path), runtime, config);
+    const authenticated = await handleApplicationRequest(
+      request(path, { cookie: "keeper.has_session=1" }),
+      runtime,
+      config,
+    );
+
+    expect(await authenticated.text()).toBe("<html>render 1</html>");
+    expect(authenticated.headers.get("cache-control")).toBe("private, no-store");
+    expect(authenticated.headers.get("etag")).toBeNull();
+    expect(runtime.renderApp).toHaveBeenCalledTimes(1);
   });
 
   it("keeps dashboard responses out of every cache", async () => {


### PR DESCRIPTION
The in-process `htmlCache` write in the web server was gated on `isCacheablePath` rather than `isPubliclyCacheable`, so a signed-in visitor's render of a marketing page was stored in the shared cache and then handed to later anonymous visitors — who get `public, max-age=0, s-maxage=600, stale-while-revalidate=86400` and so push it out to Cloudflare's edge. This is hardening, not a fix for an observed leak: the marketing render is genuinely session-independent today, but that safety rests on nobody ever adding session-dependent content to a marketing page instead of on the code. With the Cloudflare cache rule landing separately, the blast radius of that mistake goes from 60 seconds in one process to 600 seconds across every colo.

- writes to the shared cache now only happen for renders produced for anonymous requests
- the read path is unchanged: an authenticated visitor still gets anonymous-generated HTML, since the nav corrects itself before paint from `data-session`
- authenticated requests keep `private, no-store`, no etag, and still work on a cold cache
- tests cover the authenticated-render-never-cached case, the reverse direction, and the existing anonymous cache/304 flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmFcV1wCy2785Spmy5dEzY