### PR TITLE
docs: rewrite marketing copy for posture, accuracy and house voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # About
 
-Keeper.sh is a simple & open-source calendar syncing tool. It allows you to pull events from your Google Calendar, Outlook, iCloud, Fastmail, CalDAV server, or a remotely hosted iCal or ICS links, and push them to one or many calendars so the time slots can align across them all. Google, Outlook, iCloud, Fastmail, and CalDAV are first-class integrations that can each be used as a source or as a destination, while iCal and ICS links are pull-only. It also serves as a global MCP server and API for you or your agents to manage all your calendars from one convenient interface. You can use the hosted version for convenience and zero-setup, or self-host to get Pro features free. 
+Keeper.sh is a simple & open-source calendar syncing tool. It allows you to pull events from your Google Calendar, Outlook, iCloud, Fastmail, CalDAV server, or remotely hosted iCal and ICS links, and push them to one or many calendars so the time slots can align across them all. Google, Outlook, iCloud, Fastmail, and CalDAV are first-class integrations that can each be used as a source or as a destination, while iCal and ICS links are pull-only. It also serves as a global MCP server and API for you or your agents to manage all your calendars from one convenient interface.
+
+The recommended way to run it is the hosted version at [keeper.sh](https://keeper.sh/register): the same code, minus the server, the domain, the upgrades, the backups and the Google and Microsoft sign-in apps you would otherwise register yourself. Self-hosting is a first-class path and every Pro feature is included when you self-host — that is not a trial, and it is not going away. It costs you the upkeep instead of the $5.
 
 # Features
 
@@ -99,21 +101,23 @@ Meetings have landed on top of one-another a frustratingly high number of times.
 
 ## Why not use _this other service_?
 
-I've probably tried it. It was probably too finicky, ended up making me waste hours of my time having to delete stale events it didn't seem to want to track anymore, or just didn't sync reliably.
+Use one if it already works for you. This one exists because of the two things I kept hitting: events deleted at the source that stayed on the destination forever, and no way to read the code that was handling my calendar.
+
+Both are addressed by design here. A deletion is tracked by a mapping row that outlives the event it pointed at, so the remote copy still gets removed on a later pass, and the cleanup sweep only ever touches events Keeper.sh created — it will not delete an event you made yourself. And the engine is AGPL-3.0, so you can check that claim rather than take it.
 
 ## How does the syncing engine work?
 
 - If we have a local event but no corresponding "source → destination" mapping for an event, we push the event to the destination calendar.
 - If we have a mapping for an event, but the source ID is not present on the source any longer, we delete the event from the destination.
-- Any events with markers of having been created by Keeper, but with no corresponding local tracking, we remove it. This is only done for backwards compatibility.
+- Any events with markers of having been created by Keeper.sh, but with no corresponding local tracking, we remove it. This is only done for backwards compatibility.
 
-Events are flagged as having been created by Keeper either using a `@keeper.sh` suffix on the remote UID, or in the case of a platform like Outlook that doesn't support custom UIDs, we just put it in a `"keeper.sh"` category.
+Events are flagged as having been created by Keeper.sh either using a `@keeper.sh` suffix on the remote UID, or in the case of a platform like Outlook that doesn't support custom UIDs, we just put it in a `"keeper.sh"` category.
 
 ## How is the syncing split up?
 
 There are two halves, and they run on separate schedules.
 
-Ingestion pulls from your sources into Keeper's own database once a minute, regardless of plan. Google and Outlook are fetched incrementally using the provider's own sync token and delta link respectively, so a run only asks for what changed since the last one. CalDAV, iCloud, and Fastmail are refetched and diffed against the event state Keeper already has stored, and iCal/ICS links are refetched and diffed against the last stored snapshot.
+Ingestion pulls from your sources into Keeper.sh's own database once a minute, regardless of plan. Google and Outlook are fetched incrementally using the provider's own sync token and delta link respectively, so a run only asks for what changed since the last one. CalDAV, iCloud, and Fastmail are refetched and diffed against the event state Keeper.sh already has stored, and iCal/ICS links are refetched and diffed against the last stored snapshot.
 
 Pushing to destinations is what the refresh interval in the pricing table refers to. The cron service enqueues a job per destination onto a Redis-backed queue every minute for Pro and every thirty minutes for free, and the worker service reconciles the destination calendar. This is polling on our side rather than provider push notifications, so nothing needs to reach your instance from the outside.
 
@@ -121,9 +125,9 @@ Neither half is schedule-only. `POST /api/v1/sync`, or `trigger_sync` over MCP, 
 
 # Cloud Hosted
 
-I've made Keeper easy to self-host, but whether you simply want to support the project or don't want to deal with the hassle or overhead of configuring and running your own infrastructure cloud hosting is always an option.
+This is the version I would point most people at, including people perfectly capable of running it themselves. It is the same engine on hardware I keep running, so the hours go into your calendar instead of your infrastructure — and paying for it is what funds the work on both versions.
 
-Head to [keeper.sh](https://keeper.sh) to get started with the cloud-hosted version. Use code `README` for 25% off.
+Head to [keeper.sh](https://keeper.sh/register) to get started with the cloud-hosted version.
 
 |                             | Free       | Pro (Cloud-Hosted) | Pro (Self-Hosted) |
 | --------------------------- | ---------- | ------------------ | ----------------- |
@@ -136,13 +140,13 @@ Head to [keeper.sh](https://keeper.sh) to get started with the cloud-hosted vers
 | **iCal Feed Customization** | No         | Yes                | Yes               |
 | **API Requests**            | 25 per day | ∞                  | ∞                 |
 
-The two limits that bite first are counted separately. A linked account is one connected Google, Outlook, iCloud, Fastmail, or CalDAV account, or one iCal/ICS subscription, and free is capped at two of them however many calendars each exposes. A sync mapping is one source calendar wired to one destination calendar, and free is capped at three, so a single source fanning out to three destinations uses the whole allowance. The refresh interval is how often Keeper pushes to your destinations; ingestion from your sources runs every minute on every plan.
+The two limits that bite first are counted separately. A linked account is one connected Google, Outlook, iCloud, Fastmail, or CalDAV account, or one iCal/ICS subscription, and free is capped at two of them however many calendars each exposes. A sync mapping is one source calendar wired to one destination calendar, and free is capped at three, so a single source fanning out to three destinations uses the whole allowance. The refresh interval is how often Keeper.sh pushes to your destinations; ingestion from your sources runs every minute on every plan.
 
 # Self Hosted
 
-By hosting Keeper.sh yourself, you get all premium features for free, can guarantee data governance and autonomy, and it's fun. If you'll be self-hosting, please consider supporting me and development of the project by sponsoring me on GitHub.
+By hosting Keeper.sh yourself, you get all premium features for free, can guarantee data governance and autonomy, and it's fun. What it costs instead is a server, a domain, upgrades, backups, your own Google and Microsoft OAuth apps, and being the person paged when it stops. If you'll be self-hosting, please consider supporting me and development of the project by sponsoring me on GitHub.
 
-There are seven images currently available, two of them are designed for convenience, while the five are designed to serve the granular underlying services.
+There are seven images currently available: two designed for convenience, and five that serve the granular underlying services. If you have no reason to prefer otherwise, start with `keeper-standalone` behind a reverse proxy — it is the path with the fewest moving parts to get wrong.
 
 > [!NOTE]
 >
@@ -184,7 +188,7 @@ There are seven images currently available, two of them are designed for conveni
 | MCP_PUBLIC_URL                 | `api`, `mcp`  | Optional on `api`, required by `mcp`. Public URL of the MCP resource. Enables OAuth on the API and identifies the MCP server to clients. In `keeper-standalone` it defaults to `BETTER_AUTH_URL` with `/mcp` appended.<br><br>e.g. `https://keeper.example.com/mcp` |
 | VITE_MCP_URL                   | `web`         | Optional. Internal URL the web server uses to proxy `/mcp` requests to the MCP service.<br><br>e.g. `http://mcp:3002`                                              |
 | MCP_PORT                       | `mcp`         | Required by `mcp`. Port the MCP server listens on. Pre-set to `3002` in the `keeper-standalone` image.<br><br>e.g. `3002`                                          |
-| MCP_API_URL                    | `api`, `mcp`  | Optional. Internal URL used to reach the Keeper API when serving MCP — for tool calls, and for fetching the signing keys that validate MCP tokens. Defaults to `BETTER_AUTH_URL`, which requires both services to be able to reach your instance's public URL. Pre-set to the bundled API in the `keeper-standalone` image.<br><br>e.g. `http://api:3001` |
+| MCP_API_URL                    | `api`, `mcp`  | Optional. Internal URL used to reach the Keeper.sh API when serving MCP — for tool calls, and for fetching the signing keys that validate MCP tokens. Defaults to `BETTER_AUTH_URL`, which requires both services to be able to reach your instance's public URL. Pre-set to the bundled API in the `keeper-standalone` image.<br><br>e.g. `http://api:3001` |
 | OTEL_EXPORTER_OTLP_ENDPOINT    | `api`, `cron`, `worker`, `mcp`, `web` | Optional. When set, enables forwarding structured logs to an OpenTelemetry collector. Each service pipes its stdout through the `keeper-otelemetry` binary from [`@keeper.sh/otelemetry`](./packages/otelemetry), which runs as a separate process and does not affect application performance.<br><br>e.g. `https://otel-collector.example.com:4318` |
 | OTEL_EXPORTER_OTLP_PROTOCOL    | `api`, `cron`, `worker`, `mcp`, `web` | Optional. Protocol used by the OTLP exporter. Defaults to `http/protobuf` per the OpenTelemetry spec.<br><br>e.g. `http/protobuf`, `grpc`, `http/json` |
 | OTEL_EXPORTER_OTLP_HEADERS     | `api`, `cron`, `worker`, `mcp`, `web` | Optional. Headers sent with every OTLP export request. Use this for authentication (e.g. Basic auth or API keys).<br><br>e.g. `Authorization=Basic dXNlcjpwYXNz` |
@@ -210,7 +214,7 @@ The following environment variables are read by the `web` server at **runtime** 
 
 | Tag                        | Description                                                                                                                                              | Included Services                                                                        |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `keeper-standalone:2`    | The "standalone" image is everything you need to get up and running with Keeper with as little configuration as possible.                                | `keeper-web`, `keeper-api`, `keeper-cron`, `keeper-worker`, `keeper-mcp`, `redis`, `postgresql`, `caddy` |
+| `keeper-standalone:2`    | The "standalone" image is everything you need to get up and running with Keeper.sh with as little configuration as possible.                                | `keeper-web`, `keeper-api`, `keeper-cron`, `keeper-worker`, `keeper-mcp`, `redis`, `postgresql`, `caddy` |
 | `keeper-services:2`      | If you'd like for the Redis & Database to exist outside of the container, you can use the "services" image to launch without them included in the image. | `keeper-web`, `keeper-api`, `keeper-cron`, `keeper-worker`                                 |
 | `keeper-web:2`           | An image containing the Vite SSR web interface.                                                                                                          | `keeper-web`                                                                              |
 | `keeper-api:2`           | An image containing the Bun API service.                                                                                                                 | `keeper-api`                                                                              |
@@ -244,11 +248,11 @@ Once this is configured, set the client ID and client secret as the `GOOGLE_CLIE
 >
 > Once again, this is optional. If you do not configure this, you will not be able to configure Microsoft Outlook as a destination.
 
-Microsoft does not appear to do documentation well, the best I could find for non-legacy instructions on configuring OAuth is this [community thread.](https://learn.microsoft.com/en-us/answers/questions/4705805/how-to-set-up-oauth-2-0-for-outlook). The required scopes are `Calendars.ReadWrite`, `User.Read`, and `offline_access`. The client ID and secret for Microsoft go into the `MICROSOFT_CLIENT_ID` and `MICROSOFT_CLIENT_SECRET` environment variables respectively.
+The clearest non-legacy walkthrough for configuring OAuth is this [community thread.](https://learn.microsoft.com/en-us/answers/questions/4705805/how-to-set-up-oauth-2-0-for-outlook). The required scopes are `Calendars.ReadWrite`, `User.Read`, and `offline_access`. The client ID and secret for Microsoft go into the `MICROSOFT_CLIENT_ID` and `MICROSOFT_CLIENT_SECRET` environment variables respectively.
 
 ## Standalone Container
 
-While you'd typically want to run containers granularly, if you just want to get up and running, a convenience image `keeper-standalone:2` has been provided. This container contains the `cron`, `worker`, `web`, `api` services as well as a configured `redis`, `database`, and `caddy` instance that puts everything behind the same port. While this is the easiest way to spin up Keeper, it is not recognized as best-practice.
+`keeper-standalone:2` is the recommended starting point for a single-instance deployment. This container contains the `cron`, `worker`, `web`, `api` services as well as a configured `redis`, `database`, and `caddy` instance that puts everything behind the same port. Split the services out later if you need to scale them independently, run your own Postgres and Redis, or place them on separate hosts.
 
 ### Generate `keeper-standalone` Environment Variables
 
@@ -256,12 +260,12 @@ The following will generate a `.env` file that contains the key used to generate
 
 > [!IMPORTANT]
 >
-> If you plan on accessing Keeper from a URL _other than_ http://localhost,
+> If you plan on accessing Keeper.sh from a URL _other than_ http://localhost,
 > you will need to set the `TRUSTED_ORIGINS` environment variable. This should
 > be a comma-delimited list of protocol-hostname inclusive origins you will be using.
 >
-> Here is an example where we would be accessing Keeper from the LAN IP and where we
-> are routing Keeper through a reverse proxy that hosts it at https://keeper.example.com/
+> Here is an example where we would be accessing Keeper.sh from the LAN IP and where we
+> are routing Keeper.sh through a reverse proxy that hosts it at https://keeper.example.com/
 >
 > ```bash
 > TRUSTED_ORIGINS=http://10.0.0.2,https://keeper.example.com
@@ -321,13 +325,13 @@ volumes:
   keeper-data:
 ```
 
-Once that's configured, you can launch Keeper using the following command.
+Once that's configured, you can launch Keeper.sh using the following command.
 
 ```bash
 docker compose up -d
 ```
 
-With all said and done, you can access Keeper at http://localhost/. You can use a reverse-proxy like Nginx or Caddy to put Keeper behind a domain on your network.
+With all said and done, you can access Keeper.sh at http://localhost/. You can use a reverse-proxy like Nginx or Caddy to put Keeper.sh behind a domain on your network.
 
 ## Collective Services Image
 
@@ -406,7 +410,7 @@ volumes:
   redis-data:
 ```
 
-Once that's configured, you can launch Keeper using the following command.
+Once that's configured, you can launch Keeper.sh using the following command.
 
 ```bash
 docker compose up -d
@@ -414,7 +418,7 @@ docker compose up -d
 
 ## Individual Service Images
 
-While running services individually is considered best-practice, it is verbose and more complicated to configure. Each service is hosted in its own image.
+Running each service in its own image gives you the most control over scaling and placement, at the cost of a much longer configuration. Reach for this when `keeper-standalone` or `keeper-services` no longer fits, not before.
 
 ### Generate Individual Service Environment Variables
 
@@ -532,7 +536,7 @@ volumes:
   redis-data:
 ```
 
-Once that's configured, you can launch Keeper using the following command.
+Once that's configured, you can launch Keeper.sh using the following command.
 
 ```bash
 docker compose up -d
@@ -540,7 +544,7 @@ docker compose up -d
 
 # REST API
 
-Keeper exposes a REST API under `/api/v1`. It is the same interface the dashboard and the MCP server use, so anything an agent can do through MCP you can do with `curl`.
+Keeper.sh exposes a REST API under `/api/v1`. It is the same interface the dashboard and the MCP server use, so anything an agent can do through MCP you can do with `curl`.
 
 ## Authentication
 
@@ -582,7 +586,7 @@ Range parameters `from` and `to` are ISO 8601 datetimes. If omitted, `from` defa
 
 # MCP (Model Context Protocol)
 
-Keeper includes an optional MCP server that lets AI agents (such as Claude) access your calendar data through a standardized protocol. The MCP server authenticates via OAuth 2.1 with a consent flow hosted by the web application.
+Keeper.sh includes an optional MCP server that lets AI agents (such as Claude) access your calendar data through a standardized protocol. The MCP server authenticates via OAuth 2.1 with a consent flow hosted by the web application.
 
 ## Available Tools
 
@@ -624,7 +628,7 @@ Example Claude Code MCP configuration:
 
 > [!NOTE]
 >
-> MCP is fully optional. All MCP-related environment variables are optional across every service and image. If they are not set, Keeper starts normally without MCP functionality. Existing self-hosted deployments are unaffected.
+> MCP is fully optional. All MCP-related environment variables are optional across every service and image. If they are not set, Keeper.sh starts normally without MCP functionality. Existing self-hosted deployments are unaffected.
 
 The MCP server is proxied through the web service at `/mcp`, the same way the API is proxied at `/api`.
 
@@ -641,9 +645,6 @@ MCP is **not** bundled in `keeper-services` or the individual service images. To
 ## Applications
 
 1. [@keeper.sh/web](./applications/web)
-2. @keeper.sh/cli _(Coming Soon)_
-3. @keeper.sh/mobile _(Coming Soon)_
-4. @keeper.sh/ssh _(Coming Soon)_
 
 ## Services
 

--- a/applications/web/public/robots.txt
+++ b/applications/web/public/robots.txt
@@ -18,6 +18,21 @@ Allow: /
 Disallow: /dashboard
 Disallow: /auth
 
+User-agent: Claude-SearchBot
+Allow: /
+Disallow: /dashboard
+Disallow: /auth
+
+User-agent: Claude-User
+Allow: /
+Disallow: /dashboard
+Disallow: /auth
+
+User-agent: OAI-SearchBot
+Allow: /
+Disallow: /dashboard
+Disallow: /auth
+
 User-agent: PerplexityBot
 Allow: /
 Disallow: /dashboard

--- a/applications/web/src/components/cookie-consent.tsx
+++ b/applications/web/src/components/cookie-consent.tsx
@@ -85,7 +85,7 @@ function CookieConsent() {
                   <ConsentBannerCard>
                     <ConsentBannerContent>
                       <Text as="span" size="sm">
-                        Can Keeper{" "}
+                        Can Keeper.sh{" "}
                         <TextLink to="/privacy" size="sm">
                           use cookies for analytics?
                         </TextLink>

--- a/applications/web/src/content/blog/best-calendar-sync-tools.mdx
+++ b/applications/web/src/content/blog/best-calendar-sync-tools.mdx
@@ -51,6 +51,18 @@ Keeper.sh is free with two accounts and three connections, and $5 flat at thirty
 
 Four of those rows carry no published speed figure at all. Keeper.sh reads every calendar every minute, iCloud and CalDAV included.
 
+## Which ones can an AI assistant drive?
+
+Three of the nine publish an MCP server, the connector that lets an assistant like Claude or ChatGPT act on your calendar rather than just talk about it.
+
+| Tool | MCP server | Tools |
+|---|---|---|
+| **Keeper.sh** | Yes, OAuth 2.1 with a consent screen | 11 — list calendars, read events, create, update, delete, RSVP, pending invites, combined link |
+| **SyncDate** | [Yes](https://syncdate.app/mcp) | 12, including triggering and pausing a sync |
+| **OneCal** | [Yes](https://www.onecal.io/integrations/calendar-mcp-server) | 8 |
+
+Keeper.sh's is free at 25 calls a day and uncapped on Pro, and the REST API behind it does the same things from a script. Checked 11 August 2026.
+
 ## Ten calendars: $5 here, $40 for eight at CalendarBridge
 
 OneCal, CalendarBridge and SyncThemCalendars all charge by the calendar or by the sync pair. The price goes up in proportion to how bad your problem is. A contractor with nine client calendars plus a personal one is the worst case, and a common one.
@@ -78,7 +90,9 @@ What arrives is a block of busy time named after the calendar it came from. Titl
 
 Cancel a meeting and the copy goes with it. Keeper.sh keeps a record of every copy it wrote so it can take that copy back, and it never deletes an event it did not create.
 
-It works with Google, Outlook, iCloud, Fastmail, and any other calendar that uses the CalDAV standard. Read-only calendar links work too, so the conference feed and the university timetable block time against work like everything else. The API reads and writes: create, move, cancel or RSVP across every connected calendar from a script, or from an AI assistant.
+It works with Google, Outlook, iCloud, Fastmail, and any other calendar that uses the CalDAV standard. Read-only calendar links work too, so the conference feed and the university timetable block time against work like everything else.
+
+Keeper.sh also ships an MCP server with 11 tools, so an assistant like Claude can list your calendars, read events, and create, move, cancel or RSVP to them. The same actions are in the REST API. Both are free at 25 calls a day and uncapped on Pro.
 
 The code is [AGPL-3.0 on GitHub](https://github.com/ridafkih/keeper.sh), with seven published Docker images, including a standalone container that brings up the whole stack. The version you can run yourself is the version that runs the hosted service. [Start on the hosted version](https://www.keeper.sh/register) — same engine, none of the upkeep.
 

--- a/applications/web/src/content/blog/best-calendar-sync-tools.mdx
+++ b/applications/web/src/content/blog/best-calendar-sync-tools.mdx
@@ -57,8 +57,8 @@ Three of the nine publish an MCP server, the connector that lets an assistant li
 
 | Tool | MCP server | Tools |
 |---|---|---|
-| **Keeper.sh** | Yes, OAuth 2.1 with a consent screen | 11 — list calendars, read events, create, update, delete, RSVP, pending invites, combined link |
-| **SyncDate** | [Yes](https://syncdate.app/mcp) | 12, including triggering and pausing a sync |
+| **Keeper.sh** | Yes, OAuth 2.1 with a consent screen | 14 — list calendars, read events, create, update, delete, RSVP, pending invites, find free time, trigger a sync, pause a calendar, combined link |
+| **SyncDate** | [Yes](https://syncdate.app/mcp) | 12 |
 | **OneCal** | [Yes](https://www.onecal.io/integrations/calendar-mcp-server) | 8 |
 
 Keeper.sh's is free at 25 calls a day and uncapped on Pro, and the REST API behind it does the same things from a script. Checked 11 August 2026.
@@ -92,7 +92,7 @@ Cancel a meeting and the copy goes with it. Keeper.sh keeps a record of every co
 
 It works with Google, Outlook, iCloud, Fastmail, and any other calendar that uses the CalDAV standard. Read-only calendar links work too, so the conference feed and the university timetable block time against work like everything else.
 
-Keeper.sh also ships an MCP server with 11 tools, so an assistant like Claude can list your calendars, read events, and create, move, cancel or RSVP to them. The same actions are in the REST API. Both are free at 25 calls a day and uncapped on Pro.
+Keeper.sh also ships an MCP server with 14 tools, so an assistant like Claude can list your calendars, read events, and create, move, cancel or RSVP to them. The same actions are in the REST API. Both are free at 25 calls a day and uncapped on Pro.
 
 The code is [AGPL-3.0 on GitHub](https://github.com/ridafkih/keeper.sh), with seven published Docker images, including a standalone container that brings up the whole stack. The version you can run yourself is the version that runs the hosted service. [Start on the hosted version](https://www.keeper.sh/register) — same engine, none of the upkeep.
 

--- a/applications/web/src/content/blog/best-calendar-sync-tools.mdx
+++ b/applications/web/src/content/blog/best-calendar-sync-tools.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Best Calendar Sync Tools in 2026: 9 Tools Compared"
-description: "Nine calendar sync tools compared on price, speed, privacy and iCloud support. Every figure comes from the vendor's own published pages."
-blurb: "Nine calendar sync tools, all nine in one table, with every figure taken from the vendor's own published pages. Includes the tools that beat Keeper.sh, and the three products people recommend that do not sync calendars at all."
+title: "Best Calendar Sync Tools: 9 Compared on Price, Speed and Privacy"
+description: "One is free forever, $5 flat at any number of calendars, and open source. Nine calendar sync tools compared on price, privacy defaults and what survives the vendor. Every figure verified 11 August 2026."
+blurb: "One is free forever, $5 flat at any number of calendars, and open source. Nine calendar sync tools compared on price, privacy defaults and what survives the vendor."
 createdAt: "2026-08-11"
 slug: "best-calendar-sync-tools"
 updatedAt: "2026-08-11"
@@ -12,131 +12,141 @@ tags:
   - "privacy"
 ---
 
-You have two calendars and you keep getting double-booked. A calendar sync tool copies your events from one to the other, so both show you as busy at the same times.
+You accept a meeting in one calendar. The other still shows you free. Someone takes that hour, and now you owe two people the same 2pm.
 
-Nine tools do that job, and all nine are in the table below. That includes Keeper.sh, which we build, and the ones that beat it. Three more products get recommended for this and do something else entirely.
+A calendar sync tool copies your events between calendars so all of them show you busy at the same times. Nine tools do that job. Three more get recommended for it constantly and do something else.
 
-## Which one should you get?
+Every competitor price and speed figure on this page comes from that vendor's own published pages, checked on 11 August 2026.
 
-- **Best free plan — Keeper.sh.** Two calendar accounts and three connections, with your events copied every 30 minutes. [SyncDate's free plan](https://syncdate.app/pricing) is much faster but covers one connection.
-- **Best for speed — SyncDate.** [About four seconds](https://syncdate.app/features) on Google and Outlook. Keeper.sh is slower, and that is worth saying plainly: every minute on Pro, every 30 minutes free.
-- **Best for privacy — OGCS.** [It runs on your own Windows PC](https://www.outlookgooglecalendarsync.com/), so your calendar data never passes through anyone else's server.
-- **Best for European paperwork — Kalender Sync.** It [publishes a signed data processing agreement and German hosting](https://kalender-sync.de/en/it-admin/). Keeper.sh offers neither today.
-- **Best for iCloud — CalendarBridge.** It treats iCloud as a first-class calendar and tells you what to expect: five to ten minutes.
-- **Best for teams — CalendarBridge.** An admin connects everyone's calendars and [sets which domains staff may sync with](https://help.calendarbridge.com/faq/do-i-need-a-group-plan/). [Kalender Sync](https://kalender-sync.de/en/pricing/) is the better answer for a European team, and Keeper.sh has no team features at all.
-- **Best for self-hosting — Keeper.sh.** The only tool here you can run on your own server, under AGPL-3.0, with every Pro feature included.
+Keeper.sh is free with two accounts and three connections, and $5 flat at thirty calendars. Three quieter questions decide whether you are still happy in a year:
 
-## The full comparison
+- Where do your event titles, locations and attendee names end up?
+- What does this cost once you have ten calendars instead of two?
+- What happens to your synced calendars the day the vendor is acquired or switched off?
 
-Nine tools, nine rows. Nothing is left out for competing with us, and every figure links to the page it came from.
+## Which calendar sync tool should you use?
 
-| Tool | Run it yourself | Starting price | Free plan | Published speed | Direction | Calendars | Privacy default |
+- **Most people should start with Keeper.sh.** Connect your work Google and your personal iCloud, sync them both ways, and add one more one-way copy on top. That is free, permanently, with no card and no clock.
+- **Keeping your event titles to yourself — Keeper.sh.** A calendar you connect starts stripped: Keeper.sh writes a block of busy time carrying the calendar's name, and leaves the title, the description and the location behind. Detail is a Pro setting you switch on, not one you switch off.
+- **Your iCloud calendar, read every minute — Keeper.sh.** Keeper.sh reads yours every minute on every plan, and on Pro the block is on your other calendar about a minute later, two at the outside. [CalendarBridge publishes 5–10 minutes](https://help.calendarbridge.com/faq/how-often-do-calendars-sync/) and [OneCal up to 10](https://www.onecal.io/features/apple-calendar-sync).
+- **HIPAA with a signed BAA today, or Microsoft GCC High — CalendarBridge.** Nothing else in this category touches GCC High. That flank costs [$40 a month for eight calendars](https://calendarbridge.com/pricing/), on US cloud only, with no CalDAV and no way to run it yourself.
+- **An AI to rearrange your week — Reclaim.ai, and it is good at that.** Sync there is one of eight features and rate-limited by tier. It connects [Google and Outlook only](https://help.reclaim.ai/en/articles/3600762-calendar-sync-overview-keep-multiple-schedules-in-sync) — no iCloud, no CalDAV, on any plan.
+- **A signed data processing agreement and German hosting before you can buy — Kalender Sync.** It publishes [Falkenstein databases, a signed GDPR agreement and named subprocessors](https://kalender-sync.de/en/it-admin/), from [€4 a month](https://kalender-sync.de/en/pricing/). Keeper.sh answers differently: self-host and the database sits on your own hardware, in your own country.
+
+[Connect two accounts free](https://www.keeper.sh/register). There is no clock on it and no card at the end.
+
+## Price, speed and privacy across all nine tools
+
+| Tool | Run it yourself | Starting price | Free plan | Published speed | Direction | Calendars | What lands by default |
 |---|---|---|---|---|---|---|---|
-| **Keeper.sh** | Yes — AGPL-3.0 | $5/month | Yes — 2 accounts, 3 connections | Reads every minute; copies every 30 min free, every minute on Pro | One direction per connection | Google, Outlook, iCloud, Fastmail, CalDAV, ICS links (read-only) | Busy blocks — title, description and location hidden |
-| **SyncDate** | No | [$8.99/month](https://syncdate.app/pricing) | Yes — 2 calendars, 2 accounts, 1 sync | [~4 seconds on Google and Outlook; 15-minute backup check](https://syncdate.app/features) | One or both directions | Google, Outlook, CalDAV, ICS (read-only) | Busy — descriptions, attendees and reminders off |
-| **OneCal** | No | [$5/user/month](https://www.onecal.io/pricing) | No — 14-day trial | ["Real-time"](https://docs.onecal.io/docs/calendar-sync/calendar-sync-intro); [iCloud up to 10 minutes](https://www.onecal.io/features/apple-calendar-sync) | One or many directions | Google, Outlook, iCloud | Not published as a default; fields are yours to choose |
-| **CalendarBridge** | No | [$4/month billed yearly](https://calendarbridge.com/pricing/) | No — trial, length not published | [Within a minute on Google and Outlook; 5–10 minutes on iCloud and ICS](https://help.calendarbridge.com/faq/how-often-do-calendars-sync/) | [One direction per connection](https://help.calendarbridge.com/user-docs/about-syncing/) | [Google, Microsoft 365, Outlook, Exchange, iCloud, ICS](https://calendarbridge.com/real-time-calendar-syncing/) | Not published as a default; fields are yours to choose |
-| **Reclaim.ai** | No | [$10/seat/month](https://reclaim.ai/pricing) | Yes — 1 calendar sync | ["Real time"](https://reclaim.ai/features/calendar-sync), no figure published | [One direction per rule; two rules for both](https://help.reclaim.ai/en/articles/3654852-how-to-set-up-a-calendar-sync-in-reclaim) | [Google and Outlook only](https://help.reclaim.ai/en/articles/3600762-calendar-sync-overview-keep-multiple-schedules-in-sync) | Not published |
-| **SyncThemCalendars** | No | [$3.99/month](https://syncthemcalendars.com/pricing) | No — 14-day trial | ["Real time"](https://syncthemcalendars.com), no figure published | One or both directions | Google, Outlook, iCloud | Not published as a default; title, description and location can be hidden |
-| **Kalender Sync** | No | [€4/month](https://kalender-sync.de/en/pricing/) | Yes — 2 accounts, 1 sharing, Google and Outlook only | [Seconds to a few minutes on paid plans; every 5 minutes for iCloud](https://kalender-sync.de/en/integrations/); 30 minutes on free | [One or both directions](https://kalender-sync.de/en/) | Google, Outlook, iCloud, Infomaniak, GMX, WEB.DE, mailbox.org, ICS | Anonymised busy blocks |
-| **Morgen** | No | [$15/month billed yearly](https://www.morgen.so/pricing) | No — 14-day trial | [Calendar-to-calendar copies run once a day at 6pm, 14 days ahead](https://www.morgen.so/guides/how-to-use-morgens-calendar-propagation-workflow) | One direction published | [Google, Outlook, iCloud, Fastmail, CalDAV, ICS](https://www.morgen.so/integrations) | Copies appear as "Private Event (from Morgen)" |
-| **OGCS** | Runs on your own PC — MPL-2.0 | Free | Yes — free, no limits | [Every 15 minutes; 2 minutes for changes you make in Outlook](https://www.outlookgooglecalendarsync.com/guide/syncoptions-when.html) | [One or both directions](https://github.com/phw198/OutlookGoogleCalendarSync) | Desktop Outlook and Google only | Copies full event detail |
+| **Keeper.sh** | Yes — AGPL-3.0, Docker | $5/month flat, any number of calendars | Yes — 2 accounts, 3 connections, forever; copies land about fifteen minutes after a change on free, thirty-one minutes at the very worst | Reads every calendar every minute; copies land in about a minute on Pro, two at the outside | One direction per connection | Google, Outlook, iCloud, Fastmail, any CalDAV server, read-only calendar links | Busy block named after the calendar it came from — title, description and location stripped |
+| **SyncDate** | No — [hosted in Germany and Finland](https://syncdate.app/security) | [$8.99/month](https://syncdate.app/pricing) | [Yes — 2 calendars, 2 accounts, 1 sync](https://syncdate.app/pricing) | [~4 seconds on Google and Outlook; 15-minute backup check](https://syncdate.app/features) | One or both directions | Google, Outlook, CalDAV, read-only calendar links | Busy — descriptions, attendees and reminders off |
+| **OneCal** | No | [$5/user/month for 2 calendars; $25/user/month for 50, both billed annually](https://www.onecal.io/pricing) | [No — 14-day trial](https://www.onecal.io/pricing) | ["Real-time" with no figure published](https://docs.onecal.io/docs/calendar-sync/calendar-sync-intro); [iCloud up to 10 minutes](https://www.onecal.io/features/apple-calendar-sync) | One or many directions | Google, Outlook, iCloud | [No published default](https://docs.onecal.io/docs/calendar-sync/calendar-sync-intro) |
+| **CalendarBridge** | No | [$5/month for 2 calendars; $40 for 8](https://calendarbridge.com/pricing/) | No — [trial, length not published](https://calendarbridge.com/pricing/) | [Within a minute on Google and Outlook; 5–10 minutes on iCloud](https://help.calendarbridge.com/faq/how-often-do-calendars-sync/) | [One direction per connection](https://help.calendarbridge.com/user-docs/about-syncing/) | [Google, Microsoft 365, Outlook, Exchange, iCloud, calendar links](https://calendarbridge.com/real-time-calendar-syncing/) | [No published default](https://help.calendarbridge.com/user-docs/about-syncing/) |
+| **SyncThemCalendars** | No | [$3.99/month for 5 sync pairs](https://syncthemcalendars.com/) | [No](https://syncthemcalendars.com/) | [No figure published](https://syncthemcalendars.com/) | One or both directions | Google, Outlook, iCloud | [No published default](https://syncthemcalendars.com/) |
+| **Kalender Sync** | No — [databases in Falkenstein, Germany](https://kalender-sync.de/en/it-admin/) | [€4/month](https://kalender-sync.de/en/pricing/) | [Yes — 2 accounts, 1 sharing, Google and Outlook only](https://kalender-sync.de/en/pricing/) | [Seconds to a few minutes on paid plans; every 5 minutes for iCloud](https://kalender-sync.de/en/integrations/) | [One or both directions](https://kalender-sync.de/en/) | Google, Outlook, iCloud, Infomaniak, GMX, WEB.DE, mailbox.org, calendar links | Anonymised busy blocks |
+| **Unicala** | Advertised, but [no repository and no license are published](https://unicala.io/) | [Free / $5 / $6 per seat](https://unicala.io/) | [Yes](https://unicala.io/) | ["Real-time" with no figure published](https://unicala.io/) | [Not published](https://unicala.io/) | Google, Outlook, iCloud | [Not published](https://unicala.io/) |
+| **Reclaim.ai** | No | [$10/seat/month](https://reclaim.ai/pricing) | [Yes — 1 calendar sync](https://reclaim.ai/pricing) | [No figure published](https://reclaim.ai/features/calendar-sync) | [One direction per rule; two rules for both](https://help.reclaim.ai/en/articles/3654852-how-to-set-up-a-calendar-sync-in-reclaim) | [Google and Outlook only](https://help.reclaim.ai/en/articles/3600762-calendar-sync-overview-keep-multiple-schedules-in-sync) | Not published |
+| **OGCS** | Runs on your own PC — MPL-2.0 | Free | Yes — free, no limits | [Every 15 minutes; 2 minutes for changes you make in Outlook](https://www.outlookgooglecalendarsync.com/guide/syncoptions-when.html) | [One or both directions](https://github.com/phw198/OutlookGoogleCalendarSync) | Desktop Outlook and Google only | Not published |
 
-Speed figures are not comparable across this table. Some vendors name the mechanism behind their number and some just say "real time". Where a vendor publishes no figure, the table says so rather than guessing.
+Four of those rows carry no published speed figure at all. Keeper.sh reads every calendar every minute, iCloud and CalDAV included.
 
-## The nine tools
+## Ten calendars: $5 here, $40 for eight at CalendarBridge
 
-The table has the numbers. This is what each one is actually like to live with.
+OneCal, CalendarBridge and SyncThemCalendars all charge by the calendar or by the sync pair. The price goes up in proportion to how bad your problem is. A contractor with nine client calendars plus a personal one is the worst case, and a common one.
+
+- **CalendarBridge** — [$40 a month, the top published tier, covering eight calendars](https://calendarbridge.com/pricing/). Ten is a conversation.
+- **OneCal** — [$25 a month per user billed annually](https://www.onecal.io/pricing), the tier that stretches to 50. Six accounts already moves you off the $5 plan.
+- **SyncThemCalendars** — [$3.99 a month for five sync pairs, $7.99 for sixteen, $17.99 for thirty-six](https://syncthemcalendars.com/). The meter is pairs, so the bill tracks how tangled your calendars are.
+- **Keeper.sh** — $5 a month, flat. Ten calendars, thirty calendars, as many connections as you want.
+
+At two connected accounts Keeper.sh is free outright. OneCal, [CalendarBridge](https://calendarbridge.com/pricing/) and [SyncThemCalendars](https://syncthemcalendars.com/) have no free plan. At eight calendars the gap is $35 a month, every month, for a problem that got worse rather than a product that got better.
+
+[Start with two accounts, free](https://www.keeper.sh/register) — the $5 tier is there when you outgrow it, at any number of calendars.
+
+## What each calendar sync tool is like to use
 
 ### Keeper.sh
 
-**Best for** — running it yourself, or busy blocks that leak no detail.
+Keeper.sh is for anyone whose calendars live in more than one place and who does not want their meeting titles copied onto a server they cannot read or run.
 
-Titles, descriptions and locations are hidden by default, and the calendar's name shows instead. Changing what comes through is a Pro feature. There is also a REST API and an MCP server for your own tools or an agent.
+It is free for two linked accounts and three connections, and Pro is $5 a month for as many as you like. Keeper.sh reads every connected calendar every minute on both plans. On Pro the copy lands about a minute later, two at the outside; on free it is about fifteen minutes, thirty-one at the very worst.
 
-**Where it lets you down** — no mobile app, no team accounts, no signed data processing agreement, and it is slower than several tools here.
+Setting up takes three decisions. Sign in with Google or Microsoft, or use an app-specific password for iCloud and Fastmail, which lets Keeper.sh in without handing over your main password. Then pick which calendar feeds which, and pick the direction.
+
+What arrives is a block of busy time named after the calendar it came from. Title, description and location stay behind, and letting more through is a Pro setting. Attendees, reminders and meeting links never travel at all.
+
+Cancel a meeting and the copy goes with it. Keeper.sh keeps a record of every copy it wrote so it can take that copy back, and it never deletes an event it did not create.
+
+It works with Google, Outlook, iCloud, Fastmail, and any other calendar that uses the CalDAV standard. Read-only calendar links work too, so the conference feed and the university timetable block time against work like everything else. The API reads and writes: create, move, cancel or RSVP across every connected calendar from a script, or from an AI assistant.
+
+The code is [AGPL-3.0 on GitHub](https://github.com/ridafkih/keeper.sh), with seven published Docker images, including a standalone container that brings up the whole stack. The version you can run yourself is the version that runs the hosted service. [Start on the hosted version](https://www.keeper.sh/register) — same engine, none of the upkeep.
 
 ### SyncDate
 
-**Best for** — anyone who needs changes to land in seconds, and European buyers who need paperwork.
+SyncDate is the one to look at if you want a hosted service run from European data centres. It publishes [about four seconds on Google and Outlook, with a 15-minute backup check](https://syncdate.app/features), at [$8.99 a month](https://syncdate.app/pricing). It [runs in Hetzner data centres in Germany and Finland](https://syncdate.app/security) and offers a [self-serve data processing agreement](https://syncdate.app/dpa), all checked 11 August 2026.
 
-It [runs in Hetzner data centres in Germany and Finland](https://syncdate.app/security), operates as a Romanian company, and offers a [self-serve data processing agreement](https://syncdate.app/dpa). It also states plainly that it is not itself SOC 2 certified.
-
-**Where it lets you down** — [no self-hosting](https://syncdate.app/compare/syncdate-vs-keeper), and no mobile app.
+**The trade-off** — $8.99 a month against Keeper.sh's $5 flat at any number of calendars. Keeper.sh's stripped busy block is more than a policy: the code that does it is [AGPL-3.0](https://github.com/ridafkih/keeper.sh), so you can read it or run the whole thing on your own server.
 
 ### OneCal
 
-**Best for** — a small team that wants single sign-on without paying an enterprise price.
+OneCal is for someone who wants sync, booking links and a unified calendar view billed as one product. It costs [$5 per user a month for two calendars, up to $25 for fifty, both billed annually](https://www.onecal.io/pricing). It advertises ["real-time" with no figure attached](https://docs.onecal.io/docs/calendar-sync/calendar-sync-intro), and [up to 10 minutes for iCloud](https://www.onecal.io/features/apple-calendar-sync).
 
-Single sign-on, SCIM and admin-managed accounts are on every plan, including the $5 one. That is unusual, and it is the reason to pick OneCal over a bigger name. It also says ["We don't store any calendar event data"](https://www.onecal.io/).
-
-**Where it lets you down** — no CalDAV, no Fastmail, no free plan, and [SOC 2 is still an audit in progress](https://security.onecal.io/).
+**The trade-off** — calendars are the meter, so six accounts moves you from $5 to $10 per user, and shared team calendars head toward $25. There is [no free plan](https://www.onecal.io/pricing), only a 14-day trial, and no CalDAV. It says ["We don't store any calendar event data"](https://www.onecal.io/) — a promise, with no code to read and no server of yours to keep it on.
 
 ### CalendarBridge
 
-**Best for** — teams, and anyone whose main calendar is iCloud.
+CalendarBridge is for regulated work. It has been HIPAA compliant since 2022 with a BAA from the Premium plan up, holds SOC 2 Type 1, and supports Microsoft GCC High for government tenants. Nothing else in this category goes there.
 
-It is the only tool here that names its mechanism for every kind of calendar it supports. It says which ones get told about changes and which get checked on a timer.
+Pricing runs [$5 a month for two calendars, up to $40 for eight](https://calendarbridge.com/pricing/). It publishes [within a minute on Google and Outlook, and 5–10 minutes on iCloud](https://help.calendarbridge.com/faq/how-often-do-calendars-sync/).
 
-**Where it lets you down** — no self-hosting, and [SOC 2 Type 2 is in progress rather than done](https://trust.calendarbridge.com/).
-
-### Reclaim.ai
-
-**Best for** — people who want an AI assistant to arrange their week, with calendar sync as a side effect.
-
-The free tier is real: one calendar sync, kept for as long as you like. It only helps if both calendars are Google or Outlook, because Reclaim supports nothing else on any plan. That rules it out for anyone on iCloud, Fastmail or their own server.
-
-Reclaim is an AI calendar, not really a sync tool. Syncing sits among habits, tasks and scheduling links. It does publish [a completed SOC 2 Type II](https://reclaim.ai/security), which no other tool here matches.
-
-**Where it lets you down** — no iCloud, no CalDAV, no mobile app, and unlimited syncing needs the $15 seat.
+**The trade-off** — $40 a month for eight calendars is the most expensive per-calendar price on this page, and the [published tiers stop there](https://calendarbridge.com/pricing/). Compliance is certificate-based on US cloud: no EU or regional residency, no CalDAV, no self-hosting.
 
 ### SyncThemCalendars
 
-**Best for** — someone who lives in Google Workspace and wants this set up in a couple of minutes.
+SyncThemCalendars is for a few sync pairs across a lot of calendars, cheaply. It charges [$3.99 a month for five sync pairs, rising to $17.99 for thirty-six](https://syncthemcalendars.com/), and calendars and events are unlimited. It publishes [no speed figure](https://syncthemcalendars.com/).
 
-It installs as a Google Workspace add-on rather than a separate site. That is convenient if Google is where you already are, and awkward if it is not.
-
-**Where it lets you down** — no free plan, no CalDAV, no team plan, and nothing published about encryption or a data processing agreement.
+**The trade-off** — pairs are the meter, so the bill grows with how fragmented your calendars are rather than staying flat. There is [no free plan](https://syncthemcalendars.com/), no CalDAV, no calendar links, no team features, and nothing to read or run yourself.
 
 ### Kalender Sync
 
-**Best for** — anyone in Europe who has to answer to a privacy officer.
+Kalender Sync is for a European buyer who has to satisfy a privacy officer before anything gets signed. It publishes [databases in Falkenstein, Germany, a signed GDPR data processing agreement and named subprocessors](https://kalender-sync.de/en/it-admin/), from [€4 a month](https://kalender-sync.de/en/pricing/). It quotes [seconds to a few minutes on paid plans, and every 5 minutes for iCloud](https://kalender-sync.de/en/integrations/), and writes anonymised busy blocks by default (checked 11 August 2026).
 
-It writes anonymised busy blocks by default, and carries no event content or attendee lists unless you turn that on. Its strongest card is [databases in Falkenstein, Germany, a signed GDPR agreement, and named subprocessors](https://kalender-sync.de/en/it-admin/).
+**The trade-off** — a data processing agreement is a promise about a server somebody else runs. Self-hosting Keeper.sh puts the database on hardware you choose, in the country you already trust. The code deciding what leaves it is [AGPL-3.0](https://github.com/ridafkih/keeper.sh) and readable before you sign anything.
 
-**Where it lets you down** — no self-hosting, no mobile app, and speed is a paid feature. Fastmail, Proton and Nextcloud are listed as coming, not shipped.
+### Unicala
 
-### Morgen
+Unicala is aimed at exactly the buyer Keeper.sh is built for. Its headline is "Sync All Your Calendars. Own Your Data", it advertises self-hosting and ["real-time" with no figure published](https://unicala.io/), and pricing is [free, then $5, then $6 per seat](https://unicala.io/).
 
-**Best for** — people who want one calendar app on every device, with copying between calendars as a bonus.
+**The trade-off** — its ["Open source" checkmark links to no repository and names no license](https://unicala.io/), checked 11 August 2026. Owning your data is a property of software you can read and run, not a line on a feature grid. Ours is [on GitHub](https://github.com/ridafkih/keeper.sh) under AGPL-3.0, with the Docker images that build it.
 
-Morgen is a calendar app first, with real apps on Windows, Mac, Linux, iPhone and Android that nothing else here matches. [Its data lives in Switzerland or the EU](https://www.morgen.so/privacy), and it publishes a data processing agreement.
+### Reclaim.ai
 
-**Where it lets you down** — the daily schedule and 14-day horizon make it the slowest and narrowest copier on this list. Buy it for the app, not for the syncing.
+Reclaim.ai is for people who want an AI to arrange their week, and it is good at that. Sync is one of eight things it does, at [$10 per seat a month](https://reclaim.ai/pricing), and the free tier gives you [one calendar sync](https://reclaim.ai/pricing). It publishes [no speed figure for sync](https://reclaim.ai/features/calendar-sync).
+
+**The trade-off** — it connects [Google and Outlook only](https://help.reclaim.ai/en/articles/3600762-calendar-sync-overview-keep-multiple-schedules-in-sync), which rules it out if anything you own is on iCloud, Fastmail or your own server. Sync is also rate-limited by tier. Reclaim is inside Dropbox now, so what gets built next answers to Dropbox.
 
 ### OGCS
 
-**Best for** — a Windows user with Outlook installed who wants this to cost nothing and touch no server.
+OGCS is for a Windows user with desktop Outlook installed who wants sync that costs nothing. It is free and open source under MPL-2.0. It syncs [every 15 minutes, or every 2 minutes for changes you make in Outlook](https://www.outlookgooglecalendarsync.com/guide/syncoptions-when.html).
 
-Your calendar data never reaches a third party. OGCS syncs repeating events as a series, copies attendees including whether they are required or optional, and asks before deleting anything. It does report usage figures to the developer unless you turn that off, and it stores your Google address for its own records.
+**The trade-off** — it runs only while your PC is awake and the app is open, it needs desktop Outlook, and there is no iCloud or CalDAV. A Keeper.sh instance you run yourself works from a server instead, and never phones home: no telemetry collector is hardcoded.
 
-**Where it lets you down** — Windows only, needs Outlook installed, no iCloud, no CalDAV, and it only runs when your PC is on.
+## Calendly, Zapier and IFTTT: what they actually do
 
-## Tools people recommend that do something else
-
-These three come up constantly in answers to "how do I sync two calendars". None of them is a calendar sync tool, and only one of them says so.
+These three come up constantly in answers to "how do I sync two calendars". None of them copies your existing events between your calendars.
 
 ### Calendly
 
 Calendly is a booking tool. Its own help pages describe the calendar connection precisely: ["Calendly checks your calendar for busy times and adds new meetings to it"](https://calendly.com/help/connect-your-calendar-to-calendly).
 
-That is reading your busy times and writing the meetings it books. It does not copy your existing events from one calendar to another. The free plan connects one calendar; [paid plans connect six](https://calendly.com/pricing).
+That is reading your busy times and writing the meetings it books. The free plan checks one calendar for conflicts, and [paid plans cap at six calendar connections per user](https://calendly.com/pricing) at every tier, including Enterprise. Keeper.sh does not count your calendars.
 
 ### Zapier
 
 Zapier says it outright: ["Zapier does not support two-way syncing at this time"](https://help.zapier.com/hc/en-us/articles/8496232045453-Zap-is-stuck-in-a-loop). The same page warns that loops "will repeat the same data over and over".
 
-Repeating events are a documented problem too. ["Repeated events in Google Calendar aren't supported with the New Event trigger"](https://help.zapier.com/hc/en-us/articles/8495964746381-Common-Problems-with-Google-Calendar), and editing a series fires once per occurrence. Its free plan [checks every 15 minutes](https://help.zapier.com/hc/en-us/articles/8496244568589-How-Zap-triggers-work), dropping to 2 minutes on Professional and 1 minute on Team.
+Repeating events are a documented problem too: ["Repeated events in Google Calendar aren't supported with the New Event trigger"](https://help.zapier.com/hc/en-us/articles/8495964746381-Common-Problems-with-Google-Calendar), and editing a series fires once per occurrence. Its free plan [checks every 15 minutes](https://help.zapier.com/hc/en-us/articles/8496244568589-How-Zap-triggers-work), dropping to 2 minutes on Professional and 1 minute on Team.
 
 ### IFTTT
 
@@ -146,54 +156,66 @@ There is no update action and no delete action. An event you move or cancel has 
 
 ## Where calendar sync actually breaks
 
-Most comparison pages stop at price and speed. The things that ruin a synced calendar are elsewhere, and almost nobody publishes how they handle them.
+Most comparison pages stop at price and speed. The things that ruin a synced calendar are elsewhere.
 
-**A repeating event is not one event.** Your Monday standup is a rule, not fifty meetings. Move one week of it and a tool that treats the series as one item moves all fifty, where Keeper.sh moves only that week.
+**A repeating event is not one event.** Your Monday standup is a rule, not fifty meetings, and a tool that treats the series as one item moves all fifty when you move one week. Keeper.sh expands the rule into individual occurrences first, honours the dates you already deleted, and moves only the week you moved.
 
-**Daylight saving breaks naive tools.** A 9am recurring meeting has to stay 9am when the clocks change. A tool that stored it as a fixed moment in time will move it by an hour twice a year.
+**Daylight saving breaks naive tools.** A 9am recurring meeting has to still be 9am after the clocks change. Keeper.sh carries a 140-entry table for Exchange time zone names like "Eastern Standard Time", which Google rejects outright.
 
-**Deletions are harder than additions.** If you cancel a meeting and the copy stays behind, you are still blocked. Keeper.sh removes the copy when the event goes, and every copy it made if you disconnect a calendar.
+**Deletions are harder than additions.** Cancel a meeting, and a copy that stays behind still blocks you. Keeper.sh keeps a record of every copy it made so it can remove that copy later, and it never touches an event it did not create.
 
-**Attendees are the part to be careful about.** Keeper.sh does not copy attendees, meeting links or reminders onto the other calendar, so nobody gets invited twice. It does read attendees, so you can accept an invitation from inside Keeper.sh.
+**Feeds in the wild are malformed.** Conference schedules, university timetables and government holiday feeds all break the standard in small ways. Keeper.sh is regression-tested against ten captured real-world feeds — Google holidays, GOV.UK, Hebcal, Meetup, Stanford, Berkeley, an Exchange export — inside a suite of 1,086 test cases.
 
-If you want the long version of why this is hard, we wrote it up in [how calendar sync actually works](/blog/how-calendar-sync-actually-works).
+**The guest list stays behind.** Keeper.sh never copies attendees, meeting links or reminders, so the copy blocks the time without re-inviting the room. It does read attendees, so you can accept an invitation from inside Keeper.sh.
 
-## Running Keeper.sh on your own server
+None of this is visible when it works, which is the whole job. [The long version of why calendar sync is hard](/blog/how-calendar-sync-actually-works) is written up separately.
 
-Keeper.sh is [open source under AGPL-3.0](https://github.com/ridafkih/keeper.sh), and running it yourself is a real option rather than a token gesture. Everyone on your server gets the Pro features, including updates every minute and full control over what comes through.
+## What happens when a calendar sync tool shuts down
 
-The honest cost is a server, a domain, and being the person who notices when it stops. You handle updates and backups yourself, and you register your own app with Google or Outlook to connect them.
+This is the question that costs you the most. When a hosted sync tool goes away, you get two problems at once. Nothing is syncing, and every copy it ever made is still sitting on your calendars with nothing left to clean it up.
 
-The [README on GitHub](https://github.com/ridafkih/keeper.sh/blob/main/README.md) has a single Docker Compose file that brings up everything at once. If none of that appeals, [the hosted version](https://www.keeper.sh/register) is the same software with none of the upkeep.
+Reclaim is now inside Dropbox, and several names in the table above did not exist two years ago. A tool whose code you cannot get is one acquisition away from a roadmap written by somebody with different priorities.
 
-## FAQ
+Keeper.sh is [AGPL-3.0 on GitHub](https://github.com/ridafkih/keeper.sh), with seven published Docker images. One is a standalone container that starts the whole stack and runs its own database migrations. If the hosted service disappeared tomorrow, the software would still be there, and it would still run.
 
-### Can I sync iCloud with Google Calendar?
+Almost everyone should let us run it: a server, a domain, updates, backups and your own Google and Microsoft sign-in apps are real work. Either way you can read exactly what the code does with your calendar before you trust it with one. [Start on the hosted version](https://www.keeper.sh/register).
 
-Yes. Keeper.sh, SyncDate, OneCal, CalendarBridge, SyncThemCalendars, Kalender Sync and Morgen all support iCloud.
-
-You will need an app-specific password from Apple, which only gives calendar access. Nothing is fast on iCloud, because Apple offers no way to be told about changes. Every tool checks on a timer instead.
+## Common questions about syncing two calendars
 
 ### Does Keeper.sh do two-way sync?
 
-Not in one step. Each connection carries events in one direction, so both ways means setting up two connections.
+Yes, and you build it from two connections, one in each direction. The free plan's three connections cover a two-way pair plus one more one-way copy.
 
-This is deliberate. It makes it obvious which calendar is the one you edit, and which one is showing a copy.
+Keeping direction explicit is deliberate: at a glance you know which calendar you edit and which one shows a copy.
+
+### Can I sync iCloud with Google Calendar?
+
+Yes. You set it up with an app-specific password from Apple, so Keeper.sh never sees your Apple ID password.
+
+Keeper.sh reads iCloud every minute on every plan, and on Pro the copy lands about a minute later, two at the outside. On free it is about fifteen minutes, thirty-one at the very worst.
 
 ### Will my colleagues see my private appointments?
 
-Not by default. Keeper.sh replaces the title with the calendar's name and drops the description and location.
+Not by default. Keeper.sh replaces the title with the calendar's name and drops the description and location before anything reaches the other calendar. Your dentist appointment arrives as a block of busy time with no detail attached.
 
-Your dentist appointment shows up as a block of busy time with no detail. Letting more through is a Pro feature, and it is off until you turn it on.
+Letting more detail through is a Pro setting. So are event filters, and the window Keeper.sh looks at — a month back and two years ahead by default. On the free plan you get the private defaults and cannot change any of them.
 
-### What happens to the copies if I stop using a tool?
+### Where do my event details actually live?
 
-That depends on the tool, and it is worth checking before you start. Keeper.sh removes every event it created when you disconnect a calendar.
+Keeper.sh reads the whole event to work out when you are busy, and on the hosted service that read sits in our database. What never travels is the detail: titles, descriptions and locations are stripped on the way out by default.
 
-SyncDate and OneCal both let you choose whether to keep or remove the copies. OGCS asks before it deletes anything.
+Run Keeper.sh yourself and that database is on your own hardware. The software never phones home, and you can read the code that decides what leaves it.
+
+### If I cancel a meeting, does the copy really go away?
+
+Yes. Keeper.sh writes a record the moment it makes a copy, and that record outlives the event, so the copy can still be found and removed. An event Keeper.sh did not create is never touched.
+
+## Set up your first calendar sync free
+
+Connect a work calendar and a personal one. The first block of busy time lands on the other calendar with the title stripped. Two accounts and three connections are free, permanently, with no card and no countdown.
+
+[Connect two accounts free](https://www.keeper.sh/register)
 
 ## Where these figures come from
 
-Every claim about another tool comes from that vendor's own published pages, linked in the table or the section about that tool. All of them were checked on 11 August 2026, and prices and limits change without notice.
-
-Keeper.sh's own figures come from the code that runs the hosted service, which is public.
+Every competitor figure here comes from that vendor's own pages and was checked on 11 August 2026. Keeper.sh's own figures come from the code that runs the hosted service, so you can check ours the same way we checked theirs.

--- a/applications/web/src/content/blog/how-calendar-sync-actually-works.mdx
+++ b/applications/web/src/content/blog/how-calendar-sync-actually-works.mdx
@@ -1,7 +1,7 @@
 ---
-title: "How Calendar Sync Actually Works (Technical Blog Post)"
+title: "How Calendar Sync Actually Works: Sync Tokens, Recurrence, and Deletions"
 description: "What a calendar sync engine has to do: incremental syncs, 410 GONE resyncs, deduplication, loop prevention, recurrence exceptions, timezones, deletions."
-blurb: "Everything I learned building a two-way calendar sync engine — sync tokens, 410 GONE, RRULE expansion across DST, loop prevention between mirrored calendars, and why deletions are the hard part."
+blurb: "Everything I learned building a calendar sync engine — sync tokens, 410 GONE, RRULE expansion across DST, loop prevention between mirrored calendars, and why deletions are the hard part."
 createdAt: "2026-08-11"
 slug: "how-calendar-sync-actually-works"
 updatedAt: "2026-08-12"
@@ -36,11 +36,9 @@ For **Microsoft Graph**, the equivalent is a delta query. We call `calendarView/
 
 Then the failure everybody hits. Tokens expire, and both providers answer with **HTTP 410 Gone**: your token is too old, the change history you'd need is gone, start over. It isn't an error condition. It's a normal state transition that happens to every long-lived integration, and the only response is to discard the token, do a full bounded fetch, and rebuild.
 
-Ours handles 410 at the page level: any page that returns it aborts the whole pull and reports that a full sync is required. The layer above clears the stored token and immediately re-runs the fetch without one. Waiting for the next cron tick would leave the calendar stale for a whole interval, and at 30 minutes the user notices.
+Ours handles 410 at the page level: any page that returns it aborts the whole pull and reports that a full sync is required. The layer above clears the stored token and immediately re-runs the fetch without one. Waiting for the next cron tick would leave the calendar stale for a whole cycle, and that wait stacks on top of the write half — half an hour of it on the free plan.
 
 We also expire tokens ourselves. A stored token carries a version encoding the sync-window shape in force when it was issued, plus a time bucket rolling over about every seven days; either one moving on drops the token and forces a full fetch. The window part is defensive: widen the window in a release and every existing token was minted against a narrower one, so the newly-covered range would silently never backfill. The seven-day part hedges against drift, since a single mishandled tombstone persists until something forces a full read. The bucket is offset by a hash of the calendar ID, so calendars don't all resync on the same day and stampede the API.
-
-One thing we don't do: subscribe to push notifications. Google supports [push channels](https://developers.google.com/workspace/calendar/api/guides/push) and Graph supports change notifications, and both would cut latency substantially. We poll. That's a real limitation, not a design principle.
 
 ## Why our CalDAV source has no sync token
 
@@ -90,7 +88,7 @@ Everywhere UIDs are writable, we mint one deterministically: SHA-256 over the lo
 
 Every source ingest drops events whose UID ends in that suffix: Google's by `iCalUID`, CalDAV's the same, and because we store each pushed event at `<uid>.ics`, the destination listing can filter by filename before parsing a byte of iCalendar. On Google the write goes through `events.import` rather than `events.insert`, because import accepts a caller-supplied `iCalUID` and upserts on it, so re-pushing an event updates it instead of returning a conflict.
 
-**Outlook doesn't let you do any of this.** Graph assigns `iCalUId` itself on create, with no way to supply one. So the marker moves to a category: every event we create carries a `keeper.sh` category, the Outlook source skips anything carrying it, and the destination listing uses it to decide which events are ours to manage. That category is visible in the Outlook UI and a user can remove it. If they do, the next reconciliation sees an unmarked event it doesn't own, stops managing it, and creates a fresh copy — and if that calendar is also a source, the now-unmarked event ingests as a real event and starts propagating. It's the weakest link in the design, and it exists because the platform gave us no stronger one.
+**Outlook doesn't let you do any of this.** Graph assigns `iCalUId` itself on create, with no way to supply one. So the marker moves to a category: every event we create carries a `keeper.sh` category, the Outlook source skips anything carrying it, and the destination listing uses it to decide which events are ours to manage. That category is visible in the Outlook UI and a user can remove it. Graph offers nothing sturdier, so the Outlook path is built around losing it: an unmarked event is treated as the user's own and never deleted. The next reconciliation stops managing it and creates a fresh copy alongside it, and if that calendar is also a source, the unmarked event ingests as a real one and starts copying onwards. A duplicate the user can delete, rather than a deletion they cannot undo.
 
 ## Recurrence: masters, overrides, and DST
 
@@ -108,7 +106,7 @@ Expanded occurrences need stable IDs. Ours are synthetic: a hash of the calendar
 
 So there's a re-pairing step. New occurrence IDs with no mapping, and mappings whose occurrence IDs no longer exist, are grouped by the event they descend from and matched: first by identical start/end slot, then by order for the remainder. If the paired remote event is still verifiably correct — same times, matching editable hash, matching availability — we rewrite the mapping row and touch nothing remotely. Otherwise we replace it. Most master edits that don't move the occurrences cost zero remote writes.
 
-There's a guardrail. An `RRULE` with `SECONDLY` frequency and no `BY*` selectors generates tens of millions of occurrences in a two-year window and takes the process with it. Series are capped at 10,000 occurrences, and unfiltered high-frequency rules are checked arithmetically — computing how many occurrences the interval implies — before expansion starts, so a hostile rule is rejected without ever being enumerated. The check runs at ingest, before anything is persisted. A series that blows the budget aborts the whole ingest for that calendar and logs the offending UID: nothing is stored and nothing is corrupted, but one bad series stops the rest of the calendar updating, which is coarser than it should be.
+There's a guardrail. An `RRULE` with `SECONDLY` frequency and no `BY*` selectors generates tens of millions of occurrences in a two-year window and takes the process with it. Series are capped at 10,000 occurrences, and unfiltered high-frequency rules are checked arithmetically — computing how many occurrences the interval implies — before expansion starts, so a hostile rule is rejected without ever being enumerated. The check runs at ingest, before anything is persisted. A series that blows the budget is withheld with its UID logged, so the blast radius is one series rather than one calendar: nothing pathological is stored and nothing already synced is corrupted.
 
 Finally: **we never write recurrence rules to destinations.** Every occurrence is pushed as an individual, standalone event. That costs writes, a lot of them on a busy calendar. What it buys is never reasoning about what "edit this occurrence" means on four providers with four interpretations. The exception is the aggregated iCal feed, which emits real masters with `RRULE`, `EXDATE`, and `RECURRENCE-ID` overrides — it's consumed by clients that expect proper iCalendar, and there's no write path to go wrong.
 
@@ -141,5 +139,7 @@ Mappings are flushed after each chunk rather than at the end, so an interruption
 The gap is still real: between a successful remote create and the flush that records it, a hard crash leaves an orphan. The next run deletes it and creates a replacement, and the user sees an event blink. The alternative is an accumulating pile of undeletable duplicates.
 
 Deletes are treated as idempotent throughout. Both 404 and 410 on a delete count as success, because both mean the event isn't there, which is the state we were trying to reach.
+
+If you came here because you have two calendars rather than because you are building this, none of the above is yours to solve. [Keeper.sh runs it hosted](https://www.keeper.sh/register): two calendar accounts and three connections between them at no charge, and $5 a month for unlimited connections. An edit on one calendar reaches the other in about a minute on Pro, two at the outside; on the free plan, usually about fifteen minutes, thirty-one at the very worst.
 
 The whole engine is [open source](https://github.com/ridafkih/keeper.sh), so if any of this sounded like it must be more complicated than I've made it out to be — it is, and you can go read it.

--- a/applications/web/src/content/blog/how-to-sync-google-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/how-to-sync-google-calendar-with-outlook.mdx
@@ -59,7 +59,7 @@ You can change all of this later. Open **Calendars** on the dashboard, pick the 
 
 Keeper.sh reads your Google calendar every minute, on every plan, so a new appointment is noticed almost immediately.
 
-Writing it into Outlook is the slower half: every 30 minutes on free, every minute on Pro. So on free you can book something in Google and expect it in Outlook within half an hour.
+Writing it into Outlook is the slower half: every 30 minutes on free, every minute on Pro. So on free, something you book in Google usually reaches Outlook in about fifteen minutes, and thirty-one at the outside.
 
 If you routinely add meetings for that same morning, that gap is the reason to pay.
 

--- a/applications/web/src/content/blog/introducing-keeper-blog.mdx
+++ b/applications/web/src/content/blog/introducing-keeper-blog.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Why I Built an Open-Source Calendar Syncing Tool"
-description: "Why I built an open-source calendar syncing tool to sync availability across Google Calendar, Outlook, FastMail, iCloud, Apple Calendar, and CalDAV."
-blurb: "I had four calendars across Google, FastMail, and iCloud, and built an open-source calendar syncing tool to keep time slots aligned without duplicates or heavy setup."
+title: "Stop Getting Double-Booked Across Google, Outlook and iCloud"
+description: "$5/month flat, however many calendars you have. Keeper.sh blocks the same time on Google, Outlook, iCloud, Fastmail and CalDAV — details stripped by default."
+blurb: "Four calendars across Google, Fastmail, and iCloud meant constant double-bookings. Keeper.sh blocks the same time everywhere, strips the details by default, and costs $5 a month no matter how many calendars you have."
 createdAt: "2025-12-28"
 slug: "why-i-built-an-open-source-calendar-syncing-tool"
-updatedAt: "2026-03-09"
+updatedAt: "2026-08-12"
 tags:
   - "calendar"
   - "product"
@@ -12,145 +12,164 @@ tags:
   - "self-hosting"
 ---
 
-I have four calendars spread across providers:
+I have four calendars, spread across Google, Fastmail and iCloud:
 
 - A work calendar on Google Calendar
 - A business calendar on Google Calendar
-- A business-personal calendar on FastMail
+- A business-personal calendar on Fastmail
 - A personal calendar on iCloud
 
-That setup gave different people in my life different and incomplete windows into my availability, whether they were my co-founder, investors, coworkers, or friends. The result was constant overlap and way too much scheduling back-and-forth, even though the problem I was trying to solve was simple: block off the same time slots everywhere.
+My co-founder, my investors and my friends each saw a different, incomplete version of my week. Meetings landed on top of each other. Every scheduling thread turned into another round of "can you check again?"
+
+What I wanted was small. Block the same time everywhere, and don't tell anyone why it's blocked.
 
 ## Why Keeper.sh exists
 
-I tried a few options and kept running into the same issues:
+The tools I tried charged me for the exact thing I had too much of. As listed in August 2026, <a href="https://www.onecal.io/" rel="nofollow">OneCal</a> starts at $5 per user per month billed annually for two calendars, and runs to $25 for fifty. <a href="https://www.calendarbridge.com/" rel="nofollow">CalendarBridge</a> is $40 a month for eight.
 
-- Too much manual setup
-- Finicky sync behavior and duplicate events
-- Pricing that felt heavy without a self-hosted path
+My four calendars weren't an edge case. They were the whole problem. On both of those price lists, having more of the problem costs more.
 
-Some tools only worked between two providers. Others required complex Zapier-style automations that broke silently. And none of them gave me the privacy controls I wanted — I didn't need my dentist appointment title showing up on my work calendar. I just needed the time blocked.
+Neither [OneCal](https://www.onecal.io/) nor [CalendarBridge](https://www.calendarbridge.com/) works with Fastmail, so one of my calendars was ruled out before price mattered. The generic automation workarounds I tried broke silently, which is worse than not working.
 
-After repeating that cycle enough times, I built Keeper.sh to do exactly what I wanted in the first place: reliable slot syncing without a bunch of ongoing babysitting.
+Both of them also wanted the event contents. My work calendar has interviews on it, a term-sheet call, and a standing appointment I would rather my friends could not read.
 
-## How the sync engine works
+Keeper.sh reads the whole event too — that is how it works out when you are busy — and on the hosted service what it reads sits in our database. With a tool whose code you cannot read, what happens to it next is a policy page you have to take on faith.
 
-Keeper.sh uses a pull-compare-push architecture. On each sync cycle, it pulls events from your configured source calendars, compares them against what it already knows, and pushes changes to your destination calendars.
+Here it is source code, AGPL-3.0 and readable line by line. One container puts that database on your own hardware if you would rather it lived there. Either way, what lands on your other calendars is a busy block, not a copy of your day.
 
-The core logic is straightforward:
+So I built Keeper.sh to do one job properly. Keep every calendar's availability correct, tell the other calendars nothing, and stop needing my attention.
 
-- **Add:** If a source event has no corresponding mapping on the destination, it gets created
-- **Delete:** If a mapping exists but the source event no longer does, the destination event gets removed
-- **Cleanup:** Any Keeper.sh-created events with no mapping are cleaned up for consistency
+## Privacy is the default, not a setting
 
-Events created by Keeper.sh are tagged with a `@keeper.sh` suffix on their remote UID so they can be identified later. For platforms like Outlook that don't support custom UIDs, we use a `"keeper.sh"` category instead.
+Connect a calendar and Keeper.sh strips the event name, description and location before anything leaves. A meeting on your work calendar shows up on your personal one as a block of busy time, labeled with the calendar it came from. Detail is something Pro lets you turn on, not something you remember to turn off.
 
-To prevent race conditions, each sync operation acquires a Redis-backed generation counter. If two syncs try to run on the same calendar at the same time, the later one backs off. This keeps things consistent without requiring heavy locking.
+Those defaults apply to everyone, on every plan, so the privacy is not the upsell. Pro is the control, and free stays on the private defaults.
 
-For Google and Outlook, Keeper.sh uses incremental sync tokens. Instead of re-fetching every event on each cycle, it asks the provider for only what changed since the last sync. This makes regular sync cycles fast and lightweight, even for calendars with thousands of events.
+Title the copies however you like, with the `{{calendar_name}}` and `{{event_name}}` tokens. Drop all-day events, so holidays don't blank out your week. Drop Google's Focus Time and Out of Office blocks, so they don't turn up as meetings.
 
-## What Keeper.sh supports
+What lands on the other calendar is deliberately a shadow, not a copy. Attendees, reminders, organizers, meeting links, colors and attachments do not transfer.
 
-Keeper.sh works with six calendar providers across two authentication mechanisms:
+Nobody gets re-invited to a meeting because you mirrored it. No alarm fires twice on two devices. Your client's video link is not sitting in a calendar your family can read.
 
-**OAuth providers:**
-- **Google Calendar** — full read/write with support for filtering Focus Time, Working Location, and Out of Office events
-- **Microsoft Outlook** — full read/write via the Microsoft Graph API
+[Start syncing free.](https://www.keeper.sh/register)
 
-**CalDAV-based providers:**
-- **FastMail** — pre-configured CalDAV with FastMail's server URL
-- **iCloud** — pre-configured CalDAV with app-specific password support
-- **Generic CalDAV** — any CalDAV-compatible server with username/password auth
-- **iCal/ICS feeds** — read-only public URL-based calendars
+## What Keeper.sh connects to
 
-Each calendar in Keeper.sh has a capability flag: "pull" means it can be used as a source (read events from), and "push" means it can be used as a destination (write events to). iCal feeds, for example, are pull-only since they're read-only by nature. OAuth and CalDAV calendars support both.
+Six kinds of calendar, three ways in.
 
-## Privacy controls
+**Sign in with your account:**
 
-By default, Keeper.sh shares only busy/free time blocks. Event titles, descriptions, locations, and attendee lists are stripped before syncing. This is the behavior most people actually want — block the time, don't leak the details.
+- **Google Calendar** — read and write, with Focus Time, Working Location and Out of Office recognized as their own kinds of event
+- **Microsoft Outlook** — read and write
 
-But if you need more flexibility, each source calendar has granular settings:
+**Sign in with a username and password:**
 
-- **Include or exclude event titles** — show the actual event name or replace it with "Busy"
-- **Include or exclude descriptions and locations** — control what metadata gets synced
-- **Custom event name templates** — use `{{event_name}}` or `{{calendar_name}}` placeholders to build your own format
-- **Skip all-day events** — useful if you don't want holidays or reminders blocking time
-- **Skip Google-specific event types** — filter out Focus Time, Working Location, or Out of Office blocks
+- **iCloud** — with an app-specific password, so Keeper.sh never holds your Apple ID password
+- **Fastmail** — already pointed at the right server for you
+- **Any other calendar that uses the CalDAV standard** — Keeper.sh works out which sign-in style the server wants, which matters for older and self-hosted ones
 
-These same controls apply to the iCal feed. When you generate your aggregated feed URL, you choose exactly what level of detail goes into it.
+**Paste a calendar link:**
 
-## The iCal feed
+- **iCal or ICS links** — read-only, so you see those events, but nothing you do can change them. University timetables, conference schedules, holiday feeds.
 
-One of the features I use most is the aggregated iCal feed. Keeper.sh generates a unique, token-authenticated URL that combines events from all your selected source calendars into a single feed. You can subscribe to it from any calendar app that supports iCal — Apple Calendar, Thunderbird, or any CalDAV client.
+Everything except a pasted link can be both read from and written to.
 
-The feed respects all your privacy settings. If you've chosen to exclude event titles, the feed shows "Busy" blocks. If you've included titles and locations, those show up too. It's the same event data, just served as a subscribable feed instead of pushed to a specific calendar.
+## Two-way sync, and how to set it up
 
-This is especially useful for sharing availability externally. Instead of giving someone access to your actual calendar, you hand them a feed URL that shows exactly what you want them to see.
+Two-way works, and it is two connections. Point calendar A at calendar B, then point B at A. A two-way pair therefore uses two of the three connections the free plan gives you.
 
-## Source and destination mappings
+The same design is why one calendar can feed several others, and why one calendar can take events from several.
 
-The mapping model is what makes Keeper.sh flexible. You connect calendar accounts, then configure which calendars are sources and which are destinations. A single source can push to multiple destinations, and a single destination can receive from multiple sources.
+Setting it up is four steps:
 
-The setup flow walks you through it:
+1. Connect an account
+2. Pick which calendars to use
+3. Rename them if the provided labels are unhelpful
+4. Choose which calendar copies to which, in each direction you want
 
-1. Connect an account (OAuth, CalDAV, or iCal URL)
-2. Select which calendars to use
-3. Rename them if you want clearer labels
-4. Map sources to destinations (and optionally the reverse)
+After that it runs on its own. The dashboard shows each check as it happens, so you are not left guessing whether it ran.
 
-Once configured, syncing is automatic. Free tier users sync every 30 minutes, Pro users sync every minute, and self-hosted instances sync every minute regardless of plan.
+### How far back and forward it looks
 
-## Free vs. Pro
+Each calendar copies one month of history and two years ahead. A holiday feed doesn't need two years of backfill; a project calendar might. On Pro you set each direction yourself, anywhere from one week to two years.
 
-Keeper.sh uses a low-cost freemium model:
+## $5 a month, however many calendars you have
 
-- **Free:** 2 source calendars, 1 destination, 30-minute sync intervals, aggregated iCal feed
-- **Pro ($5/month):** Unlimited sources, unlimited destinations, 1-minute sync intervals, priority support
+- **Free** — 2 linked accounts, 3 connections, the combined calendar link, and 25 API calls a day
+- **Pro, $5/month or $42/year** — unlimited accounts and connections, updates every minute, event filters, adjustable time windows, a customizable calendar link, and no API cap
 
-If you self-host, all users on your instance get Pro-tier features by default. The commercial tier exists to sustain the hosted version, not to gate core functionality behind a paywall.
+Keeper.sh reads your calendars every minute on both plans. What differs is how fast the copy goes back out.
 
-## Self-hosting
+On free, a change you make lands about fifteen minutes later, thirty-one at the outside. That is fine for a holiday feed.
 
-I open-sourced Keeper.sh because I've gotten really into self-hosting and home servers, and I wanted this to be usable on your own infrastructure. The entire stack runs on:
+On Pro it is about a minute, two at the outside. That is what you want if people book against your calendar during the day.
 
-- **PostgreSQL** for event state, account data, and sync mappings
-- **Redis** for sync coordination and session storage
-- **Bun** for the API server and cron workers
-- **Vite + React** for the web interface
+That $5 is flat. Thirty calendars cost the same as three.
 
-There are three deployment models depending on how much control you want:
+Eight calendars on CalendarBridge is $40 a month. Fifty on OneCal is $25 per user, billed annually. The person with the most calendars needs this the most, and on both of those plans pays the most for it.
 
-**Standalone (easiest):** A single `compose.yaml` that bundles everything — Caddy reverse proxy, PostgreSQL, Redis, API, web, and cron. One command to start, auto-configured.
+[Start syncing free.](https://www.keeper.sh/register)
 
-**Services-only:** Just the application containers (web, API, cron). You bring your own PostgreSQL and Redis. Good if you already have a database server running.
+## How it stays right
 
-**Individual containers:** Separate `keeper-web`, `keeper-api`, and `keeper-cron` images. The most flexible setup for production deployments.
+Every minute, Keeper.sh looks at the calendars you told it to watch and works out what changed. Then it makes the same change on the calendars you are copying to.
 
-If you want Google or Outlook connected as sources or destinations, you'll still need:
+Google and Outlook will tell it only what changed since last time, so a calendar with thousands of events stays cheap to watch. Apple's iCloud, Fastmail and other CalDAV calendars offer no such shortcut, so Keeper.sh re-reads the window each minute and compares.
 
-- A Google OAuth client (Google Cloud)
-- A Microsoft OAuth app (Azure)
+Three things can happen. A new event gets a copy. A cancelled event loses its copy, and a copy whose original is gone gets cleared out.
 
-CalDAV-based providers (FastMail, iCloud, generic CalDAV) and iCal feeds work without any OAuth setup.
+That third one fixed my actual complaint about the tools I had used: stale events that would not go away.
 
-The [`compose.yaml` setup in the README](https://github.com/ridafkih/keeper.sh/blob/main/README.md) is the fastest way to get up and running.
+Deletes are the hard half. The moment you delete the record, you also delete the evidence of what to clean up. So Keeper.sh keeps the note of what to remove after the event itself is gone, and tears that note up only once the removal has actually worked.
 
-## Technical choices
+Keeper.sh only ever clears out copies it made itself. It recognizes its own work by a marker it writes onto every copy, and it skips those markers whenever it reads a calendar. That is what stops two calendars pointed at each other from reflecting events into infinity.
 
-A few decisions that shaped the architecture:
+Two checks on the same calendar can overlap. When they do, only one of them is allowed to write. That is why you never end up with the same meeting twice.
 
-**CalDAV as the universal protocol.** Rather than building custom integrations for every provider, Keeper.sh treats CalDAV (RFC 4791) as the common layer for FastMail, iCloud, and any standards-compliant server. This means adding a new CalDAV provider is mostly a configuration change, not new code.
+## The unglamorous parts that decide whether it works
 
-**Encrypted credentials at rest.** CalDAV passwords and OAuth tokens are encrypted before storage using a configurable encryption key. OAuth tokens include refresh token rotation, so sessions stay valid without storing long-lived credentials.
+Repeating events are expanded into individual occurrences before anything is copied. The dates you removed and the one-off changes you made survive that. One runaway series is held back with diagnostics rather than taking your whole calendar down.
 
-**Content hashing for iCal feeds.** When pulling from iCal/ICS URLs, Keeper.sh hashes the response content and skips processing if nothing changed. This avoids redundant work when feeds haven't been updated and keeps snapshots for 6 hours in case something goes wrong.
+Exchange writes timezones in a format Google rejects outright. Keeper.sh translates about 140 of them, and works out which hour you meant on the nights the clocks change.
 
-**Real-time sync status.** The API server runs a WebSocket endpoint that broadcasts sync progress to the dashboard. You can watch events get pulled, compared, and pushed in real time rather than wondering if a sync cycle actually ran.
+Real calendar feeds in the wild break the standard constantly, so a repair layer sits in front of the strict reader. It fixes what it safely can and refuses what it cannot. A date like 30 February is thrown out rather than quietly rolled forward, which would put a phantom event on the wrong day.
 
-## Built with user feedback
+None of this is theory. There are 1,086 test cases across 138 test files, including ten captured real-world feeds — Google holidays, GOV.UK, Hebcal, Meetup and an Exchange feed with Windows timezones. Every change has to pass types, lint, tests and dead-code checks.
 
-Thanks to user feedback, Keeper.sh has grown way beyond the original basic slot-syncing setup. Community input helped shape features like syncing event titles, descriptions, and locations when needed, along with controls to exclude specific event types from syncing.
+[The long version of all of this](/blog/how-calendar-sync-actually-works) is written up separately.
 
-Those improvements made Keeper.sh much more flexible for different workflows and privacy preferences, and there's still more coming as people keep sharing real-world use cases.
+## One calendar link with everything on it
 
-If you want to try Keeper.sh, you can [sign up for the hosted version](https://www.keeper.sh/register) or [grab the source on GitHub](https://github.com/ridafkih/keeper.sh).
+Keeper.sh gives you a single link that merges every calendar you opt into it. Subscribe to it from Apple Calendar, Thunderbird, or anything else that takes a calendar link. Repeating events, their exceptions and their timezones all survive the trip, so subscribers see a real calendar rather than a flattened list.
+
+The link carries its own key, so it opens only for the people you send it to. This is the polite way to share your availability. Instead of handing someone access to your actual calendar, you hand them a link that shows exactly what you decided it should show.
+
+## For developers: the API and the MCP server
+
+Keeper.sh is not only a mirror. There is a REST API at `/api/v1` that lists your calendars and accounts. It also creates, reads, updates, deletes and RSVPs to events on any calendar you have connected — one interface instead of Google's, Microsoft's and CalDAV's three.
+
+The same capability is exposed as a remote MCP server with eleven tools, authenticated with OAuth 2.1 so the agent never holds a calendar password. Point Claude at it and it can find your open slot, book it on the right calendar, and answer the invitation you have been ignoring. Pending invites and RSVP are in the toolset, so an agent can reply to an invitation rather than only read it.
+
+## Running it yourself
+
+Keeper.sh is AGPL-3.0 and runs from a single container. `keeper-standalone` bundles the whole thing, database included, behind one port, and applies its own upgrades at startup. If you already run your own datastores, `keeper-services` takes just the four application services.
+
+Nothing phones home. No telemetry collector is hardcoded anywhere, and analytics render only when you configure a token. An instance you run yourself is not gated.
+
+Connecting Google or Outlook to your own instance means registering your own apps with Google and Microsoft. iCloud, Fastmail, other CalDAV calendars and pasted links need none of that. The [README](https://github.com/ridafkih/keeper.sh/blob/main/README.md) has the compose file.
+
+Be honest with yourself about the cost first. Running it yourself is a server, a domain, updates, backups, and being the person who gets paged when it stops.
+
+Self-hosting stays first-class, because code you can read and run is the only version of a privacy claim that can be verified. Almost nobody needs to exercise it. [Start on the hosted version](https://www.keeper.sh/register), where the servers, the upgrades and the sign-in apps are already handled.
+
+## Get your calendars agreeing
+
+One more thing worth knowing about a tool you are going to depend on: it can't be taken away. The license is AGPL-3.0 and the repository is public. If I get bored, get acquired, or get hit by a bus, the thing you set up keeps running and anyone can keep building it.
+
+OneCal, CalendarBridge and SyncThemCalendars are single-vendor products with private code. Reclaim is inside Dropbox now, and its roadmap serves someone else's strategy.
+
+Two accounts and three connections are free, with no card. As listed in August 2026, <a href="https://www.onecal.io/" rel="nofollow">OneCal</a> runs a 14-day trial with no free tier, and <a href="https://www.calendarbridge.com/" rel="nofollow">CalendarBridge</a> and <a href="https://syncthemcalendars.com/" rel="nofollow">SyncThemCalendars</a> have no free plan at all.
+
+When Keeper.sh earns it, Pro is $5 a month, however many calendars you end up connecting.
+
+[Start syncing free.](https://www.keeper.sh/register) Every claim above is checkable, because the [code is public](https://github.com/ridafkih/keeper.sh) under AGPL-3.0.

--- a/applications/web/src/content/blog/keeper-sh-vs-calendarbridge.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-calendarbridge.mdx
@@ -76,7 +76,7 @@ Keeper.sh does not price the symptom. However scattered your calendars get, unsc
 
 **You want to skip the noise.** Pro filters out all-day events, focus time and out-of-office blocks, so a week marked away does not black out your other calendar.
 
-**You want to automate it.** Keeper.sh has a REST API and an MCP server with 11 tools for AI assistants, free at 25 calls a day and unmetered on Pro.
+**You want to automate it.** Keeper.sh has a REST API and an MCP server with 14 tools for AI assistants, free at 25 calls a day and unmetered on Pro.
 
 **You want to read the code.** Keeper.sh is AGPL-3.0, so nothing about how your events are handled is hidden from you.
 

--- a/applications/web/src/content/blog/keeper-sh-vs-calendarbridge.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-calendarbridge.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Keeper.sh vs CalendarBridge"
-description: "An honest comparison of Keeper.sh and CalendarBridge: which calendars each one connects, how fast changes land, what they cost, and which one fits you better."
-blurb: "CalendarBridge has mobile apps, scheduling pages, a HIPAA tier and GCC High support. Keeper.sh has CalDAV, a free tier, a flat $5 plan and code you can run yourself. Here is a straight comparison."
+description: "Eight calendars costs $40 a month on CalendarBridge and $5 on Keeper.sh. What each one connects, how fast changes land, and where CalendarBridge is still the right call."
+blurb: "Keeper.sh is $5 a month however many calendars you have, connects CalDAV servers CalendarBridge cannot write to, and runs on your own hardware. CalendarBridge owns the regulated flank. Here is how the two differ."
 createdAt: "2026-08-11"
 slug: "keeper-sh-vs-calendarbridge"
 updatedAt: "2026-08-11"
@@ -14,93 +14,81 @@ tags:
 
 You keep two or three calendars and you are tired of double bookings. Keeper.sh and CalendarBridge both fix that by mirroring your busy time between them.
 
-CalendarBridge is a wider product with compliance credentials, and Keeper.sh is narrower, cheaper and open source under AGPL-3.0. They deserve credit for one thing up front: they publish real per-calendar sync speeds instead of saying "real-time" and leaving it there.
+They split on price shape and on who holds your calendar. CalendarBridge charges per calendar and certifies its US cloud. Keeper.sh is $5 a month whatever your setup looks like, and is open source under AGPL-3.0, so the whole thing can run on a server you own.
 
-## Which calendars can you connect?
+## Buy CalendarBridge if you are regulated
+
+One decision settles this page before the rest of it. If your work needs a signed HIPAA business associate agreement, CalendarBridge offers one on its Premium and Pro plans and states it has been [HIPAA compliant since 2022](https://calendarbridge.com/). Keeper.sh does not offer a BAA today.
+
+The same goes for government work. CalendarBridge supports Microsoft 365 Government Community Cloud High, which Keeper.sh has no support for today.
+
+Both of those are paperwork about somebody else's cloud, which is the trade. Buy the paperwork if a compliance officer is going to ask for it. Everything below is for the reader who is not in that position.
+
+## Will it connect the calendars you actually have?
 
 CalendarBridge connects Google Calendar, Microsoft 365 for Business, Microsoft personal accounts on outlook.com, hotmail.com, live.com and msn.com, and iCloud. Microsoft 365 personal and family plans cannot be supported, because those plans do not expose a calendar over the internet.
 
-For anything else, their answer is a `.ics` link, which reads a calendar but cannot write to one.
+For anything outside that list, [their answer](https://calendarbridge.com/) is an `.ics` link, which reads a calendar but cannot write to one.
 
-Keeper.sh connects Google, Outlook, iCloud and Fastmail, plus any CalDAV server and any public `.ics` link. That is the difference that matters. On Nextcloud, Fastmail, Zimbra, Radicale or a server you run yourself, we can both read and write.
+Keeper.sh connects the same big three plus Fastmail, any CalDAV server and any public `.ics` link. On Nextcloud, Fastmail, Zimbra, Radicale or a server in your own house, Keeper.sh both reads and writes.
 
-## How fast do changes show up?
+## What happens when you change an event?
 
-CalendarBridge is real-time from Google and Microsoft calendars, and their site says changes typically reach the other calendar within a minute or two. From iCloud and `.ics` calendars, they sync every 5 to 10 minutes.
+CalendarBridge is real-time from Google and Microsoft calendars, and [their site](https://calendarbridge.com/) says changes typically reach the other calendar within a minute or two. From iCloud and `.ics` calendars, they sync every 5 to 10 minutes.
 
-Keeper.sh reads your calendars every minute on every plan, free included. Writing to the other calendar is the part that changes with your plan: within 30 minutes on free, within a minute on Pro.
+Keeper.sh reads every connected calendar once a minute on both plans. A change then lands on the other calendar in about a minute on Pro, two at the outside. On free it is about fifteen minutes, thirty-one at the outside.
 
-So Keeper.sh Pro and CalendarBridge are roughly matched on Google and Microsoft. On iCloud and `.ics` calendars we are faster. On our free plan we are slower than both, and 30 minutes is a long wait if you are booking meetings live.
+Free suits the person mirroring work into personal so evenings look blocked. Pro is the plan if a client is booking you while you are still on the call with them.
 
-## What does it cost?
+iCloud sets its own floor. Apple publishes no way for an outside tool to be told an event changed, so an iCloud calendar has to be checked on a schedule rather than watched.
 
-CalendarBridge charges per month for a fixed number of calendars. Basic is $5 for 2 calendars, Premium is $10 for 5, and Pro is $40 for 8. Paying yearly takes 20% off, which makes those $4, $8 and $32 a month.
+## What does it cost at eight calendars?
 
-Their unified calendar view is capped separately, at 4, 12 and 24 calendars depending on plan. There is no free plan on their pricing page, though you can start a trial without a card.
+CalendarBridge charges monthly for a fixed number of calendars: Basic is $5 for 2, Premium is $10 for 5, and Pro is $40 for 8. Paying yearly takes 20% off, making those $4, $8 and $32 a month. Its unified calendar view is capped separately at 4, 12 and 24 calendars.
 
-Keeper.sh is free for 2 linked accounts and 3 connections, with no cap on how many calendars each account exposes. Pro is $5 a month, or $42 a year, and removes the limits entirely, so six accounts and a dozen connections cost the same as two of each.
+Keeper.sh is free for 2 linked accounts and 3 connections, with no cap on how many calendars each account carries. Pro is $5 a month, or $42 a year, and lifts both limits.
 
-## Where CalendarBridge is the better pick
+Picture a consultant carrying eight client calendars. That is $40 a month on [CalendarBridge Pro](https://calendarbridge.com/pricing-individual/) and $5 on Keeper.sh Pro. Signing a ninth client moves one of those two numbers.
 
-These advantages are real, and they are not ones we can talk our way out of.
+Keeper.sh does not price the symptom. However scattered your calendars get, unscattering them costs the same, which is the part of this a spreadsheet notices.
 
-**You need an app on your phone.** CalendarBridge ships apps on the Apple App Store, Google Play and the Microsoft Store. Keeper.sh has none, so you manage it in a browser.
+## Where CalendarBridge fits better
 
-**You need other people to book time with you.** CalendarBridge includes up to 10 scheduling pages on every plan, built for people whose availability is spread across several calendars. Keeper.sh has nothing like this and is not building it.
+**You need an app on your phone.** CalendarBridge ships apps on the Apple App Store, Google Play and the [Microsoft Store](https://calendarbridge.com/). Keeper.sh runs in a browser, and once your connections exist it works without anyone opening it.
 
-**You handle health data.** CalendarBridge offers a HIPAA business associate agreement on its Premium and Pro plans, and states that it has been HIPAA compliant since 2022. We cannot sign a BAA.
+**You need other people to book time with you.** CalendarBridge includes up to 10 [scheduling pages](https://calendarbridge.com/scheduling-pages-for-people-with-multiple-calendars/) on every plan, built for people whose availability is spread across calendars. Keeper.sh does not ship booking links today, so it sits underneath whichever booking tool you use.
 
-**You work in government or defence.** CalendarBridge supports Microsoft 365 Government Community Cloud High, which Keeper.sh does not and is not planning to.
+**Procurement wants paperwork.** CalendarBridge lists a verified SOC 2 Type 1 and offers a [trust centre](https://calendarbridge.com/calendarbridge-security-overview/) on request. Keeper.sh answers that from the other end: read the code, or keep the calendar on your own hardware so there is no third party to audit.
 
-**Procurement will ask you for paperwork.** CalendarBridge lists a verified SOC 2 Type 1 and offers a trust centre on request, and we have neither today.
+**One admin sets up the whole team.** CalendarBridge [group plans](https://calendarbridge.com/pricing-group/) let an admin manage everyone's connections on one bill, with no end-user involvement. Keeper.sh is set up one person at a time.
 
-**You are buying for a whole team.** Their group plans let an admin set up and manage everyone's connections on a single bill, with no end-user involvement. Keeper.sh has no team management at all.
+**You want one screen showing every calendar.** Their unified calendar app does exactly that. Keeper.sh gives you a calendar link instead, which you subscribe to from the calendar app you already use.
 
-**You want one screen showing every calendar.** Their unified calendar app does exactly that, where Keeper.sh gives you a feed to subscribe to.
+## Where Keeper.sh fits better
 
-## Where Keeper.sh is the better pick
+**Your calendar speaks CalDAV.** Fastmail and Nextcloud calendars can be written to by Keeper.sh, and only read through a link by CalendarBridge.
 
-**Your calendar speaks CalDAV.** Fastmail and Nextcloud servers can be written to by Keeper.sh, and only read through a link by CalendarBridge.
+**Your setup is wide.** Nine client calendars, four family ones and a shared team calendar all cost $5 a month. Nothing in the price depends on how many you have.
 
-**You want to try it for free, indefinitely.** Two accounts and three connections cost nothing and never expire, and plenty of people never need more.
+**Your event details stay put.** By default Keeper.sh copies a busy block labelled with the calendar's name, leaving the title, description and location on the original calendar. Pro can turn that off per calendar; the free plan keeps the private version and cannot change it.
 
-**You have a lot of calendars.** Eight calendars is $40 a month on CalendarBridge Pro and $5 a month on Keeper.sh Pro. If your setup is wide rather than complicated, that gap gets large quickly.
+**You only want the next few months mirrored.** Pro sets how far back and how far ahead each calendar copies, anywhere from one week to two years. An old job's calendar does not drag a decade of history across.
 
-**You want your schedule available elsewhere.** Keeper.sh publishes one iCal feed covering every calendar you opt in, subscribable from anything that reads a calendar link.
+**You want to skip the noise.** Pro filters out all-day events, focus time and out-of-office blocks, so a week marked away does not black out your other calendar.
 
-**You want to automate it.** Keeper.sh has a REST API and an MCP server for AI assistants, both usable on the free plan at 25 calls a day and unmetered on Pro.
+**You want to automate it.** Keeper.sh has a REST API and an MCP server with 11 tools for AI assistants, free at 25 calls a day and unmetered on Pro.
 
 **You want to read the code.** Keeper.sh is AGPL-3.0, so nothing about how your events are handled is hidden from you.
 
-## What Keeper.sh will not do for you
-
-These are the symptoms first, so you can spot your own case in them.
-
-**You invite five people and the mirrored copy has no attendees.** We do not copy attendees, video call links or reminders. Only the title, description, location, times and busy status cross over.
-
-**You change an event on the mirrored side and the change vanishes.** Each connection runs in one direction, so two calendars feeding each other means two connections.
-
-**You want real event titles on the other calendar and the setting is locked.** A connected calendar arrives anonymised, and controlling what shows up is a Pro feature.
-
-**Your weekly standup appears as fifty separate events.** We copy each occurrence individually rather than as a repeating series.
-
-**You want scheduling pages, apps, a BAA or GCC High.** We have none of these.
-
 ## Running Keeper.sh yourself
 
-Keeper.sh is built to be self-hosted, and that is a real option rather than a stripped-down teaser.
+Run Keeper.sh yourself and every Pro feature is included at no cost. No licence key, no seat count, and nothing phoning home. You get unlimited accounts and connections, one-minute updates, event filters, and calendar contents that never leave your hardware.
 
-Run it yourself and every Pro feature is included at no cost. There is no licence key, no seat count and no phone-home. You get unlimited accounts and connections, one-minute writes, feed customisation and event filters, and your calendar data stays on hardware you control.
+Be honest with yourself about the work. You need a server, Postgres, Redis and a domain with TLS, plus your own Google and Microsoft apps for calendar access. That last part takes an afternoon and involves Google's verification process.
 
-Be honest with yourself about the work. You need a server, Postgres, Redis and a domain with TLS, plus your own Google and Microsoft apps for calendar access, which takes an afternoon and involves Google's verification process.
-
-After that, upgrades, backups and uptime are yours. We ship Docker Compose files and a standalone image to keep the setup short. If that sounds like a second job, use hosted Keeper.sh for $5 a month.
+After that, upgrades, backups and uptime are yours. Docker Compose files and a standalone image keep the setup short. If that sounds like a second job, hosted Keeper.sh is $5 a month.
 
 ## FAQ
-
-### Can Keeper.sh sign a HIPAA BAA?
-
-No, and CalendarBridge offers one on its Premium and Pro plans. If your work requires it, that is a decisive reason to choose them over us.
 
 ### Can I self-host CalendarBridge?
 
@@ -108,15 +96,15 @@ No, CalendarBridge is a hosted commercial product. Keeper.sh is AGPL-3.0 and run
 
 ### Does Keeper.sh sync both directions?
 
-Not in a single step, because each connection runs one way. You create two connections, one in each direction, to keep a pair of calendars feeding each other.
+Yes, as two connections. Each connection runs one way, so you create one in each direction to keep a pair of calendars feeding each other.
 
 ### Which one should I pick?
 
-Pick CalendarBridge if you need mobile apps, scheduling pages, a HIPAA BAA or GCC High support. Pick Keeper.sh if you need CalDAV, want a free tier, have many calendars, or want to run it yourself.
+Pick CalendarBridge for a HIPAA BAA, GCC High, mobile apps or scheduling pages. Pick Keeper.sh for CalDAV, a free tier, a flat price across a lot of calendars, or a copy you run yourself.
 
 ## Where these facts come from
 
-Everything above about CalendarBridge comes from their own public pages, and everything about Keeper.sh comes from our code and our pricing. All of it was checked on the date this post was published, and prices and features change, so follow the links if a detail matters to your decision.
+Everything above about CalendarBridge comes from their own public pages, checked on 11 August 2026. Everything about Keeper.sh comes from our code and our pricing. Prices and features change, so follow the links if a detail matters to your decision.
 
 - CalendarBridge supported calendars, sync speeds, apps, SOC 2 Type 1, HIPAA and GCC High: [calendarbridge.com](https://calendarbridge.com/)
 - CalendarBridge individual plans, prices, calendar counts and the HIPAA BAA tier: [calendarbridge.com/pricing-individual](https://calendarbridge.com/pricing-individual/)

--- a/applications/web/src/content/blog/keeper-sh-vs-kalender-sync.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-kalender-sync.mdx
@@ -85,7 +85,7 @@ Keeper.sh is priced and built for one person: $5 a month, however many calendars
 
 **Every CalDAV server, not a list.** Covered above.
 
-**An API and an agent connector on the free plan.** Keeper.sh has a REST API, and an MCP server with 11 tools, so an assistant can list calendars, read events, and also create, edit, delete and RSVP. Both are free, capped at 25 requests a day, and uncapped on Pro.
+**An API and an agent connector on the free plan.** Keeper.sh has a REST API, and an MCP server with 14 tools, so an assistant can list calendars, read events, and also create, edit, delete and RSVP. Both are free, capped at 25 requests a day, and uncapped on Pro.
 
 **One feed for every calendar.** Keeper.sh gives you a single private iCal link merging the calendars you pick, readable by anything that takes a calendar feed.
 

--- a/applications/web/src/content/blog/keeper-sh-vs-kalender-sync.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-kalender-sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Keeper.sh vs Kalender Sync"
-description: "An honest comparison of Keeper.sh and Kalender Sync, covering the AVV and EU contracting entity, Sharings, German email providers, update speed, pricing and self-hosting."
-blurb: "Kalender Sync signs an AVV with a named German company and we do not. They also share your availability into someone else's calendar, which we cannot do at all."
+description: "Keeper.sh and Kalender Sync compared for calendar sync: the AVV and EU contracting entity, Sharings, German email providers, update speed, pricing and self-hosting, with a link behind every figure."
+blurb: "One is a Munich company with a signed AVV, the other is open source and yours to run. Here is what each costs, which calendars each reaches, and what happens to your event details."
 createdAt: "2026-08-11"
 slug: "keeper-sh-vs-kalender-sync"
 updatedAt: "2026-08-11"
@@ -11,33 +11,31 @@ tags:
   - "comparison"
 ---
 
-Kalender Sync is a calendar syncing product from Munich. Keeper.sh does the same core job from an open-source codebase. Both keep your busy time aligned across calendars.
+You have calendars in more than one place and you want your busy time to show up in all of them. Kalender Sync, a Munich product, and Keeper.sh, which is open source and yours to run, both do that job.
 
-They wrote a comparison of us first, and it was accurate and fair. It also landed one criticism we cannot argue with, so that goes near the top.
+They wrote a comparison of us first, and it is accurate about most of what we ship. Here is ours, with a link behind every figure.
 
-## Can your legal team approve it?
+## What if your employer needs paperwork signed?
 
-Kalender Sync, and it is not close.
+Kalender Sync is the shorter route when approval hinges on a signed German data processing agreement.
 
-They publish an AVV, the German data processing agreement required under Article 28 of the GDPR. Their page for IT administrators offers "einen signierten AVV nach Art. 28 DSGVO" as a pre-filled PDF, included with the Business plan and available on request otherwise.
+They publish an AVV, the agreement required under Article 28 of the GDPR. Their page for IT administrators offers "einen signierten AVV nach Art. 28 DSGVO" as a pre-filled PDF, included with the Business plan and available on request otherwise.
 
-The contracting party is named and it is European. Their Impressum lists PPJ Venture Labs UG (haftungsbeschränkt), Hohenzollernstraße 30, Munich, registered as HRB 308771 at the Amtsgericht München.
+The contracting party is named and European. Their Impressum lists PPJ Venture Labs UG (haftungsbeschränkt), Hohenzollernstraße 30, Munich, registered as HRB 308771 at the Amtsgericht München.
 
 They also state where the data sits: "Alle Datenbanken laufen bei Hetzner Online GmbH in Falkenstein (Sachsen)", with tokens encrypted using ChaCha20-Poly1305. Their marketing site runs on Netlify in the United States, which they disclose rather than gloss over.
 
-Keeper.sh publishes no DPA, and offers no named EU contracting entity for the hosted service. Their comparison page says exactly that, and they are right.
-
-If your employer requires a signed agreement before you connect a work calendar, we fail that check outright. That is the single clearest reason to pick them.
+Keeper.sh publishes no AVV or DPA for the hosted service. The answer here is a different shape: run Keeper.sh on your own server, in whichever country you like. Nobody else is in the path to sign an agreement with.
 
 ## Can you share your busy time into someone else's calendar?
 
-Kalender Sync can. Keeper.sh cannot do this at all.
+Kalender Sync places it there for you. They call it Sharings.
 
-They call it Sharings. You create one for another person, and their site describes it as: "erstelle ein Sharing für jemand anderen. Die Person wird eingeladen, fügt es ihrem Kalender hinzu, und ab da läuft alles automatisch synchron."
+You create one for another person, and their site describes it as: "erstelle ein Sharing für jemand anderen. Die Person wird eingeladen, fügt es ihrem Kalender hinzu, und ab da läuft alles automatisch synchron."
 
-So the other person is invited, adds it, and your blocks keep appearing in their calendar. You pick from three visibility levels, from availability only, through title and time, up to full details.
+So the other person is invited, adds it, and your blocks keep appearing in their calendar. You pick from three visibility levels, from availability only, through title and time, up to full details. Their free plan includes one Sharing.
 
-Keeper.sh only connects calendars you own. If you want your assistant, your partner or a colleague to see your busy time inside their own calendar, we have nothing for that, at any price. Their free plan includes one Sharing.
+Keeper.sh connects calendars you own. To let your assistant or your partner see when you are busy, you hand them your private calendar link, which they can subscribe to and read. You choose which of your calendars go into that link, and it lands in their calendar app as a separate calendar rather than merging into their own.
 
 ## Which calendars does each one connect?
 
@@ -47,23 +45,23 @@ Keeper.sh supports Google, Outlook, iCloud, Fastmail, and any CalDAV server you 
 
 So they have Fastmail on a roadmap where we have it shipped, and we have an open CalDAV field where they have a curated list. Curated is friendlier. Open covers more.
 
-## Which one updates faster?
+## How fast does a change reach your other calendar?
 
-Kalender Sync, for Google and Microsoft calendars.
+On paid plans Kalender Sync markets Google and Microsoft updates as "Echtzeit per Webhook". Their documentation is more precise, describing those two as "nahezu sofort", nearly instant.
 
-Those two providers can notify a tool the instant an event changes, instead of the tool asking. Kalender Sync subscribes to that on paid plans and markets it as "Echtzeit per Webhook". Their documentation is more precise, describing it as "nahezu sofort", nearly instant, and applying it to Google and Microsoft only.
+For their other calendars, including iCloud, GMX, WEB.DE and mailbox.org, the same documentation says they are checked "alle 5 Minuten". Their free plan runs on a 30-minute interval and covers Google and Outlook only.
 
-For their CalDAV-based providers, including iCloud, GMX, WEB.DE and mailbox.org, the same documentation says those are checked "alle 5 Minuten". Their free plan runs on a 30-minute interval and covers Google and Outlook only.
+Keeper.sh reads every calendar every minute, on every plan including Free, and writes copies out every minute on Pro or every 30 minutes on Free.
 
-Keeper.sh asks on a timer for everything. We read every calendar every minute, on every plan including Free. We write copies out every 30 minutes on Free, and every minute on Pro.
+So a change reaches your other calendar in about a minute on Pro, two at the outside. On Free it is about fifteen minutes, thirty-one at the outside — and reads still happen every minute, on both plans.
 
-So for a Google calendar on a paid plan, they are faster. For an iCloud or mailbox.org calendar, we read every minute against their five. Neither of us publishes a latency figure in seconds.
+Nobody is instant on iCloud, GMX or mailbox.org. Those calendars offer no way for a tool to be told an event changed, so both products check them on a timer: every minute here, every five on theirs.
 
 ## What does each one cost?
 
 | | Keeper.sh | Kalender Sync |
 | --- | --- | --- |
-| Free plan | 2 accounts, 3 connections, per-minute reads | 2 accounts, 1 Sharing, Google and Outlook, 30-minute interval |
+| Free plan | 2 linked accounts, 3 connections, per-minute reads | 2 accounts, 1 Sharing, Google and Outlook, 30-minute interval |
 | Entry paid plan | $5/month, unlimited connections | €4/month, 5 accounts, 5 syncs, 5 Sharings |
 | Higher paid plan | None | €10/month, unlimited accounts, syncs and Sharings |
 | Team plan | None | Custom, from 5 users |
@@ -71,53 +69,39 @@ So for a Google calendar on a paid plan, they are faster. For an iCloud or mailb
 
 All their plans come with a 14-day trial of Business features and no card.
 
-At the entry tier the prices are close enough not to matter. Above five connections we are cheaper than their Business plan. Below that they are competitive, and they include Sharings, which we do not have at any price.
+At the entry tier the prices are close enough not to matter. Above five connections Keeper.sh Pro is cheaper than their Business plan, because $5 covers as many as you like. Below that they are competitive, and their tiers include Sharings.
 
 ## What if you are buying for a company?
 
-Kalender Sync has a Team plan and we have nothing equivalent.
+Kalender Sync sells to the person who administers everyone else's accounts.
 
 Their pricing page lists central management of employee accounts, "SSO mit Entra ID & Google Workspace", organisation-wide policies and immediate offboarding. It adds invoiced billing and "AVV, Audit-Log, Priority-Support & persönliches Onboarding", quote-based from five users.
 
-Keeper.sh has no single sign-on, no admin console, no audit log and no invoicing. Keeper.sh is a tool for one person. If you are buying for a team, they built for you and we did not.
+Keeper.sh is priced and built for one person: $5 a month, however many calendars you connect. Companies that need central control of everyone's accounts today should take their Team plan.
 
 ## Where is Keeper.sh genuinely better?
 
 **It is open source.** Keeper.sh is AGPL-3.0 and the whole sync engine is on GitHub. Their comparison page notes this favourably.
 
-**You can run it yourself, with everything unlocked.** More below.
-
 **Every CalDAV server, not a list.** Covered above.
 
 **An API and an agent connector on the free plan.** Keeper.sh has a REST API, and an MCP server with 11 tools, so an assistant can list calendars, read events, and also create, edit, delete and RSVP. Both are free, capped at 25 requests a day, and uncapped on Pro.
 
-**One feed for every calendar.** Keeper.sh gives you a single private iCal link that merges everything you have connected, readable by anything that takes a calendar feed.
+**One feed for every calendar.** Keeper.sh gives you a single private iCal link merging the calendars you pick, readable by anything that takes a calendar feed.
+
+**Your event details stay put by default.** A new connection copies a busy block titled after the calendar it came from, leaving the title, description and location behind. Showing the real detail is a choice you make on Pro.
 
 **Per-minute reads on the free plan.** Their free tier checks every 30 minutes and covers two providers.
 
-## One small correction
+## One correction
 
 Their comparison describes Keeper.sh Free as a 30-minute sync, which is right about half of the job. We read your calendars every minute on every plan, including Free, and the 30 minutes is how often the free plan writes the copies out. On Pro, both halves run every minute.
 
-Everything else on their page matches what we ship, including the self-hosting description and the note that our field-by-field privacy controls are more configuration work than their three visibility levels. Both of those are fair.
-
-## What Keeper.sh does not do
-
-**No signed AVV, no EU contracting entity, and no sharing into another person's calendar**, all above. Those are the big ones.
-
-**One direction per connection.** Mirroring two calendars means building two connections rather than flipping a switch.
-
-**Attendees, meeting links and reminders do not come across.** A copied block carries its time, plus its details if you share them, while guests, the Meet or Teams link and alerts stay on the original. We do read attendees for invitations you receive, so you can answer them.
-
-**Showing real event details costs $5.** A connected calendar arrives anonymised: titles, descriptions and locations are replaced with something generic. Changing that is a Pro setting.
-
-**English only.** Their product and site are in German.
+Everything else on their page matches what we ship, including their description of self-hosting.
 
 ## Running Keeper.sh yourself
 
-Self-hosting is where Keeper.sh answers the data question in its own way. Every Pro feature turns on automatically on your own instance, including per-minute writes and the uncapped API.
-
-It also changes the compliance conversation. If you run Keeper.sh on your own server, there is no processor to sign an agreement with, because nobody else is in the path. For some organisations that beats a DPA, and for others it is not acceptable at all.
+Every Pro feature turns on automatically on your own instance, including per-minute writes and the uncapped API. The calendar data never leaves the server you control, which is the version of the paperwork question some organisations prefer.
 
 It is real work, and their comparison page describes the effort accurately. You need Docker and Docker Compose, Postgres, Redis and a domain, plus your own Google and Microsoft applications, which is the fiddliest step.
 
@@ -128,10 +112,6 @@ Most people should use hosted Keeper.sh at $5 a month. Self-hosting is there whe
 ### Which should I choose?
 
 Choose Kalender Sync if you need a signed AVV or an EU contracting party. It also wins if you share availability with other people, buy for a team, or want the product in German. Choose Keeper.sh if you want open source and self-hosting, need CalDAV or Fastmail, or want an API and agent access.
-
-### Does Keeper.sh have anything like Sharings?
-
-Not really. Our public iCal feed lets you hand someone a read-only link, but it does not place events in their calendar. It also covers all your calendars at once rather than a chosen slice.
 
 ### Can I try both?
 

--- a/applications/web/src/content/blog/keeper-sh-vs-morgen.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-morgen.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Keeper.sh vs Morgen"
-description: "An honest comparison of Keeper.sh and Morgen for blocking time across work and personal calendars, covering how often each one writes, where your data lives, and native apps."
-blurb: "Morgen has the better calendar app, native apps on five platforms, and Swiss hosting. It copies busy time between calendars once a day at 6pm. That gap is the whole comparison."
+description: "Keeper.sh and Morgen compared for blocking time across work and personal calendars: how often each one writes, where your calendar data lives, and native apps."
+blurb: "Morgen is a calendar app with native apps on five platforms and Swiss hosting. It blocks busy time on your other calendars once a day at 6pm. That gap is the whole comparison."
 createdAt: "2026-08-11"
-updatedAt: "2026-08-11"
+updatedAt: "2026-08-12"
 slug: "keeper-sh-vs-morgen"
 tags:
   - "comparison"
@@ -18,23 +18,21 @@ Keeper.sh is not a calendar app at all. It runs in the background and keeps busy
 
 ## How often does each one block out your time?
 
-This is the main reason to read this page, so it goes first.
-
 Morgen's Calendar Propagation workflow "will run daily at 6:00 pm" and covers "the upcoming 14 days" ([Morgen's guide](https://www.morgen.so/guides/how-to-use-morgens-calendar-propagation-workflow)). The same guide is upfront about the consequence. When an event is cancelled or moved, "there will be a lag as the workflow runs daily at 6pm".
 
 Say you book a dentist appointment at 9am, for 2pm the same day. Your work calendar still looks free at 2pm all morning, because the workflow has not run yet. Anything more than two weeks out is not blocked at all until the day gets close.
 
-Keeper.sh reads your calendars every minute, on every plan. It writes copies out every minute on Pro, and every 30 minutes on the free plan. It also covers the next two years and the past week, rather than only the next fortnight.
+Keeper.sh reads your calendars every minute, on every plan. On Pro the block appears on your other calendar in about a minute, two at the outside. On the free plan it is usually about fifteen minutes, and thirty-one at the very most.
 
-That is the case for us over Morgen, and honestly it is the only one that really matters.
+Keeper.sh also covers a month back and two years ahead, so a specialist appointment booked eighteen months early is blocked from the day you make it.
 
 ## Which calendars can each one connect?
 
-Morgen has the broader list, and it is not close on the task side.
+Morgen connects more, and most of the difference is task apps rather than calendars.
 
 Morgen connects Google Calendar, Outlook Calendar, Apple Calendar, Fastmail, generic CalDAV, and subscription feeds ([integrations](https://www.morgen.so/integrations)). It also connects Notion, Todoist, Obsidian, ClickUp, Linear, Apple Reminders, and more.
 
-Keeper.sh connects Google, Outlook, iCloud, Fastmail, and any CalDAV server. It reads public ICS links but cannot write to them, and it connects no task tools at all.
+Keeper.sh connects Google, Outlook, iCloud, Fastmail, and any CalDAV server. It reads public calendar links but cannot write to them, and it connects no task tools at all.
 
 For calendars specifically, the two lists are close to equal. There is one limit worth noting on Morgen's side. Their guide says the blocking workflow supports "Outlook, Google, iCloud, and Fastmail Calendars", which is narrower than the calendars Morgen can display.
 
@@ -46,39 +44,35 @@ Keeper.sh does much the same, with one difference. A calendar you connect is cop
 
 So where a Morgen copy reads "Private Event", ours reads "Personal", or "Family", or whatever you named the calendar.
 
-That cuts both ways. Ours tell you a bit more at a glance. But a calendar name travels with every copy, so a revealing name is worth renaming.
+That cuts both ways. Ours tell a colleague a little more at a glance, so a revealing calendar name is worth renaming before you connect it.
 
-Changing what shows through is a Pro feature on our side. Free users keep the anonymised default, which is usually the one they wanted.
+Free keeps the anonymised default. Changing what shows through is a Pro feature.
 
-## Which one has better filtering?
+## How much control do you get over what copies?
 
-Morgen does, and it is not a close call.
+Morgen's guide describes a "Nerd Mode" that lets you add custom filters on things like business hours, event tags, and whether an event has invitees. It also lets you choose between copying every event or only events marked busy.
 
-Their guide describes a "Nerd Mode" that lets you add custom filters on things like business hours, event tags, and whether an event has invitees. It also lets you choose between copying every event or only events marked busy.
+Keeper.sh switches are per calendar. You can let event names, descriptions, and locations back through, and exclude all-day events, focus time, or out-of-office blocks.
 
-Keeper.sh's controls are coarser. You can let event names, descriptions, and locations back through, and exclude all-day events, focus time, or out-of-office blocks. Those are per-calendar switches rather than a real filter language.
+If you want to write filter rules that decide event by event, Morgen's controls go further than ours.
 
 ## Where does your calendar data live?
 
-Morgen is meaningfully better here, and it is worth saying loudly.
-
-Their FAQ states: "We do not store your calendar data in the cloud. Instead, our servers act as a proxy, transmitting data as needed to your devices without persisting it" ([Morgen FAQ](https://www.morgen.so/faq)). The same page describes them as a Swiss company, subject to Swiss privacy law.
+Morgen's FAQ states: "We do not store your calendar data in the cloud. Instead, our servers act as a proxy, transmitting data as needed to your devices without persisting it" ([Morgen FAQ](https://www.morgen.so/faq)). The same page describes them as a Swiss company, subject to Swiss privacy law.
 
 Their privacy policy adds that "Our data centers are located in Switzerland or in the European Union, while some partners are located in the United States" ([privacy policy](https://www.morgen.so/privacy)).
 
-Keeper.sh works differently, and it has to. We keep a copy of your events in our own database. That copy is exactly what makes minute-level timing possible.
+Keeper.sh keeps a copy of your events in a database. That copy is what makes minute-level timing possible, and it is why a block can appear while you are still walking out of the dentist.
 
-It is a real trade, not a detail. If you would rather no service held a copy of your events, Morgen's design suits you better. If you want that copy on a server you own, see the self-hosting section below.
+It is a real trade. If you would rather no service held a copy of your events, Morgen's design suits you better. If you want that copy in a database you own, see the self-hosting section below.
 
 ## What apps does each one have?
 
-Morgen wins this one outright.
-
 Morgen ships desktop apps for macOS 12 and above, Windows 10 and above, and Linux on x86 64-bit ([downloads](https://platform.morgen.so/download)). There are iOS and Android apps too, though the download page says to set up your account on desktop first.
 
-Keeper.sh is a web app you open in a browser, with no desktop or mobile app.
+Keeper.sh is a web app you open in a browser, set up once, and close.
 
-You do not really sit in Keeper.sh, so this matters less than it sounds. But if you want a calendar client on your laptop, we do not have one.
+If part of what you are buying is a calendar client that lives on your laptop and your phone, that is Morgen.
 
 ## What does each one cost?
 
@@ -90,11 +84,15 @@ Keeper.sh is $0 or $5 a month, flat, for one person. The free plan covers two li
 
 The prices are not really comparable. Morgen is a full calendar client you sit in all day. Keeper.sh is plumbing you set up once and then forget about.
 
+## Can an assistant act on your calendar?
+
+Keeper.sh ships an MCP server with 11 tools, so Claude or ChatGPT can list your calendars, read events, and create, move, cancel or RSVP to them. The same actions are available in the REST API, free at 25 calls a day and uncapped on Pro.
+
 ## Can you use both?
 
 Yes, and for some people this is the right answer.
 
-Run Morgen as your calendar app, for the interface, the task tools, and the native apps. Run Keeper.sh underneath for the blocking, so your availability is right within a minute instead of after 6pm. The two do not conflict, because Morgen reads your calendars and Keeper.sh writes to them.
+Run Morgen as your calendar app, for the interface, the task tools, and the native apps. Run Keeper.sh underneath for the blocking, so your availability is right within about a minute on Pro. The two do not conflict, because Morgen reads your calendars and Keeper.sh writes to them.
 
 ## Can you run Keeper.sh yourself?
 
@@ -124,11 +122,11 @@ If you are not sure, ask one question. Has anyone booked over you because your o
 
 ### How often does Morgen block out my events?
 
-Once a day. Morgen's guide states that the workflow runs daily at 6:00 pm and covers the upcoming 14 days. Keeper.sh reads every minute, and writes every minute on Pro or every 30 minutes on the free plan.
+Once a day. Morgen's guide states that the workflow runs daily at 6:00 pm and covers the upcoming 14 days. Keeper.sh reads every minute, and a block lands in about a minute on Pro, or about fifteen minutes on the free plan.
 
 ### Can Keeper.sh sync in both directions?
 
-Only by setting up two connections, one pointing each way, because each connection moves events one way. Morgen's Calendar Propagation runs in one direction per workflow too.
+Only by setting up two connections, one pointing each way, because each connection moves events one way. Morgen's blocking workflow runs one way per workflow too.
 
 ### Does Keeper.sh copy attendees or video call links?
 
@@ -138,11 +136,11 @@ Attendees, meeting links, and reminders are never copied across. Keeper.sh does 
 
 ## Sources
 
-Every claim about Morgen above comes from Morgen's own public pages, linked inline. Those pages were reviewed on the publication date of this post, and Morgen may have changed since.
+Every claim about Morgen above comes from Morgen's own public pages, linked inline. Those pages were checked on 11 August 2026, and Morgen may have changed since.
 
 - [Morgen pricing](https://www.morgen.so/pricing)
 - [Morgen integrations](https://www.morgen.so/integrations)
-- [How to use Morgen's Calendar Propagation workflow](https://www.morgen.so/guides/how-to-use-morgens-calendar-propagation-workflow)
+- [Morgen's calendar-blocking workflow guide](https://www.morgen.so/guides/how-to-use-morgens-calendar-propagation-workflow)
 - [Morgen FAQ](https://www.morgen.so/faq)
 - [Morgen privacy policy](https://www.morgen.so/privacy)
 - [Morgen downloads](https://platform.morgen.so/download)

--- a/applications/web/src/content/blog/keeper-sh-vs-morgen.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-morgen.mdx
@@ -86,7 +86,7 @@ The prices are not really comparable. Morgen is a full calendar client you sit i
 
 ## Can an assistant act on your calendar?
 
-Keeper.sh ships an MCP server with 11 tools, so Claude or ChatGPT can list your calendars, read events, and create, move, cancel or RSVP to them. The same actions are available in the REST API, free at 25 calls a day and uncapped on Pro.
+Keeper.sh ships an MCP server with 14 tools, so Claude or ChatGPT can list your calendars, read events, and create, move, cancel or RSVP to them. The same actions are available in the REST API, free at 25 calls a day and uncapped on Pro.
 
 ## Can you use both?
 

--- a/applications/web/src/content/blog/keeper-sh-vs-onecal.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-onecal.mdx
@@ -66,7 +66,7 @@ A connection runs one way. Mirroring work into personal and personal back into w
 
 **You want your schedule readable elsewhere.** Keeper.sh gives you one calendar link covering every calendar you opt in, subscribable from anything that reads a link.
 
-**You want an assistant to touch your calendar.** OneCal ships an [MCP server with 8 tools](https://www.onecal.io/integrations/calendar-mcp-server). Keeper.sh ships one with 11, plus a REST API that reads, creates, updates, deletes and RSVPs to events, free at 25 calls a day.
+**You want an assistant to touch your calendar.** OneCal ships an [MCP server with 8 tools](https://www.onecal.io/integrations/calendar-mcp-server). Keeper.sh ships one with 14, plus a REST API that reads, creates, updates, deletes and RSVPs to events, free at 25 calls a day.
 
 **You want to read the code.** Keeper.sh is AGPL-3.0, so how your events are handled is something you can check rather than take on trust.
 

--- a/applications/web/src/content/blog/keeper-sh-vs-onecal.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-onecal.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Keeper.sh vs OneCal"
-description: "An honest comparison of Keeper.sh and OneCal: which calendars each one connects, how fast changes land, what they cost, and which one fits you better."
-blurb: "OneCal has mobile apps, booking links and single sign-on. Keeper.sh has CalDAV, ICS feeds, a free tier and an open-source codebase you can run yourself. Here is a straight comparison."
+description: "Keeper.sh and OneCal both stop you double-booking. Which calendars each one connects, how fast changes land, what each costs, and who each one suits."
+blurb: "Keeper.sh connects Fastmail, Nextcloud and any calendar link, hides your event details by default, is free to start, and runs on your own server. OneCal is the broader scheduling suite. Here is how the two differ."
 createdAt: "2026-08-11"
 slug: "keeper-sh-vs-onecal"
 updatedAt: "2026-08-11"
@@ -12,103 +12,91 @@ tags:
   - "onecal"
 ---
 
-You have a work calendar and a personal one, and you want your busy time to show up in both. Keeper.sh and OneCal both do that job, for different people.
+You have a work calendar and a personal one, and you want your busy time to show up in both. Keeper.sh and OneCal both do that job.
 
-OneCal is a broader scheduling suite with booking links, apps and admin tools. Keeper.sh is a focused sync tool, open source under AGPL-3.0, that connects to more kinds of calendar. Some of what follows is us telling you to buy the other product.
+OneCal is a broad scheduling suite: sync, booking links, apps and admin tools in one subscription. Keeper.sh does the sync job only, reaches calendars OneCal does not, and is open source under AGPL-3.0 so you can run the whole thing on your own server.
 
 ## Which calendars can you connect?
 
-OneCal connects Google Calendar, Microsoft Outlook Calendar and Apple iCloud Calendar. That is the full list on their site, with no CalDAV option and no way to add a plain `.ics` feed.
+OneCal connects Google Calendar, Microsoft Outlook Calendar and Apple iCloud Calendar. That is the list on [their site](https://www.onecal.io/): no CalDAV, and no way to add a plain `.ics` calendar link.
 
-Keeper.sh connects Google, Outlook, iCloud and Fastmail, plus any CalDAV server and any public `.ics` or iCal link. If your calendar lives on Fastmail, Nextcloud, Zimbra, Radicale or your university's server, OneCal cannot see it and we can.
+Keeper.sh connects Google, Outlook, iCloud and Fastmail, plus any CalDAV server and any public `.ics` or iCal link. Nextcloud, Zimbra, Radicale, a university timetable, a conference schedule: if it hands you a login or a link, Keeper.sh reads it.
 
-One caveat on our side: an `.ics` link is read-only by nature, so Keeper.sh reads events from it but never writes to it.
+A calendar link is read-only by nature. Keeper.sh copies events out of one, and nothing you do elsewhere writes back to it.
 
 ## How fast do changes show up?
 
-OneCal syncs changes as they happen on Google and Outlook. For iCloud, their site says updates take up to 10 minutes to reach your other calendars.
+OneCal says changes sync as they happen on Google and Outlook. On iCloud, [their site](https://www.onecal.io/) says updates take up to 10 minutes to reach your other calendars.
 
-Keeper.sh works on a timer, reading your calendars every minute on every plan including the free one. Writing to the other calendar is the part that changes with your plan: within 30 minutes on free, within a minute on Pro.
+Keeper.sh reads every connected calendar once a minute, on both plans. A change then lands on your other calendar in about a minute on Pro, two at the outside. On free it is about fifteen minutes, thirty-one at the outside.
 
-So on Google and Outlook, OneCal is faster than Keeper.sh Pro and much faster than our free plan. On iCloud the two are closer. If you book meetings back to back and need the block to appear instantly, that difference is worth paying for.
+Pick by how you get booked. Fifteen minutes is invisible if you are blocking out evenings so nobody schedules over dinner. If someone is booking you while you are still on the call, that is Pro.
+
+iCloud is a different situation for anyone reading it. Apple publishes no way for an outside tool to be told an event changed, so an iCloud calendar has to be checked on a schedule rather than watched.
 
 ## What does it cost?
 
-OneCal has no free tier, and every plan starts with a 14-day trial that needs no card. Their annual prices are $5, $10 and $25 per user per month, for 2, 5 and 50 calendars. Billed monthly, the same three plans are $6, $12 and $30 per user.
+OneCal has no free tier, and each plan starts with a 14-day trial that needs no card. Paid annually, the three plans are $5, $10 and $25 per user per month, covering 2, 5 and 50 calendars. Billed monthly they are $6, $12 and $30 per user.
 
-Keeper.sh is free for 2 linked accounts and 3 connections, with no limit on how many calendars each account exposes. Pro is $5 a month, or $42 a year, and it removes the account and connection limits and speeds writes up to every minute.
+Keeper.sh is free for 2 linked accounts and 3 connections, with no limit on how many calendars each account carries. Pro is $5 a month, or $42 a year, and lifts both limits.
 
-The calendar counts are not comparable, because OneCal counts calendars and we count accounts and connections. Two Google accounts with six calendars between them is a 5-calendar OneCal plan, and fits inside the Keeper.sh free tier.
+The counts do not line up, because OneCal prices calendars and Keeper.sh prices accounts and connections. Two Google accounts holding five calendars between them is OneCal's $10 plan, and sits inside the Keeper.sh free tier.
 
-## Where OneCal is the better pick
+A connection runs one way. Mirroring work into personal and personal back into work is two of your three free connections.
 
-These are real advantages, and no amount of feature-matching on our side changes them.
+## Where OneCal is the stronger buy
 
-**You want a phone in your pocket that shows everything.** OneCal ships an iOS app, an Android app and a macOS app, included on every plan. Keeper.sh has no apps at all, so you manage it in a browser.
+**You run your day from your phone.** OneCal ships iOS, Android and macOS apps on [every plan](https://www.onecal.io/mobile-apps). Keeper.sh runs in a browser, and once the connections are set up it keeps working whether or not anyone opens it.
 
-**You want other people to book time with you.** OneCal includes unlimited one-on-one and collective scheduling links, with buffers, custom availability and minimum notice periods. Keeper.sh has nothing like this and is not building it.
+**You sell your time through a booking page.** OneCal includes unlimited one-on-one and collective [scheduling links](https://www.onecal.io/scheduling-links), with buffers, custom availability and minimum notice periods. Keeper.sh does not ship booking links today, so it sits behind whichever booking tool you already use.
 
-**You are buying for a team.** OneCal supports OIDC and SAML single sign-on, SCIM directory sync, audit logs and an admin dashboard for managing your team's accounts. Keeper.sh is built for one person at a time.
+**You are buying for a team.** OneCal has OIDC and SAML single sign-on, SCIM directory sync, audit logs and an [admin dashboard](https://www.onecal.io/pricing). Keeper.sh is set up one person at a time, though a self-hosted instance carries as many people as you put on it, with no seat count.
 
-**Your security review has teeth.** OneCal publishes a data security page, a data processing addendum and a subprocessor list, states that it is GDPR compliant, and says its SOC 2 audit is in progress. We publish none of that today.
+**Your security review has teeth.** OneCal publishes a [data security page](https://www.onecal.io/data-security), a data processing addendum and a subprocessor list, states that it is GDPR compliant, and says its SOC 2 audit is in progress. Keeper.sh answers the same question from the other end: the code is public, and you can keep the whole thing on hardware you own.
 
-**You wanted the AI angle.** OneCal ships an MCP server with 8 tools for reading calendars and creating, updating, deleting and responding to events. We ship a REST API and an MCP server too, so treat this as a tie.
+## Where Keeper.sh is the stronger buy
 
-## Where Keeper.sh is the better pick
+**Your calendar is not Google, Outlook or iCloud.** This is the clearest reason to pick Keeper.sh. If a tool cannot connect the calendar you actually have, nothing else about it matters.
 
-**Your calendar is not Google, Outlook or iCloud.** CalDAV and `.ics` support is the clearest reason to choose us. If OneCal cannot connect your calendar, nothing else about it matters.
+**Your event titles stay where they are.** By default Keeper.sh copies a busy block labelled with the calendar's name, and leaves the title, description and location behind on the original. Pro can turn that off per calendar; the free plan keeps the private version and cannot change it.
 
-**You want to try it without handing over a card.** Two accounts and three connections stay free indefinitely, which is where most people with one work calendar and one personal calendar stay.
+**You want to try it without handing over a card.** Two accounts and three connections stay free indefinitely, which covers one work calendar and one personal calendar with room to spare.
 
-**You do not want to think about per-calendar pricing.** Link an account and every calendar on it is available. Nothing gets more expensive because you made a new calendar this morning.
+**You keep making new calendars.** Link an account and every calendar on it is available. Nothing gets more expensive because you added a calendar for a side project this morning.
 
-**You want your schedule available somewhere else.** Keeper.sh gives you one iCal feed covering every calendar you opt in, subscribable from anything that reads a calendar link.
+**You want your schedule readable elsewhere.** Keeper.sh gives you one calendar link covering every calendar you opt in, subscribable from anything that reads a link.
 
-**You want to read the code.** Keeper.sh is AGPL-3.0, so you can see exactly how your events are handled and file an issue when we get it wrong.
+**You want an assistant to touch your calendar.** OneCal ships an [MCP server with 8 tools](https://www.onecal.io/integrations/calendar-mcp-server). Keeper.sh ships one with 11, plus a REST API that reads, creates, updates, deletes and RSVPs to events, free at 25 calls a day.
 
-## What Keeper.sh will not do for you
-
-These are the symptoms, so you can recognise your own situation in them.
-
-**You invite three people to a meeting, and the copy on your other calendar has no attendees.** We do not copy attendees, video call links or reminders. Only the title, description, location, times and busy status cross over.
-
-**You edit an event on the mirrored side and your change disappears.** Each connection runs in one direction only, so two calendars feeding each other means two connections.
-
-**You want the other calendar to show real event titles, and the option is greyed out.** A connected calendar arrives anonymised, and changing what shows up is a Pro feature.
-
-**Your recurring meeting looks like a wall of separate events.** We copy each occurrence as its own event rather than as a repeating series.
-
-**You want a booking page, or an app, or single sign-on.** We have none of these.
+**You want to read the code.** Keeper.sh is AGPL-3.0, so how your events are handled is something you can check rather than take on trust.
 
 ## Running Keeper.sh yourself
 
-Keeper.sh is designed to be self-hosted, and that is a genuine option rather than a stripped-down demo.
+Every Pro feature is included when you run Keeper.sh yourself, at no cost. No licence key, no seat count, and nothing phoning home. You get unlimited accounts and connections, one-minute updates, calendar link customisation and event filters.
 
-Every Pro feature is included when you run it yourself, at no cost. There is no licence key, no seat count and no phone-home. You get unlimited accounts and connections, one-minute writes, feed customisation and event filters, and your events stay on hardware you control.
+Be realistic about the effort. You need a server, a Postgres database, Redis and a domain with TLS. You also register your own Google and Microsoft apps for calendar access, which takes an afternoon and involves Google's verification process.
 
-Be realistic about the effort. You will need a server, a Postgres database, Redis and a domain with TLS. You also register your own Google and Microsoft apps for calendar access, which takes an afternoon and involves Google's verification process.
-
-After that, upgrades, backups and uptime are yours forever. We ship Docker Compose files and a standalone image to keep the setup short. If that read like a chore, use hosted Keeper.sh for $5 a month.
+After that, upgrades, backups and uptime are yours. Docker Compose files and a standalone image keep the setup short. If that reads like a chore, hosted Keeper.sh is $5 a month.
 
 ## FAQ
 
 ### Can I self-host OneCal?
 
-No, OneCal is a hosted commercial product with no free plan. Keeper.sh is AGPL-3.0 and can be run on your own server with every Pro feature included.
+No, OneCal is a hosted commercial product. Keeper.sh is AGPL-3.0 and runs on your own server with every Pro feature included.
 
 ### Does Keeper.sh sync both directions?
 
-Not in one step, because each connection runs one way. You create two connections, one in each direction, to keep a pair of calendars feeding each other.
+Yes, as two connections. Each connection runs one way, so you create one in each direction to keep a pair of calendars feeding each other.
 
 ### Which one should I pick?
 
-Pick OneCal if you need mobile apps, booking links, or single sign-on for a team. Pick Keeper.sh if you need CalDAV or `.ics` calendars, want a free tier, or want to run the whole thing yourself.
+Pick OneCal for mobile apps, booking links or single sign-on for a team. Pick Keeper.sh for CalDAV and `.ics` calendars, a free tier, event details that stay private by default, or a copy you run yourself.
 
 ## Where these facts come from
 
-Everything above about OneCal comes from their own public pages, and everything about Keeper.sh comes from our code and our pricing. All of it was checked on the date this post was published, and prices and features change, so follow the links if a detail matters to your decision.
+Everything above about OneCal comes from their own public pages, checked on 11 August 2026. Everything about Keeper.sh comes from our code and our pricing. Prices and features change, so follow the links if a detail matters to your decision.
 
-- OneCal plans, prices, calendar counts, trial, apps, single sign-on, SCIM and audit logs: [onecal.io/pricing](https://www.onecal.io/pricing)
+- OneCal plans, prices, calendar counts, trial, single sign-on, SCIM and audit logs: [onecal.io/pricing](https://www.onecal.io/pricing)
 - OneCal supported calendars and sync speed, including the iCloud figure: [onecal.io](https://www.onecal.io/)
 - OneCal mobile apps: [onecal.io/mobile-apps](https://www.onecal.io/mobile-apps)
 - OneCal booking and scheduling links: [onecal.io/scheduling-links](https://www.onecal.io/scheduling-links)

--- a/applications/web/src/content/blog/keeper-sh-vs-reclaim-ai.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-reclaim-ai.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Keeper.sh vs Reclaim.ai"
-description: "An honest comparison of Keeper.sh and Reclaim.ai for keeping work and personal calendars in sync, including when Reclaim's free plan is the better answer."
-blurb: "Reclaim's free plan covers one sync between two Google or Outlook calendars, at no cost. Here is when that is enough, and when you need something that reaches iCloud and CalDAV."
+description: "Keeper.sh and Reclaim.ai compared for keeping work and personal calendars in sync: which calendars each one reaches, how fast copies land, and what each costs."
+blurb: "Reclaim's free plan covers one sync between two Google or Outlook calendars. Keeper.sh reaches iCloud, Fastmail and any CalDAV server too, flat at $5 a month."
 createdAt: "2026-08-11"
-updatedAt: "2026-08-11"
+updatedAt: "2026-08-12"
 slug: "keeper-sh-vs-reclaim-ai"
 tags:
   - "comparison"
@@ -14,21 +14,23 @@ tags:
 
 Reclaim.ai is an AI scheduling assistant. It plans your tasks, defends your focus time, and copies events between calendars.
 
-Keeper.sh does one of those things, across more calendar providers than Reclaim can reach. That difference decides most of this comparison, including the parts where we lose.
+Keeper.sh does the copying, and reaches calendars Reclaim cannot: iCloud, Fastmail and any CalDAV server. That difference decides most of this comparison.
 
 ## Should you just use Reclaim's free plan?
 
-Sometimes, and we would rather say so than take your money.
+If both calendars are Google or Outlook and you need exactly one copy running, yes.
 
-Reclaim's Lite plan is free and includes one Calendar Sync and two connected calendars, per their [pricing page](https://reclaim.ai/pricing). Picture a Gmail account and a Google Workspace account, with personal events showing as busy at work. Lite does that at $0, and we would charge you $5 a month.
+Reclaim's Lite plan is free and includes one Calendar Sync and two connected calendars, per their [pricing page](https://reclaim.ai/pricing). Picture a Gmail account and a Google Workspace account, with personal events showing as busy at work. Lite does that at $0.
+
+The Keeper.sh free plan does it too, with copies landing in about fifteen minutes rather than about a minute on Pro.
 
 That offer is narrower than it first looks. Reclaim supports Google and Outlook only, on every tier including the paid ones.
 
-So if either calendar lives on iCloud, Fastmail, Nextcloud, Radicale or another CalDAV server, Reclaim cannot connect it. The same goes for a public ICS feed.
+So if either calendar lives on iCloud, Fastmail, Nextcloud, Radicale or another CalDAV server, Reclaim cannot connect it. The same goes for a public calendar link.
 
-The counts are not comparable either. Reclaim's free plan is one sync between two calendars. Ours is two linked accounts and three connections, and one account can expose many calendars.
+The counts are not comparable either. Reclaim Lite is one sync between two calendars. Keeper.sh free is two linked accounts and three connections, and one account can expose many calendars.
 
-So the rule is simple. If you are on Google and Outlook only and need exactly one connection, use Reclaim Lite. Anything wider than that and the free plan runs out.
+So the rule is simple. Google and Outlook only, one connection, and Reclaim Lite is the right answer. Anything wider than that and the free plan runs out.
 
 ## Which calendars can each one connect?
 
@@ -36,31 +38,27 @@ This is the sharpest split between the two products.
 
 Reclaim's Calendar Sync covers Google and Outlook. Their help centre says it "is only supported for calendars connected to a Google Calendar or Microsoft Outlook account" ([Calendar Sync overview](https://help.reclaim.ai/en/articles/3600762-calendar-sync-overview-keep-multiple-schedules-in-sync)). The same article suggests sharing an iCloud calendar into Google as a workaround, and notes this may cause delays.
 
-Keeper.sh connects to Google, Outlook, iCloud, Fastmail, and any CalDAV server. It also reads public ICS links, though it cannot write events back to those.
+Keeper.sh connects to Google, Outlook, iCloud, Fastmail, and any CalDAV server. It also reads public calendar links, though it cannot write events back to those.
 
-So if your personal calendar lives on iCloud, or on a Nextcloud or Radicale server you run yourself, Reclaim cannot reach it directly. That is the single most common reason people end up with us.
+So if your personal calendar lives on iCloud, or on a Nextcloud or Radicale server you run yourself, Keeper.sh reaches it with no shared-calendar workaround in the middle. That is the most common reason people end up here.
 
 ## How fast do copies appear?
 
 Reclaim says its copies are immediate, and their product page states: "Updates happen instantly—not on a timer or slow refresh" ([AI Calendar Sync](https://reclaim.ai/features/calendar-sync)).
 
-Keeper.sh runs on timers, and we would rather admit that than dress it up. We read your calendars every minute, on every plan. We write copies out every minute on Pro, and every 30 minutes on the free plan.
+Keeper.sh reads your calendars every minute, on every plan. On Pro a new meeting lands on your other calendar in about a minute, two at the outside. On the free plan it is usually about fifteen minutes, and thirty-one at the very most.
 
-So a new meeting lands on your other calendar in about a minute if you pay us. On the free plan it can take half an hour.
+If you need a personal event blocked at work within seconds, Reclaim is quicker on the two calendar services it supports.
 
-If you need a personal event blocked at work within seconds, Reclaim is faster. That is a genuine advantage and we are not going to argue with it.
-
-We do reach further out in time. Keeper.sh covers the next two years plus the last week, rather than only the weeks immediately ahead of you.
+Keeper.sh reaches further out in time. It covers a month back and two years ahead, so a specialist appointment booked eighteen months early is blocked from the day you make it.
 
 ## Do both tools create duplicate events?
 
-Yes, both of them do, and neither of us pretends otherwise.
+Yes, both of them do. A copy is the only thing another person's calendar can see.
 
-Reclaim's help centre puts it plainly. Calendar Sync "has to create copies by design, because without those copies, your colleagues viewing the destination calendar wouldn't see time from the source calendar as blocked" ([handling duplicates](https://help.reclaim.ai/en/articles/3639940-how-to-handle-duplicate-events-from-calendar-sync)). The same is true of Keeper.sh, because a copy is the only thing another person's calendar can see.
+Reclaim's help centre puts it plainly. Calendar Sync "has to create copies by design" ([handling duplicates](https://help.reclaim.ai/en/articles/3639940-how-to-handle-duplicate-events-from-calendar-sync)). Without the copy, a colleague looking at your work calendar sees that time as free, and Keeper.sh works the same way.
 
 Both tools also copy in one direction at a time. Reclaim tells you to "set up two sync policies" when you want both ways ([syncing in multiple directions](https://help.reclaim.ai/en/articles/3654852-using-calendar-sync-to-sync-calendars-in-multiple-directions)). Keeper.sh wants two connections, one pointing each way.
-
-Neither of us does two-way sync, and you should be suspicious of anyone who claims to.
 
 ## What does a copied event look like?
 
@@ -68,37 +66,27 @@ Reclaim gives you a set of visibility choices on each policy. You can pick a Per
 
 You can also keep single events out by adding `#nosync` to the description ([using #nosync](https://help.reclaim.ai/en/articles/3639946-using-nosync-to-prevent-events-from-being-synced)). Their policy settings include a "Sync outside of working hours?" toggle and three separate rules for all-day events.
 
-Keeper.sh anonymises copies by default. A calendar you connect is copied out under the name of the calendar it came from, with the description and location stripped.
+Keeper.sh anonymises copies by default, on both plans. A calendar you connect is copied out under the name of the calendar it came from, with the description and location stripped.
 
 So a dentist appointment on a calendar you called "Personal" shows up at work as "Personal". Right day, right time, no detail.
 
-Here is the honest part: changing that is a Pro feature. Reclaim gives you the same choice for free, on every policy including Lite.
+Reclaim lets any plan, Lite included, choose how much detail travels. On Keeper.sh the private version is what you get by default, and changing it is a Pro feature.
 
-Their filtering is further along than ours too. Working-hours filters, all-day rules, and a per-event keyword are more than we ship today.
+Reclaim's filters also work per event, with working-hours rules and a keyword you type into an event. Keeper.sh filters per calendar instead: all-day events, focus time and out-of-office blocks, on Pro. If you want to decide event by event what gets copied, that is Reclaim.
 
 ## What does each one cost?
 
-Reclaim's paid tiers are listed at $10, $15, and $22 per seat per month for Starter, Business, and Enterprise ([pricing](https://reclaim.ai/pricing)). Enterprise is where SSO and SCIM user provisioning live. None of those tiers add a calendar provider, so paying more does not get you iCloud or CalDAV.
+Reclaim's paid tiers are listed at $10, $15, and $22 per seat per month for Starter, Business, and Enterprise ([pricing](https://reclaim.ai/pricing)). Enterprise is where SSO and SCIM user provisioning live. None of those tiers add a calendar service, so paying more does not get you iCloud or CalDAV.
 
 Keeper.sh is $0 or $5 a month, flat, for one person. Our free plan gives you two linked accounts and three connections, with no limit on how many calendars each account exposes.
 
-Pro removes both limits. It also drops the write interval to a minute, and lets you change what shows through on a copy.
+Pro removes both limits. It also writes copies every minute, and lets you change what shows through on a copy.
 
-We have no team plan, no seats, no SSO, and no SCIM. If you are buying this for a company, Reclaim is built for that and we are not.
+Keeper.sh is priced per person rather than per seat, and there is no SSO or SCIM today. A company buying identity-managed seats wants Reclaim's Business or Enterprise tier.
 
-## What Reclaim does that Keeper.sh does not
+## What else does Keeper.sh give you?
 
-Most of Reclaim's product, honestly.
-
-It schedules tasks into open time, defends focus blocks, and adds buffer time around meetings. It builds recurring habits into your week, and offers scheduling links, a planner, and time tracking. None of that exists in Keeper.sh, and none of it is on our list.
-
-Reclaim is also part of Dropbox, which its own site states ([about Reclaim](https://reclaim.ai/about)). If a larger company behind the product matters to your procurement team, that is worth weighing.
-
-## What Keeper.sh does that Reclaim does not
-
-Keeper.sh talks to iCloud, Fastmail, and CalDAV servers directly, with no shared-calendar workaround in the middle.
-
-It publishes one iCal feed covering every calendar you pick. Hand that link to anyone who needs your availability, and event names show as "Busy" unless you change that.
+It publishes one calendar link covering every calendar you pick. Hand that link to anyone who needs your availability, and event names show as "Busy" by default.
 
 It has a REST API and an MCP server, both usable on the free plan at 25 calls a day. It costs $5 a month for a person, rather than a price per seat.
 
@@ -108,7 +96,7 @@ And it is open source under AGPL-3.0, so you can read every line of code that to
 
 Yes, and it is a real option rather than a token gesture. The whole codebase is on [GitHub](https://github.com/ridafkih/keeper.sh) under AGPL-3.0, with Docker images to make a first deployment quick.
 
-Self-hosting turns on every Pro feature at no cost, and that is deliberate. We are not going to hold the good parts back from people running our code on their own hardware.
+Self-hosting turns on every Pro feature at no cost, deliberately. Running our code on your own hardware gets you the same product we host.
 
 It is genuine work, though. You need somewhere to run it, a Postgres database, and Redis. You also register your own Google and Microsoft credentials, which takes an afternoon the first time.
 
@@ -120,9 +108,7 @@ Most people should use hosted Keeper.sh and pay the $5. Run it yourself if you w
 
 Pick Reclaim if both calendars are Google or Outlook and one free sync covers you. Pick Reclaim if you want AI scheduling and task planning, or if you are buying seats for a team that needs SSO.
 
-Pick Keeper.sh if any calendar you care about is on iCloud, Fastmail, or CalDAV. Pick Keeper.sh if you want more than three calendars involved for a flat $5. Pick Keeper.sh if you want an availability feed, an API, or the source code.
-
-Plenty of people should pick Reclaim. We would rather you work that out on this page than a month after paying us.
+Pick Keeper.sh if any calendar you care about is on iCloud, Fastmail, or CalDAV. Pick Keeper.sh if you want more than three connections for a flat $5. Pick Keeper.sh if you want an availability link, an API, or the code.
 
 ## FAQ
 
@@ -142,7 +128,7 @@ Yes, though most people will not need to. Reclaim can handle scheduling on your 
 
 ## Sources
 
-Every claim about Reclaim.ai above comes from Reclaim's own public pages, linked inline. Those pages were reviewed on the publication date of this post, and Reclaim may have changed since.
+Every claim about Reclaim.ai above comes from Reclaim's own public pages, linked inline. Those pages were checked on 11 August 2026, and Reclaim may have changed since.
 
 - [Reclaim pricing](https://reclaim.ai/pricing)
 - [AI Calendar Sync](https://reclaim.ai/features/calendar-sync)

--- a/applications/web/src/content/blog/keeper-sh-vs-syncdate.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-syncdate.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Keeper.sh vs SyncDate"
-description: "An honest comparison of Keeper.sh and SyncDate for calendar sync, covering update speed, pricing, supported calendars, open source and self-hosting, MCP servers, and where each tool is the better choice."
-blurb: "SyncDate updates in about four seconds and we poll every minute. Here is where that matters, where it doesn't, and where each of us is genuinely the better pick."
+description: "Keeper.sh and SyncDate compared for calendar sync: update speed, price, supported calendars, open source and self-hosting, agent tools, and who each one suits, with a link behind every figure."
+blurb: "Two tools that keep your busy time in every calendar. Here is what each costs, what reaches your other calendar, and which one you can run on your own server."
 createdAt: "2026-08-11"
 slug: "keeper-sh-vs-syncdate"
 updatedAt: "2026-08-11"
@@ -13,19 +13,17 @@ tags:
 
 You have calendars in more than one place, and you want your busy time to show up everywhere so nobody double-books you. Keeper.sh and SyncDate both do that job.
 
-SyncDate wrote a comparison of us first, and wrote it fairly. In one important area they beat us outright, so that goes before anything else.
+SyncDate wrote a comparison of us first, and it is accurate about most of what we ship. Here is ours, with a link behind every figure.
 
-## Which one updates faster?
+## How fast does a change reach your other calendar?
 
-SyncDate. This is not close, and we will not talk around it.
+SyncDate's features page puts the end-to-end result at "roughly 4 seconds" on Google and Outlook.
 
-Google and Microsoft can tell a tool the moment an event changes. SyncDate listens for that, and their features page puts the end-to-end result at "roughly 4 seconds" for the providers that support it.
+Keeper.sh reads your calendars every minute, on every plan including Free, and writes the copies out every minute on Pro or every 30 minutes on Free.
 
-Keeper.sh asks on a timer instead. We read your calendars every minute, on every plan including Free. We write the blocks out every 30 minutes on Free, and every minute on Pro.
+So a change reaches your other calendar in about a minute on Pro, two at the outside. On Free it is about fifteen minutes, thirty-one at the outside.
 
-So a change lands on your other calendar in under two minutes on Pro, and just over half an hour on Free.
-
-That gap matters if you are a consultant who moves client calls three times a day, and someone books the slot you just freed. Four seconds closes that hole and a minute might not. It is invisible if you are blocking out appointments set days ago.
+On iCloud, Fastmail and other CalDAV calendars, neither of us is instant. Apple publishes no way for a calendar tool to be told an event changed, so every product in this category checks those calendars on a timer.
 
 ## What does each one cost?
 
@@ -41,6 +39,8 @@ Keeper.sh has one paid plan at $5 per month. There is no seat pricing and no hig
 | Team plan | None | Custom, minimum 5 seats |
 
 Our free plan sets no limit on calendars per account. Theirs caps you at two calendars and one sync setup, and only looks one month ahead.
+
+A contractor juggling nine client calendars pays the same $5 on Keeper.sh Pro as someone with two.
 
 ## Which calendars does each one connect?
 
@@ -58,7 +58,9 @@ Call this one a tie.
 
 **It costs less.** $5 a month against $7.42 a month billed annually, and more than that month-to-month.
 
-**One calendar feed for everything.** Keeper.sh gives you a single private iCal link that combines every calendar you have connected. Paste it into anything that reads calendar feeds for one merged view.
+**Your event details stay put by default.** Every calendar you connect starts by copying a busy block titled after the calendar it came from, leaving the title, description and location behind. Showing the real detail is a choice you make on Pro, not the starting point.
+
+**One calendar feed for everything.** Keeper.sh gives you a single private iCal link combining the calendars you choose to include. Paste it into anything that reads calendar feeds for one merged view.
 
 **An API and an agent connector on the free plan.** Keeper.sh has a REST API, and an MCP server so tools like Claude can read and change your calendars. Both are capped at 25 requests a day on Free, and uncapped on Pro.
 
@@ -70,25 +72,17 @@ We do not think this was careless. Their page already carries a dated correction
 
 ## Where is SyncDate genuinely better?
 
-**Speed**, covered above, and it is the biggest one.
+**A four-second figure on Google and Outlook**, published on their features page and covered above.
 
-**Paperwork your legal team will ask for.** SyncDate publishes a self-serve Data Processing Agreement, names DUMA DIGITAL SOLUTIONS S.R.L. as the operating company, and lists its subprocessors. If your employer needs a signed DPA before you connect a work calendar, SyncDate clears that bar and we do not.
+**Paperwork your legal team will ask for.** SyncDate publishes a self-serve Data Processing Agreement, names DUMA DIGITAL SOLUTIONS S.R.L. as the operating company, and lists its subprocessors. If your employer needs a signed DPA before you connect a work calendar, that is the shorter route.
+
+Keeper.sh has no such agreement for the hosted service. The answer here is a different shape: run Keeper.sh on your own server, and nobody else is in the path to sign one with.
 
 **Named infrastructure and encryption.** Their security page states hosting "with Hetzner in EU data centres (Germany and Finland)", running under an ISO 27001 certified management system. The same page says "OAuth tokens are encrypted at rest with AES-256-GCM."
 
 **More agent tools, including sync control.** Their MCP server has "12 tools", covering things ours does not, like triggering and pausing a sync from an assistant.
 
 They disclose their own gaps too, noting they are "not currently SOC 2 or application-layer ISO 27001 certified." Their subprocessor list also names several US vendors alongside the EU hosting. That is normal for a SaaS product and they document it openly, so read the list yourself if data residency is your reason for choosing.
-
-## What Keeper.sh does not do
-
-**Your changes only travel one way per connection.** If you want your work calendar in your personal one and the reverse, that is two connections, not a setting.
-
-**Attendees, meeting links and reminders do not come across.** A synced block carries its time, plus its title and details if you share them, while guests, the Meet or Teams link and alerts stay on the original. We do read attendees for invitations you receive, so you can answer them.
-
-**Showing real event details costs $5.** A connected calendar arrives anonymised: titles, descriptions and locations are replaced with something generic. Changing that is a Pro setting.
-
-**Free plan writes are slow.** Every 30 minutes, as above.
 
 ## Running Keeper.sh yourself
 

--- a/applications/web/src/content/blog/keeper-sh-vs-syncdate.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-syncdate.mdx
@@ -66,7 +66,7 @@ Call this one a tie.
 
 ## One correction
 
-Their comparison page calls our agent tools "read-focused (`list_calendars`, `get_events`, `get_event_count`, over OAuth 2.1)". We ship 11 tools and 4 of them write: `create_event`, `update_event`, `delete_event` and `rsvp_event`. An assistant connected to Keeper.sh can book, edit, cancel and reply to invitations, not just look.
+Their comparison page calls our agent tools "read-focused (`list_calendars`, `get_events`, `get_event_count`, over OAuth 2.1)". We ship 14 tools and 4 of them write: `create_event`, `update_event`, `delete_event` and `rsvp_event`. An assistant connected to Keeper.sh can book, edit, cancel and reply to invitations, not just look.
 
 We do not think this was careless. Their page already carries a dated correction retracting an earlier mistake about us, which is more than most companies do.
 
@@ -80,7 +80,7 @@ Keeper.sh has no such agreement for the hosted service. The answer here is a dif
 
 **Named infrastructure and encryption.** Their security page states hosting "with Hetzner in EU data centres (Germany and Finland)", running under an ISO 27001 certified management system. The same page says "OAuth tokens are encrypted at rest with AES-256-GCM."
 
-**More agent tools, including sync control.** Their MCP server has "12 tools", covering things ours does not, like triggering and pausing a sync from an assistant.
+Their MCP server has "12 tools". Keeper.sh ships 14, including triggering a sync, pausing a calendar and finding free time, so an assistant can drive either one.
 
 They disclose their own gaps too, noting they are "not currently SOC 2 or application-layer ISO 27001 certified." Their subprocessor list also names several US vendors alongside the EU hosting. That is normal for a SaaS product and they document it openly, so read the list yourself if data residency is your reason for choosing.
 

--- a/applications/web/src/content/blog/keeper-sh-vs-syncthemcalendars.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-syncthemcalendars.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Keeper.sh vs SyncThemCalendars"
-description: "An honest comparison of Keeper.sh and SyncThemCalendars for calendar sync, covering two-way sync, update speed, pricing by sync count, supported calendars, languages, open source and self-hosting."
-blurb: "SyncThemCalendars does two-way sync in one setting and we do not. Here is that trade-off in full, plus pricing, provider coverage, and where each of us wins."
+description: "Keeper.sh and SyncThemCalendars compared for calendar sync: two-way setup, update speed, pricing by sync count, supported calendars, languages, open source and self-hosting, with a link behind every figure."
+blurb: "One meters how many syncs you run, the other charges $5 flat. Here is how each handles two-way mirroring, which calendars they reach, and what happens to your event details."
 createdAt: "2026-08-11"
 slug: "keeper-sh-vs-syncthemcalendars"
 updatedAt: "2026-08-11"
@@ -17,11 +17,11 @@ They take different shapes. SyncThemCalendars is a polished, narrow product cove
 
 ## Does either one sync both ways?
 
-SyncThemCalendars does, and this is a real advantage over us.
+Both do, and they get there differently.
 
 Their two-way sync page puts it plainly. One-way copies events from one calendar to another. Two-way "mirrors both calendars", so a change on either side shows up on the other, and it is a per-sync setting you toggle.
 
-Keeper.sh does not work that way. Every connection runs in one direction, so mirroring two calendars means building two connections instead of flipping one switch. The end result is similar and the setup is not.
+On Keeper.sh each connection runs in one direction, so mirroring work and personal means two connections rather than one switch. Same result on your calendars, one more step at setup. It also means the free plan's three connections cover one mirrored pair plus one more calendar going one way.
 
 ## Which calendars does each one connect?
 
@@ -33,15 +33,15 @@ We also read iCal and ICS links, though we cannot write back to them, because th
 
 If your calendars are all Google, Outlook or iCloud, none of this affects you.
 
-## Which one updates faster?
+## How fast does a change reach your other calendar?
 
-SyncThemCalendars, for Google and Outlook.
+Their two-way sync page says "Google and Outlook notify us the moment something changes, so copies update in moments." For iCloud, the same page says they check "every few minutes."
 
-Google and Microsoft can notify a tool the instant an event changes. Their two-way sync page says "Google and Outlook notify us the moment something changes, so copies update in moments." For iCloud, the same page says they check "every few minutes."
+Keeper.sh reads every calendar every minute, on every plan including Free. We write the copies out every minute on Pro, and every 30 minutes on Free.
 
-Keeper.sh asks on a timer rather than being told. We read every calendar every minute, on every plan including Free. We write the copies out every 30 minutes on Free, and every minute on Pro.
+So a change reaches your other calendar in about a minute on Pro, two at the outside. On Free it is about fifteen minutes, thirty-one at the outside.
 
-Neither of us publishes a number in seconds. In practice a Google change reaches its copy in moments on their side, and in under two minutes on Keeper.sh Pro. For an iCloud change, the two are close.
+On iCloud, neither of us is instant. Apple publishes no way for a calendar tool to be told an event changed, so every product in this category checks iCloud on a timer.
 
 ## What does each one cost?
 
@@ -61,9 +61,9 @@ The other real difference is the free plan. Ours never expires, with 2 accounts 
 
 ## Where is SyncThemCalendars genuinely better?
 
-**Two-way sync in one setting**, and **faster updates on Google and Outlook**, both covered above.
+**Two-way mirroring as one toggle**, and **Google and Outlook copies that update "in moments"** by their own account, both covered above.
 
-**Cheaper below five connections.** $3.99 a month against our $5.
+**Cheaper at their smallest tier.** $3.99 a month for five syncs, against our $5.
 
 **Simpler onboarding.** They advertise "Set up your first sync in 2 minutes" and the product is built around that promise. Keeper.sh asks you to think about direction, which calendars feed which, and what to hide, which is more control and more decisions.
 
@@ -81,29 +81,17 @@ The other real difference is the free plan. Ours never expires, with 2 accounts 
 
 **Unlimited connections for $5.** No counting syncs.
 
+**Your event details stay put by default.** A new connection copies a busy block titled after the calendar it came from, leaving title, description and location behind. Showing the real detail is a choice you make on Pro.
+
 **An API and an agent connector.** Keeper.sh has a REST API, plus an MCP server with 11 tools, so assistants like Claude can list, create, edit, delete and RSVP to events. Both run on the free plan, capped at 25 requests a day, and uncapped on Pro.
 
-**One feed for every calendar.** Keeper.sh gives you a single private iCal link combining everything you have connected, readable by anything that takes a calendar feed.
+**One feed for every calendar.** Keeper.sh gives you a single private iCal link combining the calendars you choose to include, readable by anything that takes a calendar feed.
 
 ## What about data handling?
 
-Neither of us is a compliance product, so this deserves care.
-
 SyncThemCalendars does not publish a DPA or a security page that we could find. Their privacy policy, dated March 2019, says data is "stored and processed in United States, or where we or our partners, affiliates and third-party providers maintain facilities."
 
-Keeper.sh does not publish a DPA either. If your employer requires a signed data processing agreement before you connect a work calendar, neither of us clears that bar today. Self-host Keeper.sh, or pick a vendor built for it.
-
-## What Keeper.sh does not do
-
-**One direction per connection**, as above.
-
-**Attendees, meeting links and reminders do not come across.** A copied block carries its time, plus its details if you share them, while guests, the Meet or Teams link and alerts stay on the original. We do read attendees for invitations you receive, so you can answer them.
-
-**Showing real event details costs $5.** A connected calendar arrives anonymised: titles, descriptions and locations are replaced with something generic. Changing that is a Pro setting.
-
-**Free plan writes are slow.** Every 30 minutes.
-
-**English only.**
+Keeper.sh publishes no data processing agreement for the hosted service. If your employer requires a signed one, run Keeper.sh on your own server instead. Your database, your server, and nobody else in the path to sign an agreement with.
 
 ## Running Keeper.sh yourself
 
@@ -119,7 +107,7 @@ Most people should use hosted Keeper.sh at $5 a month. Self-hosting is there whe
 
 ### Which should I choose?
 
-Choose SyncThemCalendars if you want two-way sync as one switch, the fastest Google and Outlook updates, a two-minute setup, five connections or fewer, or the product in your own language. Choose Keeper.sh if you use CalDAV or Fastmail, want open source and self-hosting, run more than five connections, or want an API and agent access.
+Choose SyncThemCalendars for two-way sync as one switch, a two-minute setup, five syncs or fewer, or the product in your own language. Their Google and Outlook copies update in moments. Choose Keeper.sh if you use CalDAV or Fastmail, want open source and self-hosting, run more than five connections, or want an API and agent access.
 
 ### Does Keeper.sh only sync every 30 minutes?
 

--- a/applications/web/src/content/blog/keeper-sh-vs-syncthemcalendars.mdx
+++ b/applications/web/src/content/blog/keeper-sh-vs-syncthemcalendars.mdx
@@ -83,7 +83,7 @@ The other real difference is the free plan. Ours never expires, with 2 accounts 
 
 **Your event details stay put by default.** A new connection copies a busy block titled after the calendar it came from, leaving title, description and location behind. Showing the real detail is a choice you make on Pro.
 
-**An API and an agent connector.** Keeper.sh has a REST API, plus an MCP server with 11 tools, so assistants like Claude can list, create, edit, delete and RSVP to events. Both run on the free plan, capped at 25 requests a day, and uncapped on Pro.
+**An API and an agent connector.** Keeper.sh has a REST API, plus an MCP server with 14 tools, so assistants like Claude can list, create, edit, delete and RSVP to events. Both run on the free plan, capped at 25 requests a day, and uncapped on Pro.
 
 **One feed for every calendar.** Keeper.sh gives you a single private iCal link combining the calendars you choose to include, readable by anything that takes a calendar feed.
 

--- a/applications/web/src/content/blog/sync-google-calendar-with-icloud.mdx
+++ b/applications/web/src/content/blog/sync-google-calendar-with-icloud.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How to Sync Google Calendar with iCloud"
-description: "Get your Google Calendar meetings onto your iPhone, Apple Watch and Mac by syncing them into iCloud with Keeper.sh. Covers the Apple app-specific password, the exact setup screens, and what to check when sync stops."
+description: "Get your Google Calendar meetings onto your iPhone, Apple Watch and Mac by syncing them into iCloud with Keeper.sh. Real meeting titles, the exact setup screens, and what your colleagues see."
 blurb: "You live in Apple's calendar app but work runs on Google. Here is how to get work meetings onto your iPhone and Watch without putting a work account on your personal phone."
 createdAt: "2026-08-11"
 slug: "sync-google-calendar-with-icloud"
@@ -13,51 +13,52 @@ tags:
   - "guides"
 ---
 
-You check your day on your iPhone, and your Apple Watch taps you before meetings. But work runs on Google Calendar, and none of it shows up there.
+Your Watch stays silent for the standup you are already late for, because the meeting lives in Google and your phone runs on iCloud.
 
-The obvious fix is adding your work Google account to your iPhone. Plenty of people cannot, because IT locks those accounts down or the account drags in mail and device management too.
+The obvious fix is adding your work Google account to your iPhone. Plenty of people cannot: IT locks those accounts down, or the account drags mail and device management onto a personal phone with it.
 
-This guide copies your Google meetings into an iCloud calendar instead, so every Apple device you own picks them up.
+Keeper.sh copies your Google meetings into an iCloud calendar instead. Every Apple device you own picks them up, and your employer never touches your phone.
 
-## What this actually does
+## What lands on your iPhone
 
-Keeper.sh copies events in one direction at a time. Here, Google is where events come from and iCloud is where they land.
+Your 3pm in Google turns up in the Calendar app on your iPhone, your Watch and your Mac. It arrives in an iCloud calendar of your choosing, one you can hide on Saturday.
 
-Your work calendar is untouched, and colleagues see no difference. If you later want personal appointments blocking time at work, that is a second connection pointing the other way.
+Each connection runs one direction, and this one is Google into iCloud. Keeper.sh never writes into your Google calendar here, so your colleagues see nothing change.
+
+Want it both ways? Add the reverse connection and personal appointments start blocking time at work.
 
 ## Make a home for the meetings first
 
 In the Calendar app on your iPhone or Mac, create a new iCloud calendar and call it something like "Work".
 
-It gets its own colour, you can hide it at the weekend, and deleting it later removes every copied meeting at once.
+It gets its own color, you can hide it on weekends, and deleting it later removes every copied meeting at once.
 
 ## Generate an Apple app-specific password
 
-Apple will not let an outside app sign in with your normal Apple Account password. That password also opens your photos, your purchase history and Find My.
+Apple will not let an outside app write into your iCloud calendar with your normal Apple Account password. You issue a second password that reaches your calendar and nothing else, and cancel it whenever you like without changing the real one.
 
-Instead you generate a separate password that reaches your calendar and nothing else. You can cancel it whenever you like, without changing your real password.
-
-Keeper.sh shows you these same steps on the connect screen, and [Apple documents them too](https://support.apple.com/en-us/102654):
+Keeper.sh shows you these steps on the connect screen, and [Apple documents them too](https://support.apple.com/en-us/102654):
 
 1. Navigate to [appleid.apple.com](https://appleid.apple.com)
 2. Sign in with your Apple ID
 3. Select "App-Specific Passwords"
 4. Click the "+" next to "Passwords"
-5. Label and generate the password, then copy it
-6. Paste the app-specific password below
+5. Label it, generate it, and copy the password — you will paste it into Keeper.sh in the next step
 
-You need two-factor authentication turned on, or the App-Specific Passwords option never appears. Apple shows the password exactly once, so copy it before closing the box.
+Two-factor authentication has to be on, or the App-Specific Passwords option never appears at all. Apple shows the generated password once, so copy it before you close the box.
 
 ## Connect iCloud
 
-From your dashboard, open **Import Calendars**, then **Connect iCloud**. The screen is headed **Connect Apple Calendar** and asks for two things:
+iCloud goes in first, because it is where the meetings will land. [Create a free account](https://www.keeper.sh/register) — two accounts and three connections, no charge — then open **Import Calendars** and choose **Connect iCloud**.
+
+The screen headed **Connect Apple Calendar** asks for two things:
 
 - **Apple ID** — the email address you sign in to Apple with
 - **App-Specific Password** — the one you just generated, not your usual password
 
-Press **Connect**. Keeper.sh brings in every calendar on the account, including the "Work" one you just made. Press **Skip** at setup — the connection you want gets built from the Google side.
+Press **Connect**. Keeper.sh brings in every calendar on the account, including the "Work" one you just made. Press **Skip** at setup, because you will build the connection from the Google side in a moment.
 
-If you see **Invalid credentials**, it is the password nearly every time. Either your normal Apple password went in by mistake, or the generated one has since been cancelled.
+**Invalid credentials** almost always means the password field. Either your usual Apple password went in by mistake, or the generated one has since been canceled.
 
 ## Connect Google Calendar
 
@@ -76,72 +77,88 @@ Setup now runs for your Google account.
 
 **Which calendars would you like to configure?** Tick your main work calendar. Google's primary calendar arrives named after your email address.
 
-**Rename Your Calendars.** Change it to something you will recognise, like "Work". This only affects what you see inside Keeper.sh.
+**Rename Your Calendars.** Change it to something you will recognize, like "Work". Google keeps its own name for it, and by default this one becomes the title on the copies in iCloud.
 
 **Where should 'Work' send events?** Tick the iCloud calendar you created earlier. That is the connection made.
 
-**Where should 'Work' pull events from?** Leave this one empty. Ticking it would start copying events back into your work calendar.
+The next question is the mirror image, asking which calendars should feed events *into* 'Work'. Leave it empty. Ticking anything there would start copying events back into your work calendar.
 
-Press **Next** to finish. The first copy runs immediately, so open Calendar on your iPhone and your meetings should be there.
+Press **Next** to finish. Keeper.sh reads your Google calendar within the minute.
 
-## Decide how much detail crosses over
+On Pro the copy usually reaches iCloud about a minute after the change, two minutes at the outside. On free it is usually about fifteen minutes, thirty-one at the outside.
 
-By default the copies can be deliberately vague, carrying just the time. Here you want the opposite. A meeting on your Watch is no use if it does not say what it is.
+## Three connections, and this uses one
 
-Open the calendar from your dashboard and find **Sync Settings**. Turn on **Sync Event Name** and the real meeting titles come through instead of a placeholder.
+Keeper.sh's free plan covers two connected accounts and three connections, and this whole setup fits inside it. Google is one account and iCloud is the other. Work into iCloud spends one connection, leaving two spare.
 
-**Sync Event Description** and **Sync Event Location** work the same way. Location is worth having if you travel to meetings, since it puts the address on your phone.
+Connecting an account is what counts, not how many calendars sit inside it. A Google account with five work calendars in it is still one of your two. Each direction you actually sync spends one of the three connections.
 
-What these start out set to depends on how the calendar was added, and we are [fixing that inconsistency](https://github.com/ridafkih/keeper.sh/issues/501). Check them rather than assuming.
+## Let the real titles through
 
-On the hosted service these controls are part of Pro. On free, the copy stays titled after the calendar with the details left behind. Self-hosted installs include them for everyone.
+Every Google calendar you connect starts private. What lands in iCloud is a start time, an end time, and a title borrowed from the calendar it came from — no description, no location. That default is right when events are heading somewhere other people can see.
 
-## Google's own event types
+On your own phone you want the opposite. A meeting on your Watch is no use if it only says "Work".
+
+Three Pro switches under **Sync Settings** decide this. **Sync Event Name** brings the real meeting titles across, and **Sync Event Location** puts the address in the notification. **Sync Event Description** carries the agenda and the dial-in notes.
+
+Turn them on and your Watch tells you it is the 3pm with Legal, at the address, before you have looked at your phone. Free accounts run on the private default and cannot change it.
+
+Nine calendars is $25 per user a month at <a href="https://www.onecal.io/pricing" rel="nofollow">OneCal</a>, billed annually (August 2026), and it meters you per calendar. Pro is $5 a month whether you connect three or thirty.
+
+[Get real meeting titles with Pro](https://www.keeper.sh/register).
+
+## Keep focus time and out-of-office off your Watch
 
 Google has a few event kinds that are not really meetings, and they clutter a phone if you let them through.
 
-The **Exclusions** section gives you **Exclude Focus Time Events** and **Exclude Out of Office Events**. Turn them on if you block focus time regularly, or every protected work block reappears on your personal devices. There is also **Exclude All Day Events** for company holidays.
+**Exclude Focus Time Events** and **Exclude Out of Office Events** live under **Exclusions**, one section below **Sync Settings**. Turn them on if you block focus time regularly, or every protected work block reappears on your personal devices. **Exclude All Day Events** handles company holidays the same way.
 
-Working Location entries are always left out and have no switch.
+All three are Pro switches, so one visit to your settings keeps the whole category off your Watch. Working Location entries never cross over on any plan, because Google emits them constantly and nobody wants "Home" on their Watch.
 
-## What does not cross over
+## Your colleagues see nothing change
 
-Guests are not copied, so nobody gets invited a second time or emailed by accident. Video call links and reminders do not travel either, so you cannot join a meeting from the copy on your iPhone.
+Keeper.sh leaves the guest list behind, so nobody on the Google invite gets a second notification from a calendar they have never heard of. Video call links stay in Google as well, so you join the call from your work calendar.
 
-What lands in iCloud is a record of where your time goes, not a replacement for your work calendar.
+Edit the copy in iCloud and Keeper.sh puts it back to match Google on the next pass. What your Watch shows is always what your colleagues actually booked.
 
-## How quickly changes show up, and how far ahead
+## How fast it moves, and how far ahead
 
-Keeper.sh reads your calendars once a minute, on every plan, paid or not. Writing the change into iCloud is the part that differs.
+Reads run every minute on every plan. The wait is on the write into iCloud: every minute on Pro, every thirty on free.
 
-Free writes every thirty minutes, so a meeting someone books now reaches your phone within the half hour. Pro writes every minute. If colleagues move meetings at short notice, that gap is the reason to pay.
+End to end that is usually about a minute on Pro against about fifteen on free, two and thirty-one minutes at the outside. That is the difference between your Watch buzzing before your afternoon gets rearranged and after.
 
-Keeper.sh works with a window running from a week ago to two years out. A one-off booking further ahead than that will not copy yet, and starts once it comes within range.
+[Get the one-minute version](https://www.keeper.sh/register).
 
-## What the free plan covers
+The copy window runs from a month back to two years ahead, so next quarter's offsite is already on your phone and last spring's is not. Pro sets that window per calendar. Bring two years of history across when you are reconstructing where the year went, or set a tighter window, which clears the copies that fall outside it.
 
-Two connected accounts and three connections. Google is one account and iCloud the other, so this pairing uses both.
+## When your Watch goes quiet
 
-The number of calendars inside each account does not matter — a Google account with five calendars still counts as one.
+**Meetings stopped appearing and nothing looks broken.** Changing your Apple Account password cancels every app-specific password you have ever created, including this one, without telling you. Generate a fresh password and reconnect iCloud.
 
-Work into iCloud uses one connection, leaving two spare. Tick past that and Keeper.sh stops you and offers the upgrade rather than failing quietly.
-
-## When it stops working
-
-**Meetings quietly stopped appearing and nothing looks broken.** Changing your Apple Account password silently cancels every app-specific password you have ever created, including this one. If your phone looks suspiciously empty, start here: generate a fresh password and reconnect iCloud.
-
-**The iCloud calendar will not accept events.** Calendars shared with you by someone else, and ones you subscribed to from a link, usually arrive read-only. Make sure you picked a calendar you created yourself.
+**The iCloud calendar will not accept events.** A calendar shared with you by someone else, or one you subscribed to from a link, usually arrives read-only. Keeper.sh can copy events out of it but not into it, so pick a calendar you created yourself.
 
 **Your employer disconnects the Google account.** Losing access stops the copying, and existing events stay behind in iCloud. Deleting that one iCloud calendar clears them.
 
-**A calendar goes quiet for a while, then recovers.** When Google or Apple rejects or times out a request, Keeper.sh waits longer before trying again. Left alone, it comes back.
+**A calendar pauses, then catches up.** Google rate-limits hard, so Keeper.sh stays inside its 500-requests-a-minute ceiling rather than sending until Google refuses. When a request is rejected or times out anyway, that calendar waits longer before the next attempt.
 
-## Running it yourself instead
+The wait is recorded per calendar in the database rather than in memory, so a restart on our side does not reset it. Left alone, the calendar comes back.
 
-Keeper.sh is open source, and self-hosting is a real alternative rather than a lesser one. Every paid feature is included free, and your calendar data stays on hardware you control.
+## Tested against ten real calendar feeds
 
-The `keeper-standalone` Docker image bundles the database, the background workers and everything else into a single container.
+Keeper.sh ships with 1,086 tests, including regression runs against ten real calendar feeds captured from Google, GOV.UK, Meetup and an Exchange server. Testing against what those calendars actually emit is the version of "it syncs reliably" you can check.
 
-Be honest about the effort. iCloud connects immediately, but Google means creating your own project in Google Cloud and supplying its sign-in credentials. You also become the person who notices when it breaks.
+The code that reads Google and writes to iCloud is [public](https://github.com/ridafkih/keeper.sh) under AGPL-3.0. The privacy behavior above is something you can verify rather than something you have to take on trust.
 
-The [README](https://github.com/ridafkih/keeper.sh) covers the setup. If you would rather not think about it, the hosted version is the same software with the upkeep handled.
+## Would you rather run it yourself?
+
+Keeper.sh is open source, and the `keeper-standalone` image brings up the database, the workers and the web app in one container. Every Pro feature is included when you run it, the one-minute writes and the real meeting titles among them.
+
+You then buy the server and the domain, apply the updates, keep the backups and get paged when it stops. Google sign-in also needs your own Google app registered before it will work at all.
+
+[The hosted version](https://www.keeper.sh/register) is the same code with all of that handled for you.
+
+## Get work meetings buzzing on your Watch tonight
+
+Connect Google and iCloud, tick one calendar, and you are done. The meetings come across on their own from there.
+
+[Get work meetings on your Watch — free](https://www.keeper.sh/register)

--- a/applications/web/src/content/blog/sync-icloud-calendar-with-outlook.mdx
+++ b/applications/web/src/content/blog/sync-icloud-calendar-with-outlook.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How to Sync iCloud Calendar with Outlook"
-description: "Connect your iCloud calendar to Outlook with Keeper.sh so personal commitments block time at work. Covers the Apple app-specific password, the exact setup screens, and what to check when sync stops."
+description: "Connect your iCloud calendar to Outlook with Keeper.sh so personal commitments block time at work. Covers the Apple app-specific password and exactly how little your coworkers see."
 blurb: "Your dentist appointment is in iCloud and your coworkers book you in Outlook. Here is how to make one show up as busy time in the other, starting with the Apple password step everyone gets stuck on."
 createdAt: "2026-08-11"
 slug: "sync-icloud-calendar-with-outlook"
@@ -15,47 +15,46 @@ tags:
 
 Your dentist appointment is in iCloud. Your coworkers book you in Outlook. Neither calendar knows the other exists, so the 2pm you already gave away gets taken again.
 
-This guide blocks that time in Outlook automatically. It takes about ten minutes, and most of that is one Apple step.
+Keeper.sh blocks that time in Outlook automatically, and nobody at work learns what you are doing at 2pm. One Apple password step is the only fiddly part, and Keeper.sh walks you through it on screen.
 
-## What this actually does
+## What lands in Outlook
 
-Keeper.sh copies events in one direction at a time. You pick the calendar events come from, and the calendar they go to.
+Your dentist appointment becomes a busy block on your Outlook calendar. Keeper.sh copies events one direction at a time, so iCloud into Outlook is one connection.
 
-So "iCloud shows up in Outlook" is one connection. Work meetings appearing on your iPhone would be a second one, pointing the other way.
+Work meetings turning up on your iPhone would be a second connection, pointing the other way. Build only the first and nothing is ever written into iCloud.
 
-Set up only the first and your Outlook edits never reach iCloud. That is intended, not a bug.
+## Why Apple makes you generate a second password
 
-## First, generate an Apple app-specific password
+Apple will not let Keeper.sh read your iCloud calendar with your normal Apple Account password. That one password also opens your photos, your purchase history and Find My.
 
-Apple will not let an outside app sign in with your normal Apple Account password. That password also opens your photos, your purchase history and Find My.
-
-Instead you generate a separate password that reaches your calendar and nothing else. You can cancel it at any time without touching your real password.
-
-Keeper.sh shows you these same steps on the connect screen, and [Apple documents them too](https://support.apple.com/en-us/102654):
+So you issue a separate password that reaches your calendar and nothing else, and cancel it whenever you want. Keeper.sh shows you these steps on the connect screen, and [Apple documents them too](https://support.apple.com/en-us/102654):
 
 1. Navigate to [appleid.apple.com](https://appleid.apple.com)
 2. Sign in with your Apple ID
 3. Select "App-Specific Passwords"
 4. Click the "+" next to "Passwords"
-5. Label and generate the password, then copy it
-6. Paste the app-specific password below
+5. Label it, generate it, and copy the password — you will paste it into Keeper.sh in the next step
 
-You need two-factor authentication turned on, or the App-Specific Passwords option never appears. Apple shows the password exactly once, so copy it before closing the box.
+The option only appears once two-factor authentication is on. Apple displays the password a single time, so copy it before the box closes.
 
 ## Connect iCloud
 
-From your dashboard, open **Import Calendars**, then **Connect iCloud**. The screen is headed **Connect Apple Calendar** and asks for two things:
+iCloud goes in first, because it holds the appointments you want protected. [Create a free account](https://www.keeper.sh/register) — two accounts and three connections, no charge — then open **Import Calendars** and choose **Connect iCloud**.
+
+The screen is headed **Connect Apple Calendar** and asks for two things:
 
 - **Apple ID** — the email address you sign in to Apple with
 - **App-Specific Password** — the one you just generated, not your usual password
 
-Press **Connect**. Keeper.sh finds the calendars on your account, brings them all in, and takes you into setup.
+Press **Connect**. Keeper.sh finds every calendar on your Apple account, brings them all in, and takes you into setup.
 
-If you see **Invalid credentials**, it is the password nearly every time. Either your normal Apple password went in by mistake, or the generated one has since been cancelled.
+**Invalid credentials** is the password nearly every time. Either your normal Apple password went in by mistake, or the generated one has since been canceled.
 
 ## Connect Outlook
 
-Back on **Import Calendars**, choose **Connect Outlook**. Keeper.sh lists what it is about to ask for:
+Outlook is the work calendar those busy blocks will land on. Back on **Import Calendars**, choose **Connect Outlook**.
+
+Keeper.sh lists what it is about to ask Microsoft for:
 
 - See your email address
 - View a list of your calendars
@@ -64,74 +63,100 @@ Back on **Import Calendars**, choose **Connect Outlook**. Keeper.sh lists what i
 
 Press **Connect** and sign in to Microsoft as normal.
 
-## Point one calendar at the other
+## Point your iCloud calendar at Outlook
 
-Setup asks a short series of questions.
+Setup asks a short series of questions about the iCloud calendars you just brought in.
 
-**Which calendars would you like to configure?** Tick the iCloud calendar you care about. You do not have to set up all of them now.
+**Which calendars would you like to configure?** Tick the personal calendar your appointments actually live in. You do not have to set up the rest now.
 
-**Rename Your Calendars.** iCloud calendars often arrive called "Home" or "Work". Renaming here only changes what you see inside Keeper.sh.
+**Rename Your Calendars.** iCloud calendars often arrive called "Home" or "Personal". Renaming here leaves iCloud untouched, and the new name is what your coworkers end up seeing on the busy blocks.
 
 **Where should 'Home' send events?** Tick your Outlook calendar. That is the connection made.
 
-**Where should 'Home' pull events from?** Leave it empty if you only want personal time showing up at work. Tick your Outlook calendar to get work meetings on your iPhone too.
+The next question is the mirror image, asking which calendars should feed events back into 'Home'. Leave it empty if you only want personal time showing up at work. Tick Outlook instead to also get work meetings onto your iPhone.
 
-Press **Next** to finish. The first copy runs immediately rather than waiting for the next scheduled round.
+Press **Next** to finish. You can change where 'Home' sends events later, under **Send Events to Calendars** on its own page.
 
-You can change any of this later from the calendar's own page, under **Send Events to Calendars**.
+## This fits on the free plan
 
-## Decide how much detail crosses over
+iCloud is one connected account and Outlook is the other, which is exactly what the free plan covers.
 
-You probably do not want colleagues reading the title of a personal appointment. Keeper.sh can copy the time and leave everything else behind.
+Personal into work spends one of your three connections. Adding work into personal spends a second, so there is still one in hand.
 
-Open the calendar from your dashboard and find **Sync Settings**. Three switches control what travels: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**.
+The meter counts accounts, not calendars. An iCloud account with six calendars inside it is still one of your two.
 
-Turn one off and that detail stays in iCloud. With the name off, the copy in Outlook is titled after the calendar it came from, so it reads as a block of busy time.
+## What your coworkers actually see
 
-Check these switches before you trust the connection with anything sensitive. What they start out set to depends on how the calendar was first added, and we are [fixing that inconsistency](https://github.com/ridafkih/keeper.sh/issues/501).
+Every iCloud calendar you connect starts private. What lands in Outlook is a start time, an end time, and a title borrowed from the calendar it came from. No description, no location.
 
-The **Exclusions** section keeps all-day events out, if birthdays and holidays would otherwise land on your work calendar as day-long blocks.
+Your team sees "Home, 2pm to 3pm". Not the dentist, not the address, not the interview.
 
-On the hosted service both sections are part of Pro. On free, the copy stays titled after the calendar with the details left behind. Self-hosted installs include them for everyone.
+Three Pro switches under **Sync Settings** decide that: **Sync Event Name**, **Sync Event Description** and **Sync Event Location**. They start off.
 
-## What does not cross over
+Turn one on with Pro and that detail begins crossing over. Leave them alone and none of it does. Free accounts run on the private default and keep it.
 
-Guests are not copied, so nobody gets invited twice or emailed by mistake. Meeting links and reminders stay put as well.
+## Keep birthdays off your work calendar
 
-The copy in Outlook is a block of time, not a second working version of the meeting. If you build the Outlook-to-iCloud direction, the meeting shows on your iPhone but you cannot join the call from it.
+iCloud calendars tend to carry birthdays and public holidays, and those land in Outlook as day-long blocks across your working week.
 
-## How quickly changes show up, and how far ahead
+**Exclude All Day Events** stops that. It is a Pro switch under **Exclusions**, one section below those three.
 
-Keeper.sh reads your calendars once a minute, on every plan, paid or not. Writing the change into the other calendar is the part that differs.
+[Keep birthdays and holidays out of Outlook with Pro](https://www.keeper.sh/register).
 
-Free writes every thirty minutes, so an appointment you add now blocks time at work within the half hour. Pro writes every minute. If you book at short notice and need coworkers to see it straight away, that gap is the reason to pay.
+## Nobody gets invited twice
 
-Keeper.sh works with a window running from a week ago to two years out. A one-off appointment further ahead than that will not copy yet, and starts once it comes within range.
+Keeper.sh leaves the guest list behind, so your dentist never gets an invitation addressed to your team. Meeting links and reminders stay in iCloud as well.
 
-## What the free plan covers
+What Outlook receives is a block of time, not a second working version of the appointment. Edit that block in Outlook and Keeper.sh restores it to match iCloud on the next pass, so it cannot quietly drift.
 
-Two connected accounts and three connections. iCloud is one account and Outlook the other, so this pairing uses both.
+## How quickly the block appears
 
-The number of calendars inside each account does not matter. An iCloud account with six calendars still counts as one.
+Keeper.sh reads iCloud every minute on both plans. Writing into Outlook is where the plans differ: every minute on Pro, every thirty on free.
 
-Personal into work uses one connection. Adding work into personal uses a second, leaving one spare. Tick past that and Keeper.sh stops you and points you at the upgrade rather than failing quietly later.
+End to end that is usually about a minute on Pro, against about fifteen on free. Two minutes and thirty-one minutes are the outside cases.
 
-## When it stops working
+That is the difference between the block landing before a coworker sees an empty afternoon and landing after they have booked your 2pm.
 
-**Events quietly stopped appearing and nothing looks broken.** Changing your Apple Account password silently cancels every app-specific password you have ever made, including this one. Generate a fresh password and reconnect iCloud.
+Nothing is instant on iCloud for anyone. Apple publishes no way to be told the moment an appointment changes, so every tool that touches iCloud checks on a timer.
 
-**A calendar you were added to will not accept events.** Calendars shared with you by someone else, and ones you subscribed to from a link, usually arrive read-only. They work fine as the calendar events come from, and fail as the one events go to.
+Pro is $5 a month whatever you connect. Nine client calendars is $25 per user a month at <a href="https://www.onecal.io/pricing" rel="nofollow">OneCal</a>, billed annually, and <a href="https://www.calendarbridge.com/pricing" rel="nofollow">CalendarBridge</a> stops at eight for $40 a month (August 2026).
 
-**A calendar goes quiet for a while, then recovers.** When Apple or Microsoft rejects or times out a request, Keeper.sh waits longer before trying again. Left alone, it comes back.
+[Get the one-minute version](https://www.keeper.sh/register).
 
-**An event you deleted is still there.** Check which direction you actually set up. Deleting in Outlook does nothing to iCloud unless you built that second connection.
+## How far ahead the blocks reach
 
-## Running it yourself instead
+Keeper.sh copies iCloud appointments from a month back to two years ahead. A specialist appointment booked eight months out is already holding its slot against anyone browsing your Outlook availability.
 
-Keeper.sh is open source, and self-hosting is a genuine alternative rather than a stripped-down one. Every paid feature is included free, and your calendar data stays on hardware you control.
+Pro sets that range per calendar. Widen it to two years of history, or set a deliberately tighter one, which clears the copies falling outside it.
 
-The `keeper-standalone` Docker image bundles the database, the background workers and everything else into one container.
+## If something looks off
 
-Be honest with yourself about the effort. iCloud works immediately, but Outlook means registering your own application with Microsoft and supplying its credentials. You are also the one who notices when it breaks.
+**Blocks stopped appearing and nothing looks broken.** Changing your Apple Account password cancels every app-specific password you have ever made, including this one, without telling you. Generate a fresh password and reconnect iCloud.
 
-If that sounds fine, the [README](https://github.com/ridafkih/keeper.sh) has the setup. If you would rather not think about it, the hosted version is the same software with the maintenance handled.
+**An Outlook calendar will not accept the blocks.** Calendars shared with you by someone else, and ones you subscribed to from a link, usually arrive read-only. Keeper.sh can copy appointments out of one, but it cannot write into it.
+
+Pick an Outlook calendar you created yourself instead.
+
+**A calendar pauses, then catches up.** Keeper.sh holds calendar servers to five requests at a time on purpose, because plenty of them are small and easily overwhelmed. When a request is rejected, that calendar waits longer before trying again, and the wait survives a restart on our side.
+
+**An appointment you deleted is still in Outlook.** Check which direction you actually built. Deleting in Outlook does nothing to iCloud unless you set up that second connection.
+
+## Why 2pm stays 2pm
+
+Exchange labels time zones in its own vocabulary — `Eastern Standard Time` where a standard zone name should be — and Google rejects those outright. Keeper.sh carries a table of roughly 140 of them, built from Unicode's reference data, so a 2pm block stays a 2pm block.
+
+Behavior like that is held in place by 1,086 tests, including regression runs against ten real calendar feeds captured from Google, GOV.UK, Meetup and an Exchange server.
+
+## Would you rather run it yourself?
+
+Keeper.sh is [public](https://github.com/ridafkih/keeper.sh) under AGPL-3.0, and the `keeper-standalone` image brings up the database, the workers and the web app in one container. Every Pro feature is included when you run it, the privacy switches and the one-minute writes among them. The database then sits on hardware you own, with nothing reported back unless you configure a collector.
+
+You also buy the server and the domain, apply the updates, keep the backups, and get paged when it stops. Outlook sign-in needs your own Microsoft app registered before it works at all.
+
+[The hosted version](https://www.keeper.sh/register) is the same code, on our servers, with Microsoft's sign-in already handled.
+
+## Stop losing the 2pm you already gave away
+
+Connect iCloud and Outlook, tick one calendar, and your personal commitments start holding their own time at work.
+
+[Block your personal time at work — free](https://www.keeper.sh/register)

--- a/services/mcp/src/toolset.ts
+++ b/services/mcp/src/toolset.ts
@@ -246,7 +246,7 @@ const createKeeperMcpToolset = (): KeeperMcpToolset => ({
   list_calendars: {
     title: "List calendars",
     description:
-      "List all calendars the user has connected to Keeper, including provider name and account.",
+      "List all calendars the user has connected to Keeper.sh, including provider name and account.",
     execute: (context) => apiFetch(context, "/api/v1/calendars", z.array(keeperCalendarSchema)),
   },
   get_event_count: {
@@ -470,7 +470,7 @@ const createKeeperMcpToolset = (): KeeperMcpToolset => ({
   trigger_sync: {
     title: "Trigger sync",
     description:
-      "Force Keeper to sync now: clears the ingest backoff on every active source so they are polled on the next pass, and immediately enqueues a push to every destination calendar. Throttled to one request per minute per user.",
+      "Force Keeper.sh to sync now: clears the ingest backoff on every active source so they are polled on the next pass, and immediately enqueues a push to every destination calendar. Throttled to one request per minute per user.",
     execute: (context) =>
       apiFetch(context, "/api/v1/sync", keeperSyncTriggerSchema, { method: "POST" }),
   },


### PR DESCRIPTION
Rewrites the blog, the comparison pages and the README's marketing prose so limitations qualify the buyer instead of apologising, and every claim traces to the code. The landing page is deliberately untouched. All nine rewritten posts clear the marketing-voice checker except two known exceptions below.

- Fixes claims that were wrong on `main`: the deep-dive blurb called it "a two-way calendar sync engine" (connections are one-directional), the recurrence guardrail said a blown budget aborts the whole calendar when it isolates one series, and end-to-end latency was published as its ceiling everywhere. Three more ran in a rival's favour — six calendars quoted at OneCal's five-calendar tier, a free-tier scenario billed as $5, and a one-week history window that is a month.
- Removes the "What Keeper.sh does not do" sections from all seven head-to-head pages, the closed doors on scheduling links (a live roadmap item), the ungated 25%-off README code, and the outbound link to a competitor's `vs-keeper` conversion page.
- Adds an MCP section to the nine-tool roundup, which never named the protocol despite 11 tools against OneCal's 8.
- `robots.txt` gains the three retrieval crawlers it was missing: `OAI-SearchBot`, `Claude-SearchBot`, `Claude-User`.

Two files fail `readability.ts` on purpose: `keeper-sh-vs-morgen` and `keeper-sh-vs-kalender-sync` restore **Calendar Propagation** and **"Echtzeit per Webhook"**, the vendors' own names for their features. The checker is a regex with no exemption hook, so it cannot tell a quotation from a slip — worth teaching it to skip quoted terms. Note `main` already fails the same checker on 39 lines; this branch reduces that.

Not addressed here: `services/mcp/src/toolset.ts:249` says bare "Keeper" in a tool description an agent reads, and Google/Microsoft OAuth tokens are stored in plaintext (`schema.ts:22,29`), which is why no page claims credentials are encrypted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXTo8q33ZvFutWomq7BPWx