### PR TITLE
fix(google): tolerate an omitted calendar list and unnamed calendars (#588)

### DIFF
--- a/packages/calendar/src/providers/google/source/utils/list-calendars.ts
+++ b/packages/calendar/src/providers/google/source/utils/list-calendars.ts
@@ -1,5 +1,8 @@
-import { googleCalendarListResponseSchema } from "@keeper.sh/data-schemas";
-import type { GoogleCalendarListEntry, GoogleCalendarListResponse } from "../types";
+import {
+  googleCalendarListEntrySchema,
+  googleCalendarListResponseSchema,
+} from "@keeper.sh/data-schemas";
+import type { GoogleCalendarListEntry } from "../types";
 import { GOOGLE_CALENDAR_LIST_URL } from "../../shared/api";
 import { isSimpleAuthError } from "../../shared/errors";
 
@@ -19,10 +22,25 @@ class CalendarListError extends Error {
   }
 }
 
+const parseCalendarEntry = (value: unknown): GoogleCalendarListEntry | null => {
+  if (!googleCalendarListEntrySchema.allows(value)) {
+    return null;
+  }
+  const entry = googleCalendarListEntrySchema.assert(value);
+  // Google omits the display name on some calendars, and the ID is the only stable label left.
+  return { ...entry, summary: entry.summary ?? entry.id };
+};
+
+interface CalendarListPage {
+  items: GoogleCalendarListEntry[];
+  invalidEntryCount: number;
+  nextPageToken?: string;
+}
+
 const fetchCalendarPage = async (
   accessToken: string,
   pageToken?: string,
-): Promise<GoogleCalendarListResponse> => {
+): Promise<CalendarListPage> => {
   const url = new URL(GOOGLE_CALENDAR_LIST_URL);
   url.searchParams.set("minAccessRole", "reader");
   if (pageToken) {
@@ -45,20 +63,53 @@ const fetchCalendarPage = async (
   }
 
   const responseBody = await response.json();
-  return googleCalendarListResponseSchema.assert(responseBody);
+  const page = googleCalendarListResponseSchema.assert(responseBody);
+
+  const items: GoogleCalendarListEntry[] = [];
+  let invalidEntryCount = 0;
+  for (const item of page.items ?? []) {
+    const entry = parseCalendarEntry(item);
+    if (entry) {
+      items.push(entry);
+      continue;
+    }
+    invalidEntryCount += 1;
+  }
+
+  const parsedPage: CalendarListPage = { invalidEntryCount, items };
+  if (page.nextPageToken) {
+    parsedPage.nextPageToken = page.nextPageToken;
+  }
+  return parsedPage;
 };
 
-const listUserCalendars = async (accessToken: string): Promise<GoogleCalendarListEntry[]> => {
+interface ListUserCalendarsOptions {
+  onInvalidEntries?: (count: number) => void;
+}
+
+const listUserCalendars = async (
+  accessToken: string,
+  options?: ListUserCalendarsOptions,
+): Promise<GoogleCalendarListEntry[]> => {
   const calendars: GoogleCalendarListEntry[] = [];
+  let invalidEntryCount = 0;
+
   let response = await fetchCalendarPage(accessToken);
   calendars.push(...response.items);
+  invalidEntryCount += response.invalidEntryCount;
 
   while (response.nextPageToken) {
     response = await fetchCalendarPage(accessToken, response.nextPageToken);
     calendars.push(...response.items);
+    invalidEntryCount += response.invalidEntryCount;
+  }
+
+  if (invalidEntryCount > 0) {
+    options?.onInvalidEntries?.(invalidEntryCount);
   }
 
   return calendars;
 };
 
 export { listUserCalendars, CalendarListError };
+export type { ListUserCalendarsOptions };

--- a/packages/calendar/tests/providers/google/source/utils/list-calendars.test.ts
+++ b/packages/calendar/tests/providers/google/source/utils/list-calendars.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { listUserCalendars } from "../../../../../src/providers/google/source/utils/list-calendars";
+
+const calendarEntry = (overrides: Record<string, unknown> = {}) => ({
+  accessRole: "owner",
+  id: "calendar-1@group.calendar.google.com",
+  summary: "Work",
+  ...overrides,
+});
+
+describe("listUserCalendars", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns no calendars when Google omits the empty items array", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(Response.json({
+      kind: "calendar#calendarList",
+    }))));
+
+    await expect(listUserCalendars("access-token")).resolves.toEqual([]);
+  });
+
+  it("falls back to the calendar ID when an entry has no display name", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(Response.json({
+      items: [{ accessRole: "owner", id: "unnamed@example.com" }],
+      kind: "calendar#calendarList",
+    }))));
+
+    const [calendar] = await listUserCalendars("access-token");
+
+    expect(calendar?.summary).toBe("unnamed@example.com");
+  });
+
+  it("keeps the readable calendars when one entry is unusable and reports the count", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(Response.json({
+      items: [
+        calendarEntry({ id: "good-1", summary: "Work" }),
+        { accessRole: "owner", summary: "Missing an ID" },
+        calendarEntry({ id: "good-2", summary: "Personal" }),
+      ],
+      kind: "calendar#calendarList",
+    }))));
+    const onInvalidEntries = vi.fn();
+
+    const calendars = await listUserCalendars("access-token", { onInvalidEntries });
+
+    expect(calendars.map((calendar) => calendar.id)).toEqual(["good-1", "good-2"]);
+    expect(onInvalidEntries).toHaveBeenCalledWith(1);
+  });
+
+  it("pages through the calendar list", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(Response.json({
+        items: [calendarEntry({ id: "page-1" })],
+        kind: "calendar#calendarList",
+        nextPageToken: "token-2",
+      }))
+      .mockResolvedValueOnce(Response.json({
+        items: [calendarEntry({ id: "page-2" })],
+        kind: "calendar#calendarList",
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const calendars = await listUserCalendars("access-token");
+
+    expect(calendars.map((calendar) => calendar.id)).toEqual(["page-1", "page-2"]);
+    expect(new URL(String(fetchMock.mock.calls[1]?.[0])).searchParams.get("pageToken")).toBe("token-2");
+  });
+
+  it("throws an authentication-required error when Google rejects the token", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(new Response(null, { status: 401 }))));
+
+    await expect(listUserCalendars("access-token")).rejects.toMatchObject({
+      authRequired: true,
+      status: 401,
+    });
+  });
+});

--- a/packages/data-schemas/src/index.ts
+++ b/packages/data-schemas/src/index.ts
@@ -315,12 +315,16 @@ const googleCalendarListEntrySchema = type({
   "foregroundColor?": "string",
   id: "string",
   "primary?": "boolean",
-  summary: "string",
+  "summary?": "string",
 });
 type GoogleCalendarListEntry = typeof googleCalendarListEntrySchema.infer;
 
+/*
+ * Google omits empty arrays, and entries are validated one by one so an unusual calendar
+ * costs that calendar rather than the whole account.
+ */
 const googleCalendarListResponseSchema = type({
-  items: googleCalendarListEntrySchema.array(),
+  "items?": "unknown[]",
   kind: "'calendar#calendarList'",
   "nextPageToken?": "string",
 });

--- a/services/api/src/routes/api/sources/google/calendars.ts
+++ b/services/api/src/routes/api/sources/google/calendars.ts
@@ -16,7 +16,11 @@ const GET = withWideEvent(
       isCalendarListError: (error): error is CalendarListError =>
         error instanceof CalendarListError,
       listCalendars: async (accessToken) => {
-        const calendars = await listUserCalendars(accessToken);
+        const calendars = await listUserCalendars(accessToken, {
+          onInvalidEntries: (count) => {
+            widelog.set("provider.calendar_entries_invalid", count);
+          },
+        });
         return calendars.map((calendar) => ({
           id: calendar.id,
           primary: calendar.primary,


### PR DESCRIPTION
Not stacked on anything: merges cleanly against `main` and against all of #602, #603, #604 and #606.

Closes #588. `googleCalendarListResponseSchema` required `items` and `summary`, but Google omits empty arrays and some calendars have no display name, so a user with no readable calendars — or one odd calendar — got `TraversalError: items must be an array (was missing)` and an opaque 500 from `GET /api/sources/google/calendars`, blocking the whole connect flow. The two sibling event schemas already treat `items` as optional; this one now matches.

- `items` optional and absent treated as empty; `summary` optional with the calendar ID as the display fallback
- entries are validated one at a time, so an unusable calendar costs that calendar instead of the whole account
- skipped entries are not silent: the route records `provider.calendar_entries_invalid` on the wide event
- tests cover the omitted array, the missing summary, a bad entry among good ones, pagination, and the auth-error path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmVsczuP6e2i7VwjhvXxH
