### PR TITLE
fix(api): record configured sync ranges for on-demand ICS ingest

### DIFF
--- a/packages/calendar/src/core/sync/required-source-ranges.ts
+++ b/packages/calendar/src/core/sync/required-source-ranges.ts
@@ -1,10 +1,14 @@
+import { syncRangeSchema, type SyncRange } from "@keeper.sh/data-schemas";
 import {
   DEFAULT_FUTURE_SYNC_RANGE,
   DEFAULT_HISTORIC_SYNC_RANGE,
   getWiderSyncRange,
-} from "@keeper.sh/calendar";
-import { syncRangeSchema } from "@keeper.sh/data-schemas";
-import type { RequiredSourceRanges } from "./oauth-ingestion-state";
+} from "./sync-range";
+
+interface RequiredSourceRanges {
+  futureRange: SyncRange;
+  historicRange: SyncRange;
+}
 
 interface StoredDestinationRanges {
   syncFutureRange: string;
@@ -36,4 +40,4 @@ const createRequiredSourceRanges = (
 };
 
 export { BASE_SOURCE_SYNC_RANGES, createRequiredSourceRanges };
-export type { StoredDestinationRanges };
+export type { RequiredSourceRanges, StoredDestinationRanges };

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -134,6 +134,12 @@ export {
   type SyncWindow,
 } from "./core/sync/sync-range";
 export {
+  BASE_SOURCE_SYNC_RANGES,
+  createRequiredSourceRanges,
+  type RequiredSourceRanges,
+  type StoredDestinationRanges,
+} from "./core/sync/required-source-ranges";
+export {
   type DestinationSyncResult,
   type SyncProgressUpdate,
   type SyncStage,

--- a/packages/calendar/tests/core/sync/required-source-ranges.test.ts
+++ b/packages/calendar/tests/core/sync/required-source-ranges.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   BASE_SOURCE_SYNC_RANGES,
   createRequiredSourceRanges,
-} from "../../src/utils/source-ingestion-ranges";
+} from "../../../src/core/sync/required-source-ranges";
 
 describe("createRequiredSourceRanges", () => {
   it("does not let a narrow destination prune the shared source baseline", () => {

--- a/services/api/src/utils/source-ingestion-ranges.ts
+++ b/services/api/src/utils/source-ingestion-ranges.ts
@@ -1,0 +1,37 @@
+import { calendarsTable, sourceDestinationMappingsTable } from "@keeper.sh/database/schema";
+import { createRequiredSourceRanges, createSourceIngestionPlan } from "@keeper.sh/calendar";
+import type { SourceIngestionPlan, StoredDestinationRanges } from "@keeper.sh/calendar";
+import { and, arrayContains, eq } from "drizzle-orm";
+import type { KeeperDatabase } from "@/types";
+
+type DestinationRangesReader = (sourceCalendarId: string) => Promise<StoredDestinationRanges[]>;
+
+const createDestinationRangesReader = (
+  database: KeeperDatabase,
+): DestinationRangesReader => (sourceCalendarId) => database
+  .select({
+    syncFutureRange: calendarsTable.syncFutureRange,
+    syncHistoricRange: calendarsTable.syncHistoricRange,
+  })
+  .from(sourceDestinationMappingsTable)
+  .innerJoin(
+    calendarsTable,
+    eq(sourceDestinationMappingsTable.destinationCalendarId, calendarsTable.id),
+  )
+  .where(and(
+    eq(sourceDestinationMappingsTable.sourceCalendarId, sourceCalendarId),
+    eq(calendarsTable.disabled, false),
+    arrayContains(calendarsTable.capabilities, ["push"]),
+  ));
+
+const buildSourceIngestionPlan = async (
+  sourceCalendarId: string,
+  readDestinationRanges: DestinationRangesReader,
+  now: Date = new Date(),
+): Promise<SourceIngestionPlan> => {
+  const ranges = createRequiredSourceRanges(await readDestinationRanges(sourceCalendarId));
+  return createSourceIngestionPlan(ranges.historicRange, ranges.futureRange, now);
+};
+
+export { buildSourceIngestionPlan, createDestinationRangesReader };
+export type { DestinationRangesReader };

--- a/services/api/src/utils/sources.ts
+++ b/services/api/src/utils/sources.ts
@@ -10,9 +10,6 @@ import {
   ingestSource,
   insertEventStatesWithConflictResolution,
   withSourceIngestLock,
-  createSourceIngestionPlan,
-  DEFAULT_FUTURE_SYNC_RANGE,
-  DEFAULT_HISTORIC_SYNC_RANGE,
 } from "@keeper.sh/calendar";
 import type { IngestionPersistenceWork } from "@keeper.sh/calendar";
 import { and, count, eq, inArray, sql } from "drizzle-orm";
@@ -24,6 +21,10 @@ import {
   runCreateSource,
 } from "./source-lifecycle";
 import { applySourceSyncDefaults } from "./source-sync-defaults";
+import {
+  buildSourceIngestionPlan,
+  createDestinationRangesReader,
+} from "./source-ingestion-ranges";
 import { safeFetchOptions } from "./safe-fetch-options";
 
 import { spawnBackgroundJob } from "./background-task";
@@ -33,6 +34,7 @@ import { createSyncLock } from "@keeper.sh/sync";
 const USER_ACCOUNT_LOCK_NAMESPACE = 9002;
 const SOURCE_INGEST_LOCK_KEY_PREFIX = "source-ingest:";
 const sourceIngestLock = createSyncLock(redis);
+const destinationRangesReader = createDestinationRangesReader(database);
 
 const FIRST_RESULT_LIMIT = 1;
 const ICAL_CALENDAR_TYPE = "ical";
@@ -111,10 +113,7 @@ const ingestIcsSource = async (source: Source): Promise<void> => {
     calendarId: source.id,
     url: source.url,
     database,
-    plan: createSourceIngestionPlan(
-      DEFAULT_HISTORIC_SYNC_RANGE,
-      DEFAULT_FUTURE_SYNC_RANGE,
-    ),
+    plan: await buildSourceIngestionPlan(source.id, destinationRangesReader),
     safeFetchOptions,
   });
 

--- a/services/api/tests/utils/source-ingestion-ranges.test.ts
+++ b/services/api/tests/utils/source-ingestion-ranges.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  BASE_SOURCE_SYNC_RANGES,
+  getConfigurableSyncWindow,
+} from "@keeper.sh/calendar";
+import type { StoredDestinationRanges } from "@keeper.sh/calendar";
+import { buildSourceIngestionPlan } from "../../src/utils/source-ingestion-ranges";
+
+const SOURCE_CALENDAR_ID = "source-1";
+const NOW = new Date("2026-03-08T12:00:00.000Z");
+
+const readerFor = (
+  destinations: StoredDestinationRanges[],
+): ((sourceCalendarId: string) => Promise<StoredDestinationRanges[]>) =>
+  () => Promise.resolve(destinations);
+
+describe("buildSourceIngestionPlan", () => {
+  it("covers the widest range configured across a source's destinations", async () => {
+    const plan = await buildSourceIngestionPlan(
+      SOURCE_CALENDAR_ID,
+      readerFor([
+        { syncFutureRange: "1_month", syncHistoricRange: "12_months" },
+        { syncFutureRange: "2_years", syncHistoricRange: "3_months" },
+      ]),
+      NOW,
+    );
+
+    expect(plan.historicRange).toBe("12_months");
+    expect(plan.futureRange).toBe("2_years");
+    expect(plan.window).toEqual(getConfigurableSyncWindow("12_months", "2_years", NOW));
+  });
+
+  it("keeps the shared baseline when every destination is narrower", async () => {
+    const plan = await buildSourceIngestionPlan(
+      SOURCE_CALENDAR_ID,
+      readerFor([{ syncFutureRange: "1_week", syncHistoricRange: "1_week" }]),
+      NOW,
+    );
+
+    expect(plan.historicRange).toBe(BASE_SOURCE_SYNC_RANGES.historicRange);
+    expect(plan.futureRange).toBe(BASE_SOURCE_SYNC_RANGES.futureRange);
+  });
+
+  it("falls back to the baseline when the source has no destinations", async () => {
+    const plan = await buildSourceIngestionPlan(
+      SOURCE_CALENDAR_ID,
+      readerFor([]),
+      NOW,
+    );
+
+    expect(plan.historicRange).toBe(BASE_SOURCE_SYNC_RANGES.historicRange);
+    expect(plan.futureRange).toBe(BASE_SOURCE_SYNC_RANGES.futureRange);
+  });
+
+  it("reads the ranges for the source being ingested", async () => {
+    const requested: string[] = [];
+
+    await buildSourceIngestionPlan(
+      SOURCE_CALENDAR_ID,
+      (sourceCalendarId) => {
+        requested.push(sourceCalendarId);
+        return Promise.resolve([]);
+      },
+      NOW,
+    );
+
+    expect(requested).toEqual([SOURCE_CALENDAR_ID]);
+  });
+});

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -12,10 +12,11 @@ import {
   isTimeoutError,
   buildCalendarBackoffState,
   SOURCE_INGEST_LOCK_NAMESPACE,
+  createRequiredSourceRanges,
   createSourceIngestionPlan,
 } from "@keeper.sh/calendar";
 import { INGEST_SOURCE_TIMEOUT_MS, PROVIDER_INGEST_REQUEST_TIMEOUT_MS } from "@keeper.sh/constants";
-import type { CalendarBackoffState, IngestionFetchEventsResult, IngestionPersistenceWork, RedisRateLimiter, TokenState } from "@keeper.sh/calendar";
+import type { CalendarBackoffState, IngestionFetchEventsResult, IngestionPersistenceWork, RedisRateLimiter, RequiredSourceRanges, TokenState } from "@keeper.sh/calendar";
 import {
   createIcsSourceFetcher,
   interpretFullDayTimedEventsAsAllDay,
@@ -44,14 +45,10 @@ import { database, refreshLockRedis, refreshLockStore } from "@/context";
 import env from "@/env";
 import { safeFetchOptions } from "@/utils/safe-fetch-options";
 import { resolveMissingCalendarFailure } from "@/utils/provider-ingest-failure";
-import {
-  resolveOAuthIngestionState,
-  type RequiredSourceRanges,
-} from "@/utils/oauth-ingestion-state";
+import { resolveOAuthIngestionState } from "@/utils/oauth-ingestion-state";
 import { withAbortTimeout } from "@/utils/with-abort-timeout";
 import { createSyncLock } from "@keeper.sh/sync";
 import { enqueueDestinationSyncsForUsers } from "@/utils/enqueue-destination-syncs";
-import { createRequiredSourceRanges } from "@/utils/source-ingestion-ranges";
 import { deleteEventStatesInChunks } from "@/utils/delete-event-states";
 
 const SOURCE_TIMEOUT_MS = INGEST_SOURCE_TIMEOUT_MS;

--- a/services/cron/src/utils/oauth-ingestion-state.ts
+++ b/services/cron/src/utils/oauth-ingestion-state.ts
@@ -1,9 +1,5 @@
-import { syncRangeSchema, type SyncRange } from "@keeper.sh/data-schemas";
-
-interface RequiredSourceRanges {
-  futureRange: SyncRange;
-  historicRange: SyncRange;
-}
+import { syncRangeSchema } from "@keeper.sh/data-schemas";
+import type { RequiredSourceRanges } from "@keeper.sh/calendar";
 
 interface StoredOAuthIngestionState {
   futureRange: string;
@@ -91,4 +87,4 @@ const resolveOAuthIngestionState = (
 };
 
 export { resolveOAuthIngestionState };
-export type { OAuthIngestionState, RequiredSourceRanges, StoredOAuthIngestionState };
+export type { OAuthIngestionState, StoredOAuthIngestionState };


### PR DESCRIPTION
On-demand ICS ingest built its plan from `DEFAULT_HISTORIC_SYNC_RANGE`/`DEFAULT_FUTURE_SYNC_RANGE` while cron used the widest range configured across the source's push destinations, so the `coverage` a source recorded flapped depending on which path ran last. Both paths now derive ranges the same way, from the same helper. Closes #574.

- moves `createRequiredSourceRanges`/`BASE_SOURCE_SYNC_RANGES` out of `services/cron` into `@keeper.sh/calendar` so both services share one implementation, with its test moved alongside
- `services/api` gains `buildSourceIngestionPlan`, which reads the source's enabled push destinations and plans from the widened ranges
- regression test fails pre-fix with `expected '1_month' to be '12_months'` for a source mapped to a destination on a wider historic range

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTqvCoAV7hZzybpqV6cSj3