### PR TITLE
ci: run checks on pull requests to any base branch

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,7 +2,6 @@ name: Check Code Standards
 
 on:
   pull_request:
-    branches: [main]
 
 jobs:
   types:


### PR DESCRIPTION
`checks.yml` was filtered to `branches: [main]`, so a pull request stacked on another branch got no checks at all — not a failure, just silence, which reads identically to "nothing to run". Dropping the filter runs types, lint, test, and unused on every pull request regardless of base.

- Hit this on #583, which is stacked on #552 and reported "no checks reported on the branch" while being locally green.
- Only the bottom PR of a stack was ever getting CI, so every future stack would have had the same blind spot.
- No job definitions change; this is a one-line removal of the base-branch filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bBKPZhpDah8CHTkb8srRD