### PR TITLE
fix: unblock google ads conversion tracking

### DIFF
--- a/applications/web/src/components/analytics-scripts.tsx
+++ b/applications/web/src/components/analytics-scripts.tsx
@@ -1,28 +1,26 @@
 import { useEffect, useRef } from "react";
 import { useLocation } from "@tanstack/react-router";
 import type { PublicRuntimeConfig } from "@/lib/runtime-config";
-import { identify, track } from "@/lib/analytics";
+import { identify, track, updateGoogleConsent } from "@/lib/analytics";
 import { useEffectiveConsent } from "@/hooks/use-effective-consent";
 import { useGdprApplies } from "@/hooks/use-gdpr-applies";
 import { useSession } from "@/hooks/use-session";
-
-function resolveConsentLabel(hasConsent: boolean): "granted" | "denied" {
-  if (hasConsent) return "granted";
-  return "denied";
-}
 
 function AnalyticsScripts({ runtimeConfig }: { runtimeConfig: PublicRuntimeConfig }) {
   const { googleAdsId, visitorsNowToken } = runtimeConfig;
   const gdprApplies = useGdprApplies();
   const hasConsent = useEffectiveConsent();
   const location = useLocation();
-  const consentState = resolveConsentLabel(hasConsent);
   const { user } = useSession();
   const identifiedUserId = useRef<string | null>(null);
 
   useEffect(() => {
     track("page_view", { path: location.pathname });
   }, [location.pathname]);
+
+  useEffect(() => {
+    updateGoogleConsent(hasConsent);
+  }, [hasConsent]);
 
   useEffect(() => {
     if (!user) return;
@@ -45,16 +43,15 @@ function AnalyticsScripts({ runtimeConfig }: { runtimeConfig: PublicRuntimeConfi
       {googleAdsId && (
         <>
           <script
-            defer
             dangerouslySetInnerHTML={{
               __html: `
                 window.dataLayer = window.dataLayer || [];
                 function gtag(){dataLayer.push(arguments);}
                 gtag('consent', 'default', {
-                  'ad_storage': '${consentState}',
-                  'ad_user_data': '${consentState}',
-                  'ad_personalization': '${consentState}',
-                  'analytics_storage': '${consentState}',
+                  'ad_storage': 'denied',
+                  'ad_user_data': 'denied',
+                  'ad_personalization': 'denied',
+                  'analytics_storage': 'denied',
                   'wait_for_update': 500
                 });
               `,

--- a/applications/web/src/lib/analytics.ts
+++ b/applications/web/src/lib/analytics.ts
@@ -147,6 +147,7 @@ declare global {
 
 export {
   CONSENT_COOKIE,
+  updateGoogleConsent,
   hasAnalyticsConsent,
   hasConsentChoice,
   identify,

--- a/applications/web/src/server/http-handler.ts
+++ b/applications/web/src/server/http-handler.ts
@@ -41,8 +41,27 @@ const baseSecurityHeaders: Record<string, string> = {
   "permissions-policy": "camera=(), microphone=(), geolocation=(), interest-cohort=()",
 };
 
-const cspHeader =
-  "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://cdn.visitors.now; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://pagead2.googlesyndication.com; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://cdn.visitors.now https://e.visitors.now https://pagead2.googlesyndication.com; frame-src https://polar.sh; frame-ancestors 'none'; base-uri 'self'; form-action 'self'";
+const googleAdsHosts = [
+  "https://www.googletagmanager.com",
+  "https://www.googleadservices.com",
+  "https://googleads.g.doubleclick.net",
+  "https://ad.doubleclick.net",
+  "https://pagead2.googlesyndication.com",
+  "https://www.google.com",
+].join(" ");
+
+const cspHeader = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline' ${googleAdsHosts} https://cdn.visitors.now`,
+  "style-src 'self' 'unsafe-inline'",
+  `img-src 'self' data: ${googleAdsHosts}`,
+  "font-src 'self'",
+  `connect-src 'self' ${googleAdsHosts} https://www.google-analytics.com https://cdn.visitors.now https://e.visitors.now`,
+  "frame-src https://polar.sh",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+].join("; ");
 
 function withSecurityHeaders(response: Response, config: ServerConfig): Response {
   const headers = new Headers(response.headers);

--- a/applications/web/tests/components/analytics-scripts.test.tsx
+++ b/applications/web/tests/components/analytics-scripts.test.tsx
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { parseHTML } from "linkedom";
+import type { PublicRuntimeConfig } from "@/lib/runtime-config";
+import { AnalyticsScripts } from "@/components/analytics-scripts";
+
+const { effectiveConsentMock, gdprAppliesMock } = vi.hoisted(() => ({
+  effectiveConsentMock: vi.fn(() => false),
+  gdprAppliesMock: vi.fn(() => true),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useLocation: () => ({ pathname: "/" }),
+}));
+
+vi.mock("@/hooks/use-effective-consent", () => ({
+  useEffectiveConsent: effectiveConsentMock,
+}));
+
+vi.mock("@/hooks/use-gdpr-applies", () => ({
+  useGdprApplies: gdprAppliesMock,
+}));
+
+vi.mock("@/hooks/use-session", () => ({
+  useSession: () => ({ user: null }),
+}));
+
+const runtimeConfig: PublicRuntimeConfig = {
+  commercialMode: true,
+  googleAdsConversionLabel: "test-label",
+  googleAdsId: "AW-1234567890",
+  polarProMonthlyProductId: null,
+  polarProYearlyProductId: null,
+  visitorsNowToken: null,
+};
+
+type GtagCall = [string, string, Record<string, string | number>];
+
+let previousGlobals: Record<string, unknown>;
+let gtagSpy: ReturnType<typeof vi.fn>;
+let container: HTMLElement;
+let root: ReturnType<typeof createRoot>;
+
+beforeEach(() => {
+  const { document, window } = parseHTML("<html><body><div id='app'></div></body></html>");
+
+  previousGlobals = {
+    Event: globalThis.Event,
+    HTMLElement: globalThis.HTMLElement,
+    Node: globalThis.Node,
+    document: globalThis.document,
+    window: globalThis.window,
+  };
+
+  Object.assign(globalThis, {
+    Event: window.Event,
+    HTMLElement: window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    Node: window.Node,
+    document,
+    window,
+  });
+
+  gtagSpy = vi.fn();
+  globalThis.gtag = gtagSpy as unknown as typeof globalThis.gtag;
+
+  const appContainer = document.getElementById("app");
+  if (!(appContainer instanceof globalThis.HTMLElement)) {
+    throw new Error("Expected app container");
+  }
+
+  container = appContainer;
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+
+  globalThis.gtag = undefined;
+  Object.assign(globalThis, previousGlobals);
+  vi.clearAllMocks();
+});
+
+const consentUpdates = (): GtagCall[] =>
+  gtagSpy.mock.calls.filter(
+    (call): call is GtagCall => call[0] === "consent" && call[1] === "update",
+  );
+
+describe("AnalyticsScripts consent signalling", () => {
+  it("grants Google consent on mount when the visitor has effective consent", async () => {
+    effectiveConsentMock.mockReturnValue(true);
+    gdprAppliesMock.mockReturnValue(false);
+
+    await act(async () => {
+      root.render(<AnalyticsScripts runtimeConfig={runtimeConfig} />);
+    });
+
+    expect(consentUpdates()).toEqual([
+      [
+        "consent",
+        "update",
+        {
+          ad_personalization: "granted",
+          ad_storage: "granted",
+          ad_user_data: "granted",
+          analytics_storage: "granted",
+        },
+      ],
+    ]);
+  });
+
+  it("keeps Google consent denied on mount when the visitor has not consented", async () => {
+    effectiveConsentMock.mockReturnValue(false);
+    gdprAppliesMock.mockReturnValue(true);
+
+    await act(async () => {
+      root.render(<AnalyticsScripts runtimeConfig={runtimeConfig} />);
+    });
+
+    expect(consentUpdates()).toEqual([
+      [
+        "consent",
+        "update",
+        {
+          ad_personalization: "denied",
+          ad_storage: "denied",
+          ad_user_data: "denied",
+          analytics_storage: "denied",
+        },
+      ],
+    ]);
+  });
+
+  it("re-signals consent when the visitor accepts after mount", async () => {
+    effectiveConsentMock.mockReturnValue(false);
+    gdprAppliesMock.mockReturnValue(true);
+
+    await act(async () => {
+      root.render(<AnalyticsScripts runtimeConfig={runtimeConfig} />);
+    });
+
+    effectiveConsentMock.mockReturnValue(true);
+
+    await act(async () => {
+      root.render(<AnalyticsScripts runtimeConfig={runtimeConfig} />);
+    });
+
+    const updates = consentUpdates();
+    expect(updates).toHaveLength(2);
+    expect(updates[1]?.[2]).toMatchObject({ ad_storage: "granted" });
+  });
+
+  it("emits a denied consent default in server markup regardless of client consent", () => {
+    effectiveConsentMock.mockReturnValue(true);
+    gdprAppliesMock.mockReturnValue(false);
+
+    const markup = renderToStaticMarkup(<AnalyticsScripts runtimeConfig={runtimeConfig} />);
+
+    expect(markup).toContain("'ad_storage': 'denied'");
+    expect(markup).not.toContain("'ad_storage': 'granted'");
+  });
+});

--- a/applications/web/tests/server/http-handler.test.ts
+++ b/applications/web/tests/server/http-handler.test.ts
@@ -227,3 +227,52 @@ describe("resolveCanonicalRedirect", () => {
     expect(resolveCanonicalRedirect(new URL("https://www.keeper.sh/blog"))).toBeNull();
   });
 });
+
+function cspDirectives(header: string): Map<string, string[]> {
+  return new Map(
+    header
+      .split(";")
+      .map((directive) => directive.trim())
+      .filter((directive) => directive.length > 0)
+      .map((directive) => {
+        const [name, ...sources] = directive.split(/\s+/);
+        return [name ?? "", sources] as const;
+      }),
+  );
+}
+
+async function productionCsp(): Promise<Map<string, string[]>> {
+  const response = await handleApplicationRequest(request("/"), createRuntime([]), config);
+  const header = response.headers.get("content-security-policy");
+  if (!header) throw new Error("Expected a content-security-policy header in production");
+  return cspDirectives(header);
+}
+
+describe("content security policy", () => {
+  it("allows the hosts Google Ads loads conversion scripts from", async () => {
+    const scriptSrc = (await productionCsp()).get("script-src") ?? [];
+
+    expect(scriptSrc).toContain("https://www.googletagmanager.com");
+    expect(scriptSrc).toContain("https://www.googleadservices.com");
+    expect(scriptSrc).toContain("https://googleads.g.doubleclick.net");
+  });
+
+  it("allows the hosts Google Ads pings conversions to over fetch", async () => {
+    const connectSrc = (await productionCsp()).get("connect-src") ?? [];
+
+    expect(connectSrc).toContain("https://www.googleadservices.com");
+    expect(connectSrc).toContain("https://googleads.g.doubleclick.net");
+    expect(connectSrc).toContain("https://ad.doubleclick.net");
+    expect(connectSrc).toContain("https://www.google.com");
+    expect(connectSrc).toContain("https://pagead2.googlesyndication.com");
+  });
+
+  it("allows the hosts Google Ads falls back to pixel pings on", async () => {
+    const imgSrc = (await productionCsp()).get("img-src") ?? [];
+
+    expect(imgSrc).toContain("https://www.googleadservices.com");
+    expect(imgSrc).toContain("https://googleads.g.doubleclick.net");
+    expect(imgSrc).toContain("https://www.google.com");
+    expect(imgSrc).toContain("https://pagead2.googlesyndication.com");
+  });
+});


### PR DESCRIPTION
Google Ads has been recording nothing since launch because of two independent blockers, both verified against production. Consent was pinned to `denied` for every visitor (prod was sending `gcs=G100` on every hit), and even with consent granted the CSP refused every conversion endpoint Google tries. Fixing either one alone changes nothing, so both land here.

- The SSR consent snapshot is always `false`, so the inline `gtag('consent','default',...)` rendered `denied` even for visitors holding a `granted` cookie. React rewrote that script's text after hydration, but browsers never re-execute a script whose text changes, so `dataLayer` only ever held the denied default and no `consent update` was sent unless the visitor clicked the banner in that exact session.
- The default now stays a static `denied` (correct for publicly cached HTML) and an effect signals real consent on mount and on change.
- CSP allowed only `googletagmanager.com` and `pagead2.googlesyndication.com`; the actual conversion ping to `googleadservices.com/pagead/conversion/` was blocked on fetch, image, and script transports. Added the hosts gtag genuinely uses.
- Verified in a browser against the new header: `googleadservices.com/pagead/conversion/` and `viewthroughconversion` both return 200.

One residual: Google also duplicates first-party pings to the visitor's country domain (`www.google.ca` and friends), which stay blocked. The canonical conversion still lands on `.com`, so this is supplementary only. Enumerating ~190 ccTLDs in every response header seemed worse than the gap, but say the word and I'll add the regions you actually advertise in.

Follow-up PR covers the coverage gaps (no signup conversion, SPA navigations never reach gtag, `transactionId` vs `transaction_id`).