### PR TITLE
test: pin the withheld-series wiring and upper-edge mirror retirement

### DIFF
--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -122,6 +122,7 @@ export {
   type EventStateInsertClient,
 } from "./core/source/write-event-states";
 export { computeSyncOperations } from "./core/sync/operations";
+export type { ReconciliationScope } from "./core/sync/operations";
 export {
   DEFAULT_FUTURE_SYNC_RANGE,
   DEFAULT_HISTORIC_SYNC_RANGE,

--- a/packages/calendar/tests/integration/destination-sync-state-machine.test.ts
+++ b/packages/calendar/tests/integration/destination-sync-state-machine.test.ts
@@ -395,6 +395,65 @@ it("repairs Keeper orphans, retains user events, and converges", async () => {
   expect(provider.calls).toEqual({ deletes: [], pushes: [] });
 });
 
+/*
+ * Retirement past the upper edge is the counterpart to the lower-edge cleanup below.
+ * The source event is deliberately left in the local read, so only the window can
+ * explain the removal — a mirror the window no longer covers stops receiving updates
+ * and would otherwise sit at the destination as a stale copy forever.
+ */
+it("retires a mirror that falls past the sync window's upper edge and converges", async () => {
+  const eventStates = new InMemoryEventStateStore();
+  const mappings = new InMemoryMappingStore();
+  const provider = new StatefulDestinationProvider();
+  const farFutureEvent = makeSourceEvent(
+    "ordinary event",
+    new Date("2028-03-15T09:00:00.000Z"),
+    new Date("2028-03-15T10:00:00.000Z"),
+  );
+  let syncWindowEnd = new Date("2029-01-01T00:00:00.000Z");
+  const runSync = () => syncCalendar({
+    calendarId: DESTINATION_CALENDAR_ID,
+    flush: mappings.flush,
+    isCurrent: () => Promise.resolve(true),
+    provider,
+    readState: async () => ({
+      existingMappings: [...mappings.mappings.values()],
+      localEvents: eventStates.syncableEvents(),
+      remoteEvents: await provider.listRemoteEvents(),
+    }),
+    reconciliationScope: {
+      authoritativeWindow: {
+        timeMax: syncWindowEnd,
+        timeMin: new Date("2026-01-01T00:00:00.000Z"),
+      },
+      requestedWindow: {
+        timeMax: syncWindowEnd,
+        timeMin: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    },
+    userId: "user-1",
+  });
+
+  await ingest(eventStates, farFutureEvent);
+  await expect(runSync()).resolves.toMatchObject({ added: 1, removed: 0 });
+  expect(provider.remoteEvents).toHaveLength(1);
+  expect(mappings.mappings).toHaveLength(1);
+
+  syncWindowEnd = new Date("2027-01-01T00:00:00.000Z");
+  provider.resetCalls();
+
+  await expect(runSync()).resolves.toMatchObject({ added: 0, removed: 1 });
+  expect(provider.calls.deletes).toHaveLength(1);
+  expect(provider.calls.pushes).toEqual([]);
+  expect(provider.remoteEvents).toHaveLength(0);
+  expect(mappings.mappings).toHaveLength(0);
+  expect(eventStates.rows.size).toBe(1);
+
+  provider.resetCalls();
+  await expect(runSync()).resolves.toMatchObject({ added: 0, removed: 0 });
+  expect(provider.calls).toEqual({ deletes: [], pushes: [] });
+});
+
 it("migrates a legacy recurring Google mapping in place and converges", async () => {
   const occurrence: MaterializedSyncableEvent = {
     calendarId: SOURCE_CALENDAR_ID,

--- a/packages/sync/src/sync-user.ts
+++ b/packages/sync/src/sync-user.ts
@@ -18,6 +18,7 @@ import type {
   EventMapping,
   DestinationEventReadDiagnostics,
   MaterializedSyncableEvent,
+  ReconciliationScope,
   RefreshLockStore,
   RemoteEvent,
   SyncProgressUpdate,
@@ -278,6 +279,32 @@ const haveSourceCalendarsChanged = (
     (calendarId, index) => calendarId !== orderedAtLocalRead[index],
   );
 };
+
+interface DestinationReconciliationScopeContext {
+  authoritativeSourceWindows: ReadonlyMap<string, SyncWindow>;
+  authoritativeWindow: SyncWindow | null;
+  eventReadDiagnostics: DestinationEventReadDiagnostics;
+  requestedWindow: SyncWindow;
+  sourceCalendarIdsAtLocalRead: string[];
+}
+
+/*
+ * A series withheld for exceeding the occurrence budget is absent from the local read
+ * for a technical limit, not because the source dropped it. Reconciliation needs that
+ * distinction, or every mirror of the series is deleted at the provider and re-added
+ * the moment the series comes back under budget.
+ */
+const createDestinationReconciliationScope = (
+  context: DestinationReconciliationScopeContext,
+): ReconciliationScope => ({
+  authoritativeSourceWindows: context.authoritativeSourceWindows,
+  authoritativeWindow: context.authoritativeWindow,
+  configuredSourceCalendarIds: new Set(context.sourceCalendarIdsAtLocalRead),
+  requestedWindow: context.requestedWindow,
+  withheldSourceEventStateIds: new Set(
+    context.eventReadDiagnostics.overBudgetSourceEventStateIds,
+  ),
+});
 
 const createDestinationReconciliationWideEventFields = (
   context: DestinationReconciliationContext,
@@ -663,15 +690,13 @@ const syncDestinationsForUser = async (
             callbacks.onSyncEvent(enrichedEvent);
           }
         },
-        reconciliationScope: {
-          authoritativeWindow,
+        reconciliationScope: createDestinationReconciliationScope({
           authoritativeSourceWindows,
-          configuredSourceCalendarIds: new Set(sourceCalendarIdsAtLocalRead),
+          authoritativeWindow,
+          eventReadDiagnostics,
           requestedWindow,
-          withheldSourceEventStateIds: new Set(
-            eventReadDiagnostics.overBudgetSourceEventStateIds,
-          ),
-        },
+          sourceCalendarIdsAtLocalRead,
+        }),
       });
 
       callbacks?.onCalendarComplete?.({
@@ -726,6 +751,7 @@ const syncDestinationsForUser = async (
 };
 
 export {
+  createDestinationReconciliationScope,
   createDestinationReconciliationWideEventFields,
   readDestinationReconciliationState,
   resolveStoredSourceCoverage,

--- a/packages/sync/tests/sync-user.test.ts
+++ b/packages/sync/tests/sync-user.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
+import { computeSyncOperations } from "@keeper.sh/calendar";
+import type { EventMapping } from "@keeper.sh/calendar";
 import {
+  createDestinationReconciliationScope,
   createDestinationReconciliationWideEventFields,
   readDestinationReconciliationState,
   resolveStoredSourceCoverage,
@@ -165,5 +168,76 @@ describe("createDestinationReconciliationWideEventFields", () => {
 
     expect(reordered["reconciliation.source_calendars.changed_during_remote_read"]).toBe(false);
     expect(replaced["reconciliation.source_calendars.changed_during_remote_read"]).toBe(true);
+  });
+});
+
+describe("createDestinationReconciliationScope", () => {
+  const SOURCE_CALENDAR_ID = "source-1";
+  const WINDOW = {
+    timeMax: new Date("2028-01-01T00:00:00.000Z"),
+    timeMin: new Date("2026-01-01T00:00:00.000Z"),
+  };
+
+  const baseDiagnostics = {
+    candidateEventStateCount: 3,
+    excludedBySyncPolicyCount: 0,
+    materializedEventCount: 0,
+    missingSourceEventUidCount: 0,
+    outsideReconciliationWindowCount: 0,
+    overBudgetSourceEventStateIds: [] as string[],
+    overBudgetSourceEventUids: [] as string[],
+    syncableEventCount: 0,
+  };
+
+  const createScope = (overBudgetSourceEventStateIds: string[]) =>
+    createDestinationReconciliationScope({
+      authoritativeSourceWindows: new Map([[SOURCE_CALENDAR_ID, WINDOW]]),
+      authoritativeWindow: WINDOW,
+      eventReadDiagnostics: { ...baseDiagnostics, overBudgetSourceEventStateIds },
+      requestedWindow: WINDOW,
+      sourceCalendarIdsAtLocalRead: [SOURCE_CALENDAR_ID],
+    });
+
+  const occurrenceMappings: EventMapping[] = [1, 2, 3].map((index) => ({
+    calendarId: "destination-1",
+    deleteIdentifier: `delete-identifier-${index}`,
+    destinationEventUid: `destination-uid-${index}`,
+    endTime: new Date(`2026-03-0${index}T15:00:00.000Z`),
+    eventStateId: "over-budget-series",
+    id: `over-budget-mapping-${index}`,
+    sourceCalendarId: SOURCE_CALENDAR_ID,
+    startTime: new Date(`2026-03-0${index}T14:00:00.000Z`),
+    syncEventHash: `hash-${index}`,
+    syncEventId: `over-budget-series::occurrence-${index}`,
+  }));
+
+  /*
+   * The reconciliation scope is what stops a series withheld for exceeding the
+   * occurrence budget from reading as deleted at the source. Dropping or renaming
+   * the field mass-deletes every mirror of that series and mass-re-adds them once
+   * the series recovers, so the wiring is asserted through its real consumer.
+   */
+  it("withholds an over-budget series from removal when its state ids are threaded through", () => {
+    const scope = createScope(["over-budget-series"]);
+
+    expect(scope.withheldSourceEventStateIds).toEqual(new Set(["over-budget-series"]));
+    expect(computeSyncOperations([], occurrenceMappings, [], scope).operations).toEqual([]);
+  });
+
+  it("removes the same mirrors when the series was never withheld", () => {
+    const scope = createScope([]);
+
+    expect(computeSyncOperations([], occurrenceMappings, [], scope).operations).toHaveLength(
+      occurrenceMappings.length,
+    );
+  });
+
+  it("carries the remaining reconciliation boundaries onto the scope", () => {
+    const scope = createScope([]);
+
+    expect(scope.authoritativeWindow).toEqual(WINDOW);
+    expect(scope.requestedWindow).toEqual(WINDOW);
+    expect(scope.configuredSourceCalendarIds).toEqual(new Set([SOURCE_CALENDAR_ID]));
+    expect(scope.authoritativeSourceWindows).toEqual(new Map([[SOURCE_CALENDAR_ID, WINDOW]]));
   });
 });


### PR DESCRIPTION
`sync-user.ts` threaded `withheldSourceEventStateIds` into the reconciliation scope with nothing asserting it, so a rename or a dropped field would have shipped silently as a mass provider delete followed by a mass re-add once the series came back under budget. Scope construction moves into an exported `createDestinationReconciliationScope` and is asserted through its real consumer, `computeSyncOperations`, rather than as a fixture. Separately, moving the state-machine orphan from 2040 to 2028 removed the only end-to-end coverage of retirement past the window's upper edge, which is restored here.

- Deleting `withheldSourceEventStateIds` from the builder fails the new test; a control case asserts the same three mirrors are removed when the series was never withheld, so the assertion is not vacuous
- The upper-edge integration test keeps the source event in the local read, so only the window can explain the removal — it isolates the cleanup path from the missing-source path
- Verified by narrowing `outsideCleanupWindow` to the lower edge only: the new test is the sole failure across the whole state-machine file
- `ReconciliationScope` is now exported from `@keeper.sh/calendar` so the builder can name its return type

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTqvCoAV7hZzybpqV6cSj3