### PR TITLE
fix(sync): unify supersession on a preempting waiter

### DIFF
--- a/packages/sync/src/sync-lock.ts
+++ b/packages/sync/src/sync-lock.ts
@@ -9,6 +9,22 @@ const INVALIDATION_TTL_SECONDS = 300;
 const POLL_INTERVAL_MS = 250;
 const POLL_TIMEOUT_MS = 310_000;
 const MAPPING_MUTATION_LOCK_PREFIX = "mapping-mutation:";
+const BACKGROUND_HOLDER_PREFIX = "background:";
+const PREEMPTING_HOLDER_PREFIX = "preempting:";
+
+/**
+ * Supersession means "a waiter needs the holder to stop", not "a waiter exists".
+ * A routine background sync queued behind an identical run is not a reason to
+ * abandon reads already paid for; a mapping mutation is. The class rides inside
+ * the holder id because every script here compares holder ids as opaque strings.
+ * An unprefixed id from an older deployment is treated as preempting.
+ */
+type SyncLockAcquisition = "background" | "preempting";
+
+const HOLDER_PREFIXES: Record<SyncLockAcquisition, string> = {
+  background: BACKGROUND_HOLDER_PREFIX,
+  preempting: PREEMPTING_HOLDER_PREFIX,
+};
 
 interface SyncLockRedis {
   get: (key: string) => Promise<string | null>;
@@ -147,11 +163,42 @@ const CONFIRM_ACQUISITION_SCRIPT = `
   return 0
 `;
 
+/**
+ * Report whether the caller is still the current holder.
+ *
+ * KEYS[1] = lock key
+ * KEYS[2] = waiter stack key
+ * KEYS[3] = invalidation key
+ * ARGV[1] = holder ID
+ *
+ * The waiter stack is read rather than the signal key because
+ * ACQUIRE_OR_SIGNAL_SCRIPT overwrites the signal on every new waiter, so a
+ * preempting waiter is masked there as soon as a background one arrives behind it.
+ */
+const IS_CURRENT_SCRIPT = `
+  local holder = redis.call('GET', KEYS[1])
+  if holder ~= ARGV[1] then
+    return 0
+  end
+  if redis.call('GET', KEYS[3]) then
+    return 0
+  end
+  local prefix = '${BACKGROUND_HOLDER_PREFIX}'
+  local waiters = redis.call('LRANGE', KEYS[2], 0, -1)
+  for index = 1, #waiters do
+    local waiter = waiters[index]
+    if waiter ~= ARGV[1] and string.sub(waiter, 1, #prefix) ~= prefix then
+      return 0
+    end
+  end
+  return 1
+`;
+
 const createLockHandle = (
   redis: SyncLockRedis,
   calendarId: string,
   lockKey: string,
-  signalKey: string,
+  waiterKey: string,
   invalidationKey: string,
   holderId: string,
 ): SyncLockHandle => {
@@ -184,17 +231,16 @@ const createLockHandle = (
   const isCurrent = async (): Promise<boolean> => {
     throwIfRenewalFailed();
 
-    const [lockHolder, pendingWaiter, invalidated] = await Promise.all([
-      redis.get(lockKey),
-      redis.get(signalKey),
-      redis.get(invalidationKey),
-    ]);
+    const current = await redis.eval(
+      IS_CURRENT_SCRIPT,
+      3,
+      lockKey,
+      waiterKey,
+      invalidationKey,
+      holderId,
+    );
 
-    if (lockHolder !== holderId || invalidated !== null) {
-      return false;
-    }
-
-    return pendingWaiter === null;
+    return current === 1;
   };
 
   const release = async (): Promise<void> => {
@@ -205,7 +251,10 @@ const createLockHandle = (
   return { isCurrent, isHeld, release };
 };
 
-const createSyncLock = (redis: SyncLockRedis) => {
+const createSyncLock = (
+  redis: SyncLockRedis,
+  acquisition: SyncLockAcquisition = "preempting",
+) => {
   const acquire = async (
     calendarId: string,
     abortSignal?: AbortSignal,
@@ -216,7 +265,7 @@ const createSyncLock = (redis: SyncLockRedis) => {
     const waiterKey = `${WAITER_PREFIX}${calendarId}`;
     const invalidationKey = `${INVALIDATION_PREFIX}${calendarId}`;
     const blockerLockKey = `${LOCK_PREFIX}${blockerCalendarId ?? calendarId}`;
-    const holderId = crypto.randomUUID();
+    const holderId = `${HOLDER_PREFIXES[acquisition]}${crypto.randomUUID()}`;
     let checkBlocker = "0";
     if (blockerCalendarId) {
       checkBlocker = "1";
@@ -259,7 +308,7 @@ const createSyncLock = (redis: SyncLockRedis) => {
         redis,
         calendarId,
         lockKey,
-        signalKey,
+        waiterKey,
         invalidationKey,
         holderId,
       );
@@ -363,5 +412,5 @@ const isCalendarInvalidated = async (redis: SyncLockRedis, calendarId: string): 
   return value !== null;
 };
 
-export { createSyncLock, createMappingMutationLockId, invalidateCalendar, isCalendarInvalidated, SyncLockRenewalError, LOCK_PREFIX, SIGNAL_PREFIX, INVALIDATION_PREFIX, LOCK_TTL_SECONDS, LOCK_RENEW_INTERVAL_MS, INVALIDATION_TTL_SECONDS, POLL_INTERVAL_MS };
-export type { SyncLockHandle, SyncLockRedis, InvalidationRedis, AcquireSyncLockResult, SyncLockSkippedResult };
+export { createSyncLock, createMappingMutationLockId, invalidateCalendar, isCalendarInvalidated, SyncLockRenewalError, LOCK_PREFIX, SIGNAL_PREFIX, WAITER_PREFIX, INVALIDATION_PREFIX, LOCK_TTL_SECONDS, LOCK_RENEW_INTERVAL_MS, INVALIDATION_TTL_SECONDS, POLL_INTERVAL_MS, BACKGROUND_HOLDER_PREFIX };
+export type { SyncLockAcquisition, SyncLockHandle, SyncLockRedis, InvalidationRedis, AcquireSyncLockResult, SyncLockSkippedResult };

--- a/packages/sync/src/sync-user.ts
+++ b/packages/sync/src/sync-user.ts
@@ -435,7 +435,7 @@ const syncDestinationsForUser = async (
     return EMPTY_RESULT;
   }
 
-  const syncLock = createSyncLock(redis);
+  const syncLock = createSyncLock(redis, "background");
 
   let added = 0;
   let addFailed = 0;

--- a/packages/sync/tests/sync-lock.liveness.test.ts
+++ b/packages/sync/tests/sync-lock.liveness.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  BACKGROUND_HOLDER_PREFIX,
   createSyncLock,
   LOCK_PREFIX,
   LOCK_RENEW_INTERVAL_MS,
@@ -72,14 +73,31 @@ const createMockRedis = () => {
     return Promise.resolve(0);
   };
 
+  const isCurrent = (args: string[]): Promise<unknown> => {
+    const [lockKey = "", waiterKey = "", invalidationKey = "", holderId = ""] = args;
+    if (store.get(lockKey) !== holderId || store.has(invalidationKey)) {
+      return Promise.resolve(0);
+    }
+    const waiters = lists.get(waiterKey) ?? [];
+    const preempted = waiters.some((waiter) =>
+      waiter !== holderId && !waiter.startsWith(BACKGROUND_HOLDER_PREFIX));
+    if (preempted) {
+      return Promise.resolve(0);
+    }
+    return Promise.resolve(1);
+  };
+
   const evalImpl = (
-    _script: string,
+    script: string,
     keyCount: number,
     ...args: string[]
   ): Promise<unknown> => {
     const failure = pendingFailures.shift();
     if (failure) {
       return Promise.reject(failure);
+    }
+    if (script.includes("LRANGE")) {
+      return isCurrent(args);
     }
     if (keyCount === 4) {
       return acquireOrSignal(args);

--- a/packages/sync/tests/sync-lock.test.ts
+++ b/packages/sync/tests/sync-lock.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  BACKGROUND_HOLDER_PREFIX,
   createSyncLock,
   LOCK_PREFIX,
   LOCK_RENEW_INTERVAL_MS,
@@ -7,6 +8,7 @@ import {
   SyncLockRenewalError,
   SIGNAL_PREFIX,
   POLL_INTERVAL_MS,
+  WAITER_PREFIX,
 } from "../src/sync-lock";
 
 const createMockRedis = () => {
@@ -134,6 +136,23 @@ const createMockRedis = () => {
     return 1;
   };
 
+  const runIsCurrent = (args: string[]): unknown => {
+    const lockKey = args[0] ?? "";
+    const waiterKey = args[1] ?? "";
+    const invalidationKey = args[2] ?? "";
+    const holderId = args[3] ?? "";
+    if (readValue(lockKey) !== holderId || readValue(invalidationKey) !== null) {
+      return 0;
+    }
+    const waiters = lists.get(waiterKey) ?? [];
+    const preempted = waiters.some((waiter) =>
+      waiter !== holderId && !waiter.startsWith(BACKGROUND_HOLDER_PREFIX));
+    if (preempted) {
+      return 0;
+    }
+    return 1;
+  };
+
   const runRenew = (args: string[]): unknown => {
     const lockKey = args[0] ?? "";
     const holderId = args[1] ?? "";
@@ -156,13 +175,17 @@ const createMockRedis = () => {
   };
 
   const evalImpl = (
-    _script: string,
+    script: string,
     keyCount: number,
     ...args: string[]
   ): Promise<unknown> => {
     const evalFailure = evalFailures.shift();
     if (evalFailure) {
       return Promise.reject(new Error(evalFailure.message, { cause: evalFailure }));
+    }
+
+    if (script.includes("LRANGE")) {
+      return Promise.resolve(runIsCurrent(args));
     }
 
     if (keyCount === 4 && args.length === 8) {
@@ -212,6 +235,12 @@ const createMockRedis = () => {
     };
   };
 
+  const pushWaiter = (waiterKey: string, holderId: string): void => {
+    const waiters = (lists.get(waiterKey) ?? []).filter((waiter) => waiter !== holderId);
+    waiters.unshift(holderId);
+    lists.set(waiterKey, waiters);
+  };
+
   return {
     abortDuringNextAcquisition,
     deferNextConfirmation,
@@ -219,6 +248,7 @@ const createMockRedis = () => {
     set,
     del,
     eval: evalImpl,
+    pushWaiter,
     rejectNextEval,
   };
 };
@@ -233,6 +263,12 @@ describe("createSyncLock", () => {
   const makeSyncLock = () => {
     const redis = createMockRedis();
     const syncLock = createSyncLock(redis);
+    return { redis, syncLock };
+  };
+
+  const makeBackgroundSyncLock = () => {
+    const redis = createMockRedis();
+    const syncLock = createSyncLock(redis, "background");
     return { redis, syncLock };
   };
 
@@ -396,11 +432,89 @@ describe("createSyncLock", () => {
         throw new Error("expected acquired");
       }
 
-      // Simulate a second caller setting the signal key
-      redis.set(`${SIGNAL_PREFIX}cal-1`, "waiter-id");
+      // Simulate a second caller queueing behind the holder
+      redis.pushWaiter(`${WAITER_PREFIX}cal-1`, "waiter-id");
 
       const current = await firstResult.handle.isCurrent();
       expect(current).toBe(false);
+    });
+
+    it("stays current while another background sync waits behind it", async () => {
+      const { syncLock } = makeBackgroundSyncLock();
+      const firstResult = await syncLock.acquire("cal-1");
+
+      if (!firstResult.acquired) {
+        throw new Error("expected acquired");
+      }
+
+      const secondPromise = syncLock.acquire("cal-1");
+      await flushAsync();
+
+      expect(await firstResult.handle.isCurrent()).toBe(true);
+
+      await firstResult.handle.release();
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      const secondResult = await secondPromise;
+      expect(secondResult.acquired).toBe(true);
+      if (secondResult.acquired) {
+        await secondResult.handle.release();
+      }
+    });
+
+    it("stops being current once a mapping mutation queues behind it", async () => {
+      const { redis, syncLock } = makeBackgroundSyncLock();
+      const mutationLock = createSyncLock(redis);
+      const firstResult = await syncLock.acquire("cal-1");
+
+      if (!firstResult.acquired) {
+        throw new Error("expected acquired");
+      }
+
+      expect(await firstResult.handle.isCurrent()).toBe(true);
+
+      const mutationPromise = mutationLock.acquire("cal-1");
+      await flushAsync();
+
+      expect(await firstResult.handle.isCurrent()).toBe(false);
+
+      await firstResult.handle.release();
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      const mutationResult = await mutationPromise;
+      expect(mutationResult.acquired).toBe(true);
+      if (mutationResult.acquired) {
+        await mutationResult.handle.release();
+      }
+    });
+
+    it("treats an unprefixed waiter from an older deployment as preempting", async () => {
+      const { redis, syncLock } = makeBackgroundSyncLock();
+      const firstResult = await syncLock.acquire("cal-1");
+
+      if (!firstResult.acquired) {
+        throw new Error("expected acquired");
+      }
+
+      redis.pushWaiter(`${WAITER_PREFIX}cal-1`, "1f1a2b3c-legacy-holder-id");
+
+      expect(await firstResult.handle.isCurrent()).toBe(false);
+      await firstResult.handle.release();
+    });
+
+    it("reads the waiter list so a later background waiter cannot mask a preempting one", async () => {
+      const { redis, syncLock } = makeBackgroundSyncLock();
+      const firstResult = await syncLock.acquire("cal-1");
+
+      if (!firstResult.acquired) {
+        throw new Error("expected acquired");
+      }
+
+      const maskingWaiter = `${BACKGROUND_HOLDER_PREFIX}later-waiter`;
+      redis.pushWaiter(`${WAITER_PREFIX}cal-1`, "preempting:mapping-mutation");
+      redis.pushWaiter(`${WAITER_PREFIX}cal-1`, maskingWaiter);
+      redis.set(`${SIGNAL_PREFIX}cal-1`, maskingWaiter);
+
+      expect(await firstResult.handle.isCurrent()).toBe(false);
+      await firstResult.handle.release();
     });
 
     it("returns false when the holder no longer owns the lock key", async () => {
@@ -439,7 +553,7 @@ describe("createSyncLock", () => {
         throw new Error("expected acquired");
       }
 
-      redis.set(`${SIGNAL_PREFIX}cal-1`, "waiter-id");
+      redis.pushWaiter(`${WAITER_PREFIX}cal-1`, "waiter-id");
 
       expect(await result.handle.isHeld()).toBe(true);
       expect(await result.handle.isCurrent()).toBe(false);
@@ -692,8 +806,8 @@ describe("createSyncLock", () => {
         throw new Error("expected acquired");
       }
 
-      // Signal only cal-1
-      redis.set(`${SIGNAL_PREFIX}cal-1`, "waiter");
+      // Queue a waiter on cal-1 only
+      redis.pushWaiter(`${WAITER_PREFIX}cal-1`, "waiter");
 
       // Cal-1 should be superseded
       expect(await resultA.handle.isCurrent()).toBe(false);


### PR DESCRIPTION
`isCurrent()` treated any queued waiter as supersession, so a routine background destination sync queueing behind an identical run made the holder abandon reads it had already paid for. Holder ids now carry their acquisition class and only a non-background waiter supersedes, which leaves a mapping mutation as the one thing that preempts a running sync. The worker's cross-id `cancelJob` path — the other half of this issue — was already retired by #452, so the lock is now the single mechanism.

- `createSyncLock(redis, "background")` at the `sync-user.ts` destination loop; every other caller keeps today's preempting semantics by default
- the current-holder check moves into a Lua script that reads the waiter LIST, because `ACQUIRE_OR_SIGNAL_SCRIPT` overwrites the signal key on each new waiter and masks a preempting one behind it
- unprefixed holder ids from an older deployment count as preempting, so a mixed-version rollout degrades to current behaviour; no key renames, TTL changes or migration
- new tests cover the background-waiter case (red before this change), mapping-mutation preemption, the legacy unprefixed waiter, and the signal-key masking case

Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTqvCoAV7hZzybpqV6cSj3