### PR TITLE
fix: cap the error and UID arrays carried on sync wide events

### DIFF
--- a/packages/calendar/src/core/sync-engine/index.ts
+++ b/packages/calendar/src/core/sync-engine/index.ts
@@ -14,6 +14,14 @@ import { computeSyncOperations } from "../sync/operations";
 import type { ReconciliationScope, StaleReasonCounts } from "../sync/operations";
 import type { CalendarSyncProvider, PendingChanges } from "./types";
 
+/*
+ * A run whose provider rejects everything produces one error per operation. The wide
+ * event is emitted once per run, so the risk is not volume but a single log line
+ * carrying thousands of objects. A sample plus the uncapped total keeps the line
+ * bounded while still reporting the true scale of the failure.
+ */
+const OPERATION_ERROR_SAMPLE_SIZE = 20;
+
 const resolveOutcome = (superseded: boolean, invalidated: boolean): string => {
   if (invalidated) {
     return "invalidated";
@@ -666,7 +674,9 @@ const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarR
     wideEvent["superseded"] = outcome.superseded;
 
     if (outcome.errors.length > 0) {
-      wideEvent["operation_errors"] = outcome.errors;
+      wideEvent["operation_errors"] = outcome.errors.slice(0, OPERATION_ERROR_SAMPLE_SIZE);
+      wideEvent["operation_errors.count"] = outcome.errors.length;
+      wideEvent["operation_errors.truncated"] = outcome.errors.length > OPERATION_ERROR_SAMPLE_SIZE;
     }
 
     const invalidated = checkpointInvalidated || outcome.checkpointRejected || (await isInvalidated?.() ?? false);
@@ -702,5 +712,5 @@ const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarR
   }
 };
 
-export { executeRemoteOperations, syncCalendar };
+export { executeRemoteOperations, syncCalendar, OPERATION_ERROR_SAMPLE_SIZE };
 export type { CalendarSyncProvider, PendingChanges, SyncCalendarOptions };

--- a/packages/calendar/tests/core/sync-engine/index.test.ts
+++ b/packages/calendar/tests/core/sync-engine/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { executeRemoteOperations } from "../../../src/core/sync-engine/index";
+import { executeRemoteOperations, OPERATION_ERROR_SAMPLE_SIZE } from "../../../src/core/sync-engine/index";
 import type {
   DeleteResult,
   MaterializedSyncableEvent,
@@ -893,6 +893,65 @@ describe("syncCalendar", () => {
     expect(emittedEvents).toHaveLength(1);
     expect(emittedEvents[0]?.["outcome"]).toBe("in-sync");
     expect(emittedEvents[0]?.["flushed"]).toBe(false);
+  });
+
+  it("caps operation_errors on the wide event and reports the uncapped total", async () => {
+    const { syncCalendar } = await import("../../../src/core/sync-engine/index");
+    const failingEventCount = 60;
+    const localEvents = Array.from({ length: failingEventCount }, (_unused, index) =>
+      makeEvent(`ev-${index}`, new Date("2026-03-15T09:00:00Z"), new Date("2026-03-15T10:00:00Z")));
+    const provider = makeProvider({
+      pushEvents: (events) => Promise.resolve(events.map(() => ({
+        success: false as const,
+        error: "provider rejected the push",
+      }))),
+    });
+
+    const emittedEvents: Record<string, unknown>[] = [];
+
+    await syncCalendar({
+      userId: "user-1",
+      calendarId: "dest-cal-1",
+      reconciliationScope: TEST_RECONCILIATION_SCOPE,
+      provider,
+      readState: () => Promise.resolve({ localEvents, existingMappings: [], remoteEvents: [] }),
+      isCurrent: () => Promise.resolve(true),
+      flush: () => Promise.resolve(),
+      onSyncEvent: (event) => { emittedEvents.push(event); },
+    });
+
+    const [event] = emittedEvents;
+    expect(event?.["events.add_failed"]).toBe(failingEventCount);
+    expect(event?.["operation_errors.count"]).toBe(failingEventCount);
+    expect(Array.isArray(event?.["operation_errors"])).toBe(true);
+    expect(event?.["operation_errors"]).toHaveLength(OPERATION_ERROR_SAMPLE_SIZE);
+    expect(event?.["operation_errors.truncated"]).toBe(true);
+  });
+
+  it("leaves operation_errors untruncated when the sample size is not exceeded", async () => {
+    const { syncCalendar } = await import("../../../src/core/sync-engine/index");
+    const localEvent = makeEvent("ev-1", new Date("2026-03-15T09:00:00Z"), new Date("2026-03-15T10:00:00Z"));
+    const provider = makeProvider({
+      pushEvents: () => Promise.resolve([{ success: false, error: "provider rejected the push" }]),
+    });
+
+    const emittedEvents: Record<string, unknown>[] = [];
+
+    await syncCalendar({
+      userId: "user-1",
+      calendarId: "dest-cal-1",
+      reconciliationScope: TEST_RECONCILIATION_SCOPE,
+      provider,
+      readState: () => Promise.resolve({ localEvents: [localEvent], existingMappings: [], remoteEvents: [] }),
+      isCurrent: () => Promise.resolve(true),
+      flush: () => Promise.resolve(),
+      onSyncEvent: (event) => { emittedEvents.push(event); },
+    });
+
+    const [event] = emittedEvents;
+    expect(event?.["operation_errors"]).toHaveLength(1);
+    expect(event?.["operation_errors.count"]).toBe(1);
+    expect(event?.["operation_errors.truncated"]).toBe(false);
   });
 
   it("emits a wide event with error details when sync throws", async () => {

--- a/packages/sync/src/sync-user.ts
+++ b/packages/sync/src/sync-user.ts
@@ -279,6 +279,14 @@ const haveSourceCalendarsChanged = (
   );
 };
 
+/*
+ * Every series a calendar withholds for exceeding the occurrence budget lands in this
+ * list, so a pathological source can push thousands of UIDs onto one log line. The
+ * adjacent over_budget_series_count still carries the uncapped total, which is what
+ * makes a truncated sample safe to read.
+ */
+const OVER_BUDGET_SERIES_UID_SAMPLE_SIZE = 20;
+
 const createDestinationReconciliationWideEventFields = (
   context: DestinationReconciliationContext,
 ): Record<string, string | number | boolean> => ({
@@ -288,7 +296,9 @@ const createDestinationReconciliationWideEventFields = (
   "local_event_states.missing_source_event_uid_count": context.eventReadDiagnostics.missingSourceEventUidCount,
   "local_event_states.outside_reconciliation_window_count": context.eventReadDiagnostics.outsideReconciliationWindowCount,
   "local_event_states.over_budget_series_count": context.eventReadDiagnostics.overBudgetSourceEventUids.length,
-  "local_event_states.over_budget_series_uids": context.eventReadDiagnostics.overBudgetSourceEventUids.join(","),
+  "local_event_states.over_budget_series_uids": context.eventReadDiagnostics.overBudgetSourceEventUids
+    .slice(0, OVER_BUDGET_SERIES_UID_SAMPLE_SIZE)
+    .join(","),
   "local_event_states.syncable_count": context.eventReadDiagnostics.syncableEventCount,
   "reconciliation.local_read.duration_ms": context.localReadDurationMs,
   "reconciliation.remote_read.duration_ms": context.remoteReadDurationMs,
@@ -727,6 +737,7 @@ const syncDestinationsForUser = async (
 
 export {
   createDestinationReconciliationWideEventFields,
+  OVER_BUDGET_SERIES_UID_SAMPLE_SIZE,
   readDestinationReconciliationState,
   resolveStoredSourceCoverage,
   syncDestinationsForUser,

--- a/packages/sync/tests/sync-user.test.ts
+++ b/packages/sync/tests/sync-user.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createDestinationReconciliationWideEventFields,
+  OVER_BUDGET_SERIES_UID_SAMPLE_SIZE,
   readDestinationReconciliationState,
   resolveStoredSourceCoverage,
 } from "../src/sync-user";
@@ -127,6 +128,36 @@ describe("createDestinationReconciliationWideEventFields", () => {
       "reconciliation.window.requested_time_max": "2028-07-18T00:00:00.000Z",
       "reconciliation.window.requested_time_min": "2026-07-11T00:00:00.000Z",
     });
+  });
+
+  it("caps the over-budget series UID list while still reporting the uncapped count", () => {
+    const overBudgetCount = 40;
+    const fields = createDestinationReconciliationWideEventFields({
+      eventReadDiagnostics: {
+        ...eventReadDiagnostics,
+        overBudgetSourceEventUids: Array.from(
+          { length: overBudgetCount },
+          (_unused, index) => `pathological-series-${index}`,
+        ),
+      },
+      localReadDurationMs: 1,
+      authoritativeWindow: null,
+      requestedWindow: {
+        timeMax: new Date("2028-07-18T00:00:00.000Z"),
+        timeMin: new Date("2026-07-11T00:00:00.000Z"),
+      },
+      remoteReadDurationMs: 2,
+      sourceCalendarIdsAtLocalRead: ["source-1"],
+      sourceCalendarIdsBeforeRemoteRead: ["source-1"],
+      verifiedSourceCalendarCount: 1,
+    });
+
+    expect(overBudgetCount).toBeGreaterThan(OVER_BUDGET_SERIES_UID_SAMPLE_SIZE);
+
+    const uids = String(fields["local_event_states.over_budget_series_uids"]).split(",");
+    expect(uids).toHaveLength(OVER_BUDGET_SERIES_UID_SAMPLE_SIZE);
+    expect(uids.at(-1)).toBe(`pathological-series-${OVER_BUDGET_SERIES_UID_SAMPLE_SIZE - 1}`);
+    expect(fields["local_event_states.over_budget_series_count"]).toBe(overBudgetCount);
   });
 
   it("detects a same-sized source mapping replacement without depending on query order", () => {


### PR DESCRIPTION
`operation_errors` was assigned the whole error array, so a run whose provider rejects everything emitted one log line carrying up to ~2500 objects; `local_event_states.over_budget_series_uids` had the same unbounded shape. Both are now sampled to the first 20 with the uncapped total reported alongside, matching the sampling already used for CalDAV missing hrefs and worker error samples. Volume was never the problem — one wide event per run — so a sample plus a count keeps the line diagnosable without the size.

- `operation_errors` truncated to 20, with new `operation_errors.count` and `operation_errors.truncated` fields
- `over_budget_series_uids` truncated to 20; the existing `over_budget_series_count` already carried the true total
- Both counts propagate to the worker wide event automatically via `applySyncEventFields`
- Regression tests in `sync-engine/index.test.ts` and `sync-user.test.ts`, both confirmed failing before the cap

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTqvCoAV7hZzybpqV6cSj3