### PR TITLE
fix(api): return 400 for recurrence budget errors on all event reads

### DIFF
--- a/services/api/src/handlers/event-routes.ts
+++ b/services/api/src/handlers/event-routes.ts
@@ -1,0 +1,45 @@
+import { normalizeDateRange, parseDateRangeParams } from "@/utils/date-range";
+import { withEventReadErrorHandling } from "@/utils/event-read-errors";
+import { ErrorResponse } from "@/utils/responses";
+import type { KeeperEvent, KeeperEventRangeInput } from "@/types";
+
+interface EventsInRangeReader {
+  getEventsInRange: (userId: string, range: KeeperEventRangeInput) => Promise<KeeperEvent[]>;
+}
+
+interface EventReader {
+  getEvent: (userId: string, eventId: string) => Promise<KeeperEvent | null>;
+}
+
+const handleGetEventsInRangeRoute = (
+  request: Request,
+  userId: string,
+  reader: EventsInRangeReader,
+): Promise<Response> => withEventReadErrorHandling(async () => {
+  const url = new URL(request.url);
+  const { from, to } = parseDateRangeParams(url);
+  const { end, start } = normalizeDateRange(from, to);
+  const events = await reader.getEventsInRange(userId, { from: start, to: end });
+  return Response.json(events);
+});
+
+const handleGetEventRoute = (
+  eventId: string | null,
+  userId: string,
+  reader: EventReader,
+): Promise<Response> => withEventReadErrorHandling(async () => {
+  if (!eventId) {
+    return ErrorResponse.badRequest("Event ID is required.").toResponse();
+  }
+
+  const event = await reader.getEvent(userId, eventId);
+
+  if (!event) {
+    return ErrorResponse.notFound("Event not found.").toResponse();
+  }
+
+  return Response.json(event);
+});
+
+export { handleGetEventsInRangeRoute, handleGetEventRoute };
+export type { EventReader, EventsInRangeReader };

--- a/services/api/src/routes/api/events/index.ts
+++ b/services/api/src/routes/api/events/index.ts
@@ -1,19 +1,10 @@
-import { normalizeDateRange, parseDateRangeParams } from "@/utils/date-range";
 import { createKeeperApi } from "@/read-models";
+import { handleGetEventsInRangeRoute } from "@/handlers/event-routes";
 import { withAuth, withWideEvent } from "@/utils/middleware";
 import { database } from "@/context";
 
 const keeperApi = createKeeperApi(database);
 
 export const GET = withWideEvent(
-  withAuth(async ({ request, userId }) => {
-    const url = new URL(request.url);
-    const { from, to } = parseDateRangeParams(url);
-    const { end, start } = normalizeDateRange(from, to);
-    const events = await keeperApi.getEventsInRange(userId, {
-      from: start,
-      to: end,
-    });
-    return Response.json(events);
-  }),
+  withAuth(({ request, userId }) => handleGetEventsInRangeRoute(request, userId, keeperApi)),
 );

--- a/services/api/src/routes/api/v1/events/[id].ts
+++ b/services/api/src/routes/api/v1/events/[id].ts
@@ -1,5 +1,6 @@
 import { HTTP_STATUS } from "@keeper.sh/constants";
 import { createKeeperApi } from "@/read-models";
+import { handleGetEventRoute } from "@/handlers/event-routes";
 import { withV1Auth, withWideEvent } from "@/utils/middleware";
 import { ErrorResponse } from "@/utils/responses";
 import { eventPatchBodySchema } from "@/utils/request-body";
@@ -12,19 +13,7 @@ const keeperApi = createKeeperApi(database, {
 });
 
 const GET = withWideEvent(
-  withV1Auth(async ({ params, userId }) => {
-    const eventId = params.id;
-    if (!eventId) {
-      return ErrorResponse.badRequest("Event ID is required.").toResponse();
-    }
-    const event = await keeperApi.getEvent(userId, eventId);
-
-    if (!event) {
-      return ErrorResponse.notFound("Event not found.").toResponse();
-    }
-
-    return Response.json(event);
-  }),
+  withV1Auth(({ params, userId }) => handleGetEventRoute(params.id ?? null, userId, keeperApi)),
 );
 
 const PATCH = withWideEvent(

--- a/services/api/src/routes/api/v1/events/index.ts
+++ b/services/api/src/routes/api/v1/events/index.ts
@@ -1,10 +1,6 @@
 import { HTTP_STATUS } from "@keeper.sh/constants";
-import { RecurrenceMaterializationLimitError } from "@keeper.sh/calendar";
-import {
-  EventRangeValidationError,
-  normalizeDateRange,
-  parseDateRangeParams,
-} from "@/utils/date-range";
+import { normalizeDateRange, parseDateRangeParams } from "@/utils/date-range";
+import { withEventReadErrorHandling } from "@/utils/event-read-errors";
 import { createKeeperApi } from "@/read-models";
 import type { KeeperEventFilters } from "@/types";
 import { withV1Auth, withWideEvent } from "@/utils/middleware";
@@ -42,35 +38,25 @@ const parseEventFilters = (url: URL): KeeperEventFilters => {
 };
 
 const GET = withWideEvent(
-  withV1Auth(async ({ request, userId }) => {
+  withV1Auth(({ request, userId }) => withEventReadErrorHandling(async () => {
     const url = new URL(request.url);
-    try {
-      const { from, to } = parseDateRangeParams(url);
-      const { end, start } = normalizeDateRange(from, to);
-      const shouldCount = url.searchParams.get("count") === "true";
+    const { from, to } = parseDateRangeParams(url);
+    const { end, start } = normalizeDateRange(from, to);
+    const shouldCount = url.searchParams.get("count") === "true";
 
-      if (shouldCount) {
-        const count = await keeperApi.getEventCount(userId, { from: start, to: end });
-        return Response.json({ count });
-      }
-
-      const filters = parseEventFilters(url);
-      const events = await keeperApi.getEventsInRange(
-        userId,
-        { from: start, to: end },
-        filters,
-      );
-      return Response.json(events);
-    } catch (error) {
-      if (
-        error instanceof RecurrenceMaterializationLimitError
-        || error instanceof EventRangeValidationError
-      ) {
-        return ErrorResponse.badRequest(error.message).toResponse();
-      }
-      throw error;
+    if (shouldCount) {
+      const count = await keeperApi.getEventCount(userId, { from: start, to: end });
+      return Response.json({ count });
     }
-  }),
+
+    const filters = parseEventFilters(url);
+    const events = await keeperApi.getEventsInRange(
+      userId,
+      { from: start, to: end },
+      filters,
+    );
+    return Response.json(events);
+  })),
 );
 
 const POST = withWideEvent(

--- a/services/api/src/utils/event-read-errors.ts
+++ b/services/api/src/utils/event-read-errors.ts
@@ -1,0 +1,22 @@
+import { RecurrenceMaterializationLimitError } from "@keeper.sh/calendar";
+import { EventRangeValidationError } from "@/utils/date-range";
+import { ErrorResponse } from "@/utils/responses";
+
+const isClientEventReadError = (error: unknown): boolean =>
+  error instanceof RecurrenceMaterializationLimitError
+  || error instanceof EventRangeValidationError;
+
+const withEventReadErrorHandling = async (
+  respond: () => Promise<Response>,
+): Promise<Response> => {
+  try {
+    return await respond();
+  } catch (error) {
+    if (error instanceof Error && isClientEventReadError(error)) {
+      return ErrorResponse.badRequest(error.message).toResponse();
+    }
+    throw error;
+  }
+};
+
+export { withEventReadErrorHandling };

--- a/services/api/tests/handlers/event-routes.test.ts
+++ b/services/api/tests/handlers/event-routes.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { RecurrenceMaterializationLimitError } from "@keeper.sh/calendar";
+import {
+  handleGetEventRoute,
+  handleGetEventsInRangeRoute,
+} from "../../src/handlers/event-routes";
+import type { KeeperEvent } from "../../src/types";
+
+const SERIES_ID = "019c0000-0000-7000-8000-000000000001";
+const SERIES_UID = "pathological-series-1";
+const OCCURRENCE_BUDGET = 10_000;
+
+const createLimitError = (): RecurrenceMaterializationLimitError =>
+  new RecurrenceMaterializationLimitError(
+    {
+      calendarId: "calendar-1",
+      eventId: SERIES_ID,
+      sourceEventUid: SERIES_UID,
+    },
+    OCCURRENCE_BUDGET,
+  );
+
+const readError = async (response: Response): Promise<string | null> => {
+  const body = await response.json() as { error: string | null };
+  return body.error;
+};
+
+describe("handleGetEventsInRangeRoute", () => {
+  it("returns the events for a valid range", async () => {
+    const event = { id: SERIES_ID, title: "Standup" } as KeeperEvent;
+
+    const response = await handleGetEventsInRangeRoute(
+      new Request("https://api.test/api/events?from=2026-03-01&to=2026-03-08"),
+      "user-1",
+      { getEventsInRange: () => Promise.resolve([event]) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([event]);
+  });
+
+  it("returns 400 when a series exceeds the recurrence budget", async () => {
+    const response = await handleGetEventsInRangeRoute(
+      new Request("https://api.test/api/events?from=2026-03-01&to=2026-03-08"),
+      "user-1",
+      { getEventsInRange: () => Promise.reject(createLimitError()) },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await readError(response)).toContain(SERIES_UID);
+  });
+
+  it("returns 400 when the requested range is invalid", async () => {
+    const response = await handleGetEventsInRangeRoute(
+      new Request("https://api.test/api/events?from=2026-03-08&to=2026-03-01"),
+      "user-1",
+      { getEventsInRange: () => Promise.reject(new Error("must not be called")) },
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rethrows unrelated failures", async () => {
+    await expect(handleGetEventsInRangeRoute(
+      new Request("https://api.test/api/events?from=2026-03-01&to=2026-03-08"),
+      "user-1",
+      { getEventsInRange: () => Promise.reject(new Error("database is down")) },
+    )).rejects.toThrow("database is down");
+  });
+});
+
+describe("handleGetEventRoute", () => {
+  it("returns the event when it exists", async () => {
+    const event = { id: SERIES_ID, title: "Standup" } as KeeperEvent;
+
+    const response = await handleGetEventRoute(SERIES_ID, "user-1", {
+      getEvent: () => Promise.resolve(event),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(event);
+  });
+
+  it("returns 404 when the event is missing", async () => {
+    const response = await handleGetEventRoute(SERIES_ID, "user-1", {
+      getEvent: () => Promise.resolve(null),
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 when the event id is absent", async () => {
+    const response = await handleGetEventRoute(null, "user-1", {
+      getEvent: () => Promise.reject(new Error("must not be called")),
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when the series exceeds the recurrence budget", async () => {
+    const response = await handleGetEventRoute(SERIES_ID, "user-1", {
+      getEvent: () => Promise.reject(createLimitError()),
+    });
+
+    expect(response.status).toBe(400);
+    expect(await readError(response)).toContain(SERIES_UID);
+  });
+
+  it("rethrows unrelated failures", async () => {
+    await expect(handleGetEventRoute(SERIES_ID, "user-1", {
+      getEvent: () => Promise.reject(new Error("database is down")),
+    })).rejects.toThrow("database is down");
+  });
+});


### PR DESCRIPTION
`RecurrenceMaterializationLimitError` is thrown deliberately so a partial range is never returned, but only `/api/v1/events` caught it — `/api/events` and `/api/v1/events/{id}` let it escape, so one pathological series 500'd the whole request. The mapping now lives in one place and all three read paths share it. Closes #577.

- adds `withEventReadErrorHandling`, which maps `RecurrenceMaterializationLimitError` and `EventRangeValidationError` to 400 and rethrows everything else
- extracts the two uncaught handlers into `src/handlers/event-routes.ts` so they are testable without booting `@/context`
- `/api/events` now also 400s on an invalid `from`/`to` instead of 500ing, matching v1
- regression tests fail on the pre-fix handlers (the error propagates) and pass after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTqvCoAV7hZzybpqV6cSj3