### PR TITLE
perf(calendar): skip recurring series whose UNTIL precedes the window

### DIFF
--- a/packages/calendar/src/core/events/recurrence-materializer.ts
+++ b/packages/calendar/src/core/events/recurrence-materializer.ts
@@ -151,6 +151,24 @@ const fromRecurrenceWallTime = (date: Date, timeZone: string | undefined): Date 
   return wallTimeToInstant(date, timeZone);
 };
 
+/*
+ * `until` is the only termination a rule states up front. `count` also terminates, but
+ * finding its last occurrence means walking the series, which is the work being avoided.
+ * Both sides move into the wall-time space the expansion runs in, so this answers exactly
+ * what `RRule.between(recurrenceWindowStart, ...)` would, without timezone skew.
+ */
+const isSeriesExhaustedBeforeWindow = (
+  rule: IcsRecurrenceRule,
+  recurrenceWindowStart: Date,
+  timeZone: string | undefined,
+): boolean => {
+  if (!rule.until) {
+    return false;
+  }
+
+  return toRecurrenceWallTime(rule.until.date, timeZone) < recurrenceWindowStart;
+};
+
 const FREQUENCIES: Record<IcsRecurrenceRule["frequency"], Frequency> = {
   DAILY: RRule.DAILY,
   HOURLY: RRule.HOURLY,
@@ -361,6 +379,9 @@ const materializeMaster = (
     new Date(window.start.getTime() - Math.max(durationForWindowLookback, 0)),
     timeZone,
   );
+  if (isSeriesExhaustedBeforeWindow(master.recurrenceRule, recurrenceWindowStart, timeZone)) {
+    return [];
+  }
   assertUnfilteredHighFrequencyRuleWithinBudget(
     master,
     recurrenceStart,

--- a/packages/calendar/tests/core/events/recurrence-materializer.test.ts
+++ b/packages/calendar/tests/core/events/recurrence-materializer.test.ts
@@ -17,6 +17,8 @@ const WINDOW = {
   start: new Date("2026-01-01T00:00:00.000Z"),
 };
 
+const EXPIRED_SERIES_BUDGET_MS = 50;
+
 const createEvent = (overrides: Partial<SyncableEvent> = {}): SyncableEvent => ({
   calendarId: "calendar-1",
   calendarName: "Primary",
@@ -622,6 +624,110 @@ describe("materializeRecurrenceEvents", () => {
         endTime: new Date("2020-01-01T00:00:00.500Z"),
         recurrenceRule: { count: 20_000, frequency: "SECONDLY" },
         startTime: new Date("2020-01-01T00:00:00.000Z"),
+      }),
+    ], WINDOW);
+
+    expect(result).toEqual([]);
+  });
+
+  it("does not walk a pathological series whose UNTIL precedes the window", () => {
+    const expired = createEvent({
+      endTime: new Date("2019-01-01T09:05:00.000Z"),
+      recurrenceRule: {
+        byDay: [{ day: "MO" }, { day: "TU" }, { day: "WE" }, { day: "TH" }, { day: "FR" }],
+        frequency: "MINUTELY",
+        until: { date: new Date("2021-01-01T00:00:00.000Z"), type: "DATE-TIME" },
+      },
+      sourceEventUid: "expired-minutely-series",
+      startTime: new Date("2019-01-01T09:00:00.000Z"),
+    });
+
+    const readStarted = performance.now();
+    const result = materializeRecurrenceEvents([expired], WINDOW);
+    const readElapsed = performance.now() - readStarted;
+
+    const source: SourceEvent = {
+      endTime: expired.endTime,
+      recurrenceRule: expired.recurrenceRule,
+      sourceEventId: expired.id,
+      startTime: expired.startTime,
+      uid: expired.sourceEventUid,
+    };
+    const scanStarted = performance.now();
+    const overBudget = findSourceEventsExceedingRecurrenceBudget(
+      "source-calendar-id",
+      [source],
+      WINDOW,
+    );
+    const scanElapsed = performance.now() - scanStarted;
+
+    expect(result).toEqual([]);
+    expect(overBudget).toEqual([]);
+    expect(readElapsed).toBeLessThan(EXPIRED_SERIES_BUDGET_MS);
+    expect(scanElapsed).toBeLessThan(EXPIRED_SERIES_BUDGET_MS);
+  });
+
+  it("keeps an override inside the window when its master's rule has already expired", () => {
+    const expiredMaster = createEvent({
+      recurrenceRule: {
+        frequency: "WEEKLY",
+        until: { date: new Date("2025-06-01T09:00:00.000Z"), type: "DATE-TIME" },
+      },
+      sourceEventUid: "expired-weekly-series",
+    });
+    const override = createEvent({
+      endTime: new Date("2026-01-15T15:00:00.000Z"),
+      id: "override-row-1",
+      recurrenceId: new Date("2025-05-05T09:00:00.000Z"),
+      sourceEventUid: "expired-weekly-series",
+      startTime: new Date("2026-01-15T14:00:00.000Z"),
+      summary: "Moved into the window",
+    });
+
+    const result = materializeRecurrenceEvents([expiredMaster, override], WINDOW);
+
+    expect(semanticOccurrences(result)).toEqual([
+      "override-row-1|2026-01-15T14:00:00.000Z|2026-01-15T15:00:00.000Z|Moved into the window",
+    ]);
+  });
+
+  it("materializes an occurrence that starts before the window and ends inside it", () => {
+    const result = materializeRecurrenceEvents([
+      createEvent({
+        endTime: new Date("2025-12-21T01:00:00.000Z"),
+        recurrenceRule: {
+          frequency: "DAILY",
+          until: { date: new Date("2025-12-31T23:00:00.000Z"), type: "DATE-TIME" },
+        },
+        startTime: new Date("2025-12-20T23:00:00.000Z"),
+      }),
+    ], WINDOW);
+
+    expect(occurrenceStarts(result)).toEqual(["2025-12-31T23:00:00.000Z"]);
+  });
+
+  it("compares a zoned UNTIL in the same wall time the expansion runs in", () => {
+    const result = materializeRecurrenceEvents([
+      createEvent({
+        endTime: new Date("2025-12-28T01:00:00.000Z"),
+        recurrenceRule: {
+          frequency: "DAILY",
+          until: { date: new Date("2026-01-01T01:00:00.000Z"), type: "DATE-TIME" },
+        },
+        startTime: new Date("2025-12-28T00:00:00.000Z"),
+        startTimeZone: "Pacific/Kiritimati",
+      }),
+    ], WINDOW);
+
+    expect(occurrenceStarts(result)).toEqual(["2026-01-01T00:00:00.000Z"]);
+  });
+
+  it("still expands a COUNT-bounded series that ran out before the window", () => {
+    const result = materializeRecurrenceEvents([
+      createEvent({
+        endTime: new Date("2025-01-06T10:00:00.000Z"),
+        recurrenceRule: { count: 4, frequency: "WEEKLY" },
+        startTime: new Date("2025-01-06T09:00:00.000Z"),
       }),
     ], WINDOW);
 


### PR DESCRIPTION
Series whose `UNTIL` has already passed are stored permanently since #452 and re-expanded on every destination read and every ingest budget scan, producing nothing each time. Both paths run through `materializeMaster`, so one predicate there serves both. On my machine an expired `MINUTELY;BYDAY` series went from ~1030ms (read) / ~1100ms (scan) to under 0.01ms, and a plain expired daily from ~1.8ms to under 0.01ms.

- Output is unchanged: an expired series already materialised zero occurrences, so this only skips the walk that produced them.
- `COUNT`-bounded rules are deliberately not skipped — finding their last occurrence means walking the series, which is the work being avoided.
- `until` and the window start are compared in the same wall-time space the expansion runs in, against `recurrenceWindowStart` (which carries the duration lookback) rather than `window.start`, so a zoned `UNTIL` and a boundary occurrence that starts before the window and ends inside it both survive.
- Overrides are untouched: a `RECURRENCE-ID` row inside the window is still emitted when its master's rule has expired.
- Filtered in code, not SQL: `recurrence_rule` is JSON text, the duration lookback is unbounded (a long `DURATION` can push the effective start arbitrarily far back, so no fixed SQL margin is safe), and a `::jsonb` cast would fail the whole read on one malformed row instead of raising a per-event parse error.

Regression tests cover all of the above. The timing test fails at ~1630ms against unfixed code; the boundary and zoned-`UNTIL` tests each fail against a naive predicate (comparing to `window.start`, or comparing raw `until` without the wall-time conversion).

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTqvCoAV7hZzybpqV6cSj3