### PR TITLE
fix(outlook): rate limit, back off, and retry throttled destination writes (#568)

### DIFF
--- a/packages/calendar/src/core/sync-engine/index.ts
+++ b/packages/calendar/src/core/sync-engine/index.ts
@@ -1,6 +1,7 @@
 import type {
   DeleteResult,
   MaterializedSyncableEvent,
+  ProviderThrottleMetrics,
   PushResult,
   RemoteEvent,
   SyncOperation,
@@ -540,6 +541,17 @@ const appendStaleReasonFields = (
   }
 };
 
+const appendThrottleFields = (
+  event: Record<string, unknown>,
+  metrics?: ProviderThrottleMetrics,
+): void => {
+  if (!metrics || metrics.retryCount === 0) {
+    return;
+  }
+  event["provider.retry_count"] = metrics.retryCount;
+  event["provider.retry_after_ms"] = metrics.retryAfterMs;
+};
+
 const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarResult> => {
   const {
     userId,
@@ -698,6 +710,7 @@ const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarR
     throw error;
   } finally {
     wideEvent["duration_ms"] = Date.now() - startTime;
+    appendThrottleFields(wideEvent, provider.getThrottleMetrics?.());
     onSyncEvent?.(wideEvent);
   }
 };

--- a/packages/calendar/src/core/sync-engine/types.ts
+++ b/packages/calendar/src/core/sync-engine/types.ts
@@ -2,6 +2,7 @@ import type {
   DeleteResult,
   ListRemoteEventsOptions,
   MaterializedSyncableEvent,
+  ProviderThrottleMetrics,
   PushResult,
   RemoteEvent,
 } from "../types";
@@ -10,6 +11,7 @@ interface CalendarSyncProvider {
   pushEvents: (events: MaterializedSyncableEvent[]) => Promise<PushResult[]>;
   deleteEvents: (eventIds: string[]) => Promise<DeleteResult[]>;
   listRemoteEvents: (options: ListRemoteEventsOptions) => Promise<RemoteEvent[]>;
+  getThrottleMetrics?: () => ProviderThrottleMetrics;
 }
 
 interface PendingInsert {

--- a/packages/calendar/src/core/types.ts
+++ b/packages/calendar/src/core/types.ts
@@ -95,6 +95,11 @@ interface DeleteResult {
   shouldContinue?: boolean;
 }
 
+interface ProviderThrottleMetrics {
+  retryCount: number;
+  retryAfterMs: number;
+}
+
 interface SyncResult {
   added: number;
   addFailed: number;
@@ -190,6 +195,7 @@ export type {
   SourcePreferencesConfig,
   SyncableEvent,
   MaterializedSyncableEvent,
+  ProviderThrottleMetrics,
   PushResult,
   DeleteResult,
   SyncResult,

--- a/packages/calendar/src/core/utils/backoff.ts
+++ b/packages/calendar/src/core/utils/backoff.ts
@@ -44,11 +44,32 @@ const abortableSleep = (delayMs: number, signal?: AbortSignal): Promise<void> =>
   });
 };
 
+interface BackoffRetry {
+  attempt: number;
+  delayMs: number;
+  error: unknown;
+}
+
 interface BackoffOptions {
   maxRetries?: number;
   signal?: AbortSignal;
   shouldRetry: (error: unknown) => boolean;
+  // A provider that tells us how long to wait knows better than the exponential curve does.
+  getRetryDelayMs?: (error: unknown) => number | null;
+  onRetry?: (retry: BackoffRetry) => void;
 }
+
+const resolveRetryDelayMs = (
+  options: BackoffOptions,
+  error: unknown,
+  attempt: number,
+): number => {
+  const providedDelayMs = options.getRetryDelayMs?.(error) ?? null;
+  if (providedDelayMs === null) {
+    return computeDelay(attempt);
+  }
+  return Math.min(providedDelayMs, MAX_BACKOFF_MS);
+};
 
 const withBackoff = async <TResult>(
   operation: () => Promise<TResult>,
@@ -64,7 +85,9 @@ const withBackoff = async <TResult>(
       if (isLastAttempt || !options.shouldRetry(error)) {
         throw error;
       }
-      await abortableSleep(computeDelay(attempt), options.signal);
+      const delayMs = resolveRetryDelayMs(options, error, attempt);
+      options.onRetry?.({ attempt, delayMs, error });
+      await abortableSleep(delayMs, options.signal);
     }
   }
 
@@ -72,4 +95,4 @@ const withBackoff = async <TResult>(
 };
 
 export { withBackoff, abortableSleep, computeDelay, DEFAULT_MAX_RETRIES };
-export type { BackoffOptions };
+export type { BackoffOptions, BackoffRetry };

--- a/packages/calendar/src/providers/google/destination/provider.ts
+++ b/packages/calendar/src/providers/google/destination/provider.ts
@@ -13,7 +13,7 @@ import { googleApiErrorSchema, googleEventListSchema } from "@keeper.sh/data-sch
 import { HTTP_STATUS, PROVIDER_PUSH_REQUEST_TIMEOUT_MS } from "@keeper.sh/constants";
 import { fetchWithTimeout } from "../../../core/utils/fetch-with-timeout";
 import { GOOGLE_CALENDAR_API, GOOGLE_CALENDAR_MAX_RESULTS, GONE_STATUS } from "../shared/api";
-import { withBackoff } from "../shared/backoff";
+import { withBackoff } from "../../../core/utils/backoff";
 import { executeBatchChunked } from "../shared/batch";
 import { isRateLimitApiError, parseGoogleApiError } from "../shared/errors";
 import type { BatchSubRequest, BatchSubResponse } from "../shared/batch";

--- a/packages/calendar/src/providers/google/shared/batch.ts
+++ b/packages/calendar/src/providers/google/shared/batch.ts
@@ -3,7 +3,7 @@ import type { RedisRateLimiter } from "../../../core/utils/redis-rate-limiter";
 import { chunkArray } from "../../../core/utils/chunk";
 import { fetchWithTimeout } from "../../../core/utils/fetch-with-timeout";
 import { GOOGLE_BATCH_API, GOOGLE_BATCH_MAX_SIZE } from "./api";
-import { withBackoff, abortableSleep, computeDelay, DEFAULT_MAX_RETRIES } from "./backoff";
+import { withBackoff, abortableSleep, computeDelay, DEFAULT_MAX_RETRIES } from "../../../core/utils/backoff";
 import { isRateLimitApiError, parseGoogleApiError, parseGoogleApiErrorFromBody } from "./errors";
 
 interface BatchSubRequest {

--- a/packages/calendar/src/providers/google/source/utils/fetch-events.ts
+++ b/packages/calendar/src/providers/google/source/utils/fetch-events.ts
@@ -15,7 +15,7 @@ import type { GoogleApiError } from "../../types";
 import { googleApiErrorSchema, googleEventListSchema } from "@keeper.sh/data-schemas";
 import { parseEventDateTime } from "../../shared/date-time";
 import { isKeeperEvent } from "../../../../core/events/identity";
-import { withBackoff } from "../../shared/backoff";
+import { withBackoff } from "../../../../core/utils/backoff";
 import { isRateLimitApiError } from "../../shared/errors";
 import { buildTimeoutSignal } from "../../../../core/utils/fetch-with-timeout";
 

--- a/packages/calendar/src/providers/outlook/destination/provider.ts
+++ b/packages/calendar/src/providers/outlook/destination/provider.ts
@@ -8,12 +8,24 @@ import type {
   DeleteResult,
   ListRemoteEventsOptions,
   MaterializedSyncableEvent,
+  ProviderThrottleMetrics,
   PushResult,
   RemoteEvent,
 } from "../../../core/types";
 import { getErrorMessage } from "../../../core/utils/error";
 import { ensureValidToken } from "../../../core/oauth/ensure-valid-token";
 import type { TokenState, TokenRefresher } from "../../../core/oauth/ensure-valid-token";
+import { withBackoff } from "../../../core/utils/backoff";
+import type { BackoffRetry } from "../../../core/utils/backoff";
+import type { RedisRateLimiter } from "../../../core/utils/redis-rate-limiter";
+import {
+  getThrottleRetryDelayMs,
+  isThrottledError,
+  isThrottleStatus,
+  OUTLOOK_MAX_THROTTLE_RETRIES,
+  OutlookThrottledError,
+  parseRetryAfterMs,
+} from "../shared/throttle";
 import { MICROSOFT_GRAPH_API, OUTLOOK_PAGE_SIZE } from "../shared/api";
 import { parseEventTime } from "../shared/date-time";
 import { serializeOutlookEvent } from "./serialize-event";
@@ -28,15 +40,37 @@ interface OutlookSyncProviderConfig {
   calendarId: string;
   userId: string;
   refreshAccessToken?: TokenRefresher;
+  rateLimiter?: RedisRateLimiter;
   signal?: AbortSignal;
 }
 
 const createCaughtFailure = (error: unknown): PushResult | DeleteResult => {
+  if (isThrottledError(error)) {
+    return {
+      error: error.message,
+      errorType: error.name,
+      statusCode: error.status,
+      success: false,
+    };
+  }
   let errorType = "UnknownError";
   if (error instanceof Error) {
     errorType = error.name;
   }
   return { error: getErrorMessage(error), errorType, success: false };
+};
+
+const readGraphErrorMessage = async (response: Response): Promise<string> => {
+  const text = await response.text();
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (microsoftApiErrorSchema.allows(parsed)) {
+      return microsoftApiErrorSchema.assert(parsed).error?.message ?? response.statusText;
+    }
+    return response.statusText;
+  } catch {
+    return response.statusText;
+  }
 };
 
 const parseRemoteAvailability = (
@@ -68,6 +102,46 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
 
   const calendarEventsUrl = `${MICROSOFT_GRAPH_API}/me/calendars/${encodeURIComponent(config.externalCalendarId)}/events`;
 
+  const throttleMetrics: ProviderThrottleMetrics = { retryAfterMs: 0, retryCount: 0 };
+
+  const recordThrottleRetry = (retry: BackoffRetry): void => {
+    throttleMetrics.retryCount += 1;
+    throttleMetrics.retryAfterMs += retry.delayMs;
+  };
+
+  const sendRequest = async (url: URL, init: RequestInit): Promise<Response> => {
+    if (config.rateLimiter) {
+      await config.rateLimiter.acquire(1, config.signal);
+    }
+
+    const response = await fetchWithTimeout(
+      url,
+      init,
+      PROVIDER_PUSH_REQUEST_TIMEOUT_MS,
+      config.signal,
+    );
+
+    if (!isThrottleStatus(response.status)) {
+      return response;
+    }
+
+    const retryAfterMs = parseRetryAfterMs(response.headers.get("Retry-After"));
+    throw new OutlookThrottledError(
+      response.status,
+      retryAfterMs,
+      await readGraphErrorMessage(response),
+    );
+  };
+
+  const sendRequestWithRetry = (url: URL, init: RequestInit): Promise<Response> =>
+    withBackoff(() => sendRequest(url, init), {
+      getRetryDelayMs: getThrottleRetryDelayMs,
+      maxRetries: OUTLOOK_MAX_THROTTLE_RETRIES,
+      onRetry: recordThrottleRetry,
+      shouldRetry: isThrottledError,
+      signal: config.signal,
+    });
+
   const pushEvents = async (events: MaterializedSyncableEvent[]): Promise<PushResult[]> => {
     await refreshIfNeeded();
     const results: PushResult[] = [];
@@ -77,17 +151,15 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
         const resource = serializeOutlookEvent(event);
         const url = new URL(calendarEventsUrl);
 
-        const response = await fetchWithTimeout(url, {
+        const response = await sendRequestWithRetry(url, {
           body: JSON.stringify(resource),
           headers: getHeaders(),
           method: "POST",
-        }, PROVIDER_PUSH_REQUEST_TIMEOUT_MS, config.signal);
+        });
 
         if (!response.ok) {
-          const body = await response.json();
-          const { error } = microsoftApiErrorSchema.assert(body);
           results.push({
-            error: error?.message ?? response.statusText,
+            error: await readGraphErrorMessage(response),
             errorType: "MicrosoftGraphHttpError",
             statusCode: response.status,
             success: false,
@@ -117,16 +189,14 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
       try {
         const url = new URL(`${MICROSOFT_GRAPH_API}/me/events/${eventId}`);
 
-        const response = await fetchWithTimeout(url, {
+        const response = await sendRequestWithRetry(url, {
           headers: { Authorization: `Bearer ${tokenState.accessToken}` },
           method: "DELETE",
-        }, PROVIDER_PUSH_REQUEST_TIMEOUT_MS, config.signal);
+        });
 
         if (!response.ok && response.status !== HTTP_STATUS.NOT_FOUND) {
-          const body = await response.json();
-          const { error } = microsoftApiErrorSchema.assert(body);
           results.push({
-            error: error?.message ?? response.statusText,
+            error: await readGraphErrorMessage(response),
             errorType: "MicrosoftGraphHttpError",
             statusCode: response.status,
             success: false,
@@ -176,18 +246,16 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
     do {
       const url = buildOutlookEventsUrl(options.timeMin, nextLink);
 
-      const response = await fetchWithTimeout(url, {
+      const response = await sendRequestWithRetry(url, {
         headers: {
           Authorization: `Bearer ${tokenState.accessToken}`,
           Prefer: `outlook.body-content-type="text"`,
         },
         method: "GET",
-      }, PROVIDER_PUSH_REQUEST_TIMEOUT_MS, config.signal);
+      });
 
       if (!response.ok) {
-        const body = await response.json();
-        const { error } = microsoftApiErrorSchema.assert(body);
-        throw new Error(error?.message ?? response.statusText);
+        throw new Error(await readGraphErrorMessage(response));
       }
 
       const body = await response.json();
@@ -228,7 +296,9 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
     return remoteEvents;
   };
 
-  return { pushEvents, deleteEvents, listRemoteEvents };
+  const getThrottleMetrics = (): ProviderThrottleMetrics => ({ ...throttleMetrics });
+
+  return { pushEvents, deleteEvents, listRemoteEvents, getThrottleMetrics };
 };
 
 export { createOutlookSyncProvider };

--- a/packages/calendar/src/providers/outlook/shared/throttle.ts
+++ b/packages/calendar/src/providers/outlook/shared/throttle.ts
@@ -1,0 +1,67 @@
+import { HTTP_STATUS } from "@keeper.sh/constants";
+
+const MAX_RETRY_AFTER_MS = 64_000;
+const OUTLOOK_MAX_THROTTLE_RETRIES = 5;
+
+/*
+ * Graph reports mailbox throttling as 429 and, for MailboxConcurrency, as 503 with a
+ * Retry-After header. Both are transient and the same occurrence succeeds on a retry.
+ */
+class OutlookThrottledError extends Error {
+  public readonly status: number;
+  public readonly retryAfterMs: number | null;
+
+  constructor(status: number, retryAfterMs: number | null, message: string) {
+    super(message);
+    this.name = "OutlookThrottledError";
+    this.status = status;
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+const isThrottleStatus = (status: number): boolean =>
+  status === HTTP_STATUS.TOO_MANY_REQUESTS || status === HTTP_STATUS.SERVICE_UNAVAILABLE;
+
+const clampRetryAfterMs = (milliseconds: number): number =>
+  Math.min(Math.max(milliseconds, 0), MAX_RETRY_AFTER_MS);
+
+const parseRetryAfterMs = (header: string | null): number | null => {
+  if (!header) {
+    return null;
+  }
+
+  const trimmed = header.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const seconds = Number(trimmed);
+  if (Number.isFinite(seconds)) {
+    return clampRetryAfterMs(seconds * 1000);
+  }
+
+  const retryAt = Date.parse(trimmed);
+  if (Number.isNaN(retryAt)) {
+    return null;
+  }
+  return clampRetryAfterMs(retryAt - Date.now());
+};
+
+const isThrottledError = (error: unknown): error is OutlookThrottledError =>
+  error instanceof OutlookThrottledError;
+
+const getThrottleRetryDelayMs = (error: unknown): number | null => {
+  if (!isThrottledError(error)) {
+    return null;
+  }
+  return error.retryAfterMs;
+};
+
+export {
+  getThrottleRetryDelayMs,
+  isThrottledError,
+  isThrottleStatus,
+  OUTLOOK_MAX_THROTTLE_RETRIES,
+  OutlookThrottledError,
+  parseRetryAfterMs,
+};

--- a/packages/calendar/tests/core/sync-engine/index.test.ts
+++ b/packages/calendar/tests/core/sync-engine/index.test.ts
@@ -792,6 +792,32 @@ describe("syncCalendar", () => {
     expect(event?.["outcome"]).toBe("success");
     expect(event?.["flushed"]).toBe(true);
     expect(typeof event?.["duration_ms"]).toBe("number");
+    expect(event?.["provider.retry_count"]).toBeUndefined();
+  });
+
+  it("emits provider throttle retries on the wide event", async () => {
+    const { syncCalendar } = await import("../../../src/core/sync-engine/index");
+    const localEvent = makeEvent("ev-1", new Date("2026-03-15T09:00:00Z"), new Date("2026-03-15T10:00:00Z"));
+    const provider = {
+      ...makeProvider({ pushEvents: () => Promise.resolve([{ success: true, remoteId: "remote-1" }]) }),
+      getThrottleMetrics: () => ({ retryAfterMs: 4200, retryCount: 3 }),
+    };
+
+    const emittedEvents: Record<string, unknown>[] = [];
+
+    await syncCalendar({
+      userId: "user-1",
+      calendarId: "dest-cal-1",
+      reconciliationScope: TEST_RECONCILIATION_SCOPE,
+      provider,
+      readState: () => Promise.resolve({ localEvents: [localEvent], existingMappings: [], remoteEvents: [] }),
+      isCurrent: () => Promise.resolve(true),
+      flush: () => Promise.resolve(),
+      onSyncEvent: (event) => { emittedEvents.push(event); },
+    });
+
+    expect(emittedEvents[0]?.["provider.retry_count"]).toBe(3);
+    expect(emittedEvents[0]?.["provider.retry_after_ms"]).toBe(4200);
   });
 
   it("emits only nonzero stale mapping reason counts", async () => {

--- a/packages/calendar/tests/core/utils/backoff.test.ts
+++ b/packages/calendar/tests/core/utils/backoff.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { withBackoff, abortableSleep, computeDelay } from "../../../../src/providers/google/shared/backoff";
+import { withBackoff, abortableSleep, computeDelay } from "../../../src/core/utils/backoff";
 
 const flushAsync = async (): Promise<void> => {
   for (let tick = 0; tick < 5; tick++) {
@@ -143,6 +143,50 @@ describe("withBackoff", () => {
     await expect(promise).rejects.toThrow("rate limited");
 
     expect(callCount).toBe(3);
+  });
+
+  it("waits the delay the provider asks for and reports each retry", async () => {
+    let callCount = 0;
+    const operation = () => {
+      callCount++;
+      if (callCount < 2) {
+        return Promise.reject(new Error("rate limited"));
+      }
+      return Promise.resolve("recovered");
+    };
+    const retries: { attempt: number; delayMs: number }[] = [];
+
+    const promise = withBackoff(operation, {
+      getRetryDelayMs: () => 250,
+      onRetry: (retry) => { retries.push({ attempt: retry.attempt, delayMs: retry.delayMs }); },
+      shouldRetry: () => true,
+    });
+
+    vi.advanceTimersByTime(250);
+    await flushAsync();
+
+    expect(await promise).toBe("recovered");
+    expect(retries).toEqual([{ attempt: 0, delayMs: 250 }]);
+  });
+
+  it("caps a provider-supplied delay at the maximum backoff", async () => {
+    const operation = vi.fn()
+      .mockRejectedValueOnce(new Error("rate limited"))
+      .mockResolvedValue("recovered");
+    const retries: number[] = [];
+
+    const promise = withBackoff(operation, {
+      getRetryDelayMs: () => 600_000,
+      onRetry: (retry) => { retries.push(retry.delayMs); },
+      shouldRetry: () => true,
+      signal: new AbortController().signal,
+    });
+
+    await flushAsync();
+    await advanceBackoff();
+
+    expect(await promise).toBe("recovered");
+    expect(retries).toEqual([64_000]);
   });
 
   it("aborts during backoff sleep when signal is triggered", async () => {

--- a/packages/calendar/tests/providers/outlook/destination/provider.test.ts
+++ b/packages/calendar/tests/providers/outlook/destination/provider.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MaterializedSyncableEvent } from "../../../../src/core/types";
 import { createOutlookSyncProvider } from "../../../../src/providers/outlook/destination/provider";
+import type { RedisRateLimiter } from "../../../../src/core/utils/redis-rate-limiter";
 import { KEEPER_CATEGORY } from "@keeper.sh/constants";
 
-const createProvider = (signal?: AbortSignal) =>
+const createProvider = (options: {
+  rateLimiter?: RedisRateLimiter;
+  signal?: AbortSignal;
+} = {}) =>
   createOutlookSyncProvider({
     accessToken: "test-token",
     refreshToken: "test-refresh",
@@ -11,8 +15,15 @@ const createProvider = (signal?: AbortSignal) =>
     externalCalendarId: "external-cal-1",
     calendarId: "cal-1",
     userId: "user-1",
-    signal,
+    rateLimiter: options.rateLimiter,
+    signal: options.signal,
   });
+
+const throttledResponse = (status: number, retryAfter: string): Response =>
+  Response.json(
+    { error: { code: "ApplicationThrottled", message: "Application is over its MailboxConcurrency limit." } },
+    { headers: { "Retry-After": retryAfter }, status },
+  );
 
 const createEvent = (): MaterializedSyncableEvent => ({
   calendarId: "source-calendar-id",
@@ -53,7 +64,7 @@ describe("createOutlookSyncProvider", () => {
   it("aborts a pending Graph event creation", async () => {
     installAbortableFetch();
     const controller = new AbortController();
-    const provider = createProvider(controller.signal);
+    const provider = createProvider({ signal: controller.signal });
     const abortError = new Error("job deadline exceeded");
 
     const pending = provider.pushEvents([createEvent()]);
@@ -82,7 +93,7 @@ describe("createOutlookSyncProvider", () => {
   it("aborts a pending Graph event deletion", async () => {
     installAbortableFetch();
     const controller = new AbortController();
-    const provider = createProvider(controller.signal);
+    const provider = createProvider({ signal: controller.signal });
     const abortError = new Error("job deadline exceeded");
 
     const pending = provider.deleteEvents(["outlook-event-id"]);
@@ -95,7 +106,7 @@ describe("createOutlookSyncProvider", () => {
   it("aborts a pending Graph event listing request", async () => {
     installAbortableFetch();
     const controller = new AbortController();
-    const provider = createProvider(controller.signal);
+    const provider = createProvider({ signal: controller.signal });
     const abortError = new Error("job deadline exceeded");
 
     const pending = provider.listRemoteEvents({
@@ -229,5 +240,104 @@ describe("createOutlookSyncProvider", () => {
     });
 
     expect(events.map((event) => event.uid)).toEqual(["titled-uid", "untitled-uid"]);
+  });
+
+  it("retries a throttled event creation after the Retry-After delay and reports success", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(throttledResponse(429, "0.05"))
+      .mockResolvedValueOnce(Response.json({
+        iCalUId: "created-event-uid",
+        id: "created-event-id",
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = createProvider();
+
+    await expect(provider.pushEvents([createEvent()])).resolves.toEqual([{
+      deleteId: "created-event-id",
+      remoteId: "created-event-uid",
+      success: true,
+    }]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(provider.getThrottleMetrics()).toEqual({ retryAfterMs: 50, retryCount: 1 });
+  });
+
+  it("retries a MailboxConcurrency 503 before giving up on the occurrence", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(throttledResponse(503, "0"))
+      .mockResolvedValueOnce(throttledResponse(503, "0"))
+      .mockResolvedValueOnce(Response.json({
+        iCalUId: "created-event-uid",
+        id: "created-event-id",
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = createProvider();
+
+    const [result] = await provider.pushEvents([createEvent()]);
+
+    expect(result).toEqual({
+      deleteId: "created-event-id",
+      remoteId: "created-event-uid",
+      success: true,
+    });
+    expect(provider.getThrottleMetrics().retryCount).toBe(2);
+  });
+
+  it("reports an occurrence that stays throttled through every retry", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(throttledResponse(429, "0")));
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = createProvider();
+
+    const [result] = await provider.pushEvents([createEvent()]);
+
+    expect(result).toMatchObject({
+      errorType: "OutlookThrottledError",
+      statusCode: 429,
+      success: false,
+    });
+    expect(result?.error).toContain("MailboxConcurrency");
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+  });
+
+  it("reports a non-throttle write failure without retrying it", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(Response.json(
+      { error: { code: "ErrorInvalidItem", message: "Invalid event payload." } },
+      { status: 400 },
+    )));
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = createProvider();
+
+    await expect(provider.pushEvents([createEvent()])).resolves.toEqual([{
+      error: "Invalid event payload.",
+      errorType: "MicrosoftGraphHttpError",
+      statusCode: 400,
+      success: false,
+    }]);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(provider.getThrottleMetrics().retryCount).toBe(0);
+  });
+
+  it("paces bulk pushes through the rate limiter, one slot per request", async () => {
+    const acquire = vi.fn(() => Promise.resolve());
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(throttledResponse(429, "0"))
+      .mockImplementation(() => Promise.resolve(Response.json({ iCalUId: "uid", id: "id" })));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createProvider({ rateLimiter: { acquire } }).pushEvents([createEvent(), createEvent()]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(acquire.mock.calls.map((call) => call[0])).toEqual([1, 1, 1]);
+  });
+
+  it("retries a throttled delete rather than dropping it", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(throttledResponse(429, "0"))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(createProvider().deleteEvents(["outlook-event-id"])).resolves.toEqual([
+      { success: true },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/calendar/tests/providers/outlook/destination/provider.test.ts
+++ b/packages/calendar/tests/providers/outlook/destination/provider.test.ts
@@ -317,7 +317,7 @@ describe("createOutlookSyncProvider", () => {
   });
 
   it("paces bulk pushes through the rate limiter, one slot per request", async () => {
-    const acquire = vi.fn(() => Promise.resolve());
+    const acquire = vi.fn((_count: number, _signal?: AbortSignal) => Promise.resolve());
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(throttledResponse(429, "0"))
       .mockImplementation(() => Promise.resolve(Response.json({ iCalUId: "uid", id: "id" })));

--- a/packages/constants/src/constants/rate-limits.ts
+++ b/packages/constants/src/constants/rate-limits.ts
@@ -8,4 +8,15 @@
 const GOOGLE_REQUESTS_PER_MINUTE = 500;
 const GOOGLE_PUSH_REQUESTS_PER_MINUTE = 350;
 
-export { GOOGLE_PUSH_REQUESTS_PER_MINUTE, GOOGLE_REQUESTS_PER_MINUTE };
+/*
+ * Microsoft Graph throttles per mailbox rather than per application, so the ceiling is
+ * a property of the destination account. Pacing under MailboxConcurrency keeps a large
+ * drain from earning the 429s the retry path would otherwise have to absorb.
+ */
+const OUTLOOK_REQUESTS_PER_MINUTE = 300;
+
+export {
+  GOOGLE_PUSH_REQUESTS_PER_MINUTE,
+  GOOGLE_REQUESTS_PER_MINUTE,
+  OUTLOOK_REQUESTS_PER_MINUTE,
+};

--- a/packages/sync/src/resolve-provider.ts
+++ b/packages/sync/src/resolve-provider.ts
@@ -108,6 +108,7 @@ const resolveOAuthProvider = async (
         refreshLockStore,
         rawRefresh: (refreshToken) => refreshMicrosoftToken(refreshToken),
       }),
+      rateLimiter,
       signal,
     });
   }

--- a/packages/sync/src/sync-user.ts
+++ b/packages/sync/src/sync-user.ts
@@ -14,6 +14,7 @@ import {
 } from "@keeper.sh/calendar";
 import { syncRangeSchema } from "@keeper.sh/data-schemas";
 import type { Plan } from "@keeper.sh/data-schemas";
+import type { RedisRateLimiter } from "@keeper.sh/calendar";
 import type {
   EventMapping,
   DestinationEventReadDiagnostics,
@@ -41,6 +42,25 @@ import {
 } from "./sync-lock";
 
 const GOOGLE_REQUESTS_PER_MINUTE = 500;
+// Graph throttles a mailbox on sustained volume as well as concurrency, so a bulk push has to be paced.
+const OUTLOOK_REQUESTS_PER_MINUTE = 300;
+
+const PROVIDER_REQUESTS_PER_MINUTE: Record<string, number> = {
+  google: GOOGLE_REQUESTS_PER_MINUTE,
+  outlook: OUTLOOK_REQUESTS_PER_MINUTE,
+};
+
+const createProviderRateLimiter = (
+  redis: Redis,
+  userId: string,
+  provider: string,
+): RedisRateLimiter | undefined => {
+  const requestsPerMinute = PROVIDER_REQUESTS_PER_MINUTE[provider];
+  if (!requestsPerMinute) {
+    return;
+  }
+  return createRedisRateLimiter(redis, `ratelimit:${userId}:${provider}`, { requestsPerMinute });
+};
 
 const resetDestinationBackoff = async (
   database: BunSQLDatabase,
@@ -444,12 +464,6 @@ const syncDestinationsForUser = async (
   const errors: string[] = [];
   const syncEvents: Record<string, unknown>[] = [];
 
-  const rateLimiter = createRedisRateLimiter(
-    redis,
-    `ratelimit:${userId}:google`,
-    { requestsPerMinute: GOOGLE_REQUESTS_PER_MINUTE },
-  );
-
   for (const destinationCandidate of destinations) {
     if (config.abortSignal?.aborted) {
       break;
@@ -489,7 +503,7 @@ const syncDestinationsForUser = async (
         oauthConfig: config.oauthConfig,
         encryptionKey: config.encryptionKey,
         refreshLockStore: config.refreshLockStore,
-        rateLimiter,
+        rateLimiter: createProviderRateLimiter(redis, userId, destination.provider),
         signal: config.abortSignal,
       });
 

--- a/packages/sync/src/sync-user.ts
+++ b/packages/sync/src/sync-user.ts
@@ -4,6 +4,7 @@ import {
   getEventMappingsForDestination,
   createDatabaseFlush,
   createGoogleUserRateLimiter,
+  createRedisRateLimiter,
   buildCalendarBackoffState,
   RESET_CALENDAR_BACKOFF_STATE,
   createSyncWindow,
@@ -12,6 +13,7 @@ import {
   getConfigurableSyncWindow,
   intersectSyncWindows,
 } from "@keeper.sh/calendar";
+import { OUTLOOK_REQUESTS_PER_MINUTE } from "@keeper.sh/constants";
 import { syncRangeSchema } from "@keeper.sh/data-schemas";
 import type { Plan } from "@keeper.sh/data-schemas";
 import type { RedisRateLimiter } from "@keeper.sh/calendar";
@@ -42,24 +44,25 @@ import {
   type SyncLockHandle,
 } from "./sync-lock";
 
-const GOOGLE_REQUESTS_PER_MINUTE = 500;
-const OUTLOOK_REQUESTS_PER_MINUTE = 300;
-
-const PROVIDER_REQUESTS_PER_MINUTE: Record<string, number> = {
-  google: GOOGLE_REQUESTS_PER_MINUTE,
-  outlook: OUTLOOK_REQUESTS_PER_MINUTE,
-};
-
+/*
+ * Google's quota is shared across ingest and push, so the push lane claims only its
+ * reserved share of the one per-user key. Outlook throttles per mailbox instead, so it
+ * gets a key of its own at the mailbox ceiling.
+ */
 const createProviderRateLimiter = (
   redis: Redis,
   userId: string,
   provider: string,
 ): RedisRateLimiter | undefined => {
-  const requestsPerMinute = PROVIDER_REQUESTS_PER_MINUTE[provider];
-  if (!requestsPerMinute) {
+  if (provider === "google") {
+    return createGoogleUserRateLimiter(redis, userId, "push");
+  }
+  if (provider !== "outlook") {
     return;
   }
-  return createRedisRateLimiter(redis, `ratelimit:${userId}:${provider}`, { requestsPerMinute });
+  return createRedisRateLimiter(redis, `ratelimit:${userId}:outlook`, {
+    requestsPerMinute: OUTLOOK_REQUESTS_PER_MINUTE,
+  });
 };
 
 const resetDestinationBackoff = async (
@@ -499,8 +502,6 @@ const syncDestinationsForUser = async (
   let removeFailed = 0;
   const errors: string[] = [];
   const syncEvents: Record<string, unknown>[] = [];
-
-  const rateLimiter = createGoogleUserRateLimiter(redis, userId, "push");
 
   for (const destinationCandidate of destinations) {
     if (config.abortSignal?.aborted) {


### PR DESCRIPTION
Not stacked on anything: merges cleanly against `main` and against all of #602, #604, #605 and #606. Note: this branch failed `bun run types` as originally pushed (the rate-limiter `vi.fn()` mock inferred a zero-length parameter tuple, so `call[0]` was a tuple out-of-range error); a follow-up commit types the mock against `acquire(count, signal?)`.

Closes #568. The Outlook destination POSTed one event per occurrence with no pacing and no retry, so every `MailboxConcurrency` 429/503 became a dropped event counted as `addFailed`. It now honours `Retry-After` on 429 and 503, retries each write through the shared backoff helper, and paces requests through the per-user Redis rate limiter that Google already uses.

- `withBackoff` moved to `core/utils/backoff.ts` and gained `getRetryDelayMs` (provider-supplied delay, capped at 64s) plus an `onRetry` observer
- Outlook config takes a `RedisRateLimiter`; `sync-user` now builds one per provider (`ratelimit:<user>:outlook`, 300 rpm) instead of only for Google
- Retries are observable: the provider reports throttle metrics and `syncCalendar` emits `provider.retry_count` / `provider.retry_after_ms` on the wide event
- A write that stays throttled through every retry is still reported, with status code, rather than swallowed
- Tests cover a 429 with `Retry-After` recovering, a 503 recovering, exhausted retries reporting failure, non-throttle failures not retrying, and rate-limiter pacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmVsczuP6e2i7VwjhvXxH
