### PR TITLE
fix(database): seed the coverage upgrade test before the check exists

### DIFF
--- a/packages/database/tests/migrations/upgrade.test.ts
+++ b/packages/database/tests/migrations/upgrade.test.ts
@@ -23,6 +23,19 @@ const DRIZZLE_DIRECTORY = `${PACKAGE_ROOT}/drizzle`;
  * index a tag shipped reproduces that tag's schema exactly without needing tag
  * history at test time. v2.12.2 shipped 0074, v2.13.5 shipped 0076.
  */
+const findSchemaIndexBeforeCoverageCheck = async (): Promise<number> => {
+  const journal = await Bun.file(`${DRIZZLE_DIRECTORY}/meta/_journal.json`)
+    .json() as Journal;
+  const ordered = journal.entries.toSorted((first, second) => first.idx - second.idx);
+  for (const entry of ordered) {
+    const migration = await Bun.file(`${DRIZZLE_DIRECTORY}/${entry.tag}.sql`).text();
+    if (migration.includes("calendars_ingest_coverage_check")) {
+      return entry.idx - 1;
+    }
+  }
+  return Math.max(...ordered.map(({ idx }) => idx));
+};
+
 const RELEASED_SCHEMA_STATES = {
   v2_12_2: 74,
   v2_13_5: 76,
@@ -295,12 +308,15 @@ describe("migration runner against postgres", () => {
    * Coverage normalisation has to run before the checks are validated, or
    * VALIDATE CONSTRAINT aborts on rows written by older writers.
    */
-  it("normalises out-of-range coverage before validating the coverage checks", async () => {
-    const journal = await Bun.file(`${DRIZZLE_DIRECTORY}/meta/_journal.json`)
-      .json() as Journal;
-    const latestIndex = Math.max(...journal.entries.map(({ idx }) => idx));
+  it("repairs out-of-range coverage while upgrading a database that predates the checks", async () => {
+    /*
+     * Seed before the coverage check exists. It is added NOT VALID, which still
+     * enforces on new rows, so a database that already carries it cannot produce
+     * the legacy row this repairs — only an older writer could.
+     */
+    const seedIndex = await findSchemaIndexBeforeCoverageCheck();
     const databaseUrl = await createDatabase("keeper_migration_coverage");
-    await applyReleasedSchemaState(databaseUrl, latestIndex);
+    await applyReleasedSchemaState(databaseUrl, seedIndex);
     await withConnection(databaseUrl, async (client) => {
       const calendars = await seedCalendarPair(client);
       await client.query(`


### PR DESCRIPTION
The `migrations` job is failing on `main`, so it is red on every open PR.

#611 added `calendars_ingest_coverage_check` in migration 0079 and #598 added this test independently. Neither is wrong on its own, but the test applies every migration and only then seeds an out-of-range row to prove the upgrade repairs it. `NOT VALID` skips existing rows and still enforces on any row you write, so the seed is rejected and the runner exits non-zero.

Seeding against the state before the check exists is also the only way such a row can really occur, since a database carrying the constraint cannot produce one.

- verified against postgres: 5/5 pass, and stripping 0079's `UPDATE` statements still fails it
- renamed, because 0079 now performs the repair rather than the runner's `normalizeCalendarCoverage`