### PR TITLE
fix(caldav): write VTIMEZONE and isolate unreadable resources

### DIFF
--- a/packages/calendar/src/core/sync-engine/ingest.ts
+++ b/packages/calendar/src/core/sync-engine/ingest.ts
@@ -24,6 +24,8 @@ interface FetchEventsResult {
   isDeltaSync?: boolean;
   fullSyncRequired?: boolean;
   unchanged?: boolean;
+  skippedResourceCount?: number;
+  skippedResourceReasons?: string[];
   syncWindow?: SyncWindow;
   coverage?: {
     futureRange: SyncRange;

--- a/packages/calendar/src/ics/utils/apply-patches.ts
+++ b/packages/calendar/src/ics/utils/apply-patches.ts
@@ -39,6 +39,20 @@ type IcsPropertyVisitor = (context: IcsPropertyContext) => void;
 const LINE_BREAK_PATTERN = /\r?\n/;
 const CONTINUATION_PATTERN = /^[ \t]/;
 const PROPERTY_LINE_PATTERN = /^([A-Za-z][A-Za-z0-9-]*)((?:;[^:]*)?):(.*)$/;
+const BYTE_ORDER_MARK = "﻿";
+
+/*
+ * Only the ICS-over-HTTP transport is accidentally BOM-safe: `Response.text()`
+ * drops a leading UTF-8 BOM while decoding. CalDAV `calendar-data` arrives as an
+ * XML text node with the BOM intact, which turns BEGIN:VCALENDAR into an
+ * unparseable property line and fails the whole resource.
+ */
+const stripIcsByteOrderMark = (ics: string): string => {
+  if (!ics.startsWith(BYTE_ORDER_MARK)) {
+    return ics;
+  }
+  return ics.slice(BYTE_ORDER_MARK.length);
+};
 
 const groupContinuations = (rawLines: readonly string[]): number[][] => {
   const groups: number[][] = [];
@@ -83,7 +97,7 @@ const parsePropertyLine = (line: string): ParsedPropertyLine | null => {
 };
 
 const visitIcsProperties = (ics: string, visitor: IcsPropertyVisitor): void => {
-  const rawLines = ics.split(LINE_BREAK_PATTERN);
+  const rawLines = stripIcsByteOrderMark(ics).split(LINE_BREAK_PATTERN);
   const componentPath: string[] = [];
   for (const indices of groupContinuations(rawLines)) {
     const parsed = parsePropertyLine(unfoldGroup(rawLines, indices));
@@ -132,7 +146,7 @@ const applyIcsPatches = (
   ics: string,
   patches: readonly IcsPatch[],
 ): string => {
-  const rawLines = ics.split(LINE_BREAK_PATTERN);
+  const rawLines = stripIcsByteOrderMark(ics).split(LINE_BREAK_PATTERN);
   const output: string[] = [];
   for (const indices of groupContinuations(rawLines)) {
     const unfolded = unfoldGroup(rawLines, indices);
@@ -157,6 +171,7 @@ const applyIcsPatches = (
 
 export {
   applyIcsPatches,
+  stripIcsByteOrderMark,
   visitIcsProperties,
   type IcsPatch,
   type IcsPatchCoercion,

--- a/packages/calendar/src/ics/utils/parse-ics-calendar.ts
+++ b/packages/calendar/src/ics/utils/parse-ics-calendar.ts
@@ -1,5 +1,7 @@
 import { convertIcsCalendar } from "ts-ics";
 import type { Line, ParseNonStandardValues } from "ts-ics";
+import { stripIcsByteOrderMark } from "./apply-patches";
+import { synthesizeMissingVtimezones } from "./synthesize-vtimezones";
 
 interface CalendarNonStandardValues {
   wrTimezone?: string;
@@ -19,9 +21,11 @@ const CALENDAR_NON_STANDARD_VALUES: ParseNonStandardValues<CalendarNonStandardVa
 };
 
 const parseIcsCalendar = (options: ParseIcsCalendarOptions) =>
-  convertIcsCalendar<CalendarNonStandardValues>(globalThis.undefined, options.icsString, {
-    nonStandard: CALENDAR_NON_STANDARD_VALUES,
-  });
+  convertIcsCalendar<CalendarNonStandardValues>(
+    globalThis.undefined,
+    synthesizeMissingVtimezones(stripIcsByteOrderMark(options.icsString)),
+    { nonStandard: CALENDAR_NON_STANDARD_VALUES },
+  );
 
 export { parseIcsCalendar };
 export type { CalendarNonStandardValues };

--- a/packages/calendar/src/ics/utils/synthesize-vtimezones.ts
+++ b/packages/calendar/src/ics/utils/synthesize-vtimezones.ts
@@ -1,0 +1,117 @@
+import { generateIcsTimezone } from "ts-ics";
+import { buildVtimezone } from "./build-vtimezone";
+
+const LINE_BREAK_PATTERN = /\r?\n/;
+const FOLD_PATTERN = /\r?\n[\t ]/g;
+const TZID_PARAMETER_PATTERN = /;TZID=("?)([^";:]+)\1(?=;|$)/i;
+const CALENDAR_START_PATTERN = /^BEGIN:VCALENDAR\s*$/i;
+const DATE_PREFIX_PATTERN = /^(\d{4})(\d{2})(\d{2})/;
+
+interface TimeZoneUsage {
+  definedIds: Set<string>;
+  referenceInstantById: Map<string, Date>;
+}
+
+/*
+ * The reference instant only selects which years buildVtimezone projects, so a
+ * value read as if it were UTC is precise enough: it can never land more than a
+ * day away from the real instant.
+ */
+const readReferenceInstant = (value: string): Date => {
+  const match = DATE_PREFIX_PATTERN.exec(value);
+  if (!match) {
+    return new Date();
+  }
+  const [, year, month, day] = match;
+  return new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)));
+};
+
+const collectTimeZoneUsage = (icsString: string): TimeZoneUsage => {
+  const definedIds = new Set<string>();
+  const referenceInstantById = new Map<string, Date>();
+  let insideTimezone = false;
+
+  for (const line of icsString.replaceAll(FOLD_PATTERN, "").split(LINE_BREAK_PATTERN)) {
+    const separatorIndex = line.indexOf(":");
+    if (separatorIndex === -1) {
+      continue;
+    }
+    const property = line.slice(0, separatorIndex);
+    const value = line.slice(separatorIndex + 1).trim();
+    const propertyName = property.toUpperCase();
+
+    if (propertyName === "BEGIN" && value.toUpperCase() === "VTIMEZONE") {
+      insideTimezone = true;
+      continue;
+    }
+    if (propertyName === "END" && value.toUpperCase() === "VTIMEZONE") {
+      insideTimezone = false;
+      continue;
+    }
+    if (insideTimezone) {
+      if (propertyName === "TZID") {
+        definedIds.add(value);
+      }
+      continue;
+    }
+
+    const timeZoneId = TZID_PARAMETER_PATTERN.exec(property)?.[2];
+    if (!timeZoneId || referenceInstantById.has(timeZoneId)) {
+      continue;
+    }
+    referenceInstantById.set(timeZoneId, readReferenceInstant(value));
+  }
+
+  return { definedIds, referenceInstantById };
+};
+
+const buildMissingTimezoneBlocks = (usage: TimeZoneUsage): string[] => {
+  const blocks: string[] = [];
+  for (const [timeZoneId, referenceInstant] of usage.referenceInstantById) {
+    if (usage.definedIds.has(timeZoneId)) {
+      continue;
+    }
+    const timezone = buildVtimezone(timeZoneId, referenceInstant);
+    if (!timezone) {
+      continue;
+    }
+    /*
+     * The generated observances describe the IANA zone, but the block has to
+     * keep the identifier the properties actually reference (a Windows name
+     * like "Eastern Standard Time" included) or nothing links to it.
+     */
+    blocks.push(generateIcsTimezone({ ...timezone, id: timeZoneId }).trim());
+  }
+  return blocks;
+};
+
+/**
+ * Adds a VTIMEZONE for every TZID a calendar references but never defines.
+ *
+ * Without one, ts-ics cannot resolve the identifier and falls back to reading
+ * the wall-clock value as if it were the UTC instant, which lands on the wrong
+ * side of every DST transition.
+ */
+const synthesizeMissingVtimezones = (icsString: string): string => {
+  const usage = collectTimeZoneUsage(icsString);
+  if (usage.referenceInstantById.size === 0) {
+    return icsString;
+  }
+  const blocks = buildMissingTimezoneBlocks(usage);
+  if (blocks.length === 0) {
+    return icsString;
+  }
+
+  const lines = icsString.split(LINE_BREAK_PATTERN);
+  const calendarStartIndex = lines.findIndex((line) => CALENDAR_START_PATTERN.test(line));
+  if (calendarStartIndex === -1) {
+    return icsString;
+  }
+  return [
+    ...lines.slice(0, calendarStartIndex + 1),
+    ...blocks,
+    ...lines.slice(calendarStartIndex + 1),
+  ].join("\r\n");
+};
+
+export { synthesizeMissingVtimezones };

--- a/packages/calendar/src/providers/caldav/destination/provider.ts
+++ b/packages/calendar/src/providers/caldav/destination/provider.ts
@@ -14,6 +14,7 @@ import type {
 } from "../../../core/types";
 import { CalDAVClient, CalDAVCreateConflictError, CalDAVHttpError } from "../shared/client";
 import {
+  assertAllResourcesRead,
   eventToICalString,
   parseICalCalendarsToRemoteEvents,
   parseICalToRemoteEvent,
@@ -220,7 +221,7 @@ const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
 
     const remoteEvents: RemoteEvent[] = [];
 
-    const parsedEvents = parseICalCalendarsToRemoteEvents(
+    const resources = parseICalCalendarsToRemoteEvents(
       objects.flatMap(({ data, url }) => {
         if (!data || !isKeeperCalendarObjectUrl(url)) {
           return [];
@@ -229,7 +230,8 @@ const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
       }),
       { rejectUnsupportedRecurrenceDates: false },
     );
-    for (const parsed of parsedEvents) {
+    assertAllResourcesRead(resources);
+    for (const parsed of resources.events) {
       if (!isKeeperEvent(parsed.uid) || parsed.endTime < options.timeMin) {
         continue;
       }

--- a/packages/calendar/src/providers/caldav/index.ts
+++ b/packages/calendar/src/providers/caldav/index.ts
@@ -11,7 +11,12 @@ export {
   CalDAVIncompleteMultiGetError,
   createCalDAVClient,
 } from "./shared/client";
-export { eventToICalString, parseICalToRemoteEvent, parseICalToRemoteEvents } from "./shared/ics";
+export {
+  CalDAVUnreadableResourceError,
+  eventToICalString,
+  parseICalToRemoteEvent,
+  parseICalToRemoteEvents,
+} from "./shared/ics";
 
 export type {
   CalDAVProviderOptions,

--- a/packages/calendar/src/providers/caldav/shared/ics.ts
+++ b/packages/calendar/src/providers/caldav/shared/ics.ts
@@ -1,6 +1,7 @@
 import { generateIcsCalendar } from "ts-ics";
 import {
   applyCalendarTimeZoneToFloatingEventDates,
+  buildVtimezone,
   buildZonedIcsDate,
   normalizeTimezone,
   parseIcsCalendar,
@@ -11,6 +12,7 @@ import type {
   IcsEvent,
   IcsExceptionDates,
   IcsRecurrenceRule,
+  IcsTimezone,
 } from "ts-ics";
 import type { MaterializedSyncableEvent, SyncableEvent } from "../../../core/types";
 import { isKeeperEvent } from "../../../core/events/identity";
@@ -23,8 +25,29 @@ import {
 const normalizeIcsText = (value: string | undefined): string | undefined =>
   value?.replaceAll(/\r\n?/g, "\n");
 
+/*
+ * A TZID-qualified DTSTART is only interpretable against a VTIMEZONE. Omitting
+ * it leaves every reader guessing the offset, and Keeper reads its own writes
+ * back: the guess lands on the wrong side of a DST transition, the event looks
+ * changed, and the destination is replaced on every run forever.
+ */
+const resolveEventTimezones = (
+  event: MaterializedSyncableEvent,
+  isAllDay: boolean,
+): IcsTimezone[] => {
+  if (isAllDay) {
+    return [];
+  }
+  const timezone = buildVtimezone(event.startTimeZone, event.startTime);
+  if (!timezone) {
+    return [];
+  }
+  return [timezone];
+};
+
 const eventToICalString = (event: MaterializedSyncableEvent, uid: string): string => {
   const isAllDay = resolveIsAllDayEvent(event);
+  const timezones = resolveEventTimezones(event, isAllDay);
   const icsEvent: IcsEvent = {
     description: normalizeIcsText(event.description),
     end: buildZonedIcsDate(event.endTime, event.startTimeZone, isAllDay),
@@ -40,6 +63,7 @@ const eventToICalString = (event: MaterializedSyncableEvent, uid: string): strin
     events: [icsEvent],
     prodId: "-//Keeper//Keeper Calendar//EN",
     version: "2.0",
+    ...(timezones.length > 0 && { timezones }),
   };
 
   return generateIcsCalendar(calendar);
@@ -67,35 +91,103 @@ interface ParseICalCalendarsOptions {
   rejectUnsupportedRecurrenceDates?: boolean;
 }
 
+interface ParsedCalendarResources {
+  events: ParsedCalendarEvent[];
+  skippedResourceCount: number;
+  skippedResourceReasons: string[];
+}
+
+class CalDAVUnreadableResourceError extends Error {
+  readonly skippedResourceCount: number;
+  readonly skippedResourceReasons: string[];
+
+  constructor(resources: Pick<
+    ParsedCalendarResources,
+    "skippedResourceCount" | "skippedResourceReasons"
+  >) {
+    super(
+      `${resources.skippedResourceCount} CalDAV resource(s) could not be read: ${resources.skippedResourceReasons.join("; ")}`,
+    );
+    this.name = "CalDAVUnreadableResourceError";
+    this.skippedResourceCount = resources.skippedResourceCount;
+    this.skippedResourceReasons = resources.skippedResourceReasons;
+  }
+}
+
+/*
+ * Skipping is only safe where a missing event means "stale", never where it
+ * means "absent". The destination reconciler re-creates any Keeper event it
+ * cannot see remotely, so an unreadable Keeper resource would be duplicated on
+ * every run instead of repaired.
+ */
+const assertAllResourcesRead = (resources: ParsedCalendarResources): void => {
+  if (resources.skippedResourceCount > 0) {
+    throw new CalDAVUnreadableResourceError(resources);
+  }
+};
+
+const parseCalendarResource = (
+  icsString: string,
+  options: ParseICalCalendarsOptions,
+): IcsCalendar => {
+  if (options.rejectUnsupportedRecurrenceDates !== false) {
+    assertNoUnsupportedRecurrenceDates(icsString);
+  }
+  const initialCalendar = parseIcsCalendar({ icsString });
+  const normalizedIcs = applyCalendarTimeZoneToFloatingEventDates(
+    icsString,
+    normalizeTimezone(initialCalendar.nonStandard?.wrTimezone),
+  );
+  if (normalizedIcs === icsString) {
+    return initialCalendar;
+  }
+  return parseIcsCalendar({ icsString: normalizedIcs });
+};
+
+const toResourceFailure = (error: unknown): Error => {
+  if (error instanceof Error) {
+    return error;
+  }
+  return new Error(String(error));
+};
+
 const parseICalCalendarsToRemoteEvents = (
   icsStrings: string[],
   options: ParseICalCalendarsOptions = {},
-): ParsedCalendarEvent[] => {
-  const calendars = icsStrings.map((icsString) => {
-    if (options.rejectUnsupportedRecurrenceDates !== false) {
-      assertNoUnsupportedRecurrenceDates(icsString);
+): ParsedCalendarResources => {
+  const calendars: IcsCalendar[] = [];
+  const failures: Error[] = [];
+  for (const icsString of icsStrings) {
+    try {
+      calendars.push(parseCalendarResource(icsString, options));
+    } catch (error) {
+      failures.push(toResourceFailure(error));
     }
-    const initialCalendar = parseIcsCalendar({ icsString });
-    const normalizedIcs = applyCalendarTimeZoneToFloatingEventDates(
-      icsString,
-      normalizeTimezone(initialCalendar.nonStandard?.wrTimezone),
-    );
-    if (normalizedIcs === icsString) {
-      return initialCalendar;
-    }
-    return parseIcsCalendar({ icsString: normalizedIcs });
-  });
+  }
+  const skippedResourceReasons = failures.map(({ message }) => message);
   const [firstCalendar] = calendars;
   if (!firstCalendar) {
-    return [];
+    /*
+     * An empty result is authoritative downstream: ingestion would read it as
+     * "the collection has no events" and delete the stored state. Only report
+     * that when the collection really was empty, never when every resource in
+     * it failed to parse.
+     */
+    if (failures.length > 0) {
+      throw new CalDAVUnreadableResourceError({
+        skippedResourceCount: failures.length,
+        skippedResourceReasons,
+      });
+    }
+    return { events: [], skippedResourceCount: 0, skippedResourceReasons };
   }
   const calendar = {
     ...firstCalendar,
     events: calendars.flatMap((entry) => entry.events ?? []),
   };
-  const events = parseIcsEvents(calendar, { includeKeeperEvents: true });
-  assertSupportedRecurrenceTimeZones(events);
-  return events.map((event) => ({
+  const parsedEvents = parseIcsEvents(calendar, { includeKeeperEvents: true });
+  assertSupportedRecurrenceTimeZones(parsedEvents);
+  const events = parsedEvents.map((event) => ({
     availability: event.availability ?? "busy",
     deleteId: event.uid,
     description: event.description,
@@ -112,10 +204,15 @@ const parseICalCalendarsToRemoteEvents = (
     title: event.title,
     uid: event.uid,
   }));
+  return {
+    events,
+    skippedResourceCount: skippedResourceReasons.length,
+    skippedResourceReasons,
+  };
 };
 
 const parseICalToRemoteEvents = (icsString: string): ParsedCalendarEvent[] =>
-  parseICalCalendarsToRemoteEvents([icsString]);
+  parseICalCalendarsToRemoteEvents([icsString]).events;
 
 const parseICalToRemoteEvent = (icsString: string): ParsedCalendarEvent | null => {
   const [event] = parseICalToRemoteEvents(icsString);
@@ -123,9 +220,11 @@ const parseICalToRemoteEvent = (icsString: string): ParsedCalendarEvent | null =
 };
 
 export {
+  assertAllResourcesRead,
+  CalDAVUnreadableResourceError,
   eventToICalString,
   parseICalCalendarsToRemoteEvents,
   parseICalToRemoteEvent,
   parseICalToRemoteEvents,
 };
-export type { ParseICalCalendarsOptions };
+export type { ParseICalCalendarsOptions, ParsedCalendarResources };

--- a/packages/calendar/src/providers/caldav/source/fetch-adapter.ts
+++ b/packages/calendar/src/providers/caldav/source/fetch-adapter.ts
@@ -52,7 +52,7 @@ const createCalDAVSourceFetcher = (config: CalDAVSourceFetcherConfig): CalDAVSou
     });
 
     const events: SourceEvent[] = [];
-    const parsedEvents = parseICalCalendarsToRemoteEvents(
+    const resources = parseICalCalendarsToRemoteEvents(
       objects.flatMap(({ data }) => {
         if (!data) {
           return [];
@@ -61,7 +61,7 @@ const createCalDAVSourceFetcher = (config: CalDAVSourceFetcherConfig): CalDAVSou
       }),
     );
 
-    for (const parsed of parsedEvents) {
+    for (const parsed of resources.events) {
       if (isKeeperEvent(parsed.uid)) {
         continue;
       }
@@ -94,6 +94,8 @@ const createCalDAVSourceFetcher = (config: CalDAVSourceFetcherConfig): CalDAVSou
         historicRange,
         window: syncWindow,
       },
+      skippedResourceCount: resources.skippedResourceCount,
+      skippedResourceReasons: resources.skippedResourceReasons,
     };
   };
 

--- a/packages/calendar/src/providers/caldav/source/provider.ts
+++ b/packages/calendar/src/providers/caldav/source/provider.ts
@@ -17,7 +17,7 @@ import { and, eq, inArray } from "drizzle-orm";
 import type { BunSQLClient } from "../../../core/database-client";
 import { CalDAVClient } from "../shared/client";
 import { resolveAuthMethod } from "../shared/digest-fetch";
-import { parseICalCalendarsToRemoteEvents } from "../shared/ics";
+import { assertAllResourcesRead, parseICalCalendarsToRemoteEvents } from "../shared/ics";
 import { isCalDAVAuthenticationError } from "./auth-error-classification";
 import { createCalDAVSourceService } from "./sync";
 import {
@@ -80,7 +80,7 @@ const createCalDAVSourceProvider = (
     });
 
     const events: SourceEvent[] = [];
-    const parsedEvents = parseICalCalendarsToRemoteEvents(
+    const resources = parseICalCalendarsToRemoteEvents(
       objects.flatMap(({ data }) => {
         if (!data) {
           return [];
@@ -88,8 +88,14 @@ const createCalDAVSourceProvider = (
         return [data];
       }),
     );
+    /*
+     * This path returns bare events with no wide-event channel to report a
+     * partial read on, so it keeps failing loudly rather than quietly syncing a
+     * subset. The cron ingest path (source/fetch-adapter) reports the count.
+     */
+    assertAllResourcesRead(resources);
 
-    for (const parsed of parsedEvents) {
+    for (const parsed of resources.events) {
       if (isKeeperEvent(parsed.uid)) {
         continue;
       }

--- a/packages/calendar/tests/providers/caldav/shared/ics-resource-isolation.test.ts
+++ b/packages/calendar/tests/providers/caldav/shared/ics-resource-isolation.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { parseICalCalendarsToRemoteEvents } from "../../../../src/providers/caldav/shared/ics";
+
+const BYTE_ORDER_MARK = "﻿";
+
+const buildResource = (uid: string, extraLines: string[] = []): string => [
+  "BEGIN:VCALENDAR",
+  "VERSION:2.0",
+  "PRODID:-//Test//Test//EN",
+  "BEGIN:VEVENT",
+  `UID:${uid}`,
+  "DTSTART:20260701T090000Z",
+  "DTEND:20260701T100000Z",
+  `SUMMARY:${uid}`,
+  ...extraLines,
+  "END:VEVENT",
+  "END:VCALENDAR",
+].join("\r\n");
+
+const TRUNCATED_RESOURCE = [
+  "BEGIN:VCALENDAR",
+  "VERSION:2.0",
+  "PRODID:-//Test//Test//EN",
+  "BEGIN:VEVENT",
+  "UID:truncated",
+  "DTSTART:20260701T090000Z",
+].join("\r\n");
+
+describe("parseICalCalendarsToRemoteEvents resource isolation", () => {
+  it.each([
+    { bad: TRUNCATED_RESOURCE, name: "truncated" },
+    { bad: buildResource("rdate", ["RDATE:20260703T090000Z"]), name: "RDATE" },
+  ])("keeps the rest of the collection when one resource is $name", (scenario) => {
+    const result = parseICalCalendarsToRemoteEvents([
+      buildResource("before"),
+      scenario.bad,
+      buildResource("after"),
+    ]);
+
+    expect(result.events.map(({ uid }) => uid)).toEqual(["before", "after"]);
+    expect(result.skippedResourceCount).toBe(1);
+    expect(result.skippedResourceReasons).toHaveLength(1);
+  });
+
+  it("reports every skipped resource", () => {
+    const result = parseICalCalendarsToRemoteEvents([
+      buildResource("before"),
+      TRUNCATED_RESOURCE,
+      buildResource("rdate", ["RDATE:20260703T090000Z"]),
+    ]);
+
+    expect(result.events.map(({ uid }) => uid)).toEqual(["before"]);
+    expect(result.skippedResourceCount).toBe(2);
+  });
+
+  it("reads a BOM-prefixed resource rather than skipping it", () => {
+    const result = parseICalCalendarsToRemoteEvents([
+      buildResource("before"),
+      `${BYTE_ORDER_MARK}${buildResource("bom")}`,
+    ]);
+
+    expect(result.events.map(({ uid }) => uid)).toEqual(["before", "bom"]);
+    expect(result.skippedResourceCount).toBe(0);
+  });
+
+  it("throws when no resource in a non-empty collection could be read", () => {
+    expect(() => parseICalCalendarsToRemoteEvents([TRUNCATED_RESOURCE]))
+      .toThrow("Malformed ICS component boundary");
+  });
+
+  it("returns an empty result for an empty collection", () => {
+    const result = parseICalCalendarsToRemoteEvents([]);
+
+    expect(result.events).toEqual([]);
+    expect(result.skippedResourceCount).toBe(0);
+  });
+});

--- a/packages/calendar/tests/providers/caldav/shared/ics-timezone.test.ts
+++ b/packages/calendar/tests/providers/caldav/shared/ics-timezone.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  eventToICalString,
+  parseICalToRemoteEvent,
+} from "../../../../src/providers/caldav/shared/ics";
+import type { MaterializedSyncableEvent } from "../../../../src/core/types";
+
+const buildEvent = (
+  overrides: Partial<MaterializedSyncableEvent>,
+): MaterializedSyncableEvent => ({
+  calendarId: "calendar-id",
+  calendarName: "Calendar",
+  calendarUrl: null,
+  endTime: new Date("2026-03-08T15:00:00.000Z"),
+  id: "event-id",
+  sourceEventUid: "source-uid",
+  startTime: new Date("2026-03-08T14:00:00.000Z"),
+  summary: "Standup",
+  ...overrides,
+} as MaterializedSyncableEvent);
+
+describe("eventToICalString timezone round trip", () => {
+  it.each([
+    {
+      endTime: new Date("2026-03-08T15:00:00.000Z"),
+      startTime: new Date("2026-03-08T14:00:00.000Z"),
+      timezone: "America/Edmonton",
+    },
+    {
+      endTime: new Date("2026-03-08T14:00:00.000Z"),
+      startTime: new Date("2026-03-08T13:00:00.000Z"),
+      timezone: "America/New_York",
+    },
+    {
+      endTime: new Date("2026-04-04T23:00:00.000Z"),
+      startTime: new Date("2026-04-04T22:00:00.000Z"),
+      timezone: "Australia/Sydney",
+    },
+  ])("preserves the instant across a $timezone transition", (scenario) => {
+    const icsString = eventToICalString(
+      buildEvent({
+        endTime: scenario.endTime,
+        startTime: scenario.startTime,
+        startTimeZone: scenario.timezone,
+      }),
+      "destination-uid",
+    );
+
+    expect(icsString).toContain(`BEGIN:VTIMEZONE`);
+    expect(icsString).toContain(`TZID:${scenario.timezone}`);
+
+    const parsedEvent = parseICalToRemoteEvent(icsString);
+
+    expect(parsedEvent?.startTime.toISOString()).toBe(scenario.startTime.toISOString());
+    expect(parsedEvent?.endTime.toISOString()).toBe(scenario.endTime.toISOString());
+    expect(parsedEvent?.startTimeZone).toBe(scenario.timezone);
+  });
+
+  it("omits VTIMEZONE for all-day events", () => {
+    const icsString = eventToICalString(
+      buildEvent({
+        endTime: new Date("2026-03-09T00:00:00.000Z"),
+        isAllDay: true,
+        startTime: new Date("2026-03-08T00:00:00.000Z"),
+        startTimeZone: "America/Edmonton",
+      }),
+      "destination-uid",
+    );
+
+    expect(icsString).not.toContain("BEGIN:VTIMEZONE");
+    expect(icsString).toContain("DTSTART;VALUE=DATE:20260308");
+  });
+});
+
+describe("parsing a TZID with no VTIMEZONE", () => {
+  it("resolves the IANA zone instead of guessing the offset", () => {
+    const icsString = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//Test//Test//EN",
+      "BEGIN:VEVENT",
+      "UID:no-vtimezone",
+      "DTSTART;TZID=America/Edmonton:20260308T080000",
+      "DTEND;TZID=America/Edmonton:20260308T090000",
+      "SUMMARY:Standup",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+
+    const parsedEvent = parseICalToRemoteEvent(icsString);
+
+    expect(parsedEvent?.startTime.toISOString()).toBe("2026-03-08T14:00:00.000Z");
+    expect(parsedEvent?.endTime.toISOString()).toBe("2026-03-08T15:00:00.000Z");
+    expect(parsedEvent?.startTimeZone).toBe("America/Edmonton");
+  });
+
+  it("resolves a quoted TZID parameter", () => {
+    const icsString = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//Test//Test//EN",
+      "BEGIN:VEVENT",
+      "UID:quoted-tzid",
+      "DTSTART;TZID=\"Europe/Berlin\":20260705T120000",
+      "DTEND;TZID=\"Europe/Berlin\":20260705T130000",
+      "SUMMARY:Standup",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+
+    const parsedEvent = parseICalToRemoteEvent(icsString);
+
+    expect(parsedEvent?.startTime.toISOString()).toBe("2026-07-05T10:00:00.000Z");
+    expect(parsedEvent?.endTime.toISOString()).toBe("2026-07-05T11:00:00.000Z");
+  });
+
+  it("keeps an explicit VTIMEZONE authoritative over the IANA database", () => {
+    const icsString = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//Test//Test//EN",
+      "BEGIN:VTIMEZONE",
+      "TZID:America/Edmonton",
+      "BEGIN:STANDARD",
+      "DTSTART:19700101T000000",
+      "TZOFFSETFROM:-0700",
+      "TZOFFSETTO:-0700",
+      "END:STANDARD",
+      "END:VTIMEZONE",
+      "BEGIN:VEVENT",
+      "UID:explicit-vtimezone",
+      "DTSTART;TZID=America/Edmonton:20260308T080000",
+      "DTEND;TZID=America/Edmonton:20260308T090000",
+      "SUMMARY:Standup",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+
+    const parsedEvent = parseICalToRemoteEvent(icsString);
+
+    expect(parsedEvent?.startTime.toISOString()).toBe("2026-03-08T15:00:00.000Z");
+  });
+});

--- a/packages/calendar/tests/providers/caldav/shared/ics.test.ts
+++ b/packages/calendar/tests/providers/caldav/shared/ics.test.ts
@@ -248,8 +248,8 @@ describe("parseICalToRemoteEvents", () => {
       STATUS: "CANCELLED",
     })]);
 
-    expect(parseICalCalendarsToRemoteEvents([active, cancellation])).toEqual([]);
-    expect(parseICalCalendarsToRemoteEvents([cancellation, active])).toEqual([]);
+    expect(parseICalCalendarsToRemoteEvents([active, cancellation]).events).toEqual([]);
+    expect(parseICalCalendarsToRemoteEvents([cancellation, active]).events).toEqual([]);
   });
 
   it("returns both master and modified occurrence from a recurring event", () => {

--- a/packages/calendar/tests/providers/caldav/source/fetch-adapter.test.ts
+++ b/packages/calendar/tests/providers/caldav/source/fetch-adapter.test.ts
@@ -145,3 +145,43 @@ describe("createCalDAVSourceFetcher against a capped multiget", () => {
     expect(result.events[0]?.uid).toBe(NATIVE_UID);
   });
 });
+
+const TRUNCATED_ICS = [
+  "BEGIN:VCALENDAR",
+  "VERSION:2.0",
+  "PRODID:-//keeper.sh//test//EN",
+  "BEGIN:VEVENT",
+  "UID:truncated@example.com",
+  "DTSTART:20260620T090000Z",
+].join("\r\n");
+
+const dataForNativeObject = (index: number): string => {
+  if (index === 1) {
+    return TRUNCATED_ICS;
+  }
+  return icsFor(`native-${index}@example.com`);
+};
+
+describe("createCalDAVSourceFetcher against an unreadable resource", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    davMocks.fetchCalendars.mockResolvedValue([]);
+  });
+
+  it("ingests the readable resources and reports the skipped count", async () => {
+    answerQueryWith(objectPaths(3));
+    answerMultigetWith((objectUrls) =>
+      objectUrls.map((path, index) => ({
+        data: dataForNativeObject(index),
+        url: `${SERVER_URL}${path}`,
+      })));
+
+    const result = await createFetcher().fetchEvents();
+
+    expect(result.events.map(({ uid }) => uid))
+      .toEqual(["native-0@example.com", "native-2@example.com"]);
+    expect(result.skippedResourceCount).toBe(1);
+    expect(result.skippedResourceReasons)
+      .toEqual(["Malformed ICS component boundary: missing END:VEVENT"]);
+  });
+});

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -25,6 +25,7 @@ import { createGoogleSourceFetcher } from "@keeper.sh/calendar/google";
 import { createOutlookSourceFetcher } from "@keeper.sh/calendar/outlook";
 import {
   CalDAVIncompleteMultiGetError,
+  CalDAVUnreadableResourceError,
   createCalDAVSourceFetcher,
   isCalDAVAuthenticationError,
 } from "@keeper.sh/calendar/caldav";
@@ -145,9 +146,21 @@ const hasErrorFlag = (error: unknown, key: string): boolean =>
 const shouldApplyOAuthIngestBackoff = (error: unknown): boolean =>
   !hasErrorFlag(error, "authRequired") && !hasErrorFlag(error, "oauthReauthRequired");
 
+const recordSkippedResources = (skippedResourceCount: number, reasons: string[]): void => {
+  if (skippedResourceCount === 0) {
+    return;
+  }
+  widelog.set("provider.resources_skipped", skippedResourceCount);
+  widelog.set("provider.resources_skipped_reasons", reasons.join("; "));
+};
+
 const resolveIngestErrorSlug = (error: unknown): string => {
   if (error instanceof CalDAVIncompleteMultiGetError) {
     return "provider-response-incomplete";
+  }
+  if (error instanceof CalDAVUnreadableResourceError) {
+    recordSkippedResources(error.skippedResourceCount, error.skippedResourceReasons);
+    return "provider-partial-response";
   }
   if (!isTimeoutError(error)) {
     return "provider-api-error";
@@ -718,7 +731,14 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
                 const ingestEvents: Record<string, unknown>[] = [];
                 const ingestionResult = await ingestSource({
                   calendarId: source.calendarId,
-                  fetchEvents: () => fetcher.fetchEvents(),
+                  fetchEvents: async () => {
+                    const fetchResult = await fetcher.fetchEvents();
+                    recordSkippedResources(
+                      fetchResult.skippedResourceCount ?? 0,
+                      fetchResult.skippedResourceReasons ?? [],
+                    );
+                    return fetchResult;
+                  },
                   isCurrent,
                   withPersistenceTransaction:
                     createIngestionPersistenceTransaction(source.calendarId, signal, deadlineAt),

--- a/services/cron/src/utils/provider-ingest-failure.ts
+++ b/services/cron/src/utils/provider-ingest-failure.ts
@@ -1,4 +1,7 @@
-import { CalDAVIncompleteMultiGetError } from "@keeper.sh/calendar/caldav";
+import {
+  CalDAVIncompleteMultiGetError,
+  CalDAVUnreadableResourceError,
+} from "@keeper.sh/calendar/caldav";
 
 interface MissingCalendarFailure {
   disableCalendar: false;
@@ -10,7 +13,10 @@ const hasNotFoundStatus = (error: Error): boolean =>
   "status" in error && error.status === 404;
 
 const resolveMissingCalendarFailure = (error: unknown): MissingCalendarFailure | null => {
-  if (error instanceof CalDAVIncompleteMultiGetError) {
+  if (
+    error instanceof CalDAVIncompleteMultiGetError
+    || error instanceof CalDAVUnreadableResourceError
+  ) {
     return null;
   }
 

--- a/services/cron/tests/utils/provider-ingest-failure.test.ts
+++ b/services/cron/tests/utils/provider-ingest-failure.test.ts
@@ -1,4 +1,7 @@
-import { CalDAVIncompleteMultiGetError } from "@keeper.sh/calendar/caldav";
+import {
+  CalDAVIncompleteMultiGetError,
+  CalDAVUnreadableResourceError,
+} from "@keeper.sh/calendar/caldav";
 import { describe, expect, it } from "vitest";
 import { resolveMissingCalendarFailure } from "../../src/utils/provider-ingest-failure";
 
@@ -37,5 +40,18 @@ describe("resolveMissingCalendarFailure", () => {
       expect(error.message).toContain("404");
       expect(resolveMissingCalendarFailure(error)).toBeNull();
     }
+  });
+
+  it("leaves an unreadable-resource failure to its own slug", () => {
+    const error = new CalDAVUnreadableResourceError({
+      skippedResourceCount: 2,
+      skippedResourceReasons: [
+        "Malformed ICS component boundary: missing END:VEVENT",
+        "Collection query failed: 404 Not Found",
+      ],
+    });
+
+    expect(error.message).toContain("404");
+    expect(resolveMissingCalendarFailure(error)).toBeNull();
   });
 });


### PR DESCRIPTION
Base of a two-PR stack: #606 is stacked on this and should merge after it. Independent of #602, #603 and #605.

Closes #586 and #587. The CalDAV destination wrote `DTSTART;TZID=...` with no VTIMEZONE, so ts-ics resolved the readback by guessing the offset and every event near a DST transition looked changed forever; the writer now attaches `buildVtimezone`, and the read path synthesizes a VTIMEZONE for any TZID a feed references but never defines. A malformed resource in a CalDAV collection also took down all N events, which left the calendar permanently stale.

- `eventToICalString` emits a VTIMEZONE for timed events (all-day stays timezone-less)
- `parseIcsCalendar` strips a leading BOM and synthesizes missing VTIMEZONEs, covering both the CalDAV and ICS transports
- `parseICalCalendarsToRemoteEvents` parses each resource in its own try/catch and returns `{ events, skippedResourceCount, skippedResourceReasons }`; cron puts the count on the wide event as `provider.resources_skipped`
- a collection where every resource failed still throws (`CalDAVUnreadableResourceError`, slug `provider-partial-response`) rather than reporting an authoritative empty; the destination read throws on any skip, since an unreadable Keeper resource would be re-created as a duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmVsczuP6e2i7VwjhvXxH
