### PR TITLE
fix: stop Google deletes doubling and hiding rate-limit usage

### DIFF
--- a/packages/calendar/src/core/sync/operations.ts
+++ b/packages/calendar/src/core/sync/operations.ts
@@ -381,9 +381,22 @@ const buildRemoveOperationsForMappings = (mappings: EventMapping[]): SyncOperati
     uid: mapping.destinationEventUid,
   }));
 
+/*
+ * A mapping written before delete identifiers were recorded stores the iCalUID, which
+ * Google's delete endpoint does not accept: the destination provider spends a second
+ * batch request resolving that UID back to an event id, doubling the rate-limit cost
+ * of the delete. Reconciliation has just listed the remote copy, so its provider id is
+ * already in hand and the lookup is only needed when no remote copy was matched.
+ */
+const resolveMappingDeleteId = (
+  mapping: EventMapping,
+  remoteEventsByMappingId: ReadonlyMap<string, RemoteEvent>,
+): string => remoteEventsByMappingId.get(mapping.id)?.deleteId ?? mapping.deleteIdentifier;
+
 const buildReplacementOperations = (
   mappings: EventMapping[],
   localEventsById: Map<string, MaterializedSyncableEvent>,
+  remoteEventsByMappingId: ReadonlyMap<string, RemoteEvent>,
 ): SyncOperation[] => {
   const operations: SyncOperation[] = [];
   for (const mapping of mappings) {
@@ -392,7 +405,7 @@ const buildReplacementOperations = (
       continue;
     }
     operations.push({
-      deleteId: mapping.deleteIdentifier,
+      deleteId: resolveMappingDeleteId(mapping, remoteEventsByMappingId),
       event,
       staleMappingId: mapping.id,
       type: "replace",
@@ -430,6 +443,7 @@ const buildRemoveOperations = (
   remoteEvents: RemoteEvent[],
   localEventIds: Set<string>,
   mappedRemoteIdentities: Set<string>,
+  remoteEventsByMappingId: ReadonlyMap<string, RemoteEvent>,
   scope: ReconciliationScope,
 ): SyncOperation[] => {
   const operations: SyncOperation[] = [];
@@ -467,7 +481,7 @@ const buildRemoveOperations = (
         && !localEventIds.has(getMappingSyncEventId(mapping))
     ) {
       operations.push({
-        deleteId: mapping.deleteIdentifier,
+        deleteId: resolveMappingDeleteId(mapping, remoteEventsByMappingId),
         startTime: mapping.startTime,
         type: "remove",
         uid: mapping.destinationEventUid,
@@ -613,12 +627,16 @@ const computeSyncOperations = (
     .filter((operation) => operation.type !== "add"
       || !replacedEventIds.has(operation.event.id)
         && !reassignedEventIds.has(operation.event.id));
-  const replacementOperations = buildReplacementOperations(staleRemoteMappings, localEventsById);
+  const replacementOperations = buildReplacementOperations(
+    staleRemoteMappings,
+    localEventsById,
+    remoteEventsByMappingId,
+  );
   const reassignmentOperations: SyncOperation[] = remoteReassignments.map(({
     event,
     mapping,
   }) => ({
-    deleteId: mapping.deleteIdentifier,
+    deleteId: resolveMappingDeleteId(mapping, remoteEventsByMappingId),
     event,
     staleMappingId: mapping.id,
     type: "replace",
@@ -630,6 +648,7 @@ const computeSyncOperations = (
     remoteEvents,
     localEventIds,
     mappedRemoteIdentities,
+    remoteEventsByMappingId,
     scope,
   );
 

--- a/packages/calendar/src/core/utils/redis-rate-limiter.ts
+++ b/packages/calendar/src/core/utils/redis-rate-limiter.ts
@@ -1,3 +1,8 @@
+import {
+  GOOGLE_PUSH_REQUESTS_PER_MINUTE,
+  GOOGLE_REQUESTS_PER_MINUTE,
+} from "@keeper.sh/constants";
+
 const MS_PER_MINUTE = 60_000;
 const RETRY_POLL_MS = 100;
 
@@ -106,5 +111,33 @@ const createRedisRateLimiter = (
   return { acquire };
 };
 
-export { createRedisRateLimiter };
-export type { RedisRateLimiter, RedisRateLimiterConfig, RedisScriptClient };
+type GoogleRateLimitLane = "ingest" | "push";
+
+const GOOGLE_LANE_REQUESTS_PER_MINUTE: Record<GoogleRateLimitLane, number> = {
+  ingest: GOOGLE_REQUESTS_PER_MINUTE,
+  push: GOOGLE_PUSH_REQUESTS_PER_MINUTE,
+};
+
+/*
+ * One key for both lanes: Google's quota is per user however it is spent, so separate
+ * keys would let the two jobs together sail past the real limit. The lanes differ only
+ * in how much of that shared key each may claim, which reserves headroom for ingestion
+ * without raising the total.
+ */
+const createGoogleUserRateLimiter = (
+  redis: RedisScriptClient,
+  userId: string,
+  lane: GoogleRateLimitLane,
+): RedisRateLimiter => createRedisRateLimiter(
+  redis,
+  `ratelimit:${userId}:google`,
+  { requestsPerMinute: GOOGLE_LANE_REQUESTS_PER_MINUTE[lane] },
+);
+
+export { createGoogleUserRateLimiter, createRedisRateLimiter };
+export type {
+  GoogleRateLimitLane,
+  RedisRateLimiter,
+  RedisRateLimiterConfig,
+  RedisScriptClient,
+};

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -50,7 +50,7 @@ export {
   wallTimeToInstant,
 } from "./ics/utils/timezone-instant";
 export { RateLimiter, type RateLimiterConfig } from "./core/utils/rate-limiter";
-export { createRedisRateLimiter, type RedisRateLimiter, type RedisRateLimiterConfig } from "./core/utils/redis-rate-limiter";
+export { createGoogleUserRateLimiter, createRedisRateLimiter, type RedisRateLimiter, type RedisRateLimiterConfig } from "./core/utils/redis-rate-limiter";
 export { allSettledWithConcurrency, type AllSettledWithConcurrencyOptions } from "./core/utils/concurrency";
 export { getErrorMessage } from "./core/utils/error";
 export {

--- a/packages/calendar/src/providers/google/shared/batch.ts
+++ b/packages/calendar/src/providers/google/shared/batch.ts
@@ -226,13 +226,23 @@ class GoogleBatchApiError extends Error {
   }
 }
 
+/*
+ * Quota is acquired inside the retried operation rather than around it: a whole-batch
+ * 429 re-sends every sub-request, and Google charges its per-user quota for each of
+ * those attempts. Acquiring once outside would let a batch that retries five times
+ * spend six times the slots the limiter believes it handed out.
+ */
 const executeBatch = (
   subRequests: BatchSubRequest[],
   accessToken: string,
-  options?: { signal?: AbortSignal; timeoutMs?: number },
+  options?: { rateLimiter?: RedisRateLimiter; signal?: AbortSignal; timeoutMs?: number },
 ): Promise<BatchSubResponse[]> =>
   withBackoff(
     async () => {
+      if (options?.rateLimiter) {
+        await options.rateLimiter.acquire(subRequests.length, options.signal);
+      }
+
       const boundary = generateBoundary();
       const requestBody = buildBatchRequestBody(subRequests, boundary);
 
@@ -308,10 +318,8 @@ const retryRateLimitedSubRequests = async (
     await abortableSleep(computeDelay(attempt), options?.signal);
 
     const retryBatch = pending.map((entry) => entry.request);
-    if (options?.rateLimiter) {
-      await options.rateLimiter.acquire(retryBatch.length, options.signal);
-    }
     const responses = await executeBatch(retryBatch, accessToken, {
+      rateLimiter: options?.rateLimiter,
       signal: options?.signal,
       timeoutMs: options?.timeoutMs,
     });
@@ -354,10 +362,8 @@ const executeBatchChunked = async (
   const allResponses: BatchSubResponse[] = [];
 
   for (const chunk of chunks) {
-    if (options?.rateLimiter) {
-      await options.rateLimiter.acquire(chunk.length, options.signal);
-    }
     const responses = await executeBatch(chunk, accessToken, {
+      rateLimiter: options?.rateLimiter,
       signal: options?.signal,
       timeoutMs: options?.timeoutMs,
     });

--- a/packages/calendar/tests/core/sync/operations.test.ts
+++ b/packages/calendar/tests/core/sync/operations.test.ts
@@ -110,6 +110,7 @@ const buildRemoveOperations = (
   remoteEvents,
   localEventIds,
   mappedRemoteIdentities,
+  matchRemoteEventsToMappings(mappings, remoteEvents),
   toReconciliationScope(boundary),
 );
 
@@ -269,6 +270,56 @@ describe("buildRemoveOperations", () => {
 });
 
 describe("computeSyncOperations", () => {
+  it("removes a legacy uid mapping by the provider event id already listed remotely", () => {
+    const mapping = createEventMapping({
+      deleteIdentifier: "legacy-uid@google.com",
+      destinationEventUid: "legacy-uid@google.com",
+    });
+    const remoteEvent = createRemoteEvent({
+      deleteId: "google-event-id",
+      endTime: mapping.endTime,
+      isKeeperEvent: true,
+      startTime: mapping.startTime,
+      uid: mapping.destinationEventUid,
+    });
+
+    const { operations } = computeSyncOperations([], [mapping], [remoteEvent]);
+
+    expect(operations).toEqual([
+      {
+        deleteId: "google-event-id",
+        startTime: mapping.startTime,
+        type: "remove",
+        uid: "legacy-uid@google.com",
+      },
+    ]);
+  });
+
+  it("replaces a legacy uid mapping by the provider event id already listed remotely", () => {
+    const event = createLocalEvent({});
+    const mapping = createEventMapping({
+      deleteIdentifier: "legacy-uid@google.com",
+      destinationEventUid: "legacy-uid@google.com",
+      syncEventHash: createSyncEventContentHash(event),
+    });
+    const remoteEvent = createRemoteEvent({
+      deleteId: "google-event-id",
+      endTime: new Date("2026-03-08T16:00:00.000Z"),
+      isKeeperEvent: true,
+      startTime: new Date("2026-03-08T15:00:00.000Z"),
+      uid: mapping.destinationEventUid,
+    });
+
+    const { operations } = computeSyncOperations([event], [mapping], [remoteEvent]);
+
+    expect(operations).toHaveLength(1);
+    expect(operations[0]).toMatchObject({
+      deleteId: "google-event-id",
+      type: "replace",
+      uid: "legacy-uid@google.com",
+    });
+  });
+
   it("keeps a matching mapped far-future event without requiring an orphan marker", () => {
     const event = createLocalEvent({
       endTime: new Date("2040-03-15T10:00:00.000Z"),
@@ -737,7 +788,7 @@ describe("computeSyncOperations", () => {
       },
     ]);
     expect(result.operations).toEqual([{
-      deleteId: "legacy-1@keeper.sh",
+      deleteId: "google-provider-id-1",
       startTime: removedSlot.startTime,
       type: "remove",
       uid: "legacy-1@keeper.sh",
@@ -777,7 +828,7 @@ describe("computeSyncOperations", () => {
       occurrenceReassigned: 1,
     });
     expect(result.operations).toEqual([{
-      deleteId: mapping.deleteIdentifier,
+      deleteId: remoteEvent.deleteId,
       event,
       staleMappingId: mapping.id,
       type: "replace",

--- a/packages/calendar/tests/core/utils/redis-rate-limiter.test.ts
+++ b/packages/calendar/tests/core/utils/redis-rate-limiter.test.ts
@@ -1,5 +1,9 @@
+import { GOOGLE_REQUESTS_PER_MINUTE } from "@keeper.sh/constants";
 import { describe, expect, it, vi } from "vitest";
-import { createRedisRateLimiter } from "../../../src/core/utils/redis-rate-limiter";
+import {
+  createGoogleUserRateLimiter,
+  createRedisRateLimiter,
+} from "../../../src/core/utils/redis-rate-limiter";
 
 describe("createRedisRateLimiter", () => {
   it("returns immediately when Redis grants capacity", async () => {
@@ -24,5 +28,31 @@ describe("createRedisRateLimiter", () => {
 
     await expect(result).rejects.toThrow("source deadline exceeded");
     expect(redis.eval).toHaveBeenCalledOnce();
+  });
+});
+
+describe("createGoogleUserRateLimiter", () => {
+  const acquireArguments = async (lane: "ingest" | "push"): Promise<string[]> => {
+    const redis = { eval: vi.fn(() => Promise.resolve(0)) };
+    await createGoogleUserRateLimiter(redis, "user-id", lane).acquire(1);
+    return vi.mocked(redis.eval).mock.calls[0]?.slice(2) as string[];
+  };
+
+  it("meters both lanes against one key so the per-user quota is never doubled", async () => {
+    const [ingestKey] = await acquireArguments("ingest");
+    const [pushKey] = await acquireArguments("push");
+
+    expect(ingestKey).toBe("ratelimit:user-id:google");
+    expect(pushKey).toBe(ingestKey);
+  });
+
+  it("caps destination push below the quota so ingestion keeps reserved headroom", async () => {
+    const ingestArguments = await acquireArguments("ingest");
+    const pushArguments = await acquireArguments("push");
+    const ingestLimit = Number(ingestArguments.at(-1));
+    const pushLimit = Number(pushArguments.at(-1));
+
+    expect(ingestLimit).toBe(GOOGLE_REQUESTS_PER_MINUTE);
+    expect(pushLimit).toBeLessThan(GOOGLE_REQUESTS_PER_MINUTE);
   });
 });

--- a/packages/calendar/tests/providers/google/shared/batch.test.ts
+++ b/packages/calendar/tests/providers/google/shared/batch.test.ts
@@ -257,4 +257,56 @@ describe("executeBatchChunked", () => {
       { rateLimiter, signal: controller.signal },
     )).rejects.toBe(abortReason);
   });
+
+  it("acquires quota for every batch attempt when the whole batch is rate limited", async () => {
+    const acquired: number[] = [];
+    const rateLimiter = {
+      acquire: (count: number): Promise<void> => {
+        acquired.push(count);
+        return Promise.resolve();
+      },
+    };
+
+    const successBody = [
+      "--response_boundary",
+      "Content-Type: application/http",
+      "Content-ID: <response-item-0>",
+      "",
+      "HTTP/1.1 204 No Content",
+      "Content-Type: application/json",
+      "",
+      "{}",
+      "--response_boundary--",
+    ].join("\r\n");
+
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = Object.assign((): Promise<Response> => {
+      calls++;
+      if (calls === 1) {
+        return Promise.resolve(Response.json(
+          { error: { code: 429, message: "rateLimitExceeded" } },
+          { status: 429 },
+        ));
+      }
+      return Promise.resolve(new Response(successBody, {
+        headers: { "Content-Type": "multipart/mixed; boundary=response_boundary" },
+        status: 200,
+      }));
+    }, { preconnect: originalFetch.preconnect });
+
+    try {
+      const responses = await executeBatchChunked(
+        [{ method: "DELETE", path: "/calendar/v3/calendars/primary/events/abc" }],
+        "access-token",
+        { rateLimiter },
+      );
+      expect(responses[0]?.statusCode).toBe(204);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls).toBe(2);
+    expect(acquired).toEqual([1, 1]);
+  });
 });

--- a/packages/constants/src/constants/rate-limits.ts
+++ b/packages/constants/src/constants/rate-limits.ts
@@ -1,0 +1,11 @@
+/*
+ * Google enforces one per-user quota across every job that touches the account, so the
+ * ceiling below is the whole budget rather than a per-job allowance. Destination push
+ * is deliberately capped under that ceiling: a large drain and a full re-ingest run
+ * concurrently, and an uncapped drain would spend the minute before ingestion could
+ * claim any of it.
+ */
+const GOOGLE_REQUESTS_PER_MINUTE = 500;
+const GOOGLE_PUSH_REQUESTS_PER_MINUTE = 350;
+
+export { GOOGLE_PUSH_REQUESTS_PER_MINUTE, GOOGLE_REQUESTS_PER_MINUTE };

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./constants/time";
 export * from "./constants/http";
 export * from "./constants/scopes";
+export * from "./constants/rate-limits";

--- a/packages/sync/src/sync-user.ts
+++ b/packages/sync/src/sync-user.ts
@@ -3,7 +3,7 @@ import {
   getEventsForCalendarsWithDiagnostics,
   getEventMappingsForDestination,
   createDatabaseFlush,
-  createRedisRateLimiter,
+  createGoogleUserRateLimiter,
   buildCalendarBackoffState,
   RESET_CALENDAR_BACKOFF_STATE,
   createSyncWindow,
@@ -39,8 +39,6 @@ import {
   isCalendarInvalidated,
   type SyncLockHandle,
 } from "./sync-lock";
-
-const GOOGLE_REQUESTS_PER_MINUTE = 500;
 
 const resetDestinationBackoff = async (
   database: BunSQLDatabase,
@@ -444,11 +442,7 @@ const syncDestinationsForUser = async (
   const errors: string[] = [];
   const syncEvents: Record<string, unknown>[] = [];
 
-  const rateLimiter = createRedisRateLimiter(
-    redis,
-    `ratelimit:${userId}:google`,
-    { requestsPerMinute: GOOGLE_REQUESTS_PER_MINUTE },
-  );
+  const rateLimiter = createGoogleUserRateLimiter(redis, userId, "push");
 
   for (const destinationCandidate of destinations) {
     if (config.abortSignal?.aborted) {

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -7,7 +7,7 @@ import {
   createGoogleTokenRefresher,
   createMicrosoftTokenRefresher,
   createCoordinatedRefresher,
-  createRedisRateLimiter,
+  createGoogleUserRateLimiter,
   ensureValidToken,
   isTimeoutError,
   buildCalendarBackoffState,
@@ -157,7 +157,6 @@ const resolveIngestErrorSlug = (error: unknown): string => {
   widelog.set("timeout.limit_ms", PROVIDER_INGEST_REQUEST_TIMEOUT_MS);
   return "provider-request-timeout";
 };
-const GOOGLE_REQUESTS_PER_MINUTE = 500;
 
 const createIngestionPersistenceTransaction = (
   calendarId: string,
@@ -303,11 +302,7 @@ const resolveRateLimiter = (provider: string, userId: string): RedisRateLimiter 
     return;
   }
 
-  return createRedisRateLimiter(
-    refreshLockRedis,
-    `ratelimit:${userId}:google`,
-    { requestsPerMinute: GOOGLE_REQUESTS_PER_MINUTE },
-  );
+  return createGoogleUserRateLimiter(refreshLockRedis, userId, "ingest");
 };
 
 const getRequiredSourceRanges = async (


### PR DESCRIPTION
Legacy mappings store an iCalUID as their delete identifier, which Google's delete endpoint won't take, so the destination provider spent an extra `iCalUID` find-batch per delete — even though reconciliation had just listed the remote copy and knew its provider event id. Separately, `executeBatch` wrapped its rate-limit acquisition outside `withBackoff`, so a whole-batch 429 could re-send every sub-request up to six times against a single acquisition. Closes #576.

- `computeSyncOperations` now emits remove/replace operations using the matched remote event's `deleteId`, so legacy deletes cost one quota unit instead of two.
- Quota is acquired inside the retried batch operation, making every real HTTP attempt metered exactly once; `retryRateLimitedSubRequests` no longer acquires separately.
- Push and cron ingestion still share `ratelimit:${userId}:google` — Google's quota is per user however it's spent — but push is capped at 350/min of the 500 so a destination drain can't starve a re-ingest. Total ceiling is unchanged.
- Effective per-user request ceiling: up to ~3000/min in the pathological retry case before, 500/min after.