### PR TITLE
fix(ci): publish a floating major tag and pin the docs to it

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,6 +52,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-') }}
+            type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-') }}
             type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
           flavor: suffix=-${{ matrix.arch }}
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -93,6 +94,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-') }}
+            type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-') }}
             type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
           flavor: suffix=-${{ matrix.arch }}
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -133,6 +135,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-') }}
+            type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-') }}
             type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
       - name: Create multi-arch manifest
         env:
@@ -167,6 +170,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-') }}
+            type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-') }}
             type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
       - name: Create multi-arch manifest
         env:

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ services:
       retries: 5
 
   keeper:
-    image: ghcr.io/ridafkih/keeper-services:latest
+    image: ghcr.io/ridafkih/keeper-services:2
     environment:
       DATABASE_URL: ${DATABASE_URL}
       REDIS_URL: ${REDIS_URL}
@@ -463,7 +463,7 @@ services:
       retries: 5
 
   api:
-    image: ghcr.io/ridafkih/keeper-api:latest
+    image: ghcr.io/ridafkih/keeper-api:2
     environment:
       API_PORT: 3001
       DATABASE_URL: postgres://keeper:keeper@postgres:5432/keeper
@@ -482,7 +482,7 @@ services:
         condition: service_healthy
 
   cron:
-    image: ghcr.io/ridafkih/keeper-cron:latest
+    image: ghcr.io/ridafkih/keeper-cron:2
     environment:
       DATABASE_URL: postgres://keeper:keeper@postgres:5432/keeper
       REDIS_URL: redis://redis:6379
@@ -499,7 +499,7 @@ services:
         condition: service_healthy
 
   worker:
-    image: ghcr.io/ridafkih/keeper-worker:latest
+    image: ghcr.io/ridafkih/keeper-worker:2
     environment:
       DATABASE_URL: postgres://keeper:keeper@postgres:5432/keeper
       REDIS_URL: redis://redis:6379
@@ -515,7 +515,7 @@ services:
         condition: service_healthy
 
   web:
-    image: ghcr.io/ridafkih/keeper-web:latest
+    image: ghcr.io/ridafkih/keeper-web:2
     environment:
       VITE_API_URL: ${VITE_API_URL}
       PORT: 3000

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -30,7 +30,7 @@ services:
     restart: unless-stopped
 
   api:
-    image: ghcr.io/ridafkih/keeper-api:latest
+    image: ghcr.io/ridafkih/keeper-api:2
     container_name: keeper-api
     env_file: .env
     environment:
@@ -50,7 +50,7 @@ services:
     restart: unless-stopped
 
   cron:
-    image: ghcr.io/ridafkih/keeper-cron:latest
+    image: ghcr.io/ridafkih/keeper-cron:2
     container_name: keeper-cron
     env_file: .env
     environment:
@@ -66,7 +66,7 @@ services:
     restart: unless-stopped
 
   worker:
-    image: ghcr.io/ridafkih/keeper-worker:latest
+    image: ghcr.io/ridafkih/keeper-worker:2
     container_name: keeper-worker
     env_file: .env
     environment:
@@ -82,7 +82,7 @@ services:
     restart: unless-stopped
 
   mcp:
-    image: ghcr.io/ridafkih/keeper-mcp:latest
+    image: ghcr.io/ridafkih/keeper-mcp:2
     container_name: keeper-mcp
     env_file: .env
     environment:
@@ -95,7 +95,7 @@ services:
     restart: unless-stopped
 
   web:
-    image: ghcr.io/ridafkih/keeper-web:latest
+    image: ghcr.io/ridafkih/keeper-web:2
     container_name: keeper-web
     env_file: .env
     environment:


### PR DESCRIPTION
The README tells self-hosters to pull `keeper-standalone:2`, but no bare major tag has ever been published — the registry only carries `{{version}}`, `{{major}}.{{minor}}` and `latest`, so those pull commands fail. This adds the major tag to the publish workflow and makes every image reference in the docs use it.

- All four `metadata-action` blocks needed the tag, not just the manifest ones: the merge steps run `imagetools create` against `${tag}-amd64` and `${tag}-arm64`, so the per-arch builds have to emit `2-amd64`/`2-arm64` before `2` can be assembled from them.
- The `enable` guard mirrors the existing tags, so a prerelease like `v2.14.0-rc.1` cannot move `:2`.
- README and `deploy/compose.yaml` now use `:2` throughout; the five `:latest` references were the odd ones out, since the image table and standalone examples were already on `:2`.
- Verified all seven images are published — `keeper-services` and `keeper-worker` included, which an earlier registry pass had missed.

Takes effect on the next `v*.*.*` push. Existing releases will not retroactively gain a `:2`, so `imagetools create` by hand if it is wanted sooner.

Closes #497
Closes #537
Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmFcV1wCy2785Spmy5dEzY