### PR TITLE
fix: fall back to entitlements when the customer state read fails

### DIFF
--- a/applications/web/src/hooks/use-subscription.ts
+++ b/applications/web/src/hooks/use-subscription.ts
@@ -1,5 +1,5 @@
 import useSWR from "swr";
-import { fetcher } from "@/lib/fetcher";
+import { fetcher, HttpError } from "@/lib/fetcher";
 import { getCommercialMode } from "@/config/commercial";
 
 export interface SubscriptionState {
@@ -15,7 +15,13 @@ interface CustomerStateResponse {
   activeSubscriptions?: ActiveSubscription[] | null;
 }
 
+interface EntitlementsPlanResponse {
+  plan: "free" | "pro";
+}
+
 const SUBSCRIPTION_STATE_CACHE_KEY = "customer-state";
+const CUSTOMER_STATE_PATH = "/api/auth/customer/state";
+const ENTITLEMENTS_PATH = "/api/entitlements";
 
 export const resolveSubscriptionState = (
   customerState: CustomerStateResponse,
@@ -32,10 +38,11 @@ export const resolveSubscriptionState = (
   };
 };
 
-const fetchSubscriptionState = async (): Promise<SubscriptionState> => {
-  const data = await fetcher<CustomerStateResponse>("/api/auth/customer/state");
-  return resolveSubscriptionState(data);
-};
+const isUnauthorized = (error: unknown): boolean =>
+  error instanceof HttpError && error.status === 401;
+
+const fetchSubscriptionState = (): Promise<SubscriptionState> =>
+  fetchSubscriptionStateWithApi((path) => fetcher(path));
 
 interface UseSubscriptionOptions {
   enabled?: boolean;
@@ -64,8 +71,17 @@ export function useSubscription(options: UseSubscriptionOptions = {}) {
 export async function fetchSubscriptionStateWithApi(
   fetchApi: <T>(path: string, init?: RequestInit) => Promise<T>,
 ): Promise<SubscriptionState> {
-  const data = await fetchApi<CustomerStateResponse>("/api/auth/customer/state");
-  return resolveSubscriptionState(data);
+  try {
+    const data = await fetchApi<CustomerStateResponse>(CUSTOMER_STATE_PATH);
+    return resolveSubscriptionState(data);
+  } catch (error) {
+    if (isUnauthorized(error)) {
+      throw error;
+    }
+
+    const entitlements = await fetchApi<EntitlementsPlanResponse>(ENTITLEMENTS_PATH);
+    return { plan: entitlements.plan, interval: null };
+  }
 }
 
 export { fetchSubscriptionState };

--- a/applications/web/tests/hooks/use-subscription.test.ts
+++ b/applications/web/tests/hooks/use-subscription.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { HttpError } from "../../src/lib/fetcher";
+import { fetchSubscriptionStateWithApi } from "../../src/hooks/use-subscription";
+
+const CUSTOMER_STATE_PATH = "/api/auth/customer/state";
+const ENTITLEMENTS_PATH = "/api/entitlements";
+
+const createFetchApi = (respond: (path: string) => unknown) => {
+  const calls: string[] = [];
+  const fetchApi = async <T,>(path: string): Promise<T> => {
+    calls.push(path);
+    return respond(path) as T;
+  };
+  return { calls, fetchApi };
+};
+
+describe("fetchSubscriptionStateWithApi", () => {
+  it("reads the plan and interval from the customer state", async () => {
+    const { fetchApi } = createFetchApi(() => ({
+      activeSubscriptions: [{ recurringInterval: "year" }],
+    }));
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+      plan: "pro",
+      interval: "year",
+    });
+  });
+
+  it("keeps a paying user on pro when the customer state fails", async () => {
+    const { calls, fetchApi } = createFetchApi((path) => {
+      if (path === CUSTOMER_STATE_PATH) {
+        throw new HttpError(500, CUSTOMER_STATE_PATH);
+      }
+      return { plan: "pro" };
+    });
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+      plan: "pro",
+      interval: null,
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH, ENTITLEMENTS_PATH]);
+  });
+
+  it("reports free when the fallback says the user is not subscribed", async () => {
+    const { fetchApi } = createFetchApi((path) => {
+      if (path === CUSTOMER_STATE_PATH) {
+        throw new HttpError(502, CUSTOMER_STATE_PATH);
+      }
+      return { plan: "free" };
+    });
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+      plan: "free",
+      interval: null,
+    });
+  });
+
+  it("propagates unauthorized responses instead of falling back", async () => {
+    const { calls, fetchApi } = createFetchApi((path) => {
+      if (path === CUSTOMER_STATE_PATH) {
+        throw new HttpError(401, CUSTOMER_STATE_PATH);
+      }
+      return { plan: "pro" };
+    });
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).rejects.toBeInstanceOf(HttpError);
+    expect(calls).toEqual([CUSTOMER_STATE_PATH]);
+  });
+
+  it("surfaces the failure when the fallback is unusable", async () => {
+    const { fetchApi } = createFetchApi((path) => {
+      throw new HttpError(500, path);
+    });
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).rejects.toBeInstanceOf(HttpError);
+  });
+});


### PR DESCRIPTION
Polar rate-limits the org, so `GET /api/auth/customer/state` returned 500 46 times over the last 48h (`Polar subscriptions list failed. Error: API error occurred: Status 429`). That breaks `/dashboard/upgrade` outright and renders paying users as free on `/dashboard/settings`. The plan is already in our own database and served by `/api/entitlements`, so the web app now reads it there when the Polar-backed endpoint fails.

- non-401 failures fall back to `/api/entitlements`; 401 still propagates so the upgrade loader's login redirect keeps working
- the fallback loses `interval` only, which the settings and upgrade pages degrade on gracefully
- if the fallback itself fails the error surfaces rather than being swallowed
- does not fix the 429 itself — caching or dropping the Polar read is tracked in the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)