### PR TITLE
feat: report google ads signup conversions for oauth signups

### DIFF
--- a/applications/web/src/components/analytics-scripts.tsx
+++ b/applications/web/src/components/analytics-scripts.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useRef } from "react";
 import { useLocation } from "@tanstack/react-router";
 import type { PublicRuntimeConfig } from "@/lib/runtime-config";
-import { identify, reportGooglePageView, track, updateGoogleConsent } from "@/lib/analytics";
+import {
+  ANALYTICS_EVENTS,
+  identify,
+  reportGooglePageView,
+  reportSignupConversion,
+  track,
+  updateGoogleConsent,
+} from "@/lib/analytics";
+import { stripSignupMarker } from "@/lib/signup-marker";
 import { useEffectiveConsent } from "@/hooks/use-effective-consent";
 import { useGdprApplies } from "@/hooks/use-gdpr-applies";
 import { useSession } from "@/hooks/use-session";
@@ -30,6 +38,15 @@ function AnalyticsScripts({ runtimeConfig }: { runtimeConfig: PublicRuntimeConfi
   useEffect(() => {
     updateGoogleConsent(hasConsent);
   }, [hasConsent]);
+
+  useEffect(() => {
+    const cleanedUrl = stripSignupMarker(globalThis.location.href);
+    if (cleanedUrl === null) return;
+
+    globalThis.history.replaceState(null, "", cleanedUrl);
+    track(ANALYTICS_EVENTS.signup_completed, { provider: "oauth" });
+    reportSignupConversion(runtimeConfig);
+  }, [runtimeConfig]);
 
   useEffect(() => {
     if (!user) return;

--- a/applications/web/src/features/auth/components/oauth-preamble.tsx
+++ b/applications/web/src/features/auth/components/oauth-preamble.tsx
@@ -3,6 +3,7 @@ import ArrowLeftRight from "lucide-react/dist/esm/icons/arrow-left-right";
 import Check from "lucide-react/dist/esm/icons/check";
 import KeeperLogo from "@/assets/keeper.svg?react";
 import { authClient } from "@/lib/auth-client";
+import { withSignupMarker } from "@/lib/signup-marker";
 import {
   resolvePathWithSearch,
   resolveClientPostAuthRedirect,
@@ -105,8 +106,11 @@ export function AuthOAuthPreamble({
     const socialProvider = PROVIDER_SOCIAL_MAP[provider];
     if (!socialProvider) return;
 
+    const callbackURL = resolveClientPostAuthRedirect(authorizationSearch);
+
     await authClient.signIn.social({
-      callbackURL: resolveClientPostAuthRedirect(authorizationSearch),
+      callbackURL,
+      newUserCallbackURL: withSignupMarker(callbackURL, globalThis.location.origin),
       provider: socialProvider,
     });
   };

--- a/applications/web/src/lib/signup-marker.ts
+++ b/applications/web/src/lib/signup-marker.ts
@@ -1,0 +1,19 @@
+const SIGNUP_MARKER = "keeper_signup";
+
+const withSignupMarker = (target: string, origin: string): string => {
+  const url = new URL(target, origin);
+  if (url.origin !== origin) return target;
+
+  url.searchParams.set(SIGNUP_MARKER, "1");
+  return `${url.pathname}${url.search}${url.hash}`;
+};
+
+const stripSignupMarker = (href: string): string | null => {
+  const url = new URL(href);
+  if (!url.searchParams.has(SIGNUP_MARKER)) return null;
+
+  url.searchParams.delete(SIGNUP_MARKER);
+  return `${url.pathname}${url.search}${url.hash}`;
+};
+
+export { SIGNUP_MARKER, stripSignupMarker, withSignupMarker };

--- a/applications/web/tests/components/analytics-scripts.test.tsx
+++ b/applications/web/tests/components/analytics-scripts.test.tsx
@@ -68,6 +68,17 @@ beforeEach(() => {
   gtagSpy = vi.fn();
   globalThis.gtag = gtagSpy as unknown as typeof globalThis.gtag;
 
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: { href: "https://www.keeper.sh/", origin: "https://www.keeper.sh" },
+    writable: true,
+  });
+  Object.defineProperty(globalThis, "history", {
+    configurable: true,
+    value: { replaceState: () => undefined },
+    writable: true,
+  });
+
   const appContainer = document.getElementById("app");
   if (!(appContainer instanceof globalThis.HTMLElement)) {
     throw new Error("Expected app container");
@@ -83,6 +94,8 @@ afterEach(async () => {
   });
 
   globalThis.gtag = undefined;
+  Reflect.deleteProperty(globalThis, "location");
+  Reflect.deleteProperty(globalThis, "history");
   Object.assign(globalThis, previousGlobals);
   vi.clearAllMocks();
 });
@@ -215,5 +228,76 @@ describe("AnalyticsScripts page views", () => {
     });
 
     expect(pageViews()).toHaveLength(0);
+  });
+});
+
+describe("AnalyticsScripts oauth signup conversions", () => {
+  const conversions = (): GtagCall[] =>
+    gtagSpy.mock.calls.filter(
+      (call): call is GtagCall => call[0] === "event" && call[1] === "conversion",
+    );
+
+  const stubLocation = (href: string): { replaced: string[] } => {
+    const replaced: string[] = [];
+
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: { href, origin: "https://www.keeper.sh" },
+      writable: true,
+    });
+    Object.defineProperty(globalThis, "history", {
+      configurable: true,
+      value: {
+        replaceState: (_state: unknown, _title: string, url: string) => {
+          replaced.push(url);
+        },
+      },
+      writable: true,
+    });
+
+    return { replaced };
+  };
+
+  it("reports a signup conversion when better-auth lands a first-time oauth user", async () => {
+    const { replaced } = stubLocation("https://www.keeper.sh/dashboard?keeper_signup=1");
+
+    await act(async () => {
+      root.render(
+        <AnalyticsScripts
+          runtimeConfig={{ ...runtimeConfig, googleAdsSignupConversionLabel: "signup-label" }}
+        />,
+      );
+    });
+
+    expect(conversions()).toEqual([
+      ["event", "conversion", { send_to: "AW-1234567890/signup-label" }],
+    ]);
+    expect(replaced).toEqual(["/dashboard"]);
+  });
+
+  it("stays silent for a returning oauth user landing without the marker", async () => {
+    stubLocation("https://www.keeper.sh/dashboard");
+
+    await act(async () => {
+      root.render(<AnalyticsScripts runtimeConfig={runtimeConfig} />);
+    });
+
+    expect(conversions()).toHaveLength(0);
+  });
+
+  it("reports once even if the marked url is rendered again", async () => {
+    const stub = stubLocation("https://www.keeper.sh/dashboard?keeper_signup=1");
+
+    await act(async () => {
+      root.render(<AnalyticsScripts runtimeConfig={runtimeConfig} />);
+    });
+
+    globalThis.location.href = `https://www.keeper.sh${stub.replaced[0]}`;
+
+    await act(async () => {
+      root.render(<AnalyticsScripts runtimeConfig={{ ...runtimeConfig }} />);
+    });
+
+    expect(conversions()).toHaveLength(1);
   });
 });

--- a/applications/web/tests/lib/signup-marker.test.ts
+++ b/applications/web/tests/lib/signup-marker.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { stripSignupMarker, withSignupMarker } from "@/lib/signup-marker";
+
+const origin = "https://www.keeper.sh";
+
+describe("withSignupMarker", () => {
+  it("marks a relative post-auth path", () => {
+    expect(withSignupMarker("/dashboard", origin)).toBe("/dashboard?keeper_signup=1");
+  });
+
+  it("keeps existing query parameters", () => {
+    expect(withSignupMarker("/dashboard?tab=sources", origin)).toBe(
+      "/dashboard?tab=sources&keeper_signup=1",
+    );
+  });
+
+  it("leaves cross-origin authorization redirects untouched", () => {
+    const target = "https://api.keeper.sh/mcp/authorize?client_id=abc";
+
+    expect(withSignupMarker(target, origin)).toBe(target);
+  });
+});
+
+describe("stripSignupMarker", () => {
+  it("returns the cleaned url when the marker is present", () => {
+    expect(stripSignupMarker(`${origin}/dashboard?keeper_signup=1`)).toBe("/dashboard");
+  });
+
+  it("preserves unrelated query parameters and the hash", () => {
+    expect(stripSignupMarker(`${origin}/dashboard?keeper_signup=1&tab=sources#feeds`)).toBe(
+      "/dashboard?tab=sources#feeds",
+    );
+  });
+
+  it("returns null when the marker is absent", () => {
+    expect(stripSignupMarker(`${origin}/dashboard?tab=sources`)).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-up to #548, which added the signup conversion but only wired it to the email/password path. Google and Microsoft signups redirect away and come back, so there was no client-side moment that knew whether the returning user was new. better-auth already solves this: its OAuth callback redirects to `newUserCallbackURL` instead of `callbackURL` when the account was created in that request, so the new-vs-returning decision stays server-side rather than being guessed in the browser.

- `signIn.social` now passes a `newUserCallbackURL` carrying a `keeper_signup=1` marker.
- On landing, the marker is stripped via `replaceState` before the conversion fires, so a refresh or a shared URL can't replay it.
- Marking is skipped for cross-origin MCP authorization redirects, where our JS never runs anyway.

Worth knowing: this reports at the moment of account creation, so a signup that abandons before connecting a calendar still counts. That matches how the email/password path already behaves, so the two stay comparable. Keeping this conversion action Secondary matters more now that both paths report it.