### PR TITLE
fix(ics): recover event-level timezones instead of failing whole feeds

### DIFF
--- a/packages/calendar/src/core/sync-engine/ingest.ts
+++ b/packages/calendar/src/core/sync-engine/ingest.ts
@@ -26,6 +26,12 @@ interface FetchEventsResult {
   unchanged?: boolean;
   skippedResourceCount?: number;
   skippedResourceReasons?: string[];
+  /**
+   * Events the provider returned that Keeper cannot represent (an RDATE series,
+   * a timezone no runtime can interpret). They stay in `events` so removal stays
+   * computed against the full feed; only ingestion withholds them.
+   */
+  unsupportedEventUids?: string[];
   syncWindow?: SyncWindow;
   coverage?: {
     futureRange: SyncRange;
@@ -141,6 +147,12 @@ const ingestSource = async (options: IngestSourceOptions): Promise<IngestionResu
     const fetchResult = await fetchEvents();
     wideEvent["source_events.count"] = fetchResult.events.length;
     let sourceEvents = fetchResult.events;
+    const unsupportedEventUids = new Set(fetchResult.unsupportedEventUids);
+    if (unsupportedEventUids.size > 0) {
+      sourceEvents = sourceEvents.filter(({ uid }) => !unsupportedEventUids.has(uid));
+      wideEvent["source_events.unsupported_count"] = unsupportedEventUids.size;
+      wideEvent["source_events.unsupported_uids"] = [...unsupportedEventUids].join(",");
+    }
     if (sourceEvents.some((event) => event.recurrenceRule)) {
       if (!fetchResult.syncWindow) {
         throw new RangeError("Recurring source ingestion requires an explicit sync window");

--- a/packages/calendar/src/ics/utils/apply-patches.ts
+++ b/packages/calendar/src/ics/utils/apply-patches.ts
@@ -32,6 +32,12 @@ interface ParsedPropertyLine {
 
 interface IcsPropertyContext extends ParsedPropertyLine {
   componentPath: readonly string[];
+  /**
+   * Parallel to componentPath, holding a unique id per component occurrence.
+   * Two sibling VEVENTs share a component path, so callers that need to group
+   * properties by the event they came from cannot key on the path alone.
+   */
+  componentInstancePath: readonly number[];
 }
 
 type IcsPropertyVisitor = (context: IcsPropertyContext) => void;
@@ -99,6 +105,8 @@ const parsePropertyLine = (line: string): ParsedPropertyLine | null => {
 const visitIcsProperties = (ics: string, visitor: IcsPropertyVisitor): void => {
   const rawLines = stripIcsByteOrderMark(ics).split(LINE_BREAK_PATTERN);
   const componentPath: string[] = [];
+  const componentInstancePath: number[] = [];
+  let componentCount = 0;
   for (const indices of groupContinuations(rawLines)) {
     const parsed = parsePropertyLine(unfoldGroup(rawLines, indices));
     if (!parsed) {
@@ -106,6 +114,8 @@ const visitIcsProperties = (ics: string, visitor: IcsPropertyVisitor): void => {
     }
     if (parsed.property === "BEGIN") {
       componentPath.push(parsed.value.toUpperCase());
+      componentCount += 1;
+      componentInstancePath.push(componentCount);
       continue;
     }
     if (parsed.property === "END") {
@@ -117,9 +127,14 @@ const visitIcsProperties = (ics: string, visitor: IcsPropertyVisitor): void => {
         );
       }
       componentPath.pop();
+      componentInstancePath.pop();
       continue;
     }
-    visitor({ ...parsed, componentPath: [...componentPath] });
+    visitor({
+      ...parsed,
+      componentInstancePath: [...componentInstancePath],
+      componentPath: [...componentPath],
+    });
   }
   if (componentPath.length > 0) {
     throw new RangeError(

--- a/packages/calendar/src/ics/utils/fetch-adapter.ts
+++ b/packages/calendar/src/ics/utils/fetch-adapter.ts
@@ -10,9 +10,14 @@ import type { BunSQLDatabase } from "drizzle-orm/bun-sql";
 import type { SourceIngestionPlan } from "../../core/sync/sync-range";
 import { normalizeTimezone } from "./normalize-timezone";
 import {
-  assertNoUnsupportedRecurrenceDates,
-  assertSupportedRecurrenceTimeZones,
+  collectRecurrenceDateEventUids,
+  resolveRecurrenceTimeZones,
 } from "./validate-recurrence-input";
+import {
+  readDeclaredTimeZoneOffsets,
+  resolveDeclaredTimeZone,
+} from "./resolve-timezone-identifier";
+import type { DeclaredTimeZoneOffsets } from "./resolve-timezone-identifier";
 import { wallTimeToInstant } from "./timezone-instant";
 
 interface IcsSourceFetcherConfig {
@@ -44,35 +49,110 @@ const FLOATING_DATE_PROPERTIES = new Set([
 ]);
 
 const FLOATING_UNTIL_PATTERN = /(^|;)UNTIL=(\d{8}T\d{6})(?=;|$)/i;
+const TZID_PARAMETER_PATTERN = /;TZID=(?:"([^"]*)"|([^;:]*))/i;
+
+interface IcsPropertyParts {
+  parameters: string[];
+  property: string;
+  propertyName: string;
+  value: string;
+}
+
+/**
+ * The zone a VEVENT's own DTSTART declares. Recurrence properties that carry no
+ * zone of their own are anchored to it, which is what every client means by a
+ * floating EXDATE/UNTIL on a zoned series.
+ */
+interface EventTimeZoneContext {
+  isAllDay: boolean;
+  timeZone?: string;
+}
+
+interface IcsLineBlock {
+  insideEvent: boolean;
+  lines: string[];
+}
+
+interface EventFloatingZones {
+  declared?: string;
+  resolved?: string;
+}
 
 const formatUtcIcsDateTime = (date: Date): string =>
   date.toISOString().replaceAll(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
 
-const applyCalendarTimeZoneToFloatingUntil = (
+const readFloatingWallTime = (recurrenceRuleValue: string): Date => {
+  const floatingUntil = FLOATING_UNTIL_PATTERN.exec(recurrenceRuleValue)?.[2] ?? "";
+  return new Date(Date.UTC(
+    Number(floatingUntil.slice(0, 4)),
+    Number(floatingUntil.slice(4, 6)) - 1,
+    Number(floatingUntil.slice(6, 8)),
+    Number(floatingUntil.slice(9, 11)),
+    Number(floatingUntil.slice(11, 13)),
+    Number(floatingUntil.slice(13, 15)),
+  ));
+};
+
+const parseIcsPropertyParts = (line: string): IcsPropertyParts | null => {
+  const separatorIndex = line.indexOf(":");
+  if (separatorIndex === -1) {
+    return null;
+  }
+  const property = line.slice(0, separatorIndex);
+  const [propertyName, ...parameters] = property.toUpperCase().split(";");
+  if (!propertyName) {
+    return null;
+  }
+  return {
+    parameters,
+    property,
+    propertyName,
+    value: line.slice(separatorIndex + 1),
+  };
+};
+
+const readEventTimeZoneContext = (lines: readonly string[]): EventTimeZoneContext => {
+  for (const line of lines) {
+    const parts = parseIcsPropertyParts(line);
+    if (!parts || parts.propertyName !== "DTSTART") {
+      continue;
+    }
+    if (parts.parameters.includes("VALUE=DATE")) {
+      return { isAllDay: true };
+    }
+    const match = TZID_PARAMETER_PATTERN.exec(parts.property);
+    const timeZone = match?.[1] ?? match?.[2];
+    if (!timeZone) {
+      return { isAllDay: false };
+    }
+    return { isAllDay: false, timeZone };
+  }
+  return { isAllDay: false };
+};
+
+const splitIcsLineBlocks = (lines: readonly string[]): IcsLineBlock[] => {
+  const blocks: IcsLineBlock[] = [{ insideEvent: false, lines: [] }];
+  for (const line of lines) {
+    const upperLine = line.toUpperCase();
+    if (upperLine === "BEGIN:VEVENT") {
+      blocks.push({ insideEvent: true, lines: [line] });
+      continue;
+    }
+    blocks.at(-1)?.lines.push(line);
+    if (upperLine === "END:VEVENT") {
+      blocks.push({ insideEvent: false, lines: [] });
+    }
+  }
+  return blocks;
+};
+
+const applyTimeZoneToFloatingUntil = (
   line: string,
-  calendarTimeZone: string | undefined,
+  timeZone: string,
 ): string => {
   const separatorIndex = line.indexOf(":");
-  if (separatorIndex === -1 || line.slice(0, separatorIndex).toUpperCase() !== "RRULE") {
-    return line;
-  }
   const value = line.slice(separatorIndex + 1);
-  const match = FLOATING_UNTIL_PATTERN.exec(value);
-  const floatingUntil = match?.[2];
-  if (!floatingUntil) {
-    return line;
-  }
-  if (!calendarTimeZone) {
-    throw new RangeError("Floating ICS RRULE UNTIL requires an explicit X-WR-TIMEZONE");
-  }
-  const year = Number(floatingUntil.slice(0, 4));
-  const month = Number(floatingUntil.slice(4, 6));
-  const day = Number(floatingUntil.slice(6, 8));
-  const hour = Number(floatingUntil.slice(9, 11));
-  const minute = Number(floatingUntil.slice(11, 13));
-  const second = Number(floatingUntil.slice(13, 15));
-  const wallTime = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
-  const instant = wallTimeToInstant(wallTime, calendarTimeZone);
+  const instant = wallTimeToInstant(readFloatingWallTime(value), timeZone);
   const normalizedValue = value.replace(
     FLOATING_UNTIL_PATTERN,
     (matched, prefix: string) => `${prefix}UNTIL=${formatUtcIcsDateTime(instant)}`,
@@ -80,53 +160,111 @@ const applyCalendarTimeZoneToFloatingUntil = (
   return `${line.slice(0, separatorIndex + 1)}${normalizedValue}`;
 };
 
+const normalizeFloatingRecurrenceRule = (
+  line: string,
+  zones: EventFloatingZones,
+): string => {
+  const separatorIndex = line.indexOf(":");
+  const match = FLOATING_UNTIL_PATTERN.exec(line.slice(separatorIndex + 1));
+  if (!match?.[2]) {
+    return line;
+  }
+  if (!zones.declared) {
+    throw new RangeError("Floating ICS RRULE UNTIL requires an explicit X-WR-TIMEZONE");
+  }
+  if (!zones.resolved) {
+    /*
+     * The event declares a zone this runtime cannot interpret. Leaving UNTIL
+     * alone keeps the feed parseable; resolveRecurrenceTimeZones reports the
+     * same event as unsupported so it is withheld and counted, not synced with
+     * a guessed offset.
+     */
+    return line;
+  }
+  return applyTimeZoneToFloatingUntil(line, zones.resolved);
+};
+
+const isAbsoluteDateEntry = (entry: string): boolean =>
+  entry.endsWith("Z") || /^\d{8}$/.test(entry);
+
+const normalizeFloatingDateProperty = (
+  line: string,
+  parts: IcsPropertyParts,
+  zones: EventFloatingZones,
+): string[] => {
+  if (
+    !FLOATING_DATE_PROPERTIES.has(parts.propertyName)
+    || parts.property.toUpperCase().includes("TZID=")
+    || parts.parameters.includes("VALUE=DATE")
+  ) {
+    return [line];
+  }
+  const entries = parts.value.split(",");
+  const floatingEntries = entries.filter((entry) => !isAbsoluteDateEntry(entry));
+  if (floatingEntries.length === 0) {
+    return [line];
+  }
+  if (!zones.declared) {
+    throw new RangeError(
+      `Floating ICS ${parts.propertyName} requires an explicit TZID or X-WR-TIMEZONE`,
+    );
+  }
+  const zonedLine = `${parts.property};TZID=${zones.declared}:${floatingEntries.join(",")}`;
+  const absoluteEntries = entries.filter((entry) => isAbsoluteDateEntry(entry));
+  if (absoluteEntries.length === 0) {
+    return [zonedLine];
+  }
+  /*
+   * A TZID parameter applies to every value on the property, so the absolute
+   * entries of a mixed multi-value list are re-emitted on their own line rather
+   * than being reinterpreted in the event's zone.
+   */
+  return [zonedLine, `${parts.property}:${absoluteEntries.join(",")}`];
+};
+
+const normalizeFloatingEventBlock = (
+  block: IcsLineBlock,
+  calendarTimeZone: string | undefined,
+  declaredOffsets: DeclaredTimeZoneOffsets,
+): string[] => {
+  const context = readEventTimeZoneContext(block.lines);
+  /*
+   * An all-day series has no wall-clock zone to resolve against: DTSTART is a
+   * date, so a date-time UNTIL or EXDATE on it is compared as a date anyway.
+   */
+  if (context.isAllDay) {
+    return block.lines;
+  }
+  const declared = context.timeZone ?? calendarTimeZone;
+  const zones: EventFloatingZones = {
+    declared,
+    resolved: resolveDeclaredTimeZone(declared, declaredOffsets),
+  };
+
+  return block.lines.flatMap((line) => {
+    const parts = parseIcsPropertyParts(line);
+    if (!parts) {
+      return [line];
+    }
+    if (parts.propertyName === "RRULE") {
+      return [normalizeFloatingRecurrenceRule(line, zones)];
+    }
+    return normalizeFloatingDateProperty(line, parts, zones);
+  });
+};
+
 const applyCalendarTimeZoneToFloatingEventDates = (
   ical: string,
   calendarTimeZone: string | undefined,
 ): string => {
   const unfolded = ical.replaceAll(/\r?\n[\t ]/g, "");
-  let insideEvent = false;
+  const declaredOffsets = readDeclaredTimeZoneOffsets(unfolded);
 
-  return unfolded.split(/\r?\n/).map((line) => {
-    if (line.toUpperCase() === "BEGIN:VEVENT") {
-      insideEvent = true;
-      return line;
+  return splitIcsLineBlocks(unfolded.split(/\r?\n/)).flatMap((block) => {
+    if (!block.insideEvent) {
+      return block.lines;
     }
-    if (line.toUpperCase() === "END:VEVENT") {
-      insideEvent = false;
-      return line;
-    }
-    if (!insideEvent) {
-      return line;
-    }
-
-    if (line.slice(0, line.indexOf(":")).toUpperCase() === "RRULE") {
-      return applyCalendarTimeZoneToFloatingUntil(line, calendarTimeZone);
-    }
-
-    const separatorIndex = line.indexOf(":");
-    if (separatorIndex === -1) {
-      return line;
-    }
-    const property = line.slice(0, separatorIndex);
-    const [propertyName, ...parameters] = property.toUpperCase().split(";");
-    const value = line.slice(separatorIndex + 1);
-    if (
-      !propertyName
-      || !FLOATING_DATE_PROPERTIES.has(propertyName)
-      || property.toUpperCase().includes("TZID=")
-      || parameters.includes("VALUE=DATE")
-      || value.split(",").every((entry) => entry.endsWith("Z") || /^\d{8}$/.test(entry))
-    ) {
-      return line;
-    }
-
-    if (!calendarTimeZone) {
-      throw new RangeError(
-        `Floating ICS ${propertyName} requires an explicit TZID or X-WR-TIMEZONE`,
-      );
-    }
-    return `${property};TZID=${calendarTimeZone}:${value}`;
+    return normalizeFloatingEventBlock(block, calendarTimeZone, declaredOffsets);
   }).join("\r\n");
 };
 
@@ -154,7 +292,7 @@ const createIcsSourceFetcher = (config: IcsSourceFetcherConfig): IcsSourceFetche
        */
       return { events: [], syncWindow, unchanged: true };
     }
-    assertNoUnsupportedRecurrenceDates(ical);
+    const recurrenceDateUids = collectRecurrenceDateEventUids(ical);
     const snapshotResult = await prepareCalendarSnapshot(config.database, config.calendarId, ical);
     const initialCalendar = parseIcsCalendarLenient({
       icsString: ical,
@@ -170,8 +308,11 @@ const createIcsSourceFetcher = (config: IcsSourceFetcherConfig): IcsSourceFetche
       });
     }
     const parsed = parseIcsEvents(calendar);
-    assertSupportedRecurrenceTimeZones(parsed);
-    let events: SourceEvent[] = parsed.map((event) => ({
+    const recurrenceTimeZones = resolveRecurrenceTimeZones(
+      parsed,
+      readDeclaredTimeZoneOffsets(ical),
+    );
+    let events: SourceEvent[] = recurrenceTimeZones.events.map((event) => ({
       availability: event.availability,
       description: event.description,
       endTime: event.endTime,
@@ -197,6 +338,16 @@ const createIcsSourceFetcher = (config: IcsSourceFetcherConfig): IcsSourceFetche
      * Filtering here would make the snapshot diff delete the stored state of
      * every historic event on the next ingest.
      */
+    /*
+     * Unsupported events stay in the returned feed so the snapshot diff still
+     * sees them as present: ingestion withholds them from inserts, but treating
+     * them as absent would delete the stored state they already have. One event
+     * Keeper cannot represent must not fail, or silently empty, the whole feed.
+     */
+    const unsupportedEventUids = [...new Set([
+      ...recurrenceDateUids,
+      ...recurrenceTimeZones.unsupportedUids,
+    ])];
     const result: FetchEventsResult = {
       events,
       syncWindow,
@@ -205,6 +356,7 @@ const createIcsSourceFetcher = (config: IcsSourceFetcherConfig): IcsSourceFetche
         historicRange,
         window: syncWindow,
       },
+      ...unsupportedEventUids.length > 0 && { unsupportedEventUids },
     };
     if (snapshotResult.changed && snapshotResult.snapshot) {
       result.snapshot = snapshotResult.snapshot;

--- a/packages/calendar/src/ics/utils/resolve-timezone-identifier.ts
+++ b/packages/calendar/src/ics/utils/resolve-timezone-identifier.ts
@@ -1,0 +1,138 @@
+/**
+ * Timezone identifier recovery for real-world ICS feeds.
+ *
+ * RFC 5545 lets a feed name its own TZID as long as a matching VTIMEZONE is
+ * declared, so plenty of clients ship identifiers Intl has never heard of:
+ * Thunderbird/Lightning writes tzurl-style `/mozilla.org/<version>/America/Denver`,
+ * and Exchange writes labels such as `Customized Time Zone` or
+ * `(UTC-07:00) Mountain Time (US & Canada)`. The zone information is still in
+ * the file, so recover it instead of rejecting the event: extract the trailing
+ * IANA zone from prefixed identifiers, and fall back to the offset the declared
+ * VTIMEZONE uses when that VTIMEZONE never changes offset.
+ *
+ * A VTIMEZONE with DST transitions is deliberately not mapped onto a fixed
+ * offset: half the year would be an hour wrong, which is worse than reporting
+ * the event as unsupported.
+ */
+
+import { normalizeTimezone } from "./normalize-timezone";
+import { visitIcsProperties } from "./apply-patches";
+
+type DeclaredTimeZoneOffsets = ReadonlyMap<string, readonly number[]>;
+
+const MINUTES_PER_HOUR = 60;
+const MAX_FIXED_OFFSET_HOURS = 14;
+const MAX_IANA_ZONE_SEGMENTS = 3;
+const UTC_OFFSET_PATTERN = /^([+-])(\d{2})(\d{2})(\d{2})?$/;
+
+const isSupportedTimeZone = (timeZone: string): boolean => {
+  try {
+    const formatter = new Intl.DateTimeFormat("en-CA", { timeZone });
+    return Boolean(formatter);
+  } catch {
+    return false;
+  }
+};
+
+const extractPrefixedIanaTimeZone = (identifier: string): string | undefined => {
+  if (!identifier.startsWith("/")) {
+    return;
+  }
+  const segments = identifier.split("/").filter(Boolean);
+  const candidates = Array.from(
+    { length: Math.min(MAX_IANA_ZONE_SEGMENTS, segments.length) },
+    (value, index) => segments.slice(-(index + 1)).join("/"),
+  ).toReversed();
+  return candidates.find((candidate) => isSupportedTimeZone(candidate));
+};
+
+const parseUtcOffsetMinutes = (offset: string): number | undefined => {
+  const match = UTC_OFFSET_PATTERN.exec(offset.trim());
+  if (!match) {
+    return;
+  }
+  const [, sign, hours, minutes] = match;
+  if (!sign || !hours || !minutes) {
+    return;
+  }
+  const magnitude = Number(hours) * MINUTES_PER_HOUR + Number(minutes);
+  if (sign === "-") {
+    return -magnitude;
+  }
+  return magnitude;
+};
+
+/**
+ * `Etc/GMT+N` is the IANA zone whose UTC offset is minus N hours, so the sign is
+ * inverted on purpose. Fixed zones are used rather than a bare `-07:00` because
+ * destination providers require an IANA identifier.
+ */
+const buildFixedOffsetTimeZone = (offsetMinutes: number): string | undefined => {
+  if (offsetMinutes % MINUTES_PER_HOUR !== 0) {
+    return;
+  }
+  const hours = offsetMinutes / MINUTES_PER_HOUR;
+  if (Math.abs(hours) > MAX_FIXED_OFFSET_HOURS) {
+    return;
+  }
+  if (hours === 0) {
+    return "Etc/UTC";
+  }
+  if (hours < 0) {
+    return `Etc/GMT+${Math.abs(hours)}`;
+  }
+  return `Etc/GMT-${hours}`;
+};
+
+const readDeclaredTimeZoneOffsets = (ical: string): DeclaredTimeZoneOffsets => {
+  const declared = new Map<string, number[]>();
+  let currentTimeZoneId = "";
+  visitIcsProperties(ical, ({ componentPath, property, value }) => {
+    if (!componentPath.includes("VTIMEZONE")) {
+      return;
+    }
+    if (property === "TZID" && componentPath.at(-1) === "VTIMEZONE") {
+      currentTimeZoneId = value;
+      declared.set(currentTimeZoneId, declared.get(currentTimeZoneId) ?? []);
+      return;
+    }
+    if (property !== "TZOFFSETTO" || !currentTimeZoneId) {
+      return;
+    }
+    const offsetMinutes = parseUtcOffsetMinutes(value);
+    if (offsetMinutes === globalThis.undefined) {
+      return;
+    }
+    declared.get(currentTimeZoneId)?.push(offsetMinutes);
+  });
+  return declared;
+};
+
+const resolveDeclaredTimeZone = (
+  identifier: string | undefined,
+  declaredOffsets: DeclaredTimeZoneOffsets,
+): string | undefined => {
+  const normalized = normalizeTimezone(identifier);
+  if (!normalized) {
+    return;
+  }
+  if (isSupportedTimeZone(normalized)) {
+    return normalized;
+  }
+  const extracted = extractPrefixedIanaTimeZone(normalized);
+  if (extracted) {
+    return extracted;
+  }
+  const offsets = declaredOffsets.get(normalized)
+    ?? declaredOffsets.get(identifier ?? "")
+    ?? [];
+  const uniqueOffsets = new Set(offsets);
+  const [offsetMinutes] = uniqueOffsets;
+  if (uniqueOffsets.size !== 1 || offsetMinutes === globalThis.undefined) {
+    return;
+  }
+  return buildFixedOffsetTimeZone(offsetMinutes);
+};
+
+export { readDeclaredTimeZoneOffsets, resolveDeclaredTimeZone };
+export type { DeclaredTimeZoneOffsets };

--- a/packages/calendar/src/ics/utils/validate-recurrence-input.ts
+++ b/packages/calendar/src/ics/utils/validate-recurrence-input.ts
@@ -1,10 +1,23 @@
 import type { IcsRecurrenceRule } from "ts-ics";
 import { visitIcsProperties } from "./apply-patches";
 import { resolveTimeZone } from "./timezone-instant";
+import { resolveDeclaredTimeZone } from "./resolve-timezone-identifier";
+import type { DeclaredTimeZoneOffsets } from "./resolve-timezone-identifier";
 
 interface RecurrenceTimeZoneInput {
   recurrenceRule?: IcsRecurrenceRule;
   startTimeZone?: string;
+  uid: string;
+}
+
+interface RecurrenceTimeZoneResolution<Event> {
+  events: Event[];
+  unsupportedUids: string[];
+}
+
+interface EventRecurrenceDateState {
+  hasRecurrenceDates: boolean;
+  uid: string;
 }
 
 const assertNoUnsupportedRecurrenceDates = (ical: string): void => {
@@ -15,8 +28,36 @@ const assertNoUnsupportedRecurrenceDates = (ical: string): void => {
   });
 };
 
+/**
+ * RDATE stays unsupported because recurrence-materializer has no handling for
+ * it and would silently drop the extra occurrences. Reporting the affected UIDs
+ * instead of throwing keeps that rejection per-event: one client-written RDATE
+ * must not stop every other event in the feed from syncing.
+ */
+const collectRecurrenceDateEventUids = (ical: string): string[] => {
+  const states = new Map<number, EventRecurrenceDateState>();
+  visitIcsProperties(ical, ({ componentInstancePath, componentPath, property, value }) => {
+    const eventDepth = componentPath.indexOf("VEVENT");
+    const eventInstance = componentInstancePath[eventDepth];
+    if (eventDepth === -1 || eventInstance === globalThis.undefined) {
+      return;
+    }
+    const current = states.get(eventInstance) ?? { hasRecurrenceDates: false, uid: "" };
+    const isEventProperty = componentPath.at(-1) === "VEVENT";
+    states.set(eventInstance, {
+      hasRecurrenceDates: current.hasRecurrenceDates
+        || isEventProperty && property === "RDATE",
+      uid: (isEventProperty && property === "UID" && value) || current.uid,
+    });
+  });
+
+  return [...states.values()]
+    .filter((state) => state.hasRecurrenceDates && state.uid)
+    .map((state) => state.uid);
+};
+
 const assertSupportedRecurrenceTimeZones = (
-  events: RecurrenceTimeZoneInput[],
+  events: Pick<RecurrenceTimeZoneInput, "recurrenceRule" | "startTimeZone">[],
 ): void => {
   for (const event of events) {
     if (event.recurrenceRule) {
@@ -25,4 +66,38 @@ const assertSupportedRecurrenceTimeZones = (
   }
 };
 
-export { assertNoUnsupportedRecurrenceDates, assertSupportedRecurrenceTimeZones };
+/**
+ * Recurring events are the only ones materialized against an Intl timezone, so
+ * they are the only ones that need a resolvable identifier. Events whose zone
+ * can be recovered are rewritten to the recovered zone; the rest are reported
+ * so the caller can withhold them and count them, rather than failing the feed.
+ */
+const resolveRecurrenceTimeZones = <Event extends RecurrenceTimeZoneInput>(
+  events: readonly Event[],
+  declaredOffsets: DeclaredTimeZoneOffsets,
+): RecurrenceTimeZoneResolution<Event> => {
+  const unsupportedUids: string[] = [];
+  const resolvedEvents = events.map((event) => {
+    if (!event.recurrenceRule || !event.startTimeZone) {
+      return event;
+    }
+    const timeZone = resolveDeclaredTimeZone(event.startTimeZone, declaredOffsets);
+    if (!timeZone) {
+      unsupportedUids.push(event.uid);
+      return event;
+    }
+    if (timeZone === event.startTimeZone) {
+      return event;
+    }
+    return { ...event, startTimeZone: timeZone };
+  });
+
+  return { events: resolvedEvents, unsupportedUids };
+};
+
+export {
+  assertNoUnsupportedRecurrenceDates,
+  assertSupportedRecurrenceTimeZones,
+  collectRecurrenceDateEventUids,
+  resolveRecurrenceTimeZones,
+};

--- a/packages/calendar/tests/core/sync-engine/ingest.test.ts
+++ b/packages/calendar/tests/core/sync-engine/ingest.test.ts
@@ -1023,6 +1023,44 @@ describe("ingestSource", () => {
     expect(emittedEvents[0]?.["outcome"]).not.toBe("error");
   });
 
+  it("withholds unsupported events, counts them, and keeps their stored state", async () => {
+    const { ingestSource } = await import("../../../src/core/sync-engine/ingest");
+    const unsupported = makeSourceEvent(
+      "unsupported-series",
+      new Date("2026-03-02T09:00:00.000Z"),
+      new Date("2026-03-02T10:00:00.000Z"),
+    );
+    const healthy = makeSourceEvent(
+      "healthy-event",
+      new Date("2026-03-03T09:00:00.000Z"),
+      new Date("2026-03-03T10:00:00.000Z"),
+    );
+    const emittedEvents: Record<string, unknown>[] = [];
+    const flushes: IngestionChanges[] = [];
+
+    const result = await ingestSource({
+      calendarId: "cal-1",
+      fetchEvents: () => Promise.resolve({
+        events: [unsupported, healthy],
+        unsupportedEventUids: ["unsupported-series"],
+      }),
+      flush: (changes) => {
+        flushes.push(changes);
+        return Promise.resolve();
+      },
+      onIngestEvent: (event) => emittedEvents.push(event),
+      readExistingEvents: () => Promise.resolve([
+        toExistingEvent("unsupported-state", unsupported),
+      ]),
+    });
+
+    expect(flushes[0]?.inserts.map(({ uid }) => uid)).toEqual(["healthy-event"]);
+    expect(flushes[0]?.deletes).toEqual([]);
+    expect(result.eventsAdded).toBe(1);
+    expect(emittedEvents[0]?.["source_events.unsupported_count"]).toBe(1);
+    expect(emittedEvents[0]?.["source_events.unsupported_uids"]).toBe("unsupported-series");
+  });
+
   it("keeps the stored events of an over-budget series instead of deleting them", async () => {
     const { ingestSource } = await import("../../../src/core/sync-engine/ingest");
     const pathological: SourceEvent = {

--- a/packages/calendar/tests/ics/utils/fetch-adapter.test.ts
+++ b/packages/calendar/tests/ics/utils/fetch-adapter.test.ts
@@ -247,20 +247,42 @@ describe("createIcsSourceFetcher", () => {
     expect(result.unchanged).toBeUndefined();
   });
 
-  it("rejects RDATE instead of silently dropping additional occurrences", async () => {
+  it("reports the RDATE event as unsupported instead of failing the whole feed", async () => {
     const { createIcsSourceFetcher } = await import("../../../src/ics/utils/fetch-adapter");
     const rdateIcs = MINIMAL_ICS.replace(
-      "DTEND:20260517T130000Z",
-      "DTEND:20260517T130000Z\r\nRDATE:20260519T120000Z",
+      "END:VCALENDAR",
+      [
+        "BEGIN:VEVENT",
+        "UID:rdate@test",
+        "DTSTAMP:20260517T000000Z",
+        "DTSTART:20260518T120000Z",
+        "DTEND:20260518T130000Z",
+        "RDATE:20260519T120000Z",
+        "END:VEVENT",
+        "END:VCALENDAR",
+      ].join("\r\n"),
     );
     mockPullRemoteCalendar.mockResolvedValueOnce({ ical: rdateIcs });
+    mockPrepareCalendarSnapshot.mockResolvedValueOnce({ changed: false });
+
+    const result = await createIcsSourceFetcher(buildConfig()).fetchEvents();
+
+    expect(result.events.map(({ uid }) => uid)).toEqual(["event-1@test", "rdate@test"]);
+    expect(result.unsupportedEventUids).toEqual(["rdate@test"]);
+    expect(mockPrepareCalendarSnapshot).toHaveBeenCalled();
+  });
+
+  it("still rejects a malformed component boundary that could hide an RDATE", async () => {
+    const { createIcsSourceFetcher } = await import("../../../src/ics/utils/fetch-adapter");
+    const malformedIcs = MINIMAL_ICS.replace("END:VEVENT", "END:VALARM");
+    mockPullRemoteCalendar.mockResolvedValueOnce({ ical: malformedIcs });
 
     await expect(createIcsSourceFetcher(buildConfig()).fetchEvents())
-      .rejects.toThrow("ICS RDATE recurrence is not supported");
+      .rejects.toThrow("expected END:VEVENT, received END:VALARM");
     expect(mockPrepareCalendarSnapshot).not.toHaveBeenCalled();
   });
 
-  it("rejects custom-timezone recurrence before it can poison destination sync", async () => {
+  it("resolves an unrecognised fixed-offset TZID from its declared VTIMEZONE", async () => {
     const { createIcsSourceFetcher } = await import("../../../src/ics/utils/fetch-adapter");
     const customTimezoneIcs = [
       "BEGIN:VCALENDAR",
@@ -283,13 +305,248 @@ describe("createIcsSourceFetcher", () => {
       "END:VCALENDAR",
     ].join("\r\n");
     mockPullRemoteCalendar.mockResolvedValueOnce({ ical: customTimezoneIcs });
-    mockPrepareCalendarSnapshot.mockResolvedValueOnce({
-      changed: true,
-      snapshot: { contentHash: "custom-timezone", ical: customTimezoneIcs },
+    mockPrepareCalendarSnapshot.mockResolvedValueOnce({ changed: false });
+
+    const result = await createIcsSourceFetcher(buildConfig()).fetchEvents();
+
+    expect(result.events[0]).toMatchObject({
+      startTime: new Date("2026-07-01T14:00:00.000Z"),
+      startTimeZone: "Etc/GMT+5",
     });
+    expect(result.unsupportedEventUids).toBeUndefined();
+  });
+
+  it("resolves a tzurl-style TZID to the IANA zone it carries", async () => {
+    const { createIcsSourceFetcher } = await import("../../../src/ics/utils/fetch-adapter");
+    const mozillaIcs = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//test//test//EN",
+      "BEGIN:VTIMEZONE",
+      "TZID:/mozilla.org/20050126_1/America/Denver",
+      "BEGIN:STANDARD",
+      "DTSTART:19701101T020000",
+      "TZOFFSETFROM:-0600",
+      "TZOFFSETTO:-0700",
+      "END:STANDARD",
+      "BEGIN:DAYLIGHT",
+      "DTSTART:19700308T020000",
+      "TZOFFSETFROM:-0700",
+      "TZOFFSETTO:-0600",
+      "END:DAYLIGHT",
+      "END:VTIMEZONE",
+      "BEGIN:VEVENT",
+      "UID:thunderbird@test",
+      "DTSTART;TZID=/mozilla.org/20050126_1/America/Denver:20260701T090000",
+      "DTEND;TZID=/mozilla.org/20050126_1/America/Denver:20260701T100000",
+      "RRULE:FREQ=DAILY;COUNT=2",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    mockPullRemoteCalendar.mockResolvedValueOnce({ ical: mozillaIcs });
+    mockPrepareCalendarSnapshot.mockResolvedValueOnce({ changed: false });
+
+    const result = await createIcsSourceFetcher(buildConfig()).fetchEvents();
+
+    expect(result.events[0]?.startTimeZone).toBe("America/Denver");
+    expect(result.unsupportedEventUids).toBeUndefined();
+  });
+
+  it("reports a recurring event whose timezone cannot be recovered without failing the feed", async () => {
+    const { createIcsSourceFetcher } = await import("../../../src/ics/utils/fetch-adapter");
+    const exchangeIcs = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//test//test//EN",
+      "BEGIN:VTIMEZONE",
+      "TZID:Customized Time Zone",
+      "BEGIN:STANDARD",
+      "DTSTART:19701101T020000",
+      "TZOFFSETFROM:-0600",
+      "TZOFFSETTO:-0700",
+      "END:STANDARD",
+      "BEGIN:DAYLIGHT",
+      "DTSTART:19700308T020000",
+      "TZOFFSETFROM:-0700",
+      "TZOFFSETTO:-0600",
+      "END:DAYLIGHT",
+      "END:VTIMEZONE",
+      "BEGIN:VEVENT",
+      "UID:exchange-custom@test",
+      "DTSTART;TZID=Customized Time Zone:20260701T090000",
+      "DTEND;TZID=Customized Time Zone:20260701T100000",
+      "RRULE:FREQ=DAILY;COUNT=2",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "UID:healthy@test",
+      "DTSTAMP:20260517T000000Z",
+      "DTSTART:20260517T120000Z",
+      "DTEND:20260517T130000Z",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    mockPullRemoteCalendar.mockResolvedValueOnce({ ical: exchangeIcs });
+    mockPrepareCalendarSnapshot.mockResolvedValueOnce({ changed: false });
+
+    const result = await createIcsSourceFetcher(buildConfig()).fetchEvents();
+
+    expect(result.events.map(({ uid }) => uid)).toEqual([
+      "exchange-custom@test",
+      "healthy@test",
+    ]);
+    expect(result.unsupportedEventUids).toEqual(["exchange-custom@test"]);
+  });
+
+  it("resolves a floating RRULE UNTIL against the event's own DTSTART timezone", async () => {
+    const { createIcsSourceFetcher } = await import("../../../src/ics/utils/fetch-adapter");
+    const zonedIcs = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//test//test//EN",
+      "BEGIN:VEVENT",
+      "UID:zoned-until@test",
+      "DTSTAMP:20260101T000000Z",
+      "DTSTART;TZID=America/Denver:20260105T090000",
+      "DTEND;TZID=America/Denver:20260105T100000",
+      "RRULE:FREQ=DAILY;UNTIL=20260112T090000",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    mockPullRemoteCalendar.mockResolvedValueOnce({ ical: zonedIcs });
+    mockPrepareCalendarSnapshot.mockResolvedValueOnce({ changed: false });
+
+    const result = await createIcsSourceFetcher(buildConfig()).fetchEvents();
+
+    expect(result.events[0]?.recurrenceRule?.until?.date).toEqual(
+      new Date("2026-01-12T16:00:00.000Z"),
+    );
+  });
+
+  it("resolves a floating EXDATE against the event's own DTSTART timezone", async () => {
+    const { createIcsSourceFetcher } = await import("../../../src/ics/utils/fetch-adapter");
+    const zonedIcs = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//test//test//EN",
+      "BEGIN:VEVENT",
+      "UID:zoned-exdate@test",
+      "DTSTAMP:20260101T000000Z",
+      "DTSTART;TZID=America/Denver:20260105T090000",
+      "DTEND;TZID=America/Denver:20260105T100000",
+      "RRULE:FREQ=DAILY;COUNT=5",
+      "EXDATE:20260106T090000",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    mockPullRemoteCalendar.mockResolvedValueOnce({ ical: zonedIcs });
+    mockPrepareCalendarSnapshot.mockResolvedValueOnce({ changed: false });
+
+    const result = await createIcsSourceFetcher(buildConfig()).fetchEvents();
+
+    expect(result.events[0]?.exceptionDates?.map(({ date }) => date)).toEqual([
+      new Date("2026-01-06T16:00:00.000Z"),
+    ]);
+  });
+
+  it("resolves only the floating entries of a mixed multi-value EXDATE", async () => {
+    const { createIcsSourceFetcher } = await import("../../../src/ics/utils/fetch-adapter");
+    const zonedIcs = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//test//test//EN",
+      "BEGIN:VEVENT",
+      "UID:mixed-exdate@test",
+      "DTSTAMP:20260101T000000Z",
+      "DTSTART;TZID=America/Denver:20260105T090000",
+      "DTEND;TZID=America/Denver:20260105T100000",
+      "RRULE:FREQ=DAILY;COUNT=5",
+      "EXDATE:20260106T090000,20260107T160000Z",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    mockPullRemoteCalendar.mockResolvedValueOnce({ ical: zonedIcs });
+    mockPrepareCalendarSnapshot.mockResolvedValueOnce({ changed: false });
+
+    const result = await createIcsSourceFetcher(buildConfig()).fetchEvents();
+
+    expect(result.events[0]?.exceptionDates?.map(({ date }) => date)).toEqual([
+      new Date("2026-01-06T16:00:00.000Z"),
+      new Date("2026-01-07T16:00:00.000Z"),
+    ]);
+  });
+
+  it("resolves a floating RECURRENCE-ID against the event's own DTSTART timezone", async () => {
+    const { createIcsSourceFetcher } = await import("../../../src/ics/utils/fetch-adapter");
+    const zonedIcs = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//test//test//EN",
+      "BEGIN:VEVENT",
+      "UID:zoned-override@test",
+      "DTSTAMP:20260101T000000Z",
+      "DTSTART;TZID=America/Denver:20260105T090000",
+      "DTEND;TZID=America/Denver:20260105T100000",
+      "RRULE:FREQ=DAILY;COUNT=5",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "UID:zoned-override@test",
+      "DTSTAMP:20260101T000000Z",
+      "RECURRENCE-ID:20260106T090000",
+      "DTSTART;TZID=America/Denver:20260106T110000",
+      "DTEND;TZID=America/Denver:20260106T120000",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    mockPullRemoteCalendar.mockResolvedValueOnce({ ical: zonedIcs });
+    mockPrepareCalendarSnapshot.mockResolvedValueOnce({ changed: false });
+
+    const result = await createIcsSourceFetcher(buildConfig()).fetchEvents();
+
+    expect(result.events.find(({ recurrenceId }) => recurrenceId)?.recurrenceId).toEqual(
+      new Date("2026-01-06T16:00:00.000Z"),
+    );
+  });
+
+  it("leaves an all-day series with a date-time UNTIL alone", async () => {
+    const { createIcsSourceFetcher } = await import("../../../src/ics/utils/fetch-adapter");
+    const allDayIcs = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//test//test//EN",
+      "BEGIN:VEVENT",
+      "UID:all-day-series@test",
+      "DTSTAMP:20260101T000000Z",
+      "DTSTART;VALUE=DATE:20260105",
+      "DTEND;VALUE=DATE:20260106",
+      "RRULE:FREQ=WEEKLY;UNTIL=20260112T090000",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    mockPullRemoteCalendar.mockResolvedValueOnce({ ical: allDayIcs });
+    mockPrepareCalendarSnapshot.mockResolvedValueOnce({ changed: false });
+
+    const result = await createIcsSourceFetcher(buildConfig()).fetchEvents();
+
+    expect(result.events[0]).toMatchObject({
+      isAllDay: true,
+      uid: "all-day-series@test",
+    });
+    expect(result.events[0]?.recurrenceRule?.until?.date).toEqual(
+      new Date("2026-01-12T09:00:00.000Z"),
+    );
+  });
+
+  it("rejects a floating EXDATE when no event or calendar timezone exists", async () => {
+    const { createIcsSourceFetcher } = await import("../../../src/ics/utils/fetch-adapter");
+    const ambiguousIcs = MINIMAL_ICS.replace(
+      "SUMMARY:Test",
+      "RRULE:FREQ=DAILY;COUNT=3\r\nEXDATE:20260518T120000\r\nSUMMARY:Test",
+    );
+    mockPullRemoteCalendar.mockResolvedValueOnce({ ical: ambiguousIcs });
+    mockPrepareCalendarSnapshot.mockResolvedValueOnce({ changed: false });
 
     await expect(createIcsSourceFetcher(buildConfig()).fetchEvents())
-      .rejects.toThrow("Unsupported calendar timezone: Custom/Eastern");
+      .rejects.toThrow("Floating ICS EXDATE requires an explicit TZID or X-WR-TIMEZONE");
   });
 
   it("returns events far outside the sync window so stored history stays unbounded", async () => {

--- a/packages/calendar/tests/ics/utils/validate-recurrence-input.test.ts
+++ b/packages/calendar/tests/ics/utils/validate-recurrence-input.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { assertNoUnsupportedRecurrenceDates } from "../../../src/ics/utils/validate-recurrence-input";
+import {
+  assertNoUnsupportedRecurrenceDates,
+  collectRecurrenceDateEventUids,
+  resolveRecurrenceTimeZones,
+} from "../../../src/ics/utils/validate-recurrence-input";
+import { readDeclaredTimeZoneOffsets } from "../../../src/ics/utils/resolve-timezone-identifier";
 
 describe("assertNoUnsupportedRecurrenceDates", () => {
   it("rejects folded RDATE properties inside VEVENT", () => {
@@ -42,5 +47,168 @@ describe("assertNoUnsupportedRecurrenceDates", () => {
 
     expect(() => assertNoUnsupportedRecurrenceDates(ics))
       .toThrow("expected END:VEVENT, received END:VALARM");
+  });
+});
+
+describe("collectRecurrenceDateEventUids", () => {
+  it("attributes RDATE to the event that declared it", () => {
+    const ics = [
+      "BEGIN:VCALENDAR",
+      "BEGIN:VEVENT",
+      "UID:with-rdate@test",
+      "RDATE;VALUE=DATE:20260701,",
+      " 20260702",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "UID:without-rdate@test",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+
+    expect(collectRecurrenceDateEventUids(ics)).toEqual(["with-rdate@test"]);
+  });
+
+  it("does not leak RDATE onto the next event when components are adjacent", () => {
+    const ics = [
+      "BEGIN:VCALENDAR",
+      "BEGIN:VEVENT",
+      "RDATE:20260701T090000Z",
+      "UID:first@test",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "UID:second@test",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+
+    expect(collectRecurrenceDateEventUids(ics)).toEqual(["first@test"]);
+  });
+
+  it("ignores RDATE inside VTIMEZONE observances supported by ts-ics", () => {
+    const ics = [
+      "BEGIN:VCALENDAR",
+      "BEGIN:VTIMEZONE",
+      "TZID:Custom/Zone",
+      "BEGIN:STANDARD",
+      "RDATE:20260701T000000",
+      "END:STANDARD",
+      "END:VTIMEZONE",
+      "BEGIN:VEVENT",
+      "UID:event@test",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+
+    expect(collectRecurrenceDateEventUids(ics)).toEqual([]);
+  });
+});
+
+const buildCalendar = (timeZoneId: string, observances: string[]): string => [
+  "BEGIN:VCALENDAR",
+  "BEGIN:VTIMEZONE",
+  `TZID:${timeZoneId}`,
+  ...observances,
+  "END:VTIMEZONE",
+  "END:VCALENDAR",
+].join("\r\n");
+
+const FIXED_OFFSET_OBSERVANCES = [
+  "BEGIN:STANDARD",
+  "DTSTART:19700101T000000",
+  "TZOFFSETFROM:-0500",
+  "TZOFFSETTO:-0500",
+  "END:STANDARD",
+];
+
+const DAYLIGHT_OBSERVANCES = [
+  "BEGIN:STANDARD",
+  "DTSTART:19701101T020000",
+  "TZOFFSETFROM:-0600",
+  "TZOFFSETTO:-0700",
+  "END:STANDARD",
+  "BEGIN:DAYLIGHT",
+  "DTSTART:19700308T020000",
+  "TZOFFSETFROM:-0700",
+  "TZOFFSETTO:-0600",
+  "END:DAYLIGHT",
+];
+
+const recurringEvent = (uid: string, startTimeZone: string) => ({
+  recurrenceRule: { frequency: "DAILY" as const },
+  startTimeZone,
+  uid,
+});
+
+describe("resolveRecurrenceTimeZones", () => {
+  it("leaves a single event with an unrecognised timezone untouched", () => {
+    const declared = readDeclaredTimeZoneOffsets(
+      buildCalendar("Customized Time Zone", DAYLIGHT_OBSERVANCES),
+    );
+
+    const result = resolveRecurrenceTimeZones(
+      [{ startTimeZone: "Customized Time Zone", uid: "single@test" }],
+      declared,
+    );
+
+    expect(result.unsupportedUids).toEqual([]);
+    expect(result.events[0]?.startTimeZone).toBe("Customized Time Zone");
+  });
+
+  it("recovers the IANA zone carried by a tzurl-style identifier", () => {
+    const identifier = "/mozilla.org/20050126_1/America/Denver";
+    const declared = readDeclaredTimeZoneOffsets(
+      buildCalendar(identifier, DAYLIGHT_OBSERVANCES),
+    );
+
+    const result = resolveRecurrenceTimeZones(
+      [recurringEvent("thunderbird@test", identifier)],
+      declared,
+    );
+
+    expect(result.unsupportedUids).toEqual([]);
+    expect(result.events[0]?.startTimeZone).toBe("America/Denver");
+  });
+
+  it("falls back to the declared offset when a VTIMEZONE never changes offset", () => {
+    const declared = readDeclaredTimeZoneOffsets(
+      buildCalendar("Customized Time Zone", FIXED_OFFSET_OBSERVANCES),
+    );
+
+    const result = resolveRecurrenceTimeZones(
+      [recurringEvent("exchange@test", "Customized Time Zone")],
+      declared,
+    );
+
+    expect(result.unsupportedUids).toEqual([]);
+    expect(result.events[0]?.startTimeZone).toBe("Etc/GMT+5");
+  });
+
+  it("refuses to flatten a DST timezone onto a fixed offset", () => {
+    const label = "(UTC-07:00) Mountain Time (US & Canada)";
+    const declared = readDeclaredTimeZoneOffsets(
+      buildCalendar(label, DAYLIGHT_OBSERVANCES),
+    );
+
+    const result = resolveRecurrenceTimeZones(
+      [recurringEvent("exchange-dst@test", label)],
+      declared,
+    );
+
+    expect(result.unsupportedUids).toEqual(["exchange-dst@test"]);
+    expect(result.events[0]?.startTimeZone).toBe(label);
+  });
+
+  it("keeps Windows identifiers resolving through the IANA mapping", () => {
+    const declared = readDeclaredTimeZoneOffsets(
+      buildCalendar("Mountain Standard Time", DAYLIGHT_OBSERVANCES),
+    );
+
+    const result = resolveRecurrenceTimeZones(
+      [recurringEvent("windows@test", "America/Denver")],
+      declared,
+    );
+
+    expect(result.unsupportedUids).toEqual([]);
+    expect(result.events[0]?.startTimeZone).toBe("America/Denver");
   });
 });


### PR DESCRIPTION
Stacked on #604 (targets `fix/caldav-vtimezone-and-resource-isolation`); merge #604 first. The two share `ingest.ts` and `apply-patches.ts`, resolved here as a union of independent additions.

Floating `UNTIL`/`EXDATE`/`RDATE`/`RECURRENCE-ID` now resolve against the TZID on the event's own DTSTART, so a zoned series is no longer rejected for lacking a calendar-level `X-WR-TIMEZONE`; the throw is kept for the genuinely ambiguous case where no zone exists anywhere. Recurring events also stop being held to a stricter timezone standard than single ones: tzurl-style identifiers (`/mozilla.org/…/America/Denver`, Thunderbird) are unwrapped, an unrecognised TZID falls back to its declared VTIMEZONE offset when that VTIMEZONE never changes offset, and anything still unresolvable is withheld per event instead of failing the feed. RDATE stays unsupported but is now scoped to the event that declared it rather than the whole calendar.

- `resolve-timezone-identifier.ts` handles prefixed identifiers and fixed-offset VTIMEZONE fallback; a DST-carrying VTIMEZONE is deliberately not flattened onto a fixed offset
- withheld events stay in the returned feed so the snapshot diff does not delete their stored state; ingestion filters them from inserts and emits `source_events.unsupported_count` / `source_events.unsupported_uids`
- `visitIcsProperties` gained `componentInstancePath` so RDATE can be attributed to the VEVENT that declared it
- CalDAV (`providers/caldav/shared/ics.ts`) is untouched; both `assert*` helpers it imports keep their existing behaviour
- 18 new tests fail against the unfixed source; `packages/calendar` is green apart from the known-local Morocco VTIMEZONE case

Closes #554
Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmVsczuP6e2i7VwjhvXxH
