### PR TITLE
feat(database): declare the calendar sync-range checks in the schema

### DIFF
--- a/packages/database/drizzle/0079_hot_whizzer.sql
+++ b/packages/database/drizzle/0079_hot_whizzer.sql
@@ -1,0 +1,13 @@
+UPDATE "calendars" SET "syncHistoricRange" = '1_month' WHERE "syncHistoricRange" NOT IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years');--> statement-breakpoint
+UPDATE "calendars" SET "syncFutureRange" = '2_years' WHERE "syncFutureRange" NOT IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years');--> statement-breakpoint
+UPDATE "calendars" SET "ingestHistoricRange" = '1_month' WHERE "ingestHistoricRange" NOT IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years');--> statement-breakpoint
+UPDATE "calendars" SET "ingestFutureRange" = '2_years' WHERE "ingestFutureRange" NOT IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years');--> statement-breakpoint
+UPDATE "calendars" SET "ingestWindowStart" = NULL, "ingestWindowEnd" = NULL, "ingestWindowRecordedAt" = NULL WHERE NOT (("ingestWindowStart" IS NULL AND "ingestWindowEnd" IS NULL AND "ingestWindowRecordedAt" IS NULL) OR ("ingestWindowStart" IS NOT NULL AND "ingestWindowEnd" IS NOT NULL AND "ingestWindowRecordedAt" IS NOT NULL AND "ingestWindowStart" < "ingestWindowEnd"));--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'calendars_sync_ranges_check' AND conrelid = 'calendars'::regclass) THEN
+    ALTER TABLE "calendars" ADD CONSTRAINT "calendars_sync_ranges_check" CHECK ("syncHistoricRange" IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years') AND "syncFutureRange" IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'calendars_ingest_coverage_check' AND conrelid = 'calendars'::regclass) THEN
+    ALTER TABLE "calendars" ADD CONSTRAINT "calendars_ingest_coverage_check" CHECK ("ingestHistoricRange" IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years') AND "ingestFutureRange" IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years') AND (("ingestWindowStart" IS NULL AND "ingestWindowEnd" IS NULL AND "ingestWindowRecordedAt" IS NULL) OR ("ingestWindowStart" IS NOT NULL AND "ingestWindowEnd" IS NOT NULL AND "ingestWindowRecordedAt" IS NOT NULL AND "ingestWindowStart" < "ingestWindowEnd")));
+  END IF;
+END $$;

--- a/packages/database/drizzle/meta/0079_snapshot.json
+++ b/packages/database/drizzle/meta/0079_snapshot.json
@@ -1,0 +1,3245 @@
+{
+  "id": "5188e253-4b6d-43f7-96c2-b38b7c34d70e",
+  "prevId": "638ed14c-113a-4f25-84b0-b448335d8b0b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_tokens_user_idx": {
+          "name": "api_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_hash_idx": {
+          "name": "api_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_userId_user_id_fk": {
+          "name": "api_tokens_userId_user_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_tokenHash_unique": {
+          "name": "api_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caldav_credentials": {
+      "name": "caldav_credentials",
+      "schema": "",
+      "columns": {
+        "authMethod": {
+          "name": "authMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'basic'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "encryptedPassword": {
+          "name": "encryptedPassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "serverUrl": {
+          "name": "serverUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_accounts": {
+      "name": "calendar_accounts",
+      "schema": "",
+      "columns": {
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authType": {
+          "name": "authType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caldavCredentialId": {
+          "name": "caldavCredentialId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "needsReauthentication": {
+          "name": "needsReauthentication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "oauthCredentialId": {
+          "name": "oauthCredentialId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_accounts_user_idx": {
+          "name": "calendar_accounts_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_accounts_provider_idx": {
+          "name": "calendar_accounts_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_accounts_needs_reauth_idx": {
+          "name": "calendar_accounts_needs_reauth_idx",
+          "columns": [
+            {
+              "expression": "needsReauthentication",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_accounts_provider_account_idx": {
+          "name": "calendar_accounts_provider_account_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_accounts_caldavCredentialId_caldav_credentials_id_fk": {
+          "name": "calendar_accounts_caldavCredentialId_caldav_credentials_id_fk",
+          "tableFrom": "calendar_accounts",
+          "tableTo": "caldav_credentials",
+          "columnsFrom": [
+            "caldavCredentialId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_accounts_oauthCredentialId_oauth_credentials_id_fk": {
+          "name": "calendar_accounts_oauthCredentialId_oauth_credentials_id_fk",
+          "tableFrom": "calendar_accounts",
+          "tableTo": "oauth_credentials",
+          "columnsFrom": [
+            "oauthCredentialId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_accounts_userId_user_id_fk": {
+          "name": "calendar_accounts_userId_user_id_fk",
+          "tableFrom": "calendar_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_snapshots": {
+      "name": "calendar_snapshots",
+      "schema": "",
+      "columns": {
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ical": {
+          "name": "ical",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "calendar_snapshots_calendarId_calendars_id_fk": {
+          "name": "calendar_snapshots_calendarId_calendars_id_fk",
+          "tableFrom": "calendar_snapshots",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_snapshots_calendarId_unique": {
+          "name": "calendar_snapshots_calendarId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendarId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendars": {
+      "name": "calendars",
+      "schema": "",
+      "columns": {
+        "accountId": {
+          "name": "accountId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarType": {
+          "name": "calendarType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarUrl": {
+          "name": "calendarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "excludeAllDayEvents": {
+          "name": "excludeAllDayEvents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeEventDescription": {
+          "name": "excludeEventDescription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "excludeEventLocation": {
+          "name": "excludeEventLocation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "excludeEventName": {
+          "name": "excludeEventName",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "excludeFocusTime": {
+          "name": "excludeFocusTime",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeOutOfOffice": {
+          "name": "excludeOutOfOffice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeInIcalFeed": {
+          "name": "includeInIcalFeed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "treatFullDayTimedEventsAsAllDay": {
+          "name": "treatFullDayTimedEventsAsAllDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customEventName": {
+          "name": "customEventName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{{calendar_name}}'"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "failureCount": {
+          "name": "failureCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastFailureAt": {
+          "name": "lastFailureAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextAttemptAt": {
+          "name": "nextAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestFailureCount": {
+          "name": "ingestFailureCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ingestLastFailureAt": {
+          "name": "ingestLastFailureAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestNextAttemptAt": {
+          "name": "ingestNextAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestFutureRange": {
+          "name": "ingestFutureRange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2_years'"
+        },
+        "ingestHistoricRange": {
+          "name": "ingestHistoricRange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1_month'"
+        },
+        "ingestWindowEnd": {
+          "name": "ingestWindowEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestWindowRecordedAt": {
+          "name": "ingestWindowRecordedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestWindowStart": {
+          "name": "ingestWindowStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalCalendarId": {
+          "name": "externalCalendarId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"pull\"}'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalName": {
+          "name": "originalName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncToken": {
+          "name": "syncToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncFutureRange": {
+          "name": "syncFutureRange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2_years'"
+        },
+        "syncHistoricRange": {
+          "name": "syncHistoricRange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1_month'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendars_user_idx": {
+          "name": "calendars_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_account_idx": {
+          "name": "calendars_account_idx",
+          "columns": [
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_capabilities_idx": {
+          "name": "calendars_capabilities_idx",
+          "columns": [
+            {
+              "expression": "capabilities",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_type_idx": {
+          "name": "calendars_type_idx",
+          "columns": [
+            {
+              "expression": "calendarType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendars_accountId_calendar_accounts_id_fk": {
+          "name": "calendars_accountId_calendar_accounts_id_fk",
+          "tableFrom": "calendars",
+          "tableTo": "calendar_accounts",
+          "columnsFrom": [
+            "accountId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendars_userId_user_id_fk": {
+          "name": "calendars_userId_user_id_fk",
+          "tableFrom": "calendars",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "calendars_sync_ranges_check": {
+          "name": "calendars_sync_ranges_check",
+          "value": "\"syncHistoricRange\" IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years') AND \"syncFutureRange\" IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years')"
+        },
+        "calendars_ingest_coverage_check": {
+          "name": "calendars_ingest_coverage_check",
+          "value": "\"ingestHistoricRange\" IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years') AND \"ingestFutureRange\" IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years') AND ((\"ingestWindowStart\" IS NULL AND \"ingestWindowEnd\" IS NULL AND \"ingestWindowRecordedAt\" IS NULL) OR (\"ingestWindowStart\" IS NOT NULL AND \"ingestWindowEnd\" IS NOT NULL AND \"ingestWindowRecordedAt\" IS NOT NULL AND \"ingestWindowStart\" < \"ingestWindowEnd\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.event_mappings": {
+      "name": "event_mappings",
+      "schema": "",
+      "columns": {
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleteIdentifier": {
+          "name": "deleteIdentifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destinationEventUid": {
+          "name": "destinationEventUid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventStateId": {
+          "name": "eventStateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "syncEventId": {
+          "name": "syncEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncEventHash": {
+          "name": "syncEventHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceCalendarId": {
+          "name": "sourceCalendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "event_mappings_sync_event_cal_idx": {
+          "name": "event_mappings_sync_event_cal_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "syncEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_mappings\".\"syncEventId\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_mappings_calendar_idx": {
+          "name": "event_mappings_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_mappings_event_state_idx": {
+          "name": "event_mappings_event_state_idx",
+          "columns": [
+            {
+              "expression": "eventStateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_mappings_missing_sync_event_idx": {
+          "name": "event_mappings_missing_sync_event_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"event_mappings\".\"syncEventId\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_mappings_sync_hash_idx": {
+          "name": "event_mappings_sync_hash_idx",
+          "columns": [
+            {
+              "expression": "syncEventHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_mappings_calendarId_calendars_id_fk": {
+          "name": "event_mappings_calendarId_calendars_id_fk",
+          "tableFrom": "event_mappings",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_mappings_eventStateId_event_states_id_fk": {
+          "name": "event_mappings_eventStateId_event_states_id_fk",
+          "tableFrom": "event_mappings",
+          "tableTo": "event_states",
+          "columnsFrom": [
+            "eventStateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_states": {
+      "name": "event_states",
+      "schema": "",
+      "columns": {
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrenceRule": {
+          "name": "recurrenceRule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exceptionDates": {
+          "name": "exceptionDates",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrenceId": {
+          "name": "recurrenceId",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAllDay": {
+          "name": "isAllDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceEventId": {
+          "name": "sourceEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceEventType": {
+          "name": "sourceEventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceEventUid": {
+          "name": "sourceEventUid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startTimeZone": {
+          "name": "startTimeZone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_states_start_time_idx": {
+          "name": "event_states_start_time_idx",
+          "columns": [
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_states_end_time_idx": {
+          "name": "event_states_end_time_idx",
+          "columns": [
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_states_calendar_idx": {
+          "name": "event_states_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_states_source_event_idx": {
+          "name": "event_states_source_event_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_states\".\"sourceEventId\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_states_recurring_instance_idx": {
+          "name": "event_states_recurring_instance_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceEventUid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurrenceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_states\".\"sourceEventId\" is null and \"event_states\".\"recurrenceId\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_states_non_recurring_instance_idx": {
+          "name": "event_states_non_recurring_instance_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceEventUid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_states\".\"sourceEventId\" is null and \"event_states\".\"recurrenceId\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_states_calendarId_calendars_id_fk": {
+          "name": "event_states_calendarId_calendars_id_fk",
+          "tableFrom": "event_states",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wantsFollowUp": {
+          "name": "wantsFollowUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "feedback_user_idx": {
+          "name": "feedback_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_userId_user_id_fk": {
+          "name": "feedback_userId_user_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ical_feed_settings": {
+      "name": "ical_feed_settings",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "includeEventName": {
+          "name": "includeEventName",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeEventDescription": {
+          "name": "includeEventDescription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeEventLocation": {
+          "name": "includeEventLocation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeAllDayEvents": {
+          "name": "excludeAllDayEvents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customEventName": {
+          "name": "customEventName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Busy'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ical_feed_settings_userId_user_id_fk": {
+          "name": "ical_feed_settings_userId_user_id_fk",
+          "tableFrom": "ical_feed_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_credentials": {
+      "name": "oauth_credentials",
+      "schema": "",
+      "columns": {
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "needsReauthentication": {
+          "name": "needsReauthentication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_credentials_user_idx": {
+          "name": "oauth_credentials_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_credentials_provider_idx": {
+          "name": "oauth_credentials_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_credentials_expires_at_idx": {
+          "name": "oauth_credentials_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_credentials_userId_user_id_fk": {
+          "name": "oauth_credentials_userId_user_id_fk",
+          "tableFrom": "oauth_credentials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_destination_mappings": {
+      "name": "source_destination_mappings",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "destinationCalendarId": {
+          "name": "destinationCalendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sourceCalendarId": {
+          "name": "sourceCalendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "source_destination_mapping_idx": {
+          "name": "source_destination_mapping_idx",
+          "columns": [
+            {
+              "expression": "sourceCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destinationCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_destination_mappings_source_idx": {
+          "name": "source_destination_mappings_source_idx",
+          "columns": [
+            {
+              "expression": "sourceCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_destination_mappings_destination_idx": {
+          "name": "source_destination_mappings_destination_idx",
+          "columns": [
+            {
+              "expression": "destinationCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_destination_mappings_destinationCalendarId_calendars_id_fk": {
+          "name": "source_destination_mappings_destinationCalendarId_calendars_id_fk",
+          "tableFrom": "source_destination_mappings",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "destinationCalendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_destination_mappings_sourceCalendarId_calendars_id_fk": {
+          "name": "source_destination_mappings_sourceCalendarId_calendars_id_fk",
+          "tableFrom": "source_destination_mappings",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "sourceCalendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "",
+      "columns": {
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "localEventCount": {
+          "name": "localEventCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remoteEventCount": {
+          "name": "remoteEventCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_status_calendar_idx": {
+          "name": "sync_status_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_status_calendarId_calendars_id_fk": {
+          "name": "sync_status_calendarId_calendars_id_fk",
+          "tableFrom": "sync_status",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_events": {
+      "name": "user_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceEventUid": {
+          "name": "sourceEventUid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAllDay": {
+          "name": "isAllDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startTimeZone": {
+          "name": "startTimeZone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_events_user_idx": {
+          "name": "user_events_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_events_calendar_idx": {
+          "name": "user_events_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_events_start_time_idx": {
+          "name": "user_events_start_time_idx",
+          "columns": [
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_events_end_time_idx": {
+          "name": "user_events_end_time_idx",
+          "columns": [
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_events_calendarId_calendars_id_fk": {
+          "name": "user_events_calendarId_calendars_id_fk",
+          "tableFrom": "user_events",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_events_userId_user_id_fk": {
+          "name": "user_events_userId_user_id_fk",
+          "tableFrom": "user_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscriptions": {
+      "name": "user_subscriptions",
+      "schema": "",
+      "columns": {
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "polarSubscriptionId": {
+          "name": "polarSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_subscriptions_userId_user_id_fk": {
+          "name": "user_subscriptions_userId_user_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sync_requests": {
+      "name": "user_sync_requests",
+      "schema": "",
+      "columns": {
+        "requestId": {
+          "name": "requestId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "requestedAt": {
+          "name": "requestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sync_requests_userId_user_id_fk": {
+          "name": "user_sync_requests_userId_user_id_fk",
+          "tableFrom": "user_sync_requests",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshId": {
+          "name": "refreshId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_idx": {
+          "name": "oauth_access_token_client_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_session_idx": {
+          "name": "oauth_access_token_session_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_idx": {
+          "name": "oauth_access_token_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_refresh_idx": {
+          "name": "oauth_access_token_refresh_idx",
+          "columns": [
+            {
+              "expression": "refreshId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_clientId_oauth_application_clientId_fk": {
+          "name": "oauth_access_token_clientId_oauth_application_clientId_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_sessionId_session_id_fk": {
+          "name": "oauth_access_token_sessionId_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_userId_user_id_fk": {
+          "name": "oauth_access_token_userId_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refreshId_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refreshId_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refreshId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientSecret": {
+          "name": "clientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "skipConsent": {
+          "name": "skipConsent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enableEndSession": {
+          "name": "enableEndSession",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjectType": {
+          "name": "subjectType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "softwareId": {
+          "name": "softwareId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "softwareVersion": {
+          "name": "softwareVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "softwareStatement": {
+          "name": "softwareStatement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirectUris": {
+          "name": "redirectUris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postLogoutRedirectUris": {
+          "name": "postLogoutRedirectUris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenEndpointAuthMethod": {
+          "name": "tokenEndpointAuthMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grantTypes": {
+          "name": "grantTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTypes": {
+          "name": "responseTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirePKCE": {
+          "name": "requirePKCE",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_application_user_idx": {
+          "name": "oauth_application_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_application_userId_user_id_fk": {
+          "name": "oauth_application_userId_user_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_clientId_unique": {
+          "name": "oauth_application_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clientId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_idx": {
+          "name": "oauth_consent_client_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_idx": {
+          "name": "oauth_consent_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_reference_idx": {
+          "name": "oauth_consent_reference_idx",
+          "columns": [
+            {
+              "expression": "referenceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_clientId_oauth_application_clientId_fk": {
+          "name": "oauth_consent_clientId_oauth_application_clientId_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_userId_user_id_fk": {
+          "name": "oauth_consent_userId_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authTime": {
+          "name": "authTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_client_idx": {
+          "name": "oauth_refresh_token_client_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_session_idx": {
+          "name": "oauth_refresh_token_session_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_user_idx": {
+          "name": "oauth_refresh_token_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_clientId_oauth_application_clientId_fk": {
+          "name": "oauth_refresh_token_clientId_oauth_application_clientId_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_sessionId_session_id_fk": {
+          "name": "oauth_refresh_token_sessionId_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_userId_user_id_fk": {
+          "name": "oauth_refresh_token_userId_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passkey_userId_user_id_fk": {
+          "name": "passkey_userId_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -554,6 +554,13 @@
       "when": 1786520823774,
       "tag": "0078_align_calendar_privacy_defaults",
       "breakpoints": true
+    },
+    {
+      "idx": 79,
+      "version": "7",
+      "when": 1786573785858,
+      "tag": "0079_hot_whizzer",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/database/schema.ts
+++ b/packages/database/src/database/schema.ts
@@ -1,5 +1,6 @@
 import {
   boolean,
+  check,
   index,
   integer,
   pgTable,
@@ -12,10 +13,15 @@ import { isNotNull, isNull, sql } from "drizzle-orm";
 import {
   DEFAULT_FUTURE_SYNC_RANGE,
   DEFAULT_HISTORIC_SYNC_RANGE,
+  SYNC_RANGE_DEFINITIONS,
 } from "@keeper.sh/data-schemas";
 import { user } from "./auth-schema";
 
 const DEFAULT_EVENT_COUNT = 0;
+
+const SYNC_RANGE_SQL_VALUES = SYNC_RANGE_DEFINITIONS
+  .map(({ value }) => `'${value}'`)
+  .join(", ");
 
 const oauthCredentialsTable = pgTable(
   "oauth_credentials",
@@ -141,6 +147,19 @@ const calendarsTable = pgTable(
     index("calendars_account_idx").on(table.accountId),
     index("calendars_capabilities_idx").on(table.capabilities),
     index("calendars_type_idx").on(table.calendarType),
+    /*
+     * Range columns are plain text so a bad write is only caught when a reader
+     * asserts it, far from the writer that caused it. Constraining them here
+     * keeps a corrupt persisted value distinguishable from a corrupt read.
+     */
+    check(
+      "calendars_sync_ranges_check",
+      sql`"syncHistoricRange" IN (${sql.raw(SYNC_RANGE_SQL_VALUES)}) AND "syncFutureRange" IN (${sql.raw(SYNC_RANGE_SQL_VALUES)})`,
+    ),
+    check(
+      "calendars_ingest_coverage_check",
+      sql`"ingestHistoricRange" IN (${sql.raw(SYNC_RANGE_SQL_VALUES)}) AND "ingestFutureRange" IN (${sql.raw(SYNC_RANGE_SQL_VALUES)}) AND (("ingestWindowStart" IS NULL AND "ingestWindowEnd" IS NULL AND "ingestWindowRecordedAt" IS NULL) OR ("ingestWindowStart" IS NOT NULL AND "ingestWindowEnd" IS NOT NULL AND "ingestWindowRecordedAt" IS NOT NULL AND "ingestWindowStart" < "ingestWindowEnd"))`,
+    ),
   ],
 );
 

--- a/packages/database/tests/database/calendar-sync-range-constraint.test.ts
+++ b/packages/database/tests/database/calendar-sync-range-constraint.test.ts
@@ -1,0 +1,353 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Client } from "pg";
+import { SYNC_RANGE_DEFINITIONS } from "@keeper.sh/data-schemas";
+
+const administrativeUrl = process.env.KEEPER_TEST_DATABASE_URL;
+const migrationScript = `${import.meta.dirname}/../../scripts/migrate.ts`;
+const templateName = `keeper_range_template_${process.pid}`;
+const scratchNames: string[] = [];
+
+const withAdministrativeClient = async <Result>(
+  run: (client: Client) => Promise<Result>,
+): Promise<Result> => {
+  const client = new Client({ connectionString: administrativeUrl });
+  await client.connect();
+  try {
+    return await run(client);
+  } finally {
+    await client.end();
+  }
+};
+
+const withDatabaseClient = async <Result>(
+  databaseName: string,
+  run: (client: Client) => Promise<Result>,
+): Promise<Result> => {
+  const url = new URL(administrativeUrl ?? "postgres://localhost");
+  url.pathname = `/${databaseName}`;
+  const client = new Client({ connectionString: url.toString() });
+  await client.connect();
+  try {
+    return await run(client);
+  } finally {
+    await client.end();
+  }
+};
+
+const runMigrations = async (databaseName: string): Promise<void> => {
+  const url = new URL(administrativeUrl ?? "postgres://localhost");
+  url.pathname = `/${databaseName}`;
+  const result = await Bun.$`bun ${migrationScript}`
+    .env({ ...process.env, DATABASE_URL: url.toString() })
+    .quiet()
+    .nothrow();
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Migration failed for ${databaseName}: ${result.stdout.toString()}${result.stderr.toString()}`,
+    );
+  }
+};
+
+const createScratchDatabase = async (label: string): Promise<string> => {
+  const name = `keeper_range_${label}_${process.pid}`;
+  scratchNames.push(name);
+  await withAdministrativeClient(async (client) => {
+    await client.query(`DROP DATABASE IF EXISTS "${name}"`);
+    await client.query(`CREATE DATABASE "${name}" TEMPLATE "${templateName}"`);
+  });
+  return name;
+};
+
+const readConstraint = async (
+  client: Client,
+  name: string,
+): Promise<{ validated: boolean } | null> => {
+  const result = await client.query<{ validated: boolean }>(`
+    SELECT convalidated AS validated
+    FROM pg_constraint
+    WHERE conname = '${name}'
+      AND conrelid = 'calendars'::regclass
+  `);
+  const [constraint = null] = result.rows;
+  return constraint;
+};
+
+/*
+ * Databases released before this change carry the schema without the checks.
+ * Dropping them and rewinding the journal row reproduces that upgrade origin
+ * exactly, rather than approximating it by replaying partial migration files.
+ */
+const rewindMigrationJournal = async (databaseName: string): Promise<void> => {
+  await withDatabaseClient(databaseName, async (client) => {
+    await client.query(`
+      DELETE FROM drizzle.__drizzle_migrations
+      WHERE id = (SELECT id FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 1)
+    `);
+  });
+};
+
+const rewindToPreConstraintState = async (databaseName: string): Promise<void> => {
+  await withDatabaseClient(databaseName, async (client) => {
+    await client.query(`
+      ALTER TABLE "calendars"
+        DROP CONSTRAINT IF EXISTS "calendars_sync_ranges_check",
+        DROP CONSTRAINT IF EXISTS "calendars_ingest_coverage_check"
+    `);
+  });
+  await rewindMigrationJournal(databaseName);
+};
+
+const seedCalendar = async (
+  client: Client,
+  overrides: Record<string, string>,
+): Promise<string> => {
+  const userId = `user-${Math.random().toString(36).slice(2)}`;
+  await client.query(
+    `INSERT INTO "user" ("id", "email", "name") VALUES ($1, $2, $3)`,
+    [userId, `${userId}@example.com`, "Range Fixture"],
+  );
+  const account = await client.query<{ id: string }>(
+    `INSERT INTO "calendar_accounts" ("authType", "provider", "userId")
+     VALUES ('oauth', 'google', $1) RETURNING "id"`,
+    [userId],
+  );
+  const accountId = account.rows[0]?.id;
+  if (!accountId) {
+    throw new Error("Failed to seed a calendar account");
+  }
+  const ranges = {
+    ingestFutureRange: "2_years",
+    ingestHistoricRange: "1_month",
+    syncFutureRange: "2_years",
+    syncHistoricRange: "1_month",
+    ...overrides,
+  };
+  const calendar = await client.query<{ id: string }>(
+    `INSERT INTO "calendars"
+       ("accountId", "calendarType", "name", "userId",
+        "syncHistoricRange", "syncFutureRange", "ingestHistoricRange", "ingestFutureRange")
+     VALUES ($1, 'google', 'Fixture', $2, $3, $4, $5, $6)
+     RETURNING "id"`,
+    [
+      accountId,
+      userId,
+      ranges.syncHistoricRange,
+      ranges.syncFutureRange,
+      ranges.ingestHistoricRange,
+      ranges.ingestFutureRange,
+    ],
+  );
+  const calendarId = calendar.rows[0]?.id;
+  if (!calendarId) {
+    throw new Error("Failed to seed a calendar");
+  }
+  return calendarId;
+};
+
+const readCalendarRanges = async (
+  client: Client,
+  calendarId: string,
+): Promise<Record<string, string>> => {
+  const result = await client.query<Record<string, string>>(
+    `SELECT "syncHistoricRange", "syncFutureRange", "ingestHistoricRange", "ingestFutureRange", "name"
+     FROM "calendars" WHERE "id" = $1`,
+    [calendarId],
+  );
+  const [row] = result.rows;
+  if (!row) {
+    throw new Error(`Calendar ${calendarId} disappeared during migration`);
+  }
+  return row;
+};
+
+describe.skipIf(!administrativeUrl)("calendar sync-range check constraints", () => {
+  beforeAll(async () => {
+    await withAdministrativeClient(async (client) => {
+      await client.query(`DROP DATABASE IF EXISTS "${templateName}"`);
+      await client.query(`CREATE DATABASE "${templateName}"`);
+    });
+    await runMigrations(templateName);
+  }, 300_000);
+
+  afterAll(async () => {
+    await withAdministrativeClient(async (client) => {
+      for (const name of [...scratchNames, templateName]) {
+        await client.query(`DROP DATABASE IF EXISTS "${name}"`);
+      }
+    });
+  }, 120_000);
+
+  it("installs validated constraints on a fresh install", async () => {
+    await withDatabaseClient(templateName, async (client) => {
+      const syncRanges = await readConstraint(client, "calendars_sync_ranges_check");
+      const ingestCoverage = await readConstraint(client, "calendars_ingest_coverage_check");
+      expect(syncRanges?.validated).toBe(true);
+      expect(ingestCoverage?.validated).toBe(true);
+
+      const applied = await client.query<{ count: string }>(
+        `SELECT count(*)::text AS count FROM drizzle.__drizzle_migrations`,
+      );
+      const journal = await Bun.file(
+        `${import.meta.dirname}/../../drizzle/meta/_journal.json`,
+      ).json() as { entries: unknown[] };
+      expect(Number(applied.rows[0]?.count)).toBe(journal.entries.length);
+    });
+  }, 120_000);
+
+  it("upgrades a populated database without touching valid rows", async () => {
+    const databaseName = await createScratchDatabase("populated");
+    await rewindToPreConstraintState(databaseName);
+
+    const calendarId = await withDatabaseClient(databaseName, (client) =>
+      seedCalendar(client, {
+        ingestFutureRange: "12_months",
+        ingestHistoricRange: "3_months",
+        syncFutureRange: "6_months",
+        syncHistoricRange: "1_week",
+      }));
+
+    await runMigrations(databaseName);
+
+    await withDatabaseClient(databaseName, async (client) => {
+      expect(await readCalendarRanges(client, calendarId)).toEqual({
+        ingestFutureRange: "12_months",
+        ingestHistoricRange: "3_months",
+        name: "Fixture",
+        syncFutureRange: "6_months",
+        syncHistoricRange: "1_week",
+      });
+      const constraint = await readConstraint(client, "calendars_sync_ranges_check");
+      expect(constraint?.validated).toBe(true);
+    });
+  }, 300_000);
+
+  it("normalizes invalid rows instead of failing the upgrade", async () => {
+    const databaseName = await createScratchDatabase("invalid");
+    await rewindToPreConstraintState(databaseName);
+
+    const seeded = await withDatabaseClient(databaseName, async (client) => {
+      const corrupt = await seedCalendar(client, {
+        ingestFutureRange: "1 Week",
+        ingestHistoricRange: "110762ms",
+        syncFutureRange: "b1f0c4d2-0000-4000-8000-000000000000",
+        syncHistoricRange: "1_fortnight",
+      });
+      const healthy = await seedCalendar(client, { syncHistoricRange: "6_months" });
+      return { corrupt, healthy };
+    });
+
+    await runMigrations(databaseName);
+
+    await withDatabaseClient(databaseName, async (client) => {
+      expect(await readCalendarRanges(client, seeded.corrupt)).toEqual({
+        ingestFutureRange: "2_years",
+        ingestHistoricRange: "1_month",
+        name: "Fixture",
+        syncFutureRange: "2_years",
+        syncHistoricRange: "1_month",
+      });
+      expect(await readCalendarRanges(client, seeded.healthy)).toEqual({
+        ingestFutureRange: "2_years",
+        ingestHistoricRange: "1_month",
+        name: "Fixture",
+        syncFutureRange: "2_years",
+        syncHistoricRange: "6_months",
+      });
+      const constraint = await readConstraint(client, "calendars_sync_ranges_check");
+      expect(constraint?.validated).toBe(true);
+    });
+  }, 300_000);
+
+  /*
+   * Every database already running this release carries these constraints from
+   * the migration runner, which installed them outside the journal. The new
+   * statement lands on top of them, so it has to tolerate their presence.
+   */
+  it("applies over constraints the migration runner already installed", async () => {
+    const databaseName = await createScratchDatabase("preinstalled");
+    await rewindMigrationJournal(databaseName);
+
+    const calendarId = await withDatabaseClient(databaseName, (client) =>
+      seedCalendar(client, { syncFutureRange: "3_months" }));
+
+    await runMigrations(databaseName);
+
+    await withDatabaseClient(databaseName, async (client) => {
+      const ranges = await readCalendarRanges(client, calendarId);
+      expect(ranges.syncFutureRange).toBe("3_months");
+      const constraint = await readConstraint(client, "calendars_sync_ranges_check");
+      expect(constraint?.validated).toBe(true);
+    });
+  }, 300_000);
+
+  /*
+   * The generated statement was hand-edited to repair rows before constraining
+   * them. Without that repair the ALTER aborts and the instance never starts,
+   * so the unrepaired form is asserted to fail rather than trusted to.
+   */
+  it("would have failed the upgrade without the normalizing statements", async () => {
+    const databaseName = await createScratchDatabase("unrepaired");
+    await rewindToPreConstraintState(databaseName);
+
+    await withDatabaseClient(databaseName, async (client) => {
+      await seedCalendar(client, { syncHistoricRange: "110762ms" });
+      await expect(client.query(`
+        ALTER TABLE "calendars" ADD CONSTRAINT "calendars_sync_ranges_check"
+        CHECK ("syncHistoricRange" IN (${SYNC_RANGE_DEFINITIONS.map(({ value }) => `'${value}'`).join(", ")}))
+      `)).rejects.toThrow(/violated by some row/);
+    });
+  }, 300_000);
+
+  it("rejects invalid writes and accepts every defined range", async () => {
+    const databaseName = await createScratchDatabase("enforcement");
+
+    await withDatabaseClient(databaseName, async (client) => {
+      const calendarId = await seedCalendar(client, {});
+
+      for (const column of [
+        "syncHistoricRange",
+        "syncFutureRange",
+        "ingestHistoricRange",
+        "ingestFutureRange",
+      ]) {
+        await expect(client.query(
+          `UPDATE "calendars" SET "${column}" = '110762ms' WHERE "id" = $1`,
+          [calendarId],
+        )).rejects.toThrow(/violates check constraint/);
+      }
+
+      for (const { value } of SYNC_RANGE_DEFINITIONS) {
+        await client.query(
+          `UPDATE "calendars"
+           SET "syncHistoricRange" = $1, "syncFutureRange" = $1,
+               "ingestHistoricRange" = $1, "ingestFutureRange" = $1
+           WHERE "id" = $2`,
+          [value, calendarId],
+        );
+        const ranges = await readCalendarRanges(client, calendarId);
+        expect(ranges.syncHistoricRange).toBe(value);
+        expect(ranges.ingestFutureRange).toBe(value);
+      }
+
+      await expect(seedCalendar(client, { syncFutureRange: "3_years" }))
+        .rejects.toThrow(/violates check constraint/);
+    });
+  }, 300_000);
+
+  it("stays safe to re-run against an already migrated database", async () => {
+    const databaseName = await createScratchDatabase("idempotent");
+
+    await runMigrations(databaseName);
+    await runMigrations(databaseName);
+
+    await withDatabaseClient(databaseName, async (client) => {
+      const duplicates = await client.query<{ count: string }>(`
+        SELECT count(*)::text AS count
+        FROM pg_constraint
+        WHERE conrelid = 'calendars'::regclass
+          AND conname IN ('calendars_sync_ranges_check', 'calendars_ingest_coverage_check')
+      `);
+      expect(Number(duplicates.rows[0]?.count)).toBe(2);
+    });
+  }, 300_000);
+});


### PR DESCRIPTION
The four sync-range columns on `calendars` were only constrained by `scripts/migrate.ts`, which installs the checks imperatively outside the journal, so the versioned schema itself carried no guarantee. This moves both checks into `schema.ts` and ships the CLI-generated migration, hand-edited only to repair rows before constraining them and to tolerate the constraints the runner already installed. Complementary hardening for #584 — read-path corruption is fixed by #610; this makes a future recurrence tell you immediately whether something *wrote* garbage or a read *returned* it.

- Normalize-then-validate rather than `NOT VALID`: a row with an invalid range never syncs at all, so repairing it can only restore function, and the migration cannot fail by construction. A bare `NOT VALID` would preserve the garbage unverified, defeating the diagnostic point.
- `migrate.ts` is unchanged; the new statement is additive and safe to replay, and the runner keeps installing the constraints for databases that have not reached this migration.
- `packages/database/tests/database/calendar-sync-range-constraint.test.ts` runs the real migration runner against throwaway databases (gated on `KEEPER_TEST_DATABASE_URL`): fresh install, populated upgrade, an upgrade carrying invalid values, upgrade over runner-installed constraints, enforcement of all six values, and re-runnability. It also asserts the unrepaired CLI output *would* have aborted the upgrade, so the hand-edit cannot be dropped unnoticed.
- Also verified out-of-band against a `pg_dump` copy of a real local dev database on Postgres 17 (the suite runs on 16): 79 accumulated migrations, runner-installed constraints present, seeded with a healthy and a corrupt calendar. The upgrade applied, repaired only the corrupt row, left the healthy row and all user rows untouched, and re-ran cleanly.

Operators can audit before upgrading:

```sql
SELECT id, "userId", "syncHistoricRange", "syncFutureRange", "ingestHistoricRange", "ingestFutureRange"
FROM calendars
WHERE "syncHistoricRange"   NOT IN ('1_week','1_month','3_months','6_months','12_months','2_years')
   OR "syncFutureRange"     NOT IN ('1_week','1_month','3_months','6_months','12_months','2_years')
   OR "ingestHistoricRange" NOT IN ('1_week','1_month','3_months','6_months','12_months','2_years')
   OR "ingestFutureRange"   NOT IN ('1_week','1_month','3_months','6_months','12_months','2_years');
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmVsczuP6e2i7VwjhvXxH