### PR TITLE
fix(api): bound the published iCal feed to its configured horizon

### DIFF
--- a/packages/calendar/src/core/sync/sync-range.ts
+++ b/packages/calendar/src/core/sync/sync-range.ts
@@ -126,6 +126,7 @@ export {
   createSourceIngestionPlan,
   getConfigurableSyncWindow,
   getStartOfToday,
+  getSyncRangeOrder,
   getWiderSyncRange,
   intersectSyncWindows,
 };

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -128,6 +128,7 @@ export {
   createSyncWindow,
   createSourceIngestionPlan,
   getConfigurableSyncWindow,
+  getSyncRangeOrder,
   getWiderSyncRange,
   intersectSyncWindows,
   type SourceIngestionPlan,

--- a/services/api/src/routes/api/cal/[identifier].ts
+++ b/services/api/src/routes/api/cal/[identifier].ts
@@ -1,25 +1,59 @@
 import { withWideEvent } from "@/utils/middleware";
 import { generateUserCalendar } from "@/utils/ical";
+import { widelog } from "@/utils/logging";
 import { ErrorResponse } from "@/utils/responses";
 
 const ICS_EXTENSION_LENGTH = 4;
+const NOT_MODIFIED_STATUS = 304;
 
-const GET = withWideEvent(async ({ params }) => {
+/*
+ * The feed is bounded only by its horizon, so a busy calendar makes a large
+ * response and serialising it is the expensive part of this route. Subscribers
+ * poll on a timer and most polls find nothing changed, so the validator is
+ * resolved from a digest first and an unchanged feed never reads an event.
+ *
+ * no-cache keeps a subscriber revalidating every time rather than showing a
+ * stale calendar, and private keeps a token-bearing URL out of shared caches.
+ */
+const CACHE_CONTROL = "private, no-cache";
+
+const GET = withWideEvent(async ({ params, request }) => {
   const { identifier } = params;
 
   if (!identifier?.endsWith(".ics")) {
     return ErrorResponse.notFound().toResponse();
   }
 
+  const startedAt = performance.now();
   const cleanIdentifier = identifier.slice(0, -ICS_EXTENSION_LENGTH);
-  const calendar = await generateUserCalendar(cleanIdentifier);
+  const feed = await generateUserCalendar(
+    cleanIdentifier,
+    request.headers.get("if-none-match"),
+  );
 
-  if (calendar === null) {
+  if (feed === null) {
     return ErrorResponse.notFound().toResponse();
   }
 
-  return new Response(calendar, {
-    headers: { "Content-Type": "text/calendar; charset=utf-8" },
+  widelog.set("feed.duration_ms", Math.round(performance.now() - startedAt));
+  widelog.set("feed.not_modified", feed.body === null);
+
+  if (feed.body === null) {
+    return new Response(null, {
+      status: NOT_MODIFIED_STATUS,
+      headers: { "Cache-Control": CACHE_CONTROL, ETag: feed.etag },
+    });
+  }
+
+  widelog.set("feed.event_count", feed.eventCount);
+  widelog.set("feed.byte_size", Buffer.byteLength(feed.body, "utf8"));
+
+  return new Response(feed.body, {
+    headers: {
+      "Cache-Control": CACHE_CONTROL,
+      "Content-Type": "text/calendar; charset=utf-8",
+      ETag: feed.etag,
+    },
   });
 });
 

--- a/services/api/src/utils/ical-feed.ts
+++ b/services/api/src/utils/ical-feed.ts
@@ -29,6 +29,7 @@ interface FeedCalendar {
 
 interface IcalFeedQuery {
   limit: number;
+  now: Date;
   windowEnd: Date;
   windowStart: Date;
 }
@@ -60,6 +61,7 @@ const createIcalFeedQuery = (
 
   return {
     limit: ICAL_FEED_EVENT_LIMIT,
+    now,
     windowEnd: window.timeMax,
     windowStart: window.timeMin,
   };

--- a/services/api/src/utils/ical-feed.ts
+++ b/services/api/src/utils/ical-feed.ts
@@ -1,23 +1,31 @@
 import {
+  DEFAULT_FUTURE_SYNC_RANGE,
+  DEFAULT_HISTORIC_SYNC_RANGE,
   getConfigurableSyncWindow,
+  getWiderSyncRange,
   parseStoredIcsExceptionDates,
   parseStoredIcsRecurrence,
 } from "@keeper.sh/calendar";
+import { syncRangeSchema } from "@keeper.sh/data-schemas";
 import type { SyncRange } from "@keeper.sh/data-schemas";
 import { formatEventsAsIcal } from "./ical-format";
 import type { CalendarEvent, FeedSettings } from "./ical-format";
 
 /**
  * A published feed is fetched whole on every poll and the ICS subscription
- * protocol has no pagination, so the response has to be bounded in place.
- * The horizon reaches a year back and two years forward, which is wider than
- * the widest configurable sync range, and the row cap keeps even a pathological
- * feed under the ~1MB that subscribers such as Google Calendar tolerate
- * (a fully detailed VEVENT measures roughly 350 bytes).
+ * protocol has no pagination, so the response has to be bounded in place. The
+ * horizon follows the widest range configured across the feed's own calendars,
+ * so it can never cut history a user deliberately asked to keep, and the row cap
+ * keeps even a pathological feed under the ~1MB that subscribers such as Google
+ * Calendar tolerate (a fully detailed VEVENT measures roughly 350 bytes).
  */
-const ICAL_FEED_HISTORIC_RANGE: SyncRange = "12_months";
-const ICAL_FEED_FUTURE_RANGE: SyncRange = "2_years";
 const ICAL_FEED_EVENT_LIMIT = 2500;
+
+interface FeedCalendar {
+  id: string;
+  syncFutureRange: string;
+  syncHistoricRange: string;
+}
 
 interface IcalFeedQuery {
   limit: number;
@@ -25,12 +33,30 @@ interface IcalFeedQuery {
   windowStart: Date;
 }
 
-const createIcalFeedQuery = (now: Date = new Date()): IcalFeedQuery => {
-  const window = getConfigurableSyncWindow(
-    ICAL_FEED_HISTORIC_RANGE,
-    ICAL_FEED_FUTURE_RANGE,
-    now,
-  );
+const toSyncRange = (value: string, fallback: SyncRange): SyncRange => {
+  if (syncRangeSchema.allows(value)) {
+    return value;
+  }
+  return fallback;
+};
+
+const createIcalFeedQuery = (
+  calendars: FeedCalendar[],
+  now: Date = new Date(),
+): IcalFeedQuery => {
+  let historicRange: SyncRange = DEFAULT_HISTORIC_SYNC_RANGE;
+  let futureRange: SyncRange = DEFAULT_FUTURE_SYNC_RANGE;
+  for (const calendar of calendars) {
+    historicRange = getWiderSyncRange(
+      historicRange,
+      toSyncRange(calendar.syncHistoricRange, DEFAULT_HISTORIC_SYNC_RANGE),
+    );
+    futureRange = getWiderSyncRange(
+      futureRange,
+      toSyncRange(calendar.syncFutureRange, DEFAULT_FUTURE_SYNC_RANGE),
+    );
+  }
+  const window = getConfigurableSyncWindow(historicRange, futureRange, now);
 
   return {
     limit: ICAL_FEED_EVENT_LIMIT,
@@ -59,7 +85,7 @@ interface FeedDependencies {
   now?: Date;
   resolveUserIdentifier: (identifier: string) => Promise<string | null>;
   readFeedSettings: (userId: string) => Promise<FeedSettings | null>;
-  readFeedCalendarIds: (userId: string) => Promise<string[]>;
+  readFeedCalendars: (userId: string) => Promise<FeedCalendar[]>;
   readFeedEvents: (
     calendarIds: string[],
     query: IcalFeedQuery,
@@ -86,20 +112,20 @@ const generateCalendarFeed = async (
     return null;
   }
 
-  const [settings, calendarIds] = await Promise.all([
+  const [settings, calendars] = await Promise.all([
     dependencies.readFeedSettings(userId),
-    dependencies.readFeedCalendarIds(userId),
+    dependencies.readFeedCalendars(userId),
   ]);
 
   const feedSettings = settings ?? DEFAULT_FEED_SETTINGS;
 
-  if (calendarIds.length === 0) {
+  if (calendars.length === 0) {
     return formatEventsAsIcal([], feedSettings);
   }
 
   const rows = await dependencies.readFeedEvents(
-    calendarIds,
-    createIcalFeedQuery(dependencies.now),
+    calendars.map(({ id }) => id),
+    createIcalFeedQuery(calendars, dependencies.now),
   );
 
   return formatEventsAsIcal(rows.map((row) => toCalendarEvent(row)), feedSettings);

--- a/services/api/src/utils/ical-feed.ts
+++ b/services/api/src/utils/ical-feed.ts
@@ -1,0 +1,114 @@
+import {
+  getConfigurableSyncWindow,
+  parseStoredIcsExceptionDates,
+  parseStoredIcsRecurrence,
+} from "@keeper.sh/calendar";
+import type { SyncRange } from "@keeper.sh/data-schemas";
+import { formatEventsAsIcal } from "./ical-format";
+import type { CalendarEvent, FeedSettings } from "./ical-format";
+
+/**
+ * A published feed is fetched whole on every poll and the ICS subscription
+ * protocol has no pagination, so the response has to be bounded in place.
+ * The horizon reaches a year back and two years forward, which is wider than
+ * the widest configurable sync range, and the row cap keeps even a pathological
+ * feed under the ~1MB that subscribers such as Google Calendar tolerate
+ * (a fully detailed VEVENT measures roughly 350 bytes).
+ */
+const ICAL_FEED_HISTORIC_RANGE: SyncRange = "12_months";
+const ICAL_FEED_FUTURE_RANGE: SyncRange = "2_years";
+const ICAL_FEED_EVENT_LIMIT = 2500;
+
+interface IcalFeedQuery {
+  limit: number;
+  windowEnd: Date;
+  windowStart: Date;
+}
+
+const createIcalFeedQuery = (now: Date = new Date()): IcalFeedQuery => {
+  const window = getConfigurableSyncWindow(
+    ICAL_FEED_HISTORIC_RANGE,
+    ICAL_FEED_FUTURE_RANGE,
+    now,
+  );
+
+  return {
+    limit: ICAL_FEED_EVENT_LIMIT,
+    windowEnd: window.timeMax,
+    windowStart: window.timeMin,
+  };
+};
+
+const DEFAULT_FEED_SETTINGS: FeedSettings = {
+  includeEventName: false,
+  includeEventDescription: false,
+  includeEventLocation: false,
+  excludeAllDayEvents: false,
+  customEventName: "Busy",
+};
+
+type StoredFeedEvent = Omit<
+  CalendarEvent,
+  "exceptionDates" | "recurrenceDuration" | "recurrenceRule"
+> & {
+  exceptionDates: string | null;
+  recurrenceRule: string | null;
+};
+
+interface FeedDependencies {
+  now?: Date;
+  resolveUserIdentifier: (identifier: string) => Promise<string | null>;
+  readFeedSettings: (userId: string) => Promise<FeedSettings | null>;
+  readFeedCalendarIds: (userId: string) => Promise<string[]>;
+  readFeedEvents: (
+    calendarIds: string[],
+    query: IcalFeedQuery,
+  ) => Promise<StoredFeedEvent[]>;
+}
+
+const toCalendarEvent = (row: StoredFeedEvent): CalendarEvent => {
+  const recurrence = parseStoredIcsRecurrence(row.recurrenceRule, row.id);
+  return {
+    ...row,
+    recurrenceDuration: recurrence?.recurrenceDuration ?? null,
+    recurrenceRule: recurrence?.recurrenceRule ?? null,
+    exceptionDates: parseStoredIcsExceptionDates(row.exceptionDates, row.id),
+  };
+};
+
+const generateCalendarFeed = async (
+  identifier: string,
+  dependencies: FeedDependencies,
+): Promise<string | null> => {
+  const userId = await dependencies.resolveUserIdentifier(identifier);
+
+  if (!userId) {
+    return null;
+  }
+
+  const [settings, calendarIds] = await Promise.all([
+    dependencies.readFeedSettings(userId),
+    dependencies.readFeedCalendarIds(userId),
+  ]);
+
+  const feedSettings = settings ?? DEFAULT_FEED_SETTINGS;
+
+  if (calendarIds.length === 0) {
+    return formatEventsAsIcal([], feedSettings);
+  }
+
+  const rows = await dependencies.readFeedEvents(
+    calendarIds,
+    createIcalFeedQuery(dependencies.now),
+  );
+
+  return formatEventsAsIcal(rows.map((row) => toCalendarEvent(row)), feedSettings);
+};
+
+export {
+  DEFAULT_FEED_SETTINGS,
+  ICAL_FEED_EVENT_LIMIT,
+  createIcalFeedQuery,
+  generateCalendarFeed,
+};
+export type { FeedDependencies, IcalFeedQuery, StoredFeedEvent };

--- a/services/api/src/utils/ical-feed.ts
+++ b/services/api/src/utils/ical-feed.ts
@@ -13,14 +13,13 @@ import type { CalendarEvent, FeedSettings } from "./ical-format";
 
 /**
  * A published feed is fetched whole on every poll and the ICS subscription
- * protocol has no pagination, so the response has to be bounded in place. The
- * horizon follows the widest range configured across the feed's own calendars,
- * so it can never cut history a user deliberately asked to keep, and the row cap
- * keeps even a pathological feed under the ~1MB that subscribers such as Google
- * Calendar tolerate (a fully detailed VEVENT measures roughly 350 bytes).
+ * protocol has no pagination, so the horizon is the only thing that bounds it.
+ * That horizon follows the widest range configured across the feed's own
+ * calendars, so the feed carries exactly the events the user asked to keep. It
+ * is deliberately not capped beyond that: a cap silently drops events a
+ * subscriber is relying on, and a feed missing a meeting is worse than a large
+ * one.
  */
-const ICAL_FEED_EVENT_LIMIT = 2500;
-
 interface FeedCalendar {
   id: string;
   syncFutureRange: string;
@@ -28,8 +27,6 @@ interface FeedCalendar {
 }
 
 interface IcalFeedQuery {
-  limit: number;
-  now: Date;
   windowEnd: Date;
   windowStart: Date;
 }
@@ -60,8 +57,6 @@ const createIcalFeedQuery = (
   const window = getConfigurableSyncWindow(historicRange, futureRange, now);
 
   return {
-    limit: ICAL_FEED_EVENT_LIMIT,
-    now,
     windowEnd: window.timeMax,
     windowStart: window.timeMin,
   };
@@ -135,7 +130,6 @@ const generateCalendarFeed = async (
 
 export {
   DEFAULT_FEED_SETTINGS,
-  ICAL_FEED_EVENT_LIMIT,
   createIcalFeedQuery,
   generateCalendarFeed,
 };

--- a/services/api/src/utils/ical-feed.ts
+++ b/services/api/src/utils/ical-feed.ts
@@ -94,7 +94,40 @@ interface FeedDependencies {
     calendarIds: string[],
     query: IcalFeedQuery,
   ) => Promise<StoredFeedEvent[]>;
+  readFeedRevision: (
+    calendarIds: string[],
+    query: IcalFeedQuery,
+  ) => Promise<string>;
 }
+
+/* A null body means the caller's validator still matches and nothing was read. */
+interface FeedResponse {
+  body: string | null;
+  etag: string;
+  eventCount: number;
+}
+
+/*
+ * Settings decide what each event renders as, so two feeds over identical rows
+ * are not interchangeable. Only the fields that reach the output are folded in,
+ * keeping the validator stable when an unrelated column on the settings row
+ * changes. The field separator cannot appear in a name, so no combination of
+ * values can produce another combination's digest.
+ */
+const describeFeedSettings = (settings: FeedSettings): string => [
+  settings.includeEventName,
+  settings.includeEventDescription,
+  settings.includeEventLocation,
+  settings.excludeAllDayEvents,
+  settings.customEventName,
+].join("\u001F");
+
+const buildFeedEtag = (revision: string, settings: FeedSettings): string => {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(revision);
+  hasher.update(describeFeedSettings(settings));
+  return `"${hasher.digest("hex")}"`;
+};
 
 const toCalendarEvent = (row: StoredFeedEvent): CalendarEvent => {
   const recurrence = parseStoredIcsRecurrence(row.recurrenceRule, row.id);
@@ -109,7 +142,8 @@ const toCalendarEvent = (row: StoredFeedEvent): CalendarEvent => {
 const generateCalendarFeed = async (
   identifier: string,
   dependencies: FeedDependencies,
-): Promise<string | null> => {
+  ifNoneMatch: string | null = null,
+): Promise<FeedResponse | null> => {
   const userId = await dependencies.resolveUserIdentifier(identifier);
 
   if (!userId) {
@@ -124,15 +158,28 @@ const generateCalendarFeed = async (
   const feedSettings = settings ?? DEFAULT_FEED_SETTINGS;
 
   if (calendars.length === 0) {
-    return formatEventsAsIcal([], feedSettings);
+    const body = formatEventsAsIcal([], feedSettings);
+    return { body, etag: buildFeedEtag("", feedSettings), eventCount: 0 };
   }
 
-  const rows = await dependencies.readFeedEvents(
-    calendars.map(({ id }) => id),
-    createIcalFeedQuery(calendars, dependencies.now),
+  const calendarIds = calendars.map(({ id }) => id);
+  const query = createIcalFeedQuery(calendars, dependencies.now);
+  const etag = buildFeedEtag(
+    await dependencies.readFeedRevision(calendarIds, query),
+    feedSettings,
   );
 
-  return formatEventsAsIcal(rows.map((row) => toCalendarEvent(row)), feedSettings);
+  if (ifNoneMatch === etag) {
+    return { body: null, etag, eventCount: 0 };
+  }
+
+  const rows = await dependencies.readFeedEvents(calendarIds, query);
+
+  return {
+    body: formatEventsAsIcal(rows.map((row) => toCalendarEvent(row)), feedSettings),
+    etag,
+    eventCount: rows.length,
+  };
 };
 
 export {
@@ -140,4 +187,4 @@ export {
   createIcalFeedQuery,
   generateCalendarFeed,
 };
-export type { FeedDependencies, IcalFeedQuery, StoredFeedEvent };
+export type { FeedDependencies, FeedResponse, IcalFeedQuery, StoredFeedEvent };

--- a/services/api/src/utils/ical-feed.ts
+++ b/services/api/src/utils/ical-feed.ts
@@ -2,7 +2,7 @@ import {
   DEFAULT_FUTURE_SYNC_RANGE,
   DEFAULT_HISTORIC_SYNC_RANGE,
   getConfigurableSyncWindow,
-  getWiderSyncRange,
+  getSyncRangeOrder,
   parseStoredIcsExceptionDates,
   parseStoredIcsRecurrence,
 } from "@keeper.sh/calendar";
@@ -31,30 +31,37 @@ interface IcalFeedQuery {
   windowStart: Date;
 }
 
-const toSyncRange = (value: string, fallback: SyncRange): SyncRange => {
-  if (syncRangeSchema.allows(value)) {
-    return value;
+const parseSyncRange = (value: string, calendarId: string): SyncRange => {
+  if (!syncRangeSchema.allows(value)) {
+    throw new Error(`Calendar ${calendarId} stores an unknown sync range "${value}"`);
   }
-  return fallback;
+  return value;
 };
+
+/*
+ * The floor is the product default rather than a fallback: a feed is never
+ * narrower than that, however its calendars are configured.
+ */
+const widestSyncRange = (floor: SyncRange, ranges: SyncRange[]): SyncRange =>
+  [floor, ...ranges]
+    .toSorted((first, second) => getSyncRangeOrder(second) - getSyncRangeOrder(first))
+    .at(0) ?? floor;
 
 const createIcalFeedQuery = (
   calendars: FeedCalendar[],
   now: Date = new Date(),
 ): IcalFeedQuery => {
-  let historicRange: SyncRange = DEFAULT_HISTORIC_SYNC_RANGE;
-  let futureRange: SyncRange = DEFAULT_FUTURE_SYNC_RANGE;
-  for (const calendar of calendars) {
-    historicRange = getWiderSyncRange(
-      historicRange,
-      toSyncRange(calendar.syncHistoricRange, DEFAULT_HISTORIC_SYNC_RANGE),
-    );
-    futureRange = getWiderSyncRange(
-      futureRange,
-      toSyncRange(calendar.syncFutureRange, DEFAULT_FUTURE_SYNC_RANGE),
-    );
-  }
-  const window = getConfigurableSyncWindow(historicRange, futureRange, now);
+  const window = getConfigurableSyncWindow(
+    widestSyncRange(
+      DEFAULT_HISTORIC_SYNC_RANGE,
+      calendars.map(({ id, syncHistoricRange }) => parseSyncRange(syncHistoricRange, id)),
+    ),
+    widestSyncRange(
+      DEFAULT_FUTURE_SYNC_RANGE,
+      calendars.map(({ id, syncFutureRange }) => parseSyncRange(syncFutureRange, id)),
+    ),
+    now,
+  );
 
   return {
     windowEnd: window.timeMax,

--- a/services/api/src/utils/ical.ts
+++ b/services/api/src/utils/ical.ts
@@ -1,103 +1,87 @@
 import { calendarsTable, eventStatesTable, icalFeedSettingsTable } from "@keeper.sh/database/schema";
-import {
-  parseStoredIcsExceptionDates,
-  parseStoredIcsRecurrence,
-} from "@keeper.sh/calendar";
-import { and, asc, eq, inArray, ne, or, isNull } from "drizzle-orm";
+import { and, asc, eq, gte, inArray, isNotNull, lte, ne, or, isNull } from "drizzle-orm";
 import { resolveUserIdentifier } from "./user";
 import { database } from "@/context";
-import { formatEventsAsIcal } from "./ical-format";
-import type { CalendarEvent, FeedSettings } from "./ical-format";
+import { generateCalendarFeed } from "./ical-feed";
+import type { IcalFeedQuery, StoredFeedEvent } from "./ical-feed";
+import type { FeedSettings } from "./ical-format";
 
-const DEFAULT_FEED_SETTINGS: FeedSettings = {
-  includeEventName: false,
-  includeEventDescription: false,
-  includeEventLocation: false,
-  excludeAllDayEvents: false,
-  customEventName: "Busy",
-};
+const FIRST_RESULT_LIMIT = 1;
 
-const getFeedSettings = async (userId: string): Promise<FeedSettings> => {
+const readFeedSettings = async (userId: string): Promise<FeedSettings | null> => {
   const [settings] = await database
     .select()
     .from(icalFeedSettingsTable)
     .where(eq(icalFeedSettingsTable.userId, userId))
-    .limit(1);
+    .limit(FIRST_RESULT_LIMIT);
 
-  return settings ?? DEFAULT_FEED_SETTINGS;
+  return settings ?? null;
 };
 
-const generateUserCalendar = async (identifier: string): Promise<string | null> => {
-  const userId = await resolveUserIdentifier(identifier);
-
-  if (!userId) {
-    return null;
-  }
-
-  const [settings, sources] = await Promise.all([
-    getFeedSettings(userId),
-    database
-      .select({ id: calendarsTable.id })
-      .from(calendarsTable)
-      .where(
-        and(
-          eq(calendarsTable.userId, userId),
-          eq(calendarsTable.includeInIcalFeed, true),
-        ),
-      ),
-  ]);
-
-  if (sources.length === 0) {
-    return formatEventsAsIcal([], settings);
-  }
-
-  const calendarIds = sources.map(({ id }) => id);
-  const rows = await database
-    .select({
-      calendarId: eventStatesTable.calendarId,
-      id: eventStatesTable.id,
-      title: eventStatesTable.title,
-      description: eventStatesTable.description,
-      location: eventStatesTable.location,
-      startTime: eventStatesTable.startTime,
-      endTime: eventStatesTable.endTime,
-      availability: eventStatesTable.availability,
-      startTimeZone: eventStatesTable.startTimeZone,
-      isAllDay: eventStatesTable.isAllDay,
-      recurrenceRule: eventStatesTable.recurrenceRule,
-      exceptionDates: eventStatesTable.exceptionDates,
-      recurrenceId: eventStatesTable.recurrenceId,
-      sourceEventUid: eventStatesTable.sourceEventUid,
-      calendarName: calendarsTable.name,
-    })
-    .from(eventStatesTable)
-    .innerJoin(calendarsTable, eq(eventStatesTable.calendarId, calendarsTable.id))
+const readFeedCalendarIds = async (userId: string): Promise<string[]> => {
+  const calendars = await database
+    .select({ id: calendarsTable.id })
+    .from(calendarsTable)
     .where(
       and(
-        inArray(eventStatesTable.calendarId, calendarIds),
-        or(
-          isNull(eventStatesTable.sourceEventType),
-          ne(eventStatesTable.sourceEventType, "workingLocation"),
-        ),
-        or(
-          isNull(eventStatesTable.availability),
-          ne(eventStatesTable.availability, "workingElsewhere"),
-        ),
+        eq(calendarsTable.userId, userId),
+        eq(calendarsTable.includeInIcalFeed, true),
       ),
-    )
-    .orderBy(asc(eventStatesTable.startTime));
+    );
 
-  const events: CalendarEvent[] = rows.map((row) => {
-    const recurrence = parseStoredIcsRecurrence(row.recurrenceRule, row.id);
-    return {
-      ...row,
-      recurrenceDuration: recurrence?.recurrenceDuration ?? null,
-      recurrenceRule: recurrence?.recurrenceRule ?? null,
-      exceptionDates: parseStoredIcsExceptionDates(row.exceptionDates, row.id),
-    };
-  });
-
-  return formatEventsAsIcal(events, settings);
+  return calendars.map(({ id }) => id);
 };
+
+const readFeedEvents = (
+  calendarIds: string[],
+  query: IcalFeedQuery,
+): Promise<StoredFeedEvent[]> => database
+  .select({
+    calendarId: eventStatesTable.calendarId,
+    id: eventStatesTable.id,
+    title: eventStatesTable.title,
+    description: eventStatesTable.description,
+    location: eventStatesTable.location,
+    startTime: eventStatesTable.startTime,
+    endTime: eventStatesTable.endTime,
+    availability: eventStatesTable.availability,
+    startTimeZone: eventStatesTable.startTimeZone,
+    isAllDay: eventStatesTable.isAllDay,
+    recurrenceRule: eventStatesTable.recurrenceRule,
+    exceptionDates: eventStatesTable.exceptionDates,
+    recurrenceId: eventStatesTable.recurrenceId,
+    sourceEventUid: eventStatesTable.sourceEventUid,
+    calendarName: calendarsTable.name,
+  })
+  .from(eventStatesTable)
+  .innerJoin(calendarsTable, eq(eventStatesTable.calendarId, calendarsTable.id))
+  .where(
+    and(
+      inArray(eventStatesTable.calendarId, calendarIds),
+      or(
+        isNull(eventStatesTable.sourceEventType),
+        ne(eventStatesTable.sourceEventType, "workingLocation"),
+      ),
+      or(
+        isNull(eventStatesTable.availability),
+        ne(eventStatesTable.availability, "workingElsewhere"),
+      ),
+      lte(eventStatesTable.startTime, query.windowEnd),
+      or(
+        gte(eventStatesTable.endTime, query.windowStart),
+        isNotNull(eventStatesTable.recurrenceRule),
+      ),
+    ),
+  )
+  .orderBy(asc(eventStatesTable.startTime))
+  .limit(query.limit);
+
+const generateUserCalendar = (identifier: string): Promise<string | null> =>
+  generateCalendarFeed(identifier, {
+    readFeedCalendarIds,
+    readFeedEvents,
+    readFeedSettings,
+    resolveUserIdentifier,
+  });
 
 export { generateUserCalendar };

--- a/services/api/src/utils/ical.ts
+++ b/services/api/src/utils/ical.ts
@@ -18,9 +18,13 @@ const readFeedSettings = async (userId: string): Promise<FeedSettings | null> =>
   return settings ?? null;
 };
 
-const readFeedCalendarIds = async (userId: string): Promise<string[]> => {
+const readFeedCalendars = async (userId: string) => {
   const calendars = await database
-    .select({ id: calendarsTable.id })
+    .select({
+      id: calendarsTable.id,
+      syncFutureRange: calendarsTable.syncFutureRange,
+      syncHistoricRange: calendarsTable.syncHistoricRange,
+    })
     .from(calendarsTable)
     .where(
       and(
@@ -29,7 +33,7 @@ const readFeedCalendarIds = async (userId: string): Promise<string[]> => {
       ),
     );
 
-  return calendars.map(({ id }) => id);
+  return calendars;
 };
 
 const readFeedEvents = (
@@ -78,7 +82,7 @@ const readFeedEvents = (
 
 const generateUserCalendar = (identifier: string): Promise<string | null> =>
   generateCalendarFeed(identifier, {
-    readFeedCalendarIds,
+    readFeedCalendars,
     readFeedEvents,
     readFeedSettings,
     resolveUserIdentifier,

--- a/services/api/src/utils/ical.ts
+++ b/services/api/src/utils/ical.ts
@@ -1,9 +1,10 @@
 import { calendarsTable, eventStatesTable, icalFeedSettingsTable } from "@keeper.sh/database/schema";
-import { and, asc, eq, gte, inArray, isNotNull, lte, ne, or, isNull } from "drizzle-orm";
+import { and, asc, eq, gte, inArray, isNotNull, lte, ne, or, isNull, sql } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
 import { resolveUserIdentifier } from "./user";
 import { database } from "@/context";
 import { generateCalendarFeed } from "./ical-feed";
-import type { IcalFeedQuery, StoredFeedEvent } from "./ical-feed";
+import type { FeedResponse, IcalFeedQuery, StoredFeedEvent } from "./ical-feed";
 import type { FeedSettings } from "./ical-format";
 
 const FIRST_RESULT_LIMIT = 1;
@@ -36,6 +37,28 @@ const readFeedCalendars = async (userId: string) => {
   return calendars;
 };
 
+/*
+ * The revision digest and the event read share this filter deliberately. If the
+ * two ever selected different rows the digest would stop tracking the body, and
+ * a subscriber would be handed a 304 for a feed that had in fact changed.
+ */
+const buildFeedEventFilter = (calendarIds: string[], query: IcalFeedQuery): SQL | undefined => and(
+  inArray(eventStatesTable.calendarId, calendarIds),
+  or(
+    isNull(eventStatesTable.sourceEventType),
+    ne(eventStatesTable.sourceEventType, "workingLocation"),
+  ),
+  or(
+    isNull(eventStatesTable.availability),
+    ne(eventStatesTable.availability, "workingElsewhere"),
+  ),
+  lte(eventStatesTable.startTime, query.windowEnd),
+  or(
+    gte(eventStatesTable.endTime, query.windowStart),
+    isNotNull(eventStatesTable.recurrenceRule),
+  ),
+);
+
 const readFeedEvents = (
   calendarIds: string[],
   query: IcalFeedQuery,
@@ -59,32 +82,64 @@ const readFeedEvents = (
   })
   .from(eventStatesTable)
   .innerJoin(calendarsTable, eq(eventStatesTable.calendarId, calendarsTable.id))
-  .where(
-    and(
-      inArray(eventStatesTable.calendarId, calendarIds),
-      or(
-        isNull(eventStatesTable.sourceEventType),
-        ne(eventStatesTable.sourceEventType, "workingLocation"),
-      ),
-      or(
-        isNull(eventStatesTable.availability),
-        ne(eventStatesTable.availability, "workingElsewhere"),
-      ),
-      lte(eventStatesTable.startTime, query.windowEnd),
-      or(
-        gte(eventStatesTable.endTime, query.windowStart),
-        isNotNull(eventStatesTable.recurrenceRule),
-      ),
-    ),
-  )
+  .where(buildFeedEventFilter(calendarIds, query))
   .orderBy(asc(eventStatesTable.startTime));
 
-const generateUserCalendar = (identifier: string): Promise<string | null> =>
+/*
+ * Every column that reaches the rendered feed is folded in, each coalesced to a
+ * concrete string so a null can never shift one field's value into another's
+ * position. Postgres does the hashing so an unchanged feed costs one aggregate
+ * rather than reading every row into the process and serialising it.
+ */
+const FEED_REVISION_COLUMNS = [
+  eventStatesTable.id,
+  eventStatesTable.title,
+  eventStatesTable.description,
+  eventStatesTable.location,
+  eventStatesTable.startTime,
+  eventStatesTable.endTime,
+  eventStatesTable.availability,
+  eventStatesTable.startTimeZone,
+  eventStatesTable.isAllDay,
+  eventStatesTable.recurrenceRule,
+  eventStatesTable.exceptionDates,
+  eventStatesTable.recurrenceId,
+  eventStatesTable.sourceEventUid,
+  calendarsTable.name,
+];
+
+const readFeedRevision = async (
+  calendarIds: string[],
+  query: IcalFeedQuery,
+): Promise<string> => {
+  const fields = sql.join(
+    FEED_REVISION_COLUMNS.map((column) => sql`coalesce(${column}::text, '')`),
+    sql`, `,
+  );
+
+  const [row] = await database
+    .select({
+      revision: sql<string>`encode(sha256(convert_to(coalesce(string_agg(
+        concat_ws(chr(31), ${fields}), chr(30) order by ${eventStatesTable.id}
+      ), ''), 'UTF8')), 'hex')`,
+    })
+    .from(eventStatesTable)
+    .innerJoin(calendarsTable, eq(eventStatesTable.calendarId, calendarsTable.id))
+    .where(buildFeedEventFilter(calendarIds, query));
+
+  return row?.revision ?? "";
+};
+
+const generateUserCalendar = (
+  identifier: string,
+  ifNoneMatch: string | null,
+): Promise<FeedResponse | null> =>
   generateCalendarFeed(identifier, {
     readFeedCalendars,
     readFeedEvents,
+    readFeedRevision,
     readFeedSettings,
     resolveUserIdentifier,
-  });
+  }, ifNoneMatch);
 
 export { generateUserCalendar };

--- a/services/api/src/utils/ical.ts
+++ b/services/api/src/utils/ical.ts
@@ -1,5 +1,5 @@
 import { calendarsTable, eventStatesTable, icalFeedSettingsTable } from "@keeper.sh/database/schema";
-import { and, asc, eq, gte, inArray, isNotNull, lte, ne, or, isNull } from "drizzle-orm";
+import { and, eq, gte, inArray, isNotNull, lte, ne, or, isNull, sql } from "drizzle-orm";
 import { resolveUserIdentifier } from "./user";
 import { database } from "@/context";
 import { generateCalendarFeed } from "./ical-feed";
@@ -77,7 +77,16 @@ const readFeedEvents = (
       ),
     ),
   )
-  .orderBy(asc(eventStatesTable.startTime))
+  /*
+   * The cap decides what a subscriber loses, so order by what they would miss
+   * most. Recurring rows come first because one master carries a whole series,
+   * then events nearest to now, so a calendar with more history than the cap
+   * still publishes what is coming rather than spending the budget on the past.
+   */
+  .orderBy(
+    sql`(${eventStatesTable.recurrenceRule} is not null) desc`,
+    sql`abs(extract(epoch from (${eventStatesTable.startTime} - ${query.now}::timestamp)))`,
+  )
   .limit(query.limit);
 
 const generateUserCalendar = (identifier: string): Promise<string | null> =>

--- a/services/api/src/utils/ical.ts
+++ b/services/api/src/utils/ical.ts
@@ -1,5 +1,5 @@
 import { calendarsTable, eventStatesTable, icalFeedSettingsTable } from "@keeper.sh/database/schema";
-import { and, eq, gte, inArray, isNotNull, lte, ne, or, isNull, sql } from "drizzle-orm";
+import { and, asc, eq, gte, inArray, isNotNull, lte, ne, or, isNull } from "drizzle-orm";
 import { resolveUserIdentifier } from "./user";
 import { database } from "@/context";
 import { generateCalendarFeed } from "./ical-feed";
@@ -77,17 +77,7 @@ const readFeedEvents = (
       ),
     ),
   )
-  /*
-   * The cap decides what a subscriber loses, so order by what they would miss
-   * most. Recurring rows come first because one master carries a whole series,
-   * then events nearest to now, so a calendar with more history than the cap
-   * still publishes what is coming rather than spending the budget on the past.
-   */
-  .orderBy(
-    sql`(${eventStatesTable.recurrenceRule} is not null) desc`,
-    sql`abs(extract(epoch from (${eventStatesTable.startTime} - ${query.now}::timestamp)))`,
-  )
-  .limit(query.limit);
+  .orderBy(asc(eventStatesTable.startTime));
 
 const generateUserCalendar = (identifier: string): Promise<string | null> =>
   generateCalendarFeed(identifier, {

--- a/services/api/tests/utils/ical-feed.test.ts
+++ b/services/api/tests/utils/ical-feed.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  ICAL_FEED_EVENT_LIMIT,
-  createIcalFeedQuery,
-  generateCalendarFeed,
-} from "../../src/utils/ical-feed";
+import { createIcalFeedQuery, generateCalendarFeed } from "../../src/utils/ical-feed";
 import type { IcalFeedQuery, StoredFeedEvent } from "../../src/utils/ical-feed";
 
 const NOW = new Date("2026-08-12T12:00:00.000Z");
@@ -41,15 +37,9 @@ const createReader = (events: StoredFeedEvent[]) =>
     const withinWindow = events.filter((event) =>
       event.startTime <= query.windowEnd
       && (event.endTime >= query.windowStart || event.recurrenceRule !== null));
-    const relevance = (event: StoredFeedEvent): number => {
-      if (event.recurrenceRule !== null) {
-        return -1;
-      }
-      return Math.abs(event.startTime.getTime() - query.now.getTime());
-    };
     const ordered = withinWindow.toSorted((first, second) =>
-      relevance(first) - relevance(second));
-    return Promise.resolve(ordered.slice(0, query.limit));
+      first.startTime.getTime() - second.startTime.getTime());
+    return Promise.resolve(ordered);
   };
 
 const feedFor = (events: StoredFeedEvent[]): Promise<string | null> =>
@@ -75,7 +65,6 @@ describe("createIcalFeedQuery", () => {
 
     expect(query.windowStart.getTime()).toBeLessThan(NOW.getTime());
     expect(query.windowEnd.getTime()).toBeGreaterThan(shiftDays(700).getTime());
-    expect(query.limit).toBe(ICAL_FEED_EVENT_LIMIT);
   });
 
   /*
@@ -152,30 +141,14 @@ describe("generateCalendarFeed", () => {
     expect(feed).toContain("weekly-standup");
   });
 
-  it("caps how many events a single feed response serialises", async () => {
-    const overflow = ICAL_FEED_EVENT_LIMIT + 10;
-    const events = Array.from({ length: overflow }, (_value, index) =>
-      createStoredEvent(`event-${index}`, new Date(NOW.getTime() + index * 60_000)));
-
-    const feed = await feedFor(events);
-
-    expect(feed?.split("BEGIN:VEVENT").length ?? 0).toBe(ICAL_FEED_EVENT_LIMIT + 1);
-    expect(feed).not.toContain(`event-${overflow - 1}`);
-    /*
-     * Serialising the cap's worth of events is real work — around half a second
-     * locally and ten times that on a loaded runner — so this needs more than the
-     * five second default rather than failing as a timeout.
-     */
-  }, 30_000);
-
   /*
    * The window reaches as far back as the widest configured range, so a busy
-   * calendar can hold more past events than the cap. Truncating in start order
-   * would spend the whole budget on history and publish a feed that stops before
-   * today, which is the opposite of what a subscriber needs.
+   * calendar can hold far more past events than upcoming ones. Any cap applied in
+   * start order would spend itself on history and publish a feed that stops
+   * before today, so the feed stays uncapped and this holds that line.
    */
-  it("keeps upcoming events when history alone exceeds the cap", async () => {
-    const past = Array.from({ length: ICAL_FEED_EVENT_LIMIT }, (_value, index) =>
+  it("publishes upcoming events on a calendar dominated by history", async () => {
+    const past = Array.from({ length: 5000 }, (_value, index) =>
       createStoredEvent(`past-${index}`, new Date(NOW.getTime() - (index + 1) * 60_000)));
     const upcoming = Array.from({ length: 5 }, (_value, index) =>
       createStoredEvent(`upcoming-${index}`, new Date(NOW.getTime() + (index + 1) * 60_000)));

--- a/services/api/tests/utils/ical-feed.test.ts
+++ b/services/api/tests/utils/ical-feed.test.ts
@@ -86,15 +86,17 @@ describe("createIcalFeedQuery", () => {
     expect(widest.windowStart.getTime()).toBeLessThan(shiftDays(-700).getTime());
   });
 
-  it("ignores an unrecognised stored range instead of widening on it", () => {
-    const query = createIcalFeedQuery([{
+  /*
+   * A check constraint pins the stored range to the enum, so an unrecognised
+   * value means that constraint is already broken. Substituting a default would
+   * publish a silently wrong horizon and hide it.
+   */
+  it("throws on a stored range outside the enum", () => {
+    expect(() => createIcalFeedQuery([{
       id: "calendar-1",
       syncFutureRange: "forever",
       syncHistoricRange: "9_years",
-    }], NOW);
-
-    expect(query.windowStart.getTime()).toBeGreaterThan(shiftDays(-400).getTime());
-    expect(query.windowEnd.getTime()).toBeGreaterThan(shiftDays(700).getTime());
+    }], NOW)).toThrow("calendar-1");
   });
 });
 

--- a/services/api/tests/utils/ical-feed.test.ts
+++ b/services/api/tests/utils/ical-feed.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createIcalFeedQuery, generateCalendarFeed } from "../../src/utils/ical-feed";
-import type { IcalFeedQuery, StoredFeedEvent } from "../../src/utils/ical-feed";
+import type { FeedResponse, IcalFeedQuery, StoredFeedEvent } from "../../src/utils/ical-feed";
 
 const NOW = new Date("2026-08-12T12:00:00.000Z");
 const MS_PER_DAY = 86_400_000;
@@ -42,7 +42,16 @@ const createReader = (events: StoredFeedEvent[]) =>
     return Promise.resolve(ordered);
   };
 
-const feedFor = (events: StoredFeedEvent[]): Promise<string | null> =>
+/* Stands in for the digest Postgres computes over the rows the feed would render. */
+const createRevisionReader = (events: StoredFeedEvent[]) =>
+  (_calendarIds: string[], query: IcalFeedQuery): Promise<string> =>
+    createReader(events)(_calendarIds, query).then((rows) =>
+      rows.map((row) => `${row.id}:${row.startTime.toISOString()}:${row.title ?? ""}`).join("|"));
+
+const responseFor = (
+  events: StoredFeedEvent[],
+  ifNoneMatch: string | null = null,
+): Promise<FeedResponse | null> =>
   generateCalendarFeed("feed-token", {
     now: NOW,
     readFeedCalendars: () => Promise.resolve([{
@@ -51,9 +60,15 @@ const feedFor = (events: StoredFeedEvent[]): Promise<string | null> =>
       syncHistoricRange: "1_month",
     }]),
     readFeedEvents: createReader(events),
+    readFeedRevision: createRevisionReader(events),
     readFeedSettings: () => Promise.resolve(null),
     resolveUserIdentifier: () => Promise.resolve("user-1"),
-  });
+  }, ifNoneMatch);
+
+const feedFor = async (events: StoredFeedEvent[]): Promise<string | null> => {
+  const response = await responseFor(events);
+  return response?.body ?? null;
+};
 
 describe("createIcalFeedQuery", () => {
   it("falls back to the default horizon when no calendar configures a wider one", () => {
@@ -106,6 +121,7 @@ describe("generateCalendarFeed", () => {
       now: NOW,
       readFeedCalendars: () => Promise.reject(new Error("must not be called")),
       readFeedEvents: () => Promise.reject(new Error("must not be called")),
+      readFeedRevision: () => Promise.reject(new Error("must not be called")),
       readFeedSettings: () => Promise.reject(new Error("must not be called")),
       resolveUserIdentifier: () => Promise.resolve(null),
     });
@@ -162,16 +178,45 @@ describe("generateCalendarFeed", () => {
     }
   }, 30_000);
 
+  it("skips reading events when the caller's validator still matches", async () => {
+    const events = [createStoredEvent("event-1", shiftDays(1))];
+    const { etag } = await responseFor(events) ?? {};
+
+    const unchanged = await generateCalendarFeed("feed-token", {
+      now: NOW,
+      readFeedCalendars: () => Promise.resolve([{
+        id: "calendar-1",
+        syncFutureRange: "2_years",
+        syncHistoricRange: "1_month",
+      }]),
+      readFeedEvents: () => Promise.reject(new Error("must not read events on a match")),
+      readFeedRevision: createRevisionReader(events),
+      readFeedSettings: () => Promise.resolve(null),
+      resolveUserIdentifier: () => Promise.resolve("user-1"),
+    }, etag ?? null);
+
+    expect(unchanged?.body).toBeNull();
+    expect(unchanged?.etag).toBe(etag);
+  });
+
+  it("changes the validator when an event changes", async () => {
+    const before = await responseFor([createStoredEvent("event-1", shiftDays(1))]);
+    const after = await responseFor([createStoredEvent("event-1", shiftDays(2))]);
+
+    expect(after?.etag).not.toBe(before?.etag);
+  });
+
   it("renders an empty calendar when no calendars opt into the feed", async () => {
     const feed = await generateCalendarFeed("feed-token", {
       now: NOW,
       readFeedCalendars: () => Promise.resolve([]),
       readFeedEvents: () => Promise.reject(new Error("must not be called")),
+      readFeedRevision: () => Promise.reject(new Error("must not be called")),
       readFeedSettings: () => Promise.resolve(null),
       resolveUserIdentifier: () => Promise.resolve("user-1"),
     });
 
-    expect(feed).toContain("BEGIN:VCALENDAR");
-    expect(feed).not.toContain("BEGIN:VEVENT");
+    expect(feed?.body).toContain("BEGIN:VCALENDAR");
+    expect(feed?.body).not.toContain("BEGIN:VEVENT");
   });
 });

--- a/services/api/tests/utils/ical-feed.test.ts
+++ b/services/api/tests/utils/ical-feed.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+  ICAL_FEED_EVENT_LIMIT,
+  createIcalFeedQuery,
+  generateCalendarFeed,
+} from "../../src/utils/ical-feed";
+import type { IcalFeedQuery, StoredFeedEvent } from "../../src/utils/ical-feed";
+
+const NOW = new Date("2026-08-12T12:00:00.000Z");
+const MS_PER_DAY = 86_400_000;
+
+const shiftDays = (days: number): Date => new Date(NOW.getTime() + days * MS_PER_DAY);
+
+const createStoredEvent = (
+  id: string,
+  startTime: Date,
+  overrides: Partial<StoredFeedEvent> = {},
+): StoredFeedEvent => ({
+  availability: "busy",
+  calendarId: "calendar-1",
+  calendarName: "Work",
+  description: null,
+  endTime: new Date(startTime.getTime() + 3_600_000),
+  exceptionDates: null,
+  id,
+  isAllDay: false,
+  location: null,
+  recurrenceId: null,
+  recurrenceRule: null,
+  sourceEventUid: id,
+  startTime,
+  startTimeZone: "Etc/UTC",
+  title: id,
+  ...overrides,
+});
+
+/** Stands in for the SQL the feed reader issues, so a query that fails to bound
+ *  the read produces the same oversized feed the database would return. */
+const createReader = (events: StoredFeedEvent[]) =>
+  (_calendarIds: string[], query: IcalFeedQuery): Promise<StoredFeedEvent[]> => {
+    const withinWindow = events.filter((event) =>
+      event.startTime <= query.windowEnd
+      && (event.endTime >= query.windowStart || event.recurrenceRule !== null));
+    const ordered = withinWindow.toSorted((first, second) =>
+      first.startTime.getTime() - second.startTime.getTime());
+    return Promise.resolve(ordered.slice(0, query.limit));
+  };
+
+const feedFor = (events: StoredFeedEvent[]): Promise<string | null> =>
+  generateCalendarFeed("feed-token", {
+    now: NOW,
+    readFeedCalendarIds: () => Promise.resolve(["calendar-1"]),
+    readFeedEvents: createReader(events),
+    readFeedSettings: () => Promise.resolve(null),
+    resolveUserIdentifier: () => Promise.resolve("user-1"),
+  });
+
+describe("createIcalFeedQuery", () => {
+  it("bounds the feed to a horizon that outreaches the widest sync range", () => {
+    const query = createIcalFeedQuery(NOW);
+
+    expect(query.windowStart.getTime()).toBeLessThan(NOW.getTime());
+    expect(query.windowEnd.getTime()).toBeGreaterThan(NOW.getTime());
+    expect(query.windowStart.getTime()).toBeGreaterThan(shiftDays(-400).getTime());
+    expect(query.windowEnd.getTime()).toBeGreaterThan(shiftDays(700).getTime());
+    expect(query.limit).toBe(ICAL_FEED_EVENT_LIMIT);
+  });
+});
+
+describe("generateCalendarFeed", () => {
+  it("returns null for an unknown identifier", async () => {
+    const feed = await generateCalendarFeed("feed-token", {
+      now: NOW,
+      readFeedCalendarIds: () => Promise.reject(new Error("must not be called")),
+      readFeedEvents: () => Promise.reject(new Error("must not be called")),
+      readFeedSettings: () => Promise.reject(new Error("must not be called")),
+      resolveUserIdentifier: () => Promise.resolve(null),
+    });
+
+    expect(feed).toBeNull();
+  });
+
+  it("drops events older than the feed horizon while keeping recent history", async () => {
+    const feed = await feedFor([
+      createStoredEvent("ancient", shiftDays(-1500)),
+      createStoredEvent("recent-history", shiftDays(-30)),
+    ]);
+
+    expect(feed).not.toContain("ancient");
+    expect(feed).toContain("recent-history");
+  });
+
+  it("drops events beyond the feed horizon", async () => {
+    const feed = await feedFor([
+      createStoredEvent("upcoming", shiftDays(30)),
+      createStoredEvent("distant", shiftDays(2000)),
+    ]);
+
+    expect(feed).toContain("upcoming");
+    expect(feed).not.toContain("distant");
+  });
+
+  it("keeps a long-running series whose first occurrence predates the horizon", async () => {
+    const feed = await feedFor([
+      createStoredEvent("weekly-standup", shiftDays(-1500), {
+        recurrenceRule: JSON.stringify({ frequency: "WEEKLY", interval: 1 }),
+      }),
+    ]);
+
+    expect(feed).toContain("weekly-standup");
+  });
+
+  it("caps how many events a single feed response serialises", async () => {
+    const overflow = ICAL_FEED_EVENT_LIMIT + 10;
+    const events = Array.from({ length: overflow }, (_value, index) =>
+      createStoredEvent(`event-${index}`, new Date(NOW.getTime() + index * 60_000)));
+
+    const feed = await feedFor(events);
+
+    expect(feed?.split("BEGIN:VEVENT").length ?? 0).toBe(ICAL_FEED_EVENT_LIMIT + 1);
+    expect(feed).not.toContain(`event-${overflow - 1}`);
+  });
+
+  it("renders an empty calendar when no calendars opt into the feed", async () => {
+    const feed = await generateCalendarFeed("feed-token", {
+      now: NOW,
+      readFeedCalendarIds: () => Promise.resolve([]),
+      readFeedEvents: () => Promise.reject(new Error("must not be called")),
+      readFeedSettings: () => Promise.resolve(null),
+      resolveUserIdentifier: () => Promise.resolve("user-1"),
+    });
+
+    expect(feed).toContain("BEGIN:VCALENDAR");
+    expect(feed).not.toContain("BEGIN:VEVENT");
+  });
+});

--- a/services/api/tests/utils/ical-feed.test.ts
+++ b/services/api/tests/utils/ical-feed.test.ts
@@ -41,8 +41,14 @@ const createReader = (events: StoredFeedEvent[]) =>
     const withinWindow = events.filter((event) =>
       event.startTime <= query.windowEnd
       && (event.endTime >= query.windowStart || event.recurrenceRule !== null));
+    const relevance = (event: StoredFeedEvent): number => {
+      if (event.recurrenceRule !== null) {
+        return -1;
+      }
+      return Math.abs(event.startTime.getTime() - query.now.getTime());
+    };
     const ordered = withinWindow.toSorted((first, second) =>
-      first.startTime.getTime() - second.startTime.getTime());
+      relevance(first) - relevance(second));
     return Promise.resolve(ordered.slice(0, query.limit));
   };
 
@@ -160,6 +166,25 @@ describe("generateCalendarFeed", () => {
      * locally and ten times that on a loaded runner — so this needs more than the
      * five second default rather than failing as a timeout.
      */
+  }, 30_000);
+
+  /*
+   * The window reaches as far back as the widest configured range, so a busy
+   * calendar can hold more past events than the cap. Truncating in start order
+   * would spend the whole budget on history and publish a feed that stops before
+   * today, which is the opposite of what a subscriber needs.
+   */
+  it("keeps upcoming events when history alone exceeds the cap", async () => {
+    const past = Array.from({ length: ICAL_FEED_EVENT_LIMIT }, (_value, index) =>
+      createStoredEvent(`past-${index}`, new Date(NOW.getTime() - (index + 1) * 60_000)));
+    const upcoming = Array.from({ length: 5 }, (_value, index) =>
+      createStoredEvent(`upcoming-${index}`, new Date(NOW.getTime() + (index + 1) * 60_000)));
+
+    const feed = await feedFor([...past, ...upcoming]);
+
+    for (const index of [0, 1, 2, 3, 4]) {
+      expect(feed).toContain(`upcoming-${index}`);
+    }
   }, 30_000);
 
   it("renders an empty calendar when no calendars opt into the feed", async () => {

--- a/services/api/tests/utils/ical-feed.test.ts
+++ b/services/api/tests/utils/ical-feed.test.ts
@@ -155,7 +155,12 @@ describe("generateCalendarFeed", () => {
 
     expect(feed?.split("BEGIN:VEVENT").length ?? 0).toBe(ICAL_FEED_EVENT_LIMIT + 1);
     expect(feed).not.toContain(`event-${overflow - 1}`);
-  });
+    /*
+     * Serialising the cap's worth of events is real work — around half a second
+     * locally and ten times that on a loaded runner — so this needs more than the
+     * five second default rather than failing as a timeout.
+     */
+  }, 30_000);
 
   it("renders an empty calendar when no calendars opt into the feed", async () => {
     const feed = await generateCalendarFeed("feed-token", {

--- a/services/api/tests/utils/ical-feed.test.ts
+++ b/services/api/tests/utils/ical-feed.test.ts
@@ -49,21 +49,57 @@ const createReader = (events: StoredFeedEvent[]) =>
 const feedFor = (events: StoredFeedEvent[]): Promise<string | null> =>
   generateCalendarFeed("feed-token", {
     now: NOW,
-    readFeedCalendarIds: () => Promise.resolve(["calendar-1"]),
+    readFeedCalendars: () => Promise.resolve([{
+      id: "calendar-1",
+      syncFutureRange: "2_years",
+      syncHistoricRange: "1_month",
+    }]),
     readFeedEvents: createReader(events),
     readFeedSettings: () => Promise.resolve(null),
     resolveUserIdentifier: () => Promise.resolve("user-1"),
   });
 
 describe("createIcalFeedQuery", () => {
-  it("bounds the feed to a horizon that outreaches the widest sync range", () => {
-    const query = createIcalFeedQuery(NOW);
+  it("falls back to the default horizon when no calendar configures a wider one", () => {
+    const query = createIcalFeedQuery([{
+      id: "calendar-1",
+      syncFutureRange: "2_years",
+      syncHistoricRange: "1_month",
+    }], NOW);
 
     expect(query.windowStart.getTime()).toBeLessThan(NOW.getTime());
-    expect(query.windowEnd.getTime()).toBeGreaterThan(NOW.getTime());
-    expect(query.windowStart.getTime()).toBeGreaterThan(shiftDays(-400).getTime());
     expect(query.windowEnd.getTime()).toBeGreaterThan(shiftDays(700).getTime());
     expect(query.limit).toBe(ICAL_FEED_EVENT_LIMIT);
+  });
+
+  /*
+   * A hardcoded horizon cut history the user deliberately kept: stored events
+   * reach as far back as the widest range configured on any feed calendar.
+   */
+  it("reaches back as far as the widest historic range across the feed", () => {
+    const narrow = createIcalFeedQuery([{
+      id: "calendar-1",
+      syncFutureRange: "2_years",
+      syncHistoricRange: "1_month",
+    }], NOW);
+    const widest = createIcalFeedQuery([
+      { id: "calendar-1", syncFutureRange: "2_years", syncHistoricRange: "1_month" },
+      { id: "calendar-2", syncFutureRange: "2_years", syncHistoricRange: "2_years" },
+    ], NOW);
+
+    expect(widest.windowStart.getTime()).toBeLessThan(narrow.windowStart.getTime());
+    expect(widest.windowStart.getTime()).toBeLessThan(shiftDays(-700).getTime());
+  });
+
+  it("ignores an unrecognised stored range instead of widening on it", () => {
+    const query = createIcalFeedQuery([{
+      id: "calendar-1",
+      syncFutureRange: "forever",
+      syncHistoricRange: "9_years",
+    }], NOW);
+
+    expect(query.windowStart.getTime()).toBeGreaterThan(shiftDays(-400).getTime());
+    expect(query.windowEnd.getTime()).toBeGreaterThan(shiftDays(700).getTime());
   });
 });
 
@@ -71,7 +107,7 @@ describe("generateCalendarFeed", () => {
   it("returns null for an unknown identifier", async () => {
     const feed = await generateCalendarFeed("feed-token", {
       now: NOW,
-      readFeedCalendarIds: () => Promise.reject(new Error("must not be called")),
+      readFeedCalendars: () => Promise.reject(new Error("must not be called")),
       readFeedEvents: () => Promise.reject(new Error("must not be called")),
       readFeedSettings: () => Promise.reject(new Error("must not be called")),
       resolveUserIdentifier: () => Promise.resolve(null),
@@ -124,7 +160,7 @@ describe("generateCalendarFeed", () => {
   it("renders an empty calendar when no calendars opt into the feed", async () => {
     const feed = await generateCalendarFeed("feed-token", {
       now: NOW,
-      readFeedCalendarIds: () => Promise.resolve([]),
+      readFeedCalendars: () => Promise.resolve([]),
       readFeedEvents: () => Promise.reject(new Error("must not be called")),
       readFeedSettings: () => Promise.resolve(null),
       resolveUserIdentifier: () => Promise.resolve("user-1"),


### PR DESCRIPTION
The feed selected every `event_states` row for a user's included calendars with no time filter, so response size tracked total stored history and every subscriber paid it on each poll. It is now bounded by the widest sync horizon configured across the feed's own calendars, and served against a digest validator so an unchanged poll costs almost nothing. Closes #573.

- the horizon follows the widest historic/future range configured across the feed's calendars, so it can never cut history a user deliberately asked to keep; an unrecognised stored range now throws rather than substituting a default, since a check constraint already pins that column to the enum
- rows carrying a recurrence rule bypass the lower bound, so a long-running series whose DTSTART predates the horizon still appears
- no event cap: a row count was never a bound on response size, and truncating in start order published a feed that stopped before today on any calendar holding more history than the cap
- Postgres hashes the rows the feed would render into an ETag, so an unchanged poll answers 304 without reading an event or building a string; the digest and the event read share one filter so the validator cannot drift from the body
- feed size, event count, duration and cache outcome land on the request wide event

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTqvCoAV7hZzybpqV6cSj3
