### PR TITLE
fix(outlook): allow a null subject on graph events

### DIFF
--- a/packages/calendar/src/providers/outlook/source/types.ts
+++ b/packages/calendar/src/providers/outlook/source/types.ts
@@ -30,7 +30,7 @@ interface OutlookCalendarEvent {
   categories?: string[];
   isAllDay?: boolean;
   isCancelled?: boolean;
-  subject?: string;
+  subject?: string | null;
   body?: { contentType?: string; content?: string } | null;
   location?: { displayName?: string };
   showAs?: string;

--- a/packages/calendar/src/providers/outlook/source/utils/fetch-events.ts
+++ b/packages/calendar/src/providers/outlook/source/utils/fetch-events.ts
@@ -536,7 +536,7 @@ const parseOutlookEvents = (events: OutlookCalendarEvent[]): EventTimeSlot[] => 
         event.originalStartTimeZone,
         start.timeZone,
       ),
-      title: event.subject,
+      ...event.subject && { title: event.subject },
       uid: event.iCalUId,
     });
   }

--- a/packages/calendar/tests/providers/outlook/destination/provider.test.ts
+++ b/packages/calendar/tests/providers/outlook/destination/provider.test.ts
@@ -200,4 +200,34 @@ describe("createOutlookSyncProvider", () => {
       startTime: new Date("2026-03-08T00:00:00.000Z"),
     });
   });
+
+  it("reads a remote calendar containing an event with a null subject", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(Response.json({
+      value: [
+        {
+          categories: [KEEPER_CATEGORY],
+          end: { dateTime: "2026-03-08T19:00:00.0000000", timeZone: "UTC" },
+          iCalUId: "titled-uid",
+          id: "titled-id",
+          start: { dateTime: "2026-03-08T18:00:00.0000000", timeZone: "UTC" },
+          subject: "Titled",
+        },
+        {
+          categories: [KEEPER_CATEGORY],
+          end: { dateTime: "2026-03-09T19:00:00.0000000", timeZone: "UTC" },
+          iCalUId: "untitled-uid",
+          id: "untitled-id",
+          start: { dateTime: "2026-03-09T18:00:00.0000000", timeZone: "UTC" },
+          subject: null,
+        },
+      ],
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const events = await createProvider().listRemoteEvents({
+      timeMin: new Date("2026-03-01T00:00:00.000Z"),
+    });
+
+    expect(events.map((event) => event.uid)).toEqual(["titled-uid", "untitled-uid"]);
+  });
 });

--- a/packages/data-schemas/src/index.ts
+++ b/packages/data-schemas/src/index.ts
@@ -157,7 +157,7 @@ const outlookEventSchema = type({
   "originalStartTimeZone?": "string",
   "showAs?": "string",
   "start?": { "dateTime?": "string", "timeZone?": "string" },
-  "subject?": "string",
+  "subject?": "string | null",
   "seriesMasterId?": "string | null",
   "type?": "string",
 });
@@ -173,7 +173,7 @@ type OutlookEventList = typeof outlookEventListSchema.infer;
 const outlookCalendarViewEventSchema = type({
   "id?": "string",
   "iCalUId?": "string | null",
-  "subject?": "string",
+  "subject?": "string | null",
   "bodyPreview?": "string",
   "location?": { "displayName?": "string" },
   "start?": { "dateTime?": "string", "timeZone?": "string" },


### PR DESCRIPTION
Microsoft Graph can return `subject: null`, and the Outlook destination read asserts the response against the arktype schema before mapping it, so a single untitled event anywhere in the calendar threw a `TraversalError` and permanently failed push-sync for that calendar. The mapping directly below the gate already handled it with `summary: event.subject ?? ""` — only the schema was too strict. Same shape as #344, which fixed `iCalUid` and missed `subject`.

- widened `subject` to `string | null` on both `outlookEventSchema` and `outlookCalendarViewEventSchema`
- widened the matching source `OutlookCalendarEvent` type and made `fetch-events` spread `title` conditionally
- added a destination-provider test that reproduces the production error byte-for-byte without the schema change

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmVsczuP6e2i7VwjhvXxH