### PR TITLE
fix(docs): four defects that missed the #553 merge window

### DIFF
--- a/applications/web/src/content/blog/best-calendar-sync-tools.mdx
+++ b/applications/web/src/content/blog/best-calendar-sync-tools.mdx
@@ -49,7 +49,7 @@ Keeper.sh is free with two accounts and three connections, and $5 flat at thirty
 | **Reclaim.ai** | No | [$10/seat/month](https://reclaim.ai/pricing) | [Yes — 1 calendar sync](https://reclaim.ai/pricing) | [No figure published](https://reclaim.ai/features/calendar-sync) | [One direction per rule; two rules for both](https://help.reclaim.ai/en/articles/3654852-how-to-set-up-a-calendar-sync-in-reclaim) | [Google and Outlook only](https://help.reclaim.ai/en/articles/3600762-calendar-sync-overview-keep-multiple-schedules-in-sync) | Not published |
 | **OGCS** | Runs on your own PC — MPL-2.0 | Free | Yes — free, no limits | [Every 15 minutes; 2 minutes for changes you make in Outlook](https://www.outlookgooglecalendarsync.com/guide/syncoptions-when.html) | [One or both directions](https://github.com/phw198/OutlookGoogleCalendarSync) | Desktop Outlook and Google only | Not published |
 
-Four of those rows carry no published speed figure at all. Keeper.sh reads every calendar every minute, iCloud and CalDAV included.
+Three of those rows carry no published speed figure at all. Keeper.sh reads every calendar every minute, iCloud and CalDAV included.
 
 ## Which ones can an AI assistant drive?
 
@@ -57,7 +57,7 @@ Three of the nine publish an MCP server, the connector that lets an assistant li
 
 | Tool | MCP server | Tools |
 |---|---|---|
-| **Keeper.sh** | Yes, OAuth 2.1 with a consent screen | 14 — list calendars, read events, create, update, delete, RSVP, pending invites, find free time, trigger a sync, pause a calendar, combined link |
+| **Keeper.sh** | Yes, OAuth 2.1 with a consent screen | 14, including list calendars, read events, create, update, delete, RSVP, pending invites, find free time, trigger a sync and pause a calendar |
 | **SyncDate** | [Yes](https://syncdate.app/mcp) | 12 |
 | **OneCal** | [Yes](https://www.onecal.io/integrations/calendar-mcp-server) | 8 |
 

--- a/applications/web/src/content/blog/how-calendar-sync-actually-works.mdx
+++ b/applications/web/src/content/blog/how-calendar-sync-actually-works.mdx
@@ -1,5 +1,5 @@
 ---
-title: "How Calendar Sync Actually Works: Sync Tokens, Recurrence, and Deletions"
+title: "How Calendar Sync Actually Works: Tokens, DST, Deletions"
 description: "What a calendar sync engine has to do: incremental syncs, 410 GONE resyncs, deduplication, loop prevention, recurrence exceptions, timezones, deletions."
 blurb: "Everything I learned building a calendar sync engine — sync tokens, 410 GONE, RRULE expansion across DST, loop prevention between mirrored calendars, and why deletions are the hard part."
 createdAt: "2026-08-11"

--- a/applications/web/src/content/blog/introducing-keeper-blog.mdx
+++ b/applications/web/src/content/blog/introducing-keeper-blog.mdx
@@ -148,7 +148,7 @@ The link carries its own key, so it opens only for the people you send it to. Th
 
 Keeper.sh is not only a mirror. There is a REST API at `/api/v1` that lists your calendars and accounts. It also creates, reads, updates, deletes and RSVPs to events on any calendar you have connected — one interface instead of Google's, Microsoft's and CalDAV's three.
 
-The same capability is exposed as a remote MCP server with eleven tools, authenticated with OAuth 2.1 so the agent never holds a calendar password. Point Claude at it and it can find your open slot, book it on the right calendar, and answer the invitation you have been ignoring. Pending invites and RSVP are in the toolset, so an agent can reply to an invitation rather than only read it.
+The same capability is exposed as a remote MCP server with fourteen tools, authenticated with OAuth 2.1 so the agent never holds a calendar password. Point Claude at it and it can find your open slot, book it on the right calendar, and answer the invitation you have been ignoring. Pending invites and RSVP are in the toolset, so an agent can reply to an invitation rather than only read it.
 
 ## Running it yourself
 


### PR DESCRIPTION
These were found by a verification pass over #553 and pushed to that branch a few minutes after it squash-merged, so they never landed. All four are live on `main` now.

- `introducing-keeper-blog.mdx` says **"eleven tools"**. The MCP server ships 14 since #482. The sweep in #553 matched the numeral `11`, so the spelled-out count survived — this was the last one in the repo.
- The roundup says **"Four of those rows carry no published speed figure at all"**. Three qualify. OneCal's row carries a linked iCloud figure, so "at all" is false for it — an adverse claim about a rival that the page's own table disproves.
- The MCP table prints **14** beside a list of 11 items, because the list merges `get_events`/`get_event` and omits `get_event_count` and `list_accounts`. Now reads "14, including…".
- The deep-dive title renders as `How Calendar Sync Actually Works: Sync Tokens, Recurrence, and Deletions · Keeper.sh` — 84 characters, ~798px against a ~600px desktop cap, and it repeats "sync" inside the tag. Both are documented rewrite triggers. It is also near-identical in construction to SYNCDATE's `How Calendar Sync Works: Webhooks, Polling & Dedup`.

New title is `How Calendar Sync Actually Works: Tokens, DST, Deletions` — 68 characters with the suffix, no repeated keyword, and "tokens", "DST" and "deletions" appear in zero of 18 competitor titles pulled for the relevant queries.

Types clean, 124 tests passing, voice checker passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXTo8q33ZvFutWomq7BPWx