### PR TITLE
fix(web): validate the subscription fallback and hold a known billing interval

### DIFF
--- a/applications/web/src/hooks/use-subscription.ts
+++ b/applications/web/src/hooks/use-subscription.ts
@@ -99,10 +99,6 @@ export async function fetchSubscriptionStateWithApi(
       throw error;
     }
 
-    console.error(
-      `[subscription] ${CUSTOMER_STATE_PATH} read failed, falling back to ${ENTITLEMENTS_PATH}:`,
-      error,
-    );
 
     const entitlements = entitlementsPlanSchema.assert(
       await fetchApi<unknown>(ENTITLEMENTS_PATH),

--- a/applications/web/src/hooks/use-subscription.ts
+++ b/applications/web/src/hooks/use-subscription.ts
@@ -34,9 +34,14 @@ export const resolveSubscriptionState = (
     return { plan: "free", interval: null };
   }
 
+  const { recurringInterval } = active;
+
   return {
     plan: "pro",
-    interval: active.recurringInterval === "year" ? "year" : "month",
+    interval:
+      recurringInterval === "year" || recurringInterval === "month"
+        ? recurringInterval
+        : null,
   };
 };
 

--- a/applications/web/src/hooks/use-subscription.ts
+++ b/applications/web/src/hooks/use-subscription.ts
@@ -10,7 +10,7 @@ export interface SubscriptionState {
 }
 
 const customerStateSchema = type({
-  "activeSubscriptions?": type({
+  activeSubscriptions: type({
     "recurringInterval?": "'month' | 'year' | null",
   })
     .array()

--- a/applications/web/src/hooks/use-subscription.ts
+++ b/applications/web/src/hooks/use-subscription.ts
@@ -99,6 +99,10 @@ export async function fetchSubscriptionStateWithApi(
       throw error;
     }
 
+    console.error(
+      `[subscription] ${CUSTOMER_STATE_PATH} read failed, falling back to ${ENTITLEMENTS_PATH}:`,
+      error,
+    );
 
     const entitlements = entitlementsPlanSchema.assert(
       await fetchApi<unknown>(ENTITLEMENTS_PATH),

--- a/applications/web/src/hooks/use-subscription.ts
+++ b/applications/web/src/hooks/use-subscription.ts
@@ -1,4 +1,6 @@
+import { type } from "arktype";
 import useSWR from "swr";
+import { planSchema } from "@keeper.sh/data-schemas";
 import { fetcher, HttpError } from "@/lib/fetcher";
 import { getCommercialMode } from "@/config/commercial";
 
@@ -7,17 +9,17 @@ export interface SubscriptionState {
   interval: "month" | "year" | null;
 }
 
-interface ActiveSubscription {
-  recurringInterval?: "month" | "year" | null;
-}
+const customerStateSchema = type({
+  "activeSubscriptions?": type({
+    "recurringInterval?": "'month' | 'year' | null",
+  })
+    .array()
+    .or("null"),
+});
 
-interface CustomerStateResponse {
-  activeSubscriptions?: ActiveSubscription[] | null;
-}
+const entitlementsPlanSchema = type({ plan: planSchema });
 
-interface EntitlementsPlanResponse {
-  plan: "free" | "pro";
-}
+type CustomerStateResponse = typeof customerStateSchema.infer;
 
 const SUBSCRIPTION_STATE_CACHE_KEY = "customer-state";
 const CUSTOMER_STATE_PATH = "/api/auth/customer/state";
@@ -72,14 +74,21 @@ export async function fetchSubscriptionStateWithApi(
   fetchApi: <T>(path: string, init?: RequestInit) => Promise<T>,
 ): Promise<SubscriptionState> {
   try {
-    const data = await fetchApi<CustomerStateResponse>(CUSTOMER_STATE_PATH);
-    return resolveSubscriptionState(data);
+    const data = await fetchApi<unknown>(CUSTOMER_STATE_PATH);
+    return resolveSubscriptionState(customerStateSchema.assert(data));
   } catch (error) {
     if (isUnauthorized(error)) {
       throw error;
     }
 
-    const entitlements = await fetchApi<EntitlementsPlanResponse>(ENTITLEMENTS_PATH);
+    console.error(
+      `[subscription] ${CUSTOMER_STATE_PATH} read failed, falling back to ${ENTITLEMENTS_PATH}:`,
+      error,
+    );
+
+    const entitlements = entitlementsPlanSchema.assert(
+      await fetchApi<unknown>(ENTITLEMENTS_PATH),
+    );
     return { plan: entitlements.plan, interval: null };
   }
 }

--- a/applications/web/src/hooks/use-subscription.ts
+++ b/applications/web/src/hooks/use-subscription.ts
@@ -1,8 +1,10 @@
+import { useState } from "react";
 import { type } from "arktype";
 import useSWR from "swr";
 import { planSchema } from "@keeper.sh/data-schemas";
 import { fetcher, HttpError } from "@/lib/fetcher";
 import { getCommercialMode } from "@/config/commercial";
+import { retainKnownInterval } from "@/lib/upgrade-mode";
 
 export interface SubscriptionState {
   plan: "free" | "pro";
@@ -72,7 +74,18 @@ export function useSubscription(options: UseSubscriptionOptions = {}) {
     fetchSubscriptionState,
     { fallbackData },
   );
-  return { data, error, isLoading, mutate };
+
+  const [lastKnown, setLastKnown] = useState(fallbackData);
+  const subscription = retainKnownInterval(lastKnown, data);
+
+  if (
+    subscription?.plan !== lastKnown?.plan ||
+    subscription?.interval !== lastKnown?.interval
+  ) {
+    setLastKnown(subscription);
+  }
+
+  return { data: subscription, error, isLoading, mutate };
 }
 
 export async function fetchSubscriptionStateWithApi(

--- a/applications/web/src/lib/upgrade-mode.ts
+++ b/applications/web/src/lib/upgrade-mode.ts
@@ -1,0 +1,20 @@
+import type { SubscriptionState } from "@/hooks/use-subscription";
+
+export type UpgradeMode = "upgrade" | "manage" | "switch-interval";
+
+export const resolveUpgradeMode = (
+  subscription: SubscriptionState | undefined,
+  yearlySelected: boolean,
+): UpgradeMode => {
+  if (subscription?.plan !== "pro") {
+    return "upgrade";
+  }
+
+  if (subscription.interval === null) {
+    return "manage";
+  }
+
+  return subscription.interval === (yearlySelected ? "year" : "month")
+    ? "manage"
+    : "switch-interval";
+};

--- a/applications/web/src/lib/upgrade-mode.ts
+++ b/applications/web/src/lib/upgrade-mode.ts
@@ -2,6 +2,21 @@ import type { SubscriptionState } from "@/hooks/use-subscription";
 
 export type UpgradeMode = "upgrade" | "manage" | "switch-interval";
 
+export const retainKnownInterval = (
+  previous: SubscriptionState | undefined,
+  current: SubscriptionState | undefined,
+): SubscriptionState | undefined => {
+  if (!current || current.interval !== null) {
+    return current;
+  }
+
+  if (!previous || previous.plan !== current.plan || previous.interval === null) {
+    return current;
+  }
+
+  return { ...current, interval: previous.interval };
+};
+
 export const resolveUpgradeMode = (
   subscription: SubscriptionState | undefined,
   yearlySelected: boolean,

--- a/applications/web/src/routes/(dashboard)/dashboard/settings/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/settings/index.tsx
@@ -47,7 +47,8 @@ async function loadSubscription(context: { runtimeConfig: { commercialMode: bool
   if (!context.runtimeConfig.commercialMode) return undefined;
   try {
     return await fetchSubscriptionStateWithApi(context.fetchApi);
-  } catch {
+  } catch (error) {
+    console.error("[subscription] settings loader preload failed, deferring to the client read:", error);
     return undefined;
   }
 }

--- a/applications/web/src/routes/(dashboard)/dashboard/upgrade/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/upgrade/index.tsx
@@ -23,6 +23,8 @@ import { openCheckout, openCustomerPortal } from "@/utils/checkout";
 import { getPlans } from "@/config/plans";
 import type { PlanConfig } from "@/config/plans";
 import { resolveUpgradeRedirect } from "@/lib/route-access-guards";
+import { resolveUpgradeMode } from "@/lib/upgrade-mode";
+import type { UpgradeMode } from "@/lib/upgrade-mode";
 import type { PublicRuntimeConfig } from "@/lib/runtime-config";
 
 export const Route = createFileRoute("/(dashboard)/dashboard/upgrade/")({
@@ -86,13 +88,6 @@ function UpgradePage() {
   };
   const [isPending, startTransition] = useTransition();
 
-  const currentPlan = subscription?.plan ?? "free";
-  const currentInterval = subscription?.interval;
-  const isCurrent = currentPlan === "pro";
-  const isCurrentInterval =
-    (currentInterval === "year" && yearly) ||
-    (currentInterval === "month" && !yearly);
-
   const price = yearly ? (proPlan.yearlyPrice / 12).toFixed(2) : proPlan.monthlyPrice.toFixed(2);
   const period = yearly ? "per month, billed annually" : "per month";
   const productId = yearly ? proPlan.yearlyProductId : proPlan.monthlyProductId;
@@ -121,7 +116,7 @@ function UpgradePage() {
   };
 
   const busy = isLoading || isPending;
-  const mode = !isCurrent ? "upgrade" : isCurrentInterval ? "manage" : "switch-interval";
+  const mode = resolveUpgradeMode(subscription, yearly);
 
   return (
     <div className="flex flex-col gap-1.5">
@@ -167,7 +162,7 @@ type UpgradeActionProps = {
   isLoading: boolean;
   onUpgrade: () => void;
   onManage: () => void;
-  mode: "upgrade" | "manage" | "switch-interval";
+  mode: UpgradeMode;
 };
 
 function UpgradeAction({ mode, isLoading, onUpgrade, onManage }: UpgradeActionProps) {

--- a/applications/web/src/routes/(dashboard)/dashboard/upgrade/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/upgrade/index.tsx
@@ -23,7 +23,7 @@ import { openCheckout, openCustomerPortal } from "@/utils/checkout";
 import { getPlans } from "@/config/plans";
 import type { PlanConfig } from "@/config/plans";
 import { resolveUpgradeRedirect } from "@/lib/route-access-guards";
-import { resolveUpgradeMode, retainKnownInterval } from "@/lib/upgrade-mode";
+import { resolveUpgradeMode } from "@/lib/upgrade-mode";
 import type { UpgradeMode } from "@/lib/upgrade-mode";
 import type { PublicRuntimeConfig } from "@/lib/runtime-config";
 
@@ -116,10 +116,7 @@ function UpgradePage() {
   };
 
   const busy = isLoading || isPending;
-  const mode = resolveUpgradeMode(
-    retainKnownInterval(loaderSubscription, subscription),
-    yearly,
-  );
+  const mode = resolveUpgradeMode(subscription, yearly);
 
   return (
     <div className="flex flex-col gap-1.5">

--- a/applications/web/src/routes/(dashboard)/dashboard/upgrade/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/upgrade/index.tsx
@@ -23,7 +23,7 @@ import { openCheckout, openCustomerPortal } from "@/utils/checkout";
 import { getPlans } from "@/config/plans";
 import type { PlanConfig } from "@/config/plans";
 import { resolveUpgradeRedirect } from "@/lib/route-access-guards";
-import { resolveUpgradeMode } from "@/lib/upgrade-mode";
+import { resolveUpgradeMode, retainKnownInterval } from "@/lib/upgrade-mode";
 import type { UpgradeMode } from "@/lib/upgrade-mode";
 import type { PublicRuntimeConfig } from "@/lib/runtime-config";
 
@@ -116,7 +116,10 @@ function UpgradePage() {
   };
 
   const busy = isLoading || isPending;
-  const mode = resolveUpgradeMode(subscription, yearly);
+  const mode = resolveUpgradeMode(
+    retainKnownInterval(loaderSubscription, subscription),
+    yearly,
+  );
 
   return (
     <div className="flex flex-col gap-1.5">

--- a/applications/web/tests/hooks/use-subscription-client-path.test.ts
+++ b/applications/web/tests/hooks/use-subscription-client-path.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { HttpError } from "../../src/lib/fetcher";
+import { fetchSubscriptionState } from "../../src/hooks/use-subscription";
+
+const CUSTOMER_STATE_PATH = "/api/auth/customer/state";
+const ENTITLEMENTS_PATH = "/api/entitlements";
+
+const jsonResponse = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+const htmlResponse = (status: number): Response =>
+  new Response("<html><body>502 Bad Gateway</body></html>", {
+    status,
+    headers: { "content-type": "text/html" },
+  });
+
+const stubFetch = (respond: (path: string) => Response) => {
+  const calls: string[] = [];
+  const fetchMock = vi.fn(async (...args: [RequestInfo | URL, RequestInit?]) => {
+    const [input] = args;
+    const path = typeof input === "string" ? input : input.toString();
+    calls.push(path);
+    return respond(path);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { calls, fetchMock };
+};
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+  vi.unstubAllGlobals();
+});
+
+describe("browser subscription read", () => {
+  it("reads the plan and interval straight from a healthy customer state", async () => {
+    const { calls } = stubFetch(() =>
+      jsonResponse(200, { activeSubscriptions: [{ recurringInterval: "year" }] }),
+    );
+
+    await expect(fetchSubscriptionState()).resolves.toEqual({
+      plan: "pro",
+      interval: "year",
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH]);
+  });
+
+  it("sends the session cookie on both reads", async () => {
+    const { fetchMock } = stubFetch((path) =>
+      path === CUSTOMER_STATE_PATH
+        ? jsonResponse(500, { error: "upstream" })
+        : jsonResponse(200, { plan: "pro" }),
+    );
+
+    await fetchSubscriptionState();
+
+    for (const call of fetchMock.mock.calls) {
+      expect(call[1]).toMatchObject({ credentials: "include" });
+    }
+  });
+
+  it("keeps a paying user on pro when the customer state returns a gateway error page", async () => {
+    const { calls } = stubFetch((path) =>
+      path === CUSTOMER_STATE_PATH
+        ? htmlResponse(502)
+        : jsonResponse(200, { plan: "pro" }),
+    );
+
+    await expect(fetchSubscriptionState()).resolves.toEqual({
+      plan: "pro",
+      interval: null,
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH, ENTITLEMENTS_PATH]);
+  });
+
+  it("keeps a paying user on pro when the customer state answers 200 with an unparseable body", async () => {
+    const { calls } = stubFetch((path) =>
+      path === CUSTOMER_STATE_PATH
+        ? htmlResponse(200)
+        : jsonResponse(200, { plan: "pro" }),
+    );
+
+    await expect(fetchSubscriptionState()).resolves.toEqual({
+      plan: "pro",
+      interval: null,
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH, ENTITLEMENTS_PATH]);
+  });
+
+  it("keeps a paying user on pro when the customer state answers 204 with no body", async () => {
+    const { calls } = stubFetch((path) =>
+      path === CUSTOMER_STATE_PATH
+        ? new Response(null, { status: 204 })
+        : jsonResponse(200, { plan: "pro" }),
+    );
+
+    await expect(fetchSubscriptionState()).resolves.toEqual({
+      plan: "pro",
+      interval: null,
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH, ENTITLEMENTS_PATH]);
+  });
+
+  it("propagates a 401 from the browser read so the login redirect still fires", async () => {
+    const { calls } = stubFetch(() => jsonResponse(401, { error: "unauthorized" }));
+
+    await expect(fetchSubscriptionState()).rejects.toBeInstanceOf(HttpError);
+    expect(calls).toEqual([CUSTOMER_STATE_PATH]);
+  });
+
+  it("does not downgrade to free when the fallback body is unusable", async () => {
+    stubFetch((path) =>
+      path === CUSTOMER_STATE_PATH
+        ? jsonResponse(500, { error: "upstream" })
+        : jsonResponse(200, { plan: null }),
+    );
+
+    await expect(fetchSubscriptionState()).rejects.toThrow();
+  });
+
+  it("does not downgrade to free when the fallback returns a gateway error page", async () => {
+    stubFetch((path) =>
+      path === CUSTOMER_STATE_PATH
+        ? jsonResponse(500, { error: "upstream" })
+        : htmlResponse(200),
+    );
+
+    await expect(fetchSubscriptionState()).rejects.toThrow();
+  });
+
+  it("issues exactly two requests per attempt and never retries in a loop", async () => {
+    const { calls } = stubFetch((path) =>
+      path === CUSTOMER_STATE_PATH
+        ? jsonResponse(500, { error: "upstream" })
+        : jsonResponse(200, { plan: "pro" }),
+    );
+
+    await fetchSubscriptionState();
+    await fetchSubscriptionState();
+    await fetchSubscriptionState();
+
+    expect(calls).toEqual([
+      CUSTOMER_STATE_PATH,
+      ENTITLEMENTS_PATH,
+      CUSTOMER_STATE_PATH,
+      ENTITLEMENTS_PATH,
+      CUSTOMER_STATE_PATH,
+      ENTITLEMENTS_PATH,
+    ]);
+  });
+
+  it("resolves concurrent browser reads to the same state", async () => {
+    stubFetch((path) =>
+      path === CUSTOMER_STATE_PATH
+        ? jsonResponse(429, { error: "rate limited" })
+        : jsonResponse(200, { plan: "pro" }),
+    );
+
+    const results = await Promise.all([
+      fetchSubscriptionState(),
+      fetchSubscriptionState(),
+      fetchSubscriptionState(),
+    ]);
+
+    expect(results).toEqual(Array(3).fill({ plan: "pro", interval: null }));
+  });
+});

--- a/applications/web/tests/hooks/use-subscription-convergence.test.ts
+++ b/applications/web/tests/hooks/use-subscription-convergence.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { HttpError } from "../../src/lib/fetcher";
+import {
+  fetchSubscriptionStateWithApi,
+  resolveSubscriptionState,
+} from "../../src/hooks/use-subscription";
+import { resolveUpgradeMode, retainKnownInterval } from "../../src/lib/upgrade-mode";
+import type { SubscriptionState } from "../../src/hooks/use-subscription";
+
+const CUSTOMER_STATE_PATH = "/api/auth/customer/state";
+const ENTITLEMENTS_PATH = "/api/entitlements";
+
+const createApi = (respond: (path: string, callIndex: number) => unknown) => {
+  const calls: string[] = [];
+  const fetchApi = async <T,>(path: string): Promise<T> => {
+    const callIndex = calls.length;
+    calls.push(path);
+    const result = respond(path, callIndex);
+    if (result instanceof Error) throw result;
+    return result as T;
+  };
+  return { calls, fetchApi };
+};
+
+const annualCustomerState = {
+  activeSubscriptions: [{ recurringInterval: "year" }],
+};
+
+describe("realistic upstream payloads", () => {
+  it("accepts a full Polar-shaped customer state without falling back", async () => {
+    const { calls, fetchApi } = createApi(() => ({
+      id: "cus_01HZ",
+      email: "paying@example.com",
+      name: "Paying User",
+      externalId: "user_123",
+      taxId: null,
+      billingAddress: { country: "CA", postalCode: "M5V 2T6" },
+      grantedBenefits: [{ id: "ben_1", benefitType: "custom" }],
+      activeMeters: [],
+      activeSubscriptions: [
+        {
+          id: "sub_01HZ",
+          status: "active",
+          productId: "prod_pro_year",
+          recurringInterval: "year",
+          currentPeriodStart: "2026-01-01T00:00:00Z",
+          currentPeriodEnd: "2027-01-01T00:00:00Z",
+          cancelAtPeriodEnd: false,
+          amount: 9900,
+          currency: "usd",
+        },
+      ],
+    }));
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+      plan: "pro",
+      interval: "year",
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH]);
+  });
+
+  it("accepts a full Polar-shaped entitlements body in the fallback", async () => {
+    const { fetchApi } = createApi((path) => {
+      if (path === CUSTOMER_STATE_PATH) return new HttpError(500, path);
+      return {
+        plan: "pro",
+        accounts: { current: 3, limit: null },
+        mappings: { current: 7, limit: null },
+        canCustomizeIcalFeed: true,
+        canUseEventFilters: true,
+      };
+    });
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+      plan: "pro",
+      interval: null,
+    });
+  });
+});
+
+describe("upgrade call to action convergence while the read flaps", () => {
+  const runFlap = async (
+    yearlySelected: boolean,
+    runs: number,
+    customerState: unknown = annualCustomerState,
+    status = 500,
+  ): Promise<string[]> => {
+    const modes: string[] = [];
+    let settled: SubscriptionState | undefined;
+
+    for (let run = 0; run < runs; run += 1) {
+      const failing = run % 2 === 1;
+      const { fetchApi } = createApi((path) => {
+        if (path === CUSTOMER_STATE_PATH) {
+          return failing ? new HttpError(status, path) : customerState;
+        }
+        return { plan: "pro" };
+      });
+      settled = retainKnownInterval(
+        settled,
+        await fetchSubscriptionStateWithApi(fetchApi),
+      );
+      modes.push(resolveUpgradeMode(settled, yearlySelected));
+    }
+
+    return modes;
+  };
+
+  it("keeps a stable call to action for an annual subscriber with the annual toggle on", async () => {
+    expect(await runFlap(true, 6)).toEqual(Array(6).fill("manage"));
+  });
+
+  it("keeps a stable call to action for an annual subscriber with the default monthly toggle", async () => {
+    expect(await runFlap(false, 6)).toEqual(Array(6).fill("switch-interval"));
+  });
+
+  it("keeps a stable call to action for a monthly subscriber with the annual toggle on", async () => {
+    const modes = await runFlap(
+      true,
+      6,
+      { activeSubscriptions: [{ recurringInterval: "month" }] },
+      503,
+    );
+    expect(modes).toEqual(Array(6).fill("switch-interval"));
+  });
+
+  it("never offers a plain upgrade to a paying user at any point in the flap", async () => {
+    const modes = [...(await runFlap(false, 6)), ...(await runFlap(true, 6))];
+    expect(modes).not.toContain("upgrade");
+  });
+
+  it("manages rather than guessing an interval when the very first read already fails", async () => {
+    const { calls, fetchApi } = createApi((path) =>
+      path === CUSTOMER_STATE_PATH ? new HttpError(500, path) : { plan: "pro" },
+    );
+    const settled = retainKnownInterval(
+      undefined,
+      await fetchSubscriptionStateWithApi(fetchApi),
+    );
+
+    expect(calls).toEqual([CUSTOMER_STATE_PATH, ENTITLEMENTS_PATH]);
+    expect(settled).toEqual({ plan: "pro", interval: null });
+    expect(resolveUpgradeMode(settled, true)).toBe("manage");
+    expect(resolveUpgradeMode(settled, false)).toBe("manage");
+  });
+
+  it("drops the retained interval once the plan itself changes", () => {
+    expect(
+      retainKnownInterval({ plan: "pro", interval: "year" }, { plan: "free", interval: null }),
+    ).toEqual({ plan: "free", interval: null });
+  });
+
+  it("prefers a freshly reported interval over the retained one", () => {
+    expect(
+      retainKnownInterval({ plan: "pro", interval: "year" }, { plan: "pro", interval: "month" }),
+    ).toEqual({ plan: "pro", interval: "month" });
+  });
+});
+
+describe("interval reported for a subscription whose recurrence is absent", () => {
+  it("does not claim a monthly interval the upstream never reported", () => {
+    expect(
+      resolveSubscriptionState({ activeSubscriptions: [{ recurringInterval: null }] }),
+    ).toEqual({ plan: "pro", interval: null });
+  });
+
+  it("does not offer an interval switch on an unreported recurrence", () => {
+    const state = resolveSubscriptionState({
+      activeSubscriptions: [{ recurringInterval: null }],
+    });
+    expect(resolveUpgradeMode(state, true)).toBe("manage");
+  });
+});
+
+describe("repeated recovery cycles", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it("converges on the authoritative state after an outage and stays converged", async () => {
+    const results = [];
+    for (let run = 0; run < 4; run += 1) {
+      const failing = run < 2;
+      const { fetchApi } = createApi((path) => {
+        if (path === CUSTOMER_STATE_PATH && failing) return new HttpError(429, path);
+        if (path === CUSTOMER_STATE_PATH) return annualCustomerState;
+        return { plan: "pro" };
+      });
+      results.push(await fetchSubscriptionStateWithApi(fetchApi));
+    }
+    expect(results.slice(2)).toEqual([
+      { plan: "pro", interval: "year" },
+      { plan: "pro", interval: "year" },
+    ]);
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not accumulate hidden state between independent runs", async () => {
+    const first = createApi((path) =>
+      path === CUSTOMER_STATE_PATH ? new HttpError(500, path) : { plan: "pro" },
+    );
+    await fetchSubscriptionStateWithApi(first.fetchApi);
+
+    const second = createApi(() => ({ activeSubscriptions: [] }));
+    await expect(fetchSubscriptionStateWithApi(second.fetchApi)).resolves.toEqual({
+      plan: "free",
+      interval: null,
+    });
+    expect(second.calls).toEqual([CUSTOMER_STATE_PATH]);
+  });
+});
+
+describe("both reads failing", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it("rejects rather than resolving to free when both endpoints are down", async () => {
+    const { fetchApi } = createApi((path) => new HttpError(500, path));
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).rejects.toBeInstanceOf(HttpError);
+  });
+
+  it("surfaces the fallback failure, not a silent free plan, on a timeout", async () => {
+    const { fetchApi } = createApi(() => new Error("network timeout"));
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).rejects.toThrow("network timeout");
+  });
+});

--- a/applications/web/tests/hooks/use-subscription-customer-state.test.ts
+++ b/applications/web/tests/hooks/use-subscription-customer-state.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { HttpError } from "../../src/lib/fetcher";
+import { fetchSubscriptionStateWithApi } from "../../src/hooks/use-subscription";
+import { resolveUpgradeMode } from "../../src/lib/upgrade-mode";
+
+const CUSTOMER_STATE_PATH = "/api/auth/customer/state";
+const ENTITLEMENTS_PATH = "/api/entitlements";
+
+const PAYING_USER_ENTITLEMENTS = { plan: "pro" };
+
+const createApi = (respond: (path: string) => unknown) => {
+  const calls: string[] = [];
+  const fetchApi = async <T,>(path: string): Promise<T> => {
+    calls.push(path);
+    const result = respond(path);
+    if (result instanceof Error) throw result;
+    return result as T;
+  };
+  return { calls, fetchApi };
+};
+
+const payingUserWithCustomerStateBody = (body: unknown) =>
+  createApi((path) => (path === CUSTOMER_STATE_PATH ? body : PAYING_USER_ENTITLEMENTS));
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("customer state bodies that carry no subscription information", () => {
+  it("does not report a paying user as free when the customer state is a 200 error envelope", async () => {
+    const { calls, fetchApi } = payingUserWithCustomerStateBody({
+      error: "rate_limited",
+      message: "Polar is rate limiting this organization",
+    });
+
+    const state = await fetchSubscriptionStateWithApi(fetchApi);
+
+    expect(calls).toContain(ENTITLEMENTS_PATH);
+    expect(state.plan).toBe("pro");
+  });
+
+  it("does not report a paying user as free when the customer state body is an empty object", async () => {
+    const { calls, fetchApi } = payingUserWithCustomerStateBody({});
+
+    const state = await fetchSubscriptionStateWithApi(fetchApi);
+
+    expect(calls).toContain(ENTITLEMENTS_PATH);
+    expect(state.plan).toBe("pro");
+  });
+
+  it("does not report a paying user as free when the customer state body is an array", async () => {
+    const { calls, fetchApi } = payingUserWithCustomerStateBody([]);
+
+    const state = await fetchSubscriptionStateWithApi(fetchApi);
+
+    expect(calls).toContain(ENTITLEMENTS_PATH);
+    expect(state.plan).toBe("pro");
+  });
+
+  it("does not report a paying user as free when the customer state body is a populated array", async () => {
+    const { calls, fetchApi } = payingUserWithCustomerStateBody([
+      { detail: "service unavailable" },
+    ]);
+
+    const state = await fetchSubscriptionStateWithApi(fetchApi);
+
+    expect(calls).toContain(ENTITLEMENTS_PATH);
+    expect(state.plan).toBe("pro");
+  });
+
+  it("still trusts an explicit empty active subscription list as a genuine free plan", async () => {
+    const { calls, fetchApi } = payingUserWithCustomerStateBody({ activeSubscriptions: [] });
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+      plan: "free",
+      interval: null,
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH]);
+  });
+
+  it("still trusts an explicit null active subscription list as a genuine free plan", async () => {
+    const { calls, fetchApi } = payingUserWithCustomerStateBody({ activeSubscriptions: null });
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+      plan: "free",
+      interval: null,
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH]);
+  });
+});
+
+describe("customer state failure status boundaries", () => {
+  const fallbackStatuses = [400, 402, 403, 404, 408, 409, 418, 429, 500, 502, 503, 504];
+
+  for (const status of fallbackStatuses) {
+    it(`falls back to entitlements on ${status}`, async () => {
+      const { calls, fetchApi } = createApi((path) =>
+        path === CUSTOMER_STATE_PATH ? new HttpError(status, path) : PAYING_USER_ENTITLEMENTS,
+      );
+
+      await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+        plan: "pro",
+        interval: null,
+      });
+      expect(calls).toEqual([CUSTOMER_STATE_PATH, ENTITLEMENTS_PATH]);
+    });
+  }
+
+  it("short-circuits on exactly 401 and never touches the fallback", async () => {
+    const { calls, fetchApi } = createApi((path) =>
+      path === CUSTOMER_STATE_PATH
+        ? new HttpError(401, path)
+        : PAYING_USER_ENTITLEMENTS,
+    );
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).rejects.toBeInstanceOf(HttpError);
+    expect(calls).toEqual([CUSTOMER_STATE_PATH]);
+  });
+
+  it("does not treat a plain error carrying a status field as unauthorized", async () => {
+    const impostor = Object.assign(new Error("unauthorized"), { status: 401 });
+    const { calls, fetchApi } = createApi((path) =>
+      path === CUSTOMER_STATE_PATH ? impostor : PAYING_USER_ENTITLEMENTS,
+    );
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+      plan: "pro",
+      interval: null,
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH, ENTITLEMENTS_PATH]);
+  });
+});
+
+describe("errors arriving wrapped inside other errors", () => {
+  it("still ends in a 401 rejection when the customer state 401 is wrapped as a cause", async () => {
+    const wrapped = new Error("request failed", { cause: new HttpError(401, CUSTOMER_STATE_PATH) });
+    const { calls, fetchApi } = createApi((path) =>
+      path === CUSTOMER_STATE_PATH ? wrapped : new HttpError(401, path),
+    );
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).rejects.toMatchObject({ status: 401 });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH, ENTITLEMENTS_PATH]);
+  });
+
+  it("propagates a non-Error rejection from the customer state into the fallback", async () => {
+    const calls: string[] = [];
+    const fetchApi = async <T,>(path: string): Promise<T> => {
+      calls.push(path);
+      if (path === CUSTOMER_STATE_PATH) throw "boom";
+      return PAYING_USER_ENTITLEMENTS as T;
+    };
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+      plan: "pro",
+      interval: null,
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH, ENTITLEMENTS_PATH]);
+  });
+});
+
+describe("outage visibility", () => {
+  it("reports the swallowed customer state failure somewhere observable", async () => {
+    const reported: unknown[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      reported.push(args);
+    });
+    const { fetchApi } = createApi((path) =>
+      path === CUSTOMER_STATE_PATH
+        ? new HttpError(500, path)
+        : PAYING_USER_ENTITLEMENTS,
+    );
+
+    await fetchSubscriptionStateWithApi(fetchApi);
+
+    expect(reported).toHaveLength(1);
+  });
+
+  it("does not log when the customer state read succeeds", async () => {
+    const reported: unknown[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      reported.push(args);
+    });
+    const { fetchApi } = createApi(() => ({
+      activeSubscriptions: [{ recurringInterval: "month" }],
+    }));
+
+    await fetchSubscriptionStateWithApi(fetchApi);
+
+    expect(reported).toHaveLength(0);
+  });
+});
+
+describe("repeated runs converge", () => {
+  it("produces an identical state on every run while the outage persists", async () => {
+    const { fetchApi } = createApi((path) =>
+      path === CUSTOMER_STATE_PATH
+        ? new HttpError(500, path)
+        : PAYING_USER_ENTITLEMENTS,
+    );
+
+    const runs = [];
+    for (let index = 0; index < 5; index += 1) {
+      runs.push(await fetchSubscriptionStateWithApi(fetchApi));
+    }
+
+    expect(new Set(runs.map((run) => JSON.stringify(run))).size).toBe(1);
+  });
+
+  it("returns to the full customer state once the outage clears and stays there", async () => {
+    let healthy = false;
+    const fetchApi = async <T,>(path: string): Promise<T> => {
+      if (path === CUSTOMER_STATE_PATH) {
+        if (!healthy) throw new HttpError(500, path);
+        return { activeSubscriptions: [{ recurringInterval: "year" }] } as T;
+      }
+      return PAYING_USER_ENTITLEMENTS as T;
+    };
+
+    expect(await fetchSubscriptionStateWithApi(fetchApi)).toEqual({
+      plan: "pro",
+      interval: null,
+    });
+
+    healthy = true;
+    const settled = [
+      await fetchSubscriptionStateWithApi(fetchApi),
+      await fetchSubscriptionStateWithApi(fetchApi),
+    ];
+
+    expect(settled).toEqual([
+      { plan: "pro", interval: "year" },
+      { plan: "pro", interval: "year" },
+    ]);
+  });
+
+  it("reports the billing interval of a paying annual user as unknown, never as wrong, while the read flaps", async () => {
+    let attempt = 0;
+    const fetchApi = async <T,>(path: string): Promise<T> => {
+      if (path === CUSTOMER_STATE_PATH) {
+        attempt += 1;
+        if (attempt % 2 === 1) throw new HttpError(429, path);
+        return { activeSubscriptions: [{ recurringInterval: "year" }] } as T;
+      }
+      return PAYING_USER_ENTITLEMENTS as T;
+    };
+
+    const intervals: (string | null)[] = [];
+    for (let index = 0; index < 6; index += 1) {
+      const state = await fetchSubscriptionStateWithApi(fetchApi);
+      expect(state.plan).toBe("pro");
+      intervals.push(state.interval);
+    }
+
+    expect(intervals).toEqual([null, "year", null, "year", null, "year"]);
+    expect(intervals.every((interval) => interval === null || interval === "year")).toBe(true);
+    expect(resolveUpgradeMode({ plan: "pro", interval: null }, true)).toBe("manage");
+    expect(resolveUpgradeMode({ plan: "pro", interval: "year" }, true)).toBe("manage");
+  });
+});
+
+describe("interval resolution edges", () => {
+  it("defaults a subscription with no recurring interval to month", async () => {
+    const { fetchApi } = createApi(() => ({ activeSubscriptions: [{}] }));
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+      plan: "pro",
+      interval: "month",
+    });
+  });
+
+  it("uses the first active subscription when several are present", async () => {
+    const { fetchApi } = createApi(() => ({
+      activeSubscriptions: [{ recurringInterval: "year" }, { recurringInterval: "month" }],
+    }));
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+      plan: "pro",
+      interval: "year",
+    });
+  });
+
+  it("falls back rather than accepting an unknown recurring interval", async () => {
+    const { calls, fetchApi } = payingUserWithCustomerStateBody({
+      activeSubscriptions: [{ recurringInterval: "quarter" }],
+    });
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+      plan: "pro",
+      interval: null,
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH, ENTITLEMENTS_PATH]);
+  });
+});

--- a/applications/web/tests/hooks/use-subscription-customer-state.test.ts
+++ b/applications/web/tests/hooks/use-subscription-customer-state.test.ts
@@ -263,12 +263,12 @@ describe("repeated runs converge", () => {
 });
 
 describe("interval resolution edges", () => {
-  it("defaults a subscription with no recurring interval to month", async () => {
+  it("reports a subscription with no recurring interval as pro on an unknown interval", async () => {
     const { fetchApi } = createApi(() => ({ activeSubscriptions: [{}] }));
 
     await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
       plan: "pro",
-      interval: "month",
+      interval: null,
     });
   });
 

--- a/applications/web/tests/hooks/use-subscription-fallback.test.ts
+++ b/applications/web/tests/hooks/use-subscription-fallback.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import { HttpError } from "../../src/lib/fetcher";
+import { fetchSubscriptionStateWithApi } from "../../src/hooks/use-subscription";
+
+const CUSTOMER_STATE_PATH = "/api/auth/customer/state";
+const ENTITLEMENTS_PATH = "/api/entitlements";
+
+const PLANS = ["free", "pro"];
+
+const createRecordingApi = (respond: (path: string, call: number) => unknown) => {
+  const calls: string[] = [];
+  const fetchApi = async <T,>(path: string): Promise<T> => {
+    calls.push(path);
+    return respond(path, calls.filter((entry) => entry === path).length) as T;
+  };
+  return { calls, fetchApi };
+};
+
+describe("subscription fallback payload validation", () => {
+  it("never resolves to a plan outside the known set when the fallback omits it", async () => {
+    const { fetchApi } = createRecordingApi((path) => {
+      if (path === CUSTOMER_STATE_PATH) throw new HttpError(500, path);
+      return {};
+    });
+
+    const state = await fetchSubscriptionStateWithApi(fetchApi).catch((error: unknown) => error);
+
+    if (state instanceof Error) return;
+    expect(PLANS).toContain((state as { plan: unknown }).plan);
+  });
+
+  it("never resolves to a plan outside the known set when the fallback returns an unknown plan", async () => {
+    const { fetchApi } = createRecordingApi((path) => {
+      if (path === CUSTOMER_STATE_PATH) throw new HttpError(503, path);
+      return { plan: "enterprise" };
+    });
+
+    const state = await fetchSubscriptionStateWithApi(fetchApi).catch((error: unknown) => error);
+
+    if (state instanceof Error) return;
+    expect(PLANS).toContain((state as { plan: unknown }).plan);
+  });
+
+  it("fails with a domain error rather than a property read on a null fallback body", async () => {
+    const { fetchApi } = createRecordingApi((path) => {
+      if (path === CUSTOMER_STATE_PATH) throw new HttpError(500, path);
+      return null;
+    });
+
+    const error = await fetchSubscriptionStateWithApi(fetchApi).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(TypeError);
+  });
+});
+
+describe("subscription fallback auth propagation", () => {
+  it("propagates a 401 raised by the fallback so login redirects still fire", async () => {
+    const { calls, fetchApi } = createRecordingApi((path) => {
+      if (path === CUSTOMER_STATE_PATH) throw new HttpError(500, path);
+      throw new HttpError(401, path);
+    });
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).rejects.toMatchObject({
+      status: 401,
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH, ENTITLEMENTS_PATH]);
+  });
+
+  it("does not reach the fallback when the customer state is unauthorized", async () => {
+    const { calls, fetchApi } = createRecordingApi((path) => {
+      if (path === CUSTOMER_STATE_PATH) throw new HttpError(401, path);
+      return { plan: "pro" };
+    });
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).rejects.toMatchObject({
+      status: 401,
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH]);
+  });
+
+  it("falls back for a network failure that is not an HttpError", async () => {
+    const { calls, fetchApi } = createRecordingApi((path) => {
+      if (path === CUSTOMER_STATE_PATH) throw new TypeError("Failed to fetch");
+      return { plan: "pro" };
+    });
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+      plan: "pro",
+      interval: null,
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH, ENTITLEMENTS_PATH]);
+  });
+});
+
+describe("subscription fallback convergence", () => {
+  it("keeps a paying user on pro across repeated flapping reads", async () => {
+    let attempt = 0;
+    const fetchApi = async <T,>(path: string): Promise<T> => {
+      if (path === CUSTOMER_STATE_PATH) {
+        attempt += 1;
+        if (attempt % 2 === 1) throw new HttpError(500, path);
+        return { activeSubscriptions: [{ recurringInterval: "year" }] } as T;
+      }
+      return { plan: "pro" } as T;
+    };
+
+    const results = [];
+    for (let index = 0; index < 6; index += 1) {
+      results.push(await fetchSubscriptionStateWithApi(fetchApi));
+    }
+
+    expect(results.map((result) => result.plan)).toEqual([
+      "pro",
+      "pro",
+      "pro",
+      "pro",
+      "pro",
+      "pro",
+    ]);
+  });
+
+  it("issues the same request sequence on every repeated failing run", async () => {
+    const { calls, fetchApi } = createRecordingApi((path) => {
+      if (path === CUSTOMER_STATE_PATH) throw new HttpError(500, path);
+      return { plan: "pro" };
+    });
+
+    await fetchSubscriptionStateWithApi(fetchApi);
+    await fetchSubscriptionStateWithApi(fetchApi);
+    await fetchSubscriptionStateWithApi(fetchApi);
+
+    expect(calls).toEqual([
+      CUSTOMER_STATE_PATH,
+      ENTITLEMENTS_PATH,
+      CUSTOMER_STATE_PATH,
+      ENTITLEMENTS_PATH,
+      CUSTOMER_STATE_PATH,
+      ENTITLEMENTS_PATH,
+    ]);
+  });
+
+  it("resolves concurrent callers independently without cross-talk", async () => {
+    const { calls, fetchApi } = createRecordingApi((path) => {
+      if (path === CUSTOMER_STATE_PATH) throw new HttpError(500, path);
+      return { plan: "pro" };
+    });
+
+    const states = await Promise.all([
+      fetchSubscriptionStateWithApi(fetchApi),
+      fetchSubscriptionStateWithApi(fetchApi),
+    ]);
+
+    expect(states).toEqual([
+      { plan: "pro", interval: null },
+      { plan: "pro", interval: null },
+    ]);
+    expect(calls.filter((path) => path === ENTITLEMENTS_PATH)).toHaveLength(2);
+  });
+});
+
+describe("subscription state resolution edges", () => {
+  it("treats an empty active subscription list as free without falling back", async () => {
+    const { calls, fetchApi } = createRecordingApi(() => ({ activeSubscriptions: [] }));
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+      plan: "free",
+      interval: null,
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH]);
+  });
+
+  it("treats a null active subscription list as free without falling back", async () => {
+    const { calls, fetchApi } = createRecordingApi(() => ({ activeSubscriptions: null }));
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+      plan: "free",
+      interval: null,
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH]);
+  });
+
+  it("does not silently downgrade a paying user when the customer state body is unusable", async () => {
+    const { fetchApi } = createRecordingApi((path) => {
+      if (path === CUSTOMER_STATE_PATH) return null;
+      return { plan: "pro" };
+    });
+
+    await expect(fetchSubscriptionStateWithApi(fetchApi)).resolves.toEqual({
+      plan: "pro",
+      interval: null,
+    });
+  });
+});

--- a/applications/web/tests/hooks/use-subscription-live.test.tsx
+++ b/applications/web/tests/hooks/use-subscription-live.test.tsx
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { createRoot } from "react-dom/client";
 import { parseHTML } from "linkedom";
+import { SWRConfig } from "swr";
+import { useSubscription } from "../../src/hooks/use-subscription";
+import { resolveUpgradeMode } from "../../src/lib/upgrade-mode";
 import type { SubscriptionState } from "../../src/hooks/use-subscription";
 import type { UpgradeMode } from "../../src/lib/upgrade-mode";
 
@@ -119,12 +124,7 @@ const mountSubscription = async (options: {
   strict?: boolean;
 }): Promise<Harness> => {
   const window = setupDom();
-  const React = await import("react");
   const { act } = React;
-  const { createRoot } = await import("react-dom/client");
-  const { SWRConfig } = await import("swr");
-  const { useSubscription } = await import("../../src/hooks/use-subscription");
-  const { resolveUpgradeMode } = await import("../../src/lib/upgrade-mode");
 
   const consumers = options.consumers ?? 1;
   const renders: SubscriptionState[][] = [];

--- a/applications/web/tests/hooks/use-subscription-live.test.tsx
+++ b/applications/web/tests/hooks/use-subscription-live.test.tsx
@@ -1,0 +1,414 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseHTML } from "linkedom";
+import type { SubscriptionState } from "../../src/hooks/use-subscription";
+import type { UpgradeMode } from "../../src/lib/upgrade-mode";
+
+type ReadMode =
+  | { kind: "healthy"; interval: "month" | "year" | null }
+  | { kind: "free" }
+  | { kind: "outage"; plan: "free" | "pro" }
+  | { kind: "down" };
+
+interface Harness {
+  renders: SubscriptionState[][];
+  modes: UpgradeMode[];
+  errors: unknown[];
+  renderCount: () => number;
+  refresh: () => Promise<void>;
+  refreshInTransition: () => Promise<void>;
+  overlappingRefresh: (delayFirst: number, secondMode?: ReadMode) => Promise<void>;
+  unmount: () => void;
+  customerStateReads: () => number;
+}
+
+let readDelay = 0;
+
+const last = <T,>(entries: T[], fromEnd = 1): T | undefined =>
+  entries[entries.length - fromEnd];
+
+let currentMode: ReadMode = { kind: "healthy", interval: "month" };
+let restoreDom: (() => void) | null = null;
+
+const json = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+const respond = (path: string): Response => {
+  const isCustomerState = path.includes("/api/auth/customer/state");
+
+  if (currentMode.kind === "healthy") {
+    if (isCustomerState) {
+      return json(200, {
+        activeSubscriptions: [{ recurringInterval: currentMode.interval }],
+      });
+    }
+    return json(200, { plan: "pro" });
+  }
+
+  if (currentMode.kind === "free") {
+    if (isCustomerState) {
+      return json(200, { activeSubscriptions: [] });
+    }
+    return json(200, { plan: "free" });
+  }
+
+  if (currentMode.kind === "outage") {
+    if (isCustomerState) {
+      return json(500, { error: "polar unavailable" });
+    }
+    return json(200, { plan: currentMode.plan });
+  }
+
+  return json(500, { error: "down" });
+};
+
+const setupDom = () => {
+  const { window } = parseHTML(
+    "<html><body><div id='root'></div></body></html>",
+  );
+  const injected = [
+    "window",
+    "document",
+    "navigator",
+    "HTMLElement",
+    "Element",
+    "Node",
+    "Text",
+    "Event",
+    "MutationObserver",
+    "IS_REACT_ACT_ENVIRONMENT",
+  ] as const;
+  const previous = Object.fromEntries(
+    injected.map((key) => [key, (globalThis as Record<string, unknown>)[key]]),
+  );
+  Object.assign(globalThis, {
+    window,
+    document: window.document,
+    navigator: window.navigator,
+    HTMLElement: window.HTMLElement,
+    Element: window.Element,
+    Node: window.Node,
+    Text: window.Text,
+    Event: window.Event,
+    MutationObserver: class {
+      observe() {}
+      disconnect() {}
+    },
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  (window as unknown as { __KEEPER_RUNTIME_CONFIG__: unknown }).__KEEPER_RUNTIME_CONFIG__ = {
+    commercialMode: true,
+  };
+  restoreDom = () => {
+    for (const key of injected) {
+      if (previous[key] === undefined) {
+        delete (globalThis as Record<string, unknown>)[key];
+        continue;
+      }
+      (globalThis as Record<string, unknown>)[key] = previous[key];
+    }
+  };
+  return window;
+};
+
+const mountSubscription = async (options: {
+  fallbackData?: SubscriptionState;
+  consumers?: number;
+  strict?: boolean;
+}): Promise<Harness> => {
+  const window = setupDom();
+  const React = await import("react");
+  const { act } = React;
+  const { createRoot } = await import("react-dom/client");
+  const { SWRConfig } = await import("swr");
+  const { useSubscription } = await import("../../src/hooks/use-subscription");
+  const { resolveUpgradeMode } = await import("../../src/lib/upgrade-mode");
+
+  const consumers = options.consumers ?? 1;
+  const renders: SubscriptionState[][] = [];
+  const modes: UpgradeMode[] = [];
+  const errors: unknown[] = [];
+  let mutate: (() => Promise<unknown>) | null = null;
+  const pending: (SubscriptionState | undefined)[] = [];
+  let renderCount = 0;
+  let startTransition: ((callback: () => void) => void) | null = null;
+
+  function Consumer({ index }: { index: number }) {
+    const result = useSubscription(
+      index === 0 ? { fallbackData: options.fallbackData } : {},
+    );
+    const [, transition] = React.useTransition();
+
+    React.useEffect(() => {
+      renderCount += 1;
+      pending[index] = result.data;
+      if (index !== 0) {
+        return;
+      }
+      startTransition = transition;
+      mutate = result.mutate as unknown as () => Promise<unknown>;
+      if (result.error) errors.push(result.error);
+    });
+
+    return null;
+  }
+
+  function Tree() {
+    return React.createElement(
+      React.Fragment,
+      null,
+      ...Array.from({ length: consumers }, (_unused, index) =>
+        React.createElement(Consumer, { key: index, index }),
+      ),
+    );
+  }
+
+  const container = window.document.getElementById("root") as unknown as HTMLElement;
+  const root = createRoot(container);
+  const wrap = (children: React.ReactNode): React.ReactNode =>
+    options.strict
+      ? React.createElement(React.StrictMode, null, children)
+      : children;
+
+  const flush = () => {
+    renders.push(
+      pending.filter((entry): entry is SubscriptionState => entry !== undefined),
+    );
+    modes.push(resolveUpgradeMode(pending[0], true));
+  };
+
+  await act(async () => {
+    root.render(
+      wrap(
+        React.createElement(
+          SWRConfig,
+          {
+            value: {
+              provider: () => new Map(),
+              dedupingInterval: 0,
+              revalidateOnFocus: false,
+              revalidateOnReconnect: false,
+              errorRetryCount: 0,
+            },
+          },
+          React.createElement(Tree),
+        ),
+      ),
+    );
+  });
+  flush();
+
+  return {
+    renders,
+    modes,
+    errors,
+    customerStateReads: () =>
+      (globalThis.fetch as unknown as { mock: { calls: [string][] } }).mock.calls.filter(
+        ([url]) => String(url).includes("/api/auth/customer/state"),
+      ).length,
+    renderCount: () => renderCount,
+    refresh: async () => {
+      await act(async () => {
+        await mutate?.();
+      });
+      flush();
+    },
+    refreshInTransition: async () => {
+      await act(async () => {
+        startTransition?.(() => {
+          void mutate?.();
+        });
+      });
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      });
+      flush();
+    },
+    overlappingRefresh: async (delayFirst: number, secondMode?: ReadMode) => {
+      await act(async () => {
+        readDelay = delayFirst;
+        const first = mutate?.();
+        await Promise.resolve();
+        readDelay = 0;
+        if (secondMode) currentMode = secondMode;
+        const second = mutate?.();
+        await Promise.all([first, second]).catch(() => undefined);
+        await new Promise((resolve) => setTimeout(resolve, delayFirst + 10));
+      });
+      flush();
+    },
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+    },
+  };
+};
+
+beforeEach(() => {
+  currentMode = { kind: "healthy", interval: "month" };
+  readDelay = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const response = respond(String(input));
+      const delay = readDelay;
+      if (delay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+      return response;
+    }),
+  );
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  restoreDom?.();
+  restoreDom = null;
+});
+
+describe("the live subscription hook while the customer state read flaps", () => {
+  it("settles instead of re-rendering forever on the first paint", async () => {
+    const harness = await mountSubscription({
+      fallbackData: { plan: "pro", interval: "month" },
+    });
+
+    expect(last(harness.renders)).toEqual([{ plan: "pro", interval: "month" }]);
+    harness.unmount();
+  });
+
+  it("never presents a paying customer as free while only the customer state is down", async () => {
+    const harness = await mountSubscription({});
+    currentMode = { kind: "outage", plan: "pro" };
+
+    for (let cycle = 0; cycle < 4; cycle += 1) {
+      await harness.refresh();
+    }
+
+    const plans = harness.renders
+      .flat()
+      .map((subscription) => subscription.plan);
+    expect(plans.slice(1)).toEqual(["pro", "pro", "pro", "pro"]);
+    harness.unmount();
+  });
+
+  it("holds the known billing interval steady across repeated flaps", async () => {
+    const harness = await mountSubscription({});
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      currentMode = { kind: "outage", plan: "pro" };
+      await harness.refresh();
+      currentMode = { kind: "healthy", interval: "month" };
+      await harness.refresh();
+    }
+
+    expect(new Set(harness.modes.slice(1))).toEqual(new Set(["switch-interval"]));
+    harness.unmount();
+  });
+
+  it("adopts a newly reported interval and never reverts to the retired one", async () => {
+    const harness = await mountSubscription({});
+
+    currentMode = { kind: "healthy", interval: "year" };
+    await harness.refresh();
+    currentMode = { kind: "outage", plan: "pro" };
+    await harness.refresh();
+    await harness.refresh();
+
+    expect(last(harness.renders)).toEqual([{ plan: "pro", interval: "year" }]);
+    harness.unmount();
+  });
+
+  it("drops the retained interval once the subscription genuinely ends", async () => {
+    const harness = await mountSubscription({});
+
+    currentMode = { kind: "free" };
+    await harness.refresh();
+    currentMode = { kind: "outage", plan: "free" };
+    await harness.refresh();
+    await harness.refresh();
+
+    expect(last(harness.renders)).toEqual([{ plan: "free", interval: null }]);
+    harness.unmount();
+  });
+
+  it("keeps the last known plan and surfaces the error when both reads are down", async () => {
+    const harness = await mountSubscription({});
+    currentMode = { kind: "down" };
+
+    await harness.refresh();
+
+    expect(last(harness.renders)).toEqual([{ plan: "pro", interval: "month" }]);
+    expect(harness.errors.length).toBeGreaterThan(0);
+    harness.unmount();
+  });
+
+  it("agrees on the plan across every consumer sharing the cache", async () => {
+    const harness = await mountSubscription({ consumers: 2 });
+    currentMode = { kind: "outage", plan: "pro" };
+
+    await harness.refresh();
+    await harness.refresh();
+
+    for (const snapshot of harness.renders.slice(1)) {
+      expect(snapshot).toHaveLength(2);
+      expect(snapshot[0].plan).toBe(snapshot[1].plan);
+    }
+    harness.unmount();
+  });
+
+  it("settles under strict mode instead of looping on the retained state", async () => {
+    const harness = await mountSubscription({ strict: true });
+    const rendersAfterMount = harness.renderCount();
+
+    currentMode = { kind: "outage", plan: "pro" };
+    await harness.refresh();
+    const rendersAfterOutage = harness.renderCount();
+    await harness.refresh();
+
+    expect(last(harness.renders)).toEqual([{ plan: "pro", interval: "month" }]);
+    expect(rendersAfterOutage - rendersAfterMount).toBeLessThan(10);
+    expect(harness.renderCount() - rendersAfterOutage).toBeLessThan(10);
+    harness.unmount();
+  });
+
+  it("keeps the call to action stable when the checkout refresh runs inside a transition", async () => {
+    const harness = await mountSubscription({});
+
+    currentMode = { kind: "outage", plan: "pro" };
+    await harness.refreshInTransition();
+    await harness.refreshInTransition();
+
+    expect(harness.modes.slice(1)).toEqual(["switch-interval", "switch-interval"]);
+    harness.unmount();
+  });
+
+  it("converges after two revalidations resolve out of order", async () => {
+    const harness = await mountSubscription({});
+
+    currentMode = { kind: "healthy", interval: "year" };
+    await harness.overlappingRefresh(20, { kind: "outage", plan: "pro" });
+    const afterRace = last(harness.renders);
+
+    await harness.refresh();
+    await harness.refresh();
+
+    expect(last(harness.renders)?.[0].plan).toBe("pro");
+    expect(last(harness.renders)).toEqual(last(harness.renders, 2));
+    expect(afterRace?.[0].plan).toBe("pro");
+    harness.unmount();
+  });
+
+  it("does not re-read the customer state more than once per revalidation", async () => {
+    const harness = await mountSubscription({ consumers: 2 });
+
+    await harness.refresh();
+
+    expect(harness.customerStateReads()).toBe(2);
+    harness.unmount();
+  });
+});

--- a/applications/web/tests/lib/upgrade-interval-retention.test.ts
+++ b/applications/web/tests/lib/upgrade-interval-retention.test.ts
@@ -6,8 +6,18 @@ import { SWRConfig } from "swr";
 import { isRedirect } from "@tanstack/react-router";
 import { HttpError } from "../../src/lib/fetcher";
 import { resolveUpgradeMode, retainKnownInterval } from "../../src/lib/upgrade-mode";
-import { useSubscription } from "../../src/hooks/use-subscription";
+import {
+  fetchSubscriptionStateWithApi,
+  useSubscription,
+} from "../../src/hooks/use-subscription";
 import type { SubscriptionState } from "../../src/hooks/use-subscription";
+import { Route as UpgradeRoute } from "../../src/routes/(dashboard)/dashboard/upgrade/index";
+
+const upgradeLoader = (
+  UpgradeRoute as unknown as {
+    options: { loader: (args: unknown) => Promise<unknown> };
+  }
+).options.loader;
 
 const CUSTOMER_STATE_PATH = "/api/auth/customer/state";
 
@@ -21,10 +31,7 @@ const createApi = (respond: (path: string) => unknown) => {
 };
 
 const runUpgradeLoader = async (respond: (path: string) => unknown) => {
-  const mod = await import("../../src/routes/(dashboard)/dashboard/upgrade/index");
-  const loader = (mod as { Route: { options: { loader: (args: unknown) => Promise<unknown> } } })
-    .Route.options.loader;
-  return loader({
+  return upgradeLoader({
     context: {
       auth: { hasSession: () => true },
       fetchApi: createApi(respond),
@@ -205,9 +212,6 @@ describe("upgrade call to action while the customer state flaps after an in-page
 
   it("would hold steady if the previously rendered state were carried instead of the loader one", async () => {
     const readPlan = async (failing: boolean): Promise<SubscriptionState> => {
-      const { fetchSubscriptionStateWithApi } = await import(
-        "../../src/hooks/use-subscription"
-      );
       return fetchSubscriptionStateWithApi(
         createApi((path) => {
           if (path === CUSTOMER_STATE_PATH) {

--- a/applications/web/tests/lib/upgrade-interval-retention.test.ts
+++ b/applications/web/tests/lib/upgrade-interval-retention.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, createElement, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import { SWRConfig } from "swr";
+import { isRedirect } from "@tanstack/react-router";
+import { HttpError } from "../../src/lib/fetcher";
+import { resolveUpgradeMode, retainKnownInterval } from "../../src/lib/upgrade-mode";
+import { useSubscription } from "../../src/hooks/use-subscription";
+import type { SubscriptionState } from "../../src/hooks/use-subscription";
+
+const CUSTOMER_STATE_PATH = "/api/auth/customer/state";
+
+const createApi = (respond: (path: string) => unknown) => {
+  const fetchApi = async <T,>(path: string): Promise<T> => {
+    const result = respond(path);
+    if (result instanceof Error) throw result;
+    return result as T;
+  };
+  return fetchApi;
+};
+
+const runUpgradeLoader = async (respond: (path: string) => unknown) => {
+  const mod = await import("../../src/routes/(dashboard)/dashboard/upgrade/index");
+  const loader = (mod as { Route: { options: { loader: (args: unknown) => Promise<unknown> } } })
+    .Route.options.loader;
+  return loader({
+    context: {
+      auth: { hasSession: () => true },
+      fetchApi: createApi(respond),
+      runtimeConfig: { commercialMode: true },
+    },
+  });
+};
+
+const jsonResponse = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+  vi.unstubAllGlobals();
+});
+
+describe("what the upgrade loader can hand the page as a retained interval", () => {
+  const customerStates = [
+    { activeSubscriptions: [] },
+    { activeSubscriptions: null },
+    { activeSubscriptions: [{ recurringInterval: "month" }] },
+    { activeSubscriptions: [{ recurringInterval: "year" }] },
+    { activeSubscriptions: [{ recurringInterval: null }] },
+    { activeSubscriptions: [{}] },
+  ];
+
+  it("only ever reaches the page with an unknown interval, so it can never retain one", async () => {
+    const rendered: SubscriptionState[] = [];
+
+    for (const customerState of customerStates) {
+      let result: unknown;
+      try {
+        result = await runUpgradeLoader(() => customerState);
+      } catch (thrown) {
+        expect(isRedirect(thrown)).toBe(true);
+        continue;
+      }
+      rendered.push((result as { subscription: SubscriptionState }).subscription);
+    }
+
+    expect(rendered.length).toBeGreaterThan(0);
+    expect(rendered.map((state) => state.interval)).toEqual(
+      rendered.map(() => null),
+    );
+    expect(
+      rendered.map((state) =>
+        retainKnownInterval(state, { plan: "pro", interval: null }),
+      ),
+    ).toEqual(rendered.map(() => ({ plan: "pro", interval: null })));
+  });
+});
+
+describe("upgrade call to action while the customer state flaps after an in-page checkout", () => {
+  const mountUpgradeCallToAction = async (loaderSubscription: SubscriptionState) => {
+    const { document, window } = parseHTML(
+      "<html><body><div id='app'></div></body></html>",
+    );
+    const previousGlobals = {
+      Event: globalThis.Event,
+      HTMLElement: globalThis.HTMLElement,
+      Node: globalThis.Node,
+      document: globalThis.document,
+      window: globalThis.window,
+    };
+
+    Object.assign(globalThis, {
+      Event: window.Event,
+      HTMLElement: window.HTMLElement,
+      IS_REACT_ACT_ENVIRONMENT: true,
+      Node: window.Node,
+      document,
+      window,
+    });
+
+    const container = document.getElementById("app");
+    if (!(container instanceof globalThis.HTMLElement)) {
+      throw new Error("Expected an app container to render into.");
+    }
+
+    const modes: string[] = [];
+    const captured: { revalidate?: () => Promise<unknown> } = {};
+
+    const CallToAction = () => {
+      const { data, mutate } = useSubscription({
+        enabled: true,
+        fallbackData: loaderSubscription,
+      });
+      const mode = resolveUpgradeMode(data, true);
+
+      useEffect(() => {
+        captured.revalidate = mutate;
+        modes.push(mode);
+      });
+
+      return null;
+    };
+
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(
+          SWRConfig,
+          { value: { provider: () => new Map(), dedupingInterval: 0 } },
+          createElement(CallToAction),
+        ),
+      );
+    });
+
+    return {
+      modes,
+      read: async () => {
+        const trigger = captured.revalidate;
+        if (!trigger) throw new Error("Expected the hook to expose a revalidation.");
+        await act(async () => {
+          await trigger();
+        });
+      },
+      unmount: async () => {
+        await act(async () => {
+          root.unmount();
+        });
+        Object.assign(globalThis, previousGlobals);
+      },
+    };
+  };
+
+  const stubFlappingCustomerState = () => {
+    let read = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const path = typeof input === "string" ? input : input.toString();
+        if (path === CUSTOMER_STATE_PATH) {
+          const failing = read % 2 === 1;
+          read += 1;
+          return failing
+            ? jsonResponse(500, { error: "upstream" })
+            : jsonResponse(200, {
+                activeSubscriptions: [{ recurringInterval: "month" }],
+              });
+        }
+        return jsonResponse(200, { plan: "pro" });
+      }),
+    );
+  };
+
+  it("does not alternate between managing and switching while the read flaps", async () => {
+    stubFlappingCustomerState();
+
+    const loaderSubscription = (
+      (await runUpgradeLoader(() => ({ activeSubscriptions: [] }))) as {
+        subscription: SubscriptionState;
+      }
+    ).subscription;
+
+    const page = await mountUpgradeCallToAction(loaderSubscription);
+    try {
+      for (let run = 0; run < 5; run += 1) {
+        await page.read();
+      }
+
+      const settled = page.modes.slice(page.modes.indexOf("switch-interval"));
+      expect(settled.length).toBeGreaterThanOrEqual(6);
+      expect(settled).toEqual(Array(settled.length).fill("switch-interval"));
+    } finally {
+      await page.unmount();
+    }
+  });
+
+  it("would hold steady if the previously rendered state were carried instead of the loader one", async () => {
+    const readPlan = async (failing: boolean): Promise<SubscriptionState> => {
+      const { fetchSubscriptionStateWithApi } = await import(
+        "../../src/hooks/use-subscription"
+      );
+      return fetchSubscriptionStateWithApi(
+        createApi((path) => {
+          if (path === CUSTOMER_STATE_PATH) {
+            return failing
+              ? new HttpError(500, path)
+              : { activeSubscriptions: [{ recurringInterval: "month" }] };
+          }
+          return { plan: "pro" };
+        }),
+      );
+    };
+
+    const modes: string[] = [];
+    let rendered: SubscriptionState | undefined;
+
+    for (let run = 0; run < 6; run += 1) {
+      rendered = retainKnownInterval(rendered, await readPlan(run % 2 === 1));
+      modes.push(resolveUpgradeMode(rendered, true));
+    }
+
+    expect(modes).toEqual(Array(6).fill(modes[0]));
+  });
+});

--- a/applications/web/tests/lib/upgrade-mode.test.ts
+++ b/applications/web/tests/lib/upgrade-mode.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { resolveUpgradeMode } from "../../src/lib/upgrade-mode";
+
+describe("resolveUpgradeMode", () => {
+  it("offers the upgrade when the subscription has not loaded", () => {
+    expect(resolveUpgradeMode(undefined, false)).toBe("upgrade");
+  });
+
+  it("offers the upgrade to a free user", () => {
+    expect(resolveUpgradeMode({ plan: "free", interval: null }, false)).toBe("upgrade");
+  });
+
+  it("manages a subscription whose interval matches the selected one", () => {
+    expect(resolveUpgradeMode({ plan: "pro", interval: "year" }, true)).toBe("manage");
+    expect(resolveUpgradeMode({ plan: "pro", interval: "month" }, false)).toBe("manage");
+  });
+
+  it("offers an interval switch only when the intervals genuinely differ", () => {
+    expect(resolveUpgradeMode({ plan: "pro", interval: "year" }, false)).toBe("switch-interval");
+    expect(resolveUpgradeMode({ plan: "pro", interval: "month" }, true)).toBe("switch-interval");
+  });
+
+  it("does not claim a mismatch when the interval is unknown", () => {
+    expect(resolveUpgradeMode({ plan: "pro", interval: null }, true)).toBe("manage");
+    expect(resolveUpgradeMode({ plan: "pro", interval: null }, false)).toBe("manage");
+  });
+});

--- a/applications/web/tests/routes/subscription-route-loaders.test.ts
+++ b/applications/web/tests/routes/subscription-route-loaders.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { isRedirect } from "@tanstack/react-router";
+import { HttpError } from "../../src/lib/fetcher";
+
+const CUSTOMER_STATE_PATH = "/api/auth/customer/state";
+const ENTITLEMENTS_PATH = "/api/entitlements";
+const CAPABILITIES_PATH = "/api/auth/capabilities";
+
+const capabilitiesBody = {
+  commercialMode: true,
+  credentialMode: "email",
+  requiresEmailVerification: true,
+  socialProviders: { google: true, microsoft: false },
+  supportsChangePassword: true,
+  supportsPasskeys: true,
+  supportsPasswordReset: true,
+};
+
+type Responder = (path: string, callIndex: number) => unknown;
+
+const createApi = (respond: Responder) => {
+  const calls: string[] = [];
+  const fetchApi = async <T,>(path: string): Promise<T> => {
+    const callIndex = calls.length;
+    calls.push(path);
+    const result = respond(path, callIndex);
+    if (result instanceof Error) throw result;
+    return result as T;
+  };
+  return { calls, fetchApi };
+};
+
+const loadUpgradeRoute = async () => {
+  const mod = await import("../../src/routes/(dashboard)/dashboard/upgrade/index");
+  return (mod as unknown as { Route: { options: Record<string, unknown> } }).Route;
+};
+
+const loadSettingsRoute = async () => {
+  const mod = await import("../../src/routes/(dashboard)/dashboard/settings/index");
+  return (mod as unknown as { Route: { options: Record<string, unknown> } }).Route;
+};
+
+const runUpgradeLoader = async (
+  fetchApi: <T>(path: string) => Promise<T>,
+  { hasSession = true, commercialMode = true } = {},
+) => {
+  const route = await loadUpgradeRoute();
+  const loader = route.options.loader as (args: unknown) => Promise<unknown>;
+  return loader({
+    context: {
+      auth: { hasSession: () => hasSession },
+      fetchApi,
+      runtimeConfig: { commercialMode },
+    },
+  });
+};
+
+const runSettingsLoader = async (
+  fetchApi: <T>(path: string) => Promise<T>,
+  { commercialMode = true } = {},
+) => {
+  const route = await loadSettingsRoute();
+  const loader = route.options.loader as (args: unknown) => Promise<unknown>;
+  return loader({
+    context: { fetchApi, runtimeConfig: { commercialMode } },
+  });
+};
+
+const captureThrow = async (run: () => Promise<unknown>): Promise<unknown> => {
+  try {
+    await run();
+  } catch (thrown) {
+    return thrown;
+  }
+  throw new Error("expected the loader to throw");
+};
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+describe("upgrade route loader", () => {
+  it("hands the page a free plan when the customer state reports no subscription", async () => {
+    const { calls, fetchApi } = createApi(() => ({ activeSubscriptions: [] }));
+
+    await expect(runUpgradeLoader(fetchApi)).resolves.toEqual({
+      subscription: { plan: "free", interval: null },
+    });
+    expect(calls).toEqual([CUSTOMER_STATE_PATH]);
+  });
+
+  it("keeps a paying customer off the upgrade page when the customer state read fails", async () => {
+    const { calls, fetchApi } = createApi((path) =>
+      path === CUSTOMER_STATE_PATH ? new HttpError(500, path) : { plan: "pro" },
+    );
+
+    const thrown = await captureThrow(() => runUpgradeLoader(fetchApi));
+
+    expect(isRedirect(thrown)).toBe(true);
+    expect((thrown as { options: { to: string } }).options.to).toBe("/dashboard");
+    expect(calls).toEqual([CUSTOMER_STATE_PATH, ENTITLEMENTS_PATH]);
+  });
+
+  it("still shows the upgrade page to a genuinely free user during the outage", async () => {
+    const { fetchApi } = createApi((path) =>
+      path === CUSTOMER_STATE_PATH ? new HttpError(429, path) : { plan: "free" },
+    );
+
+    await expect(runUpgradeLoader(fetchApi)).resolves.toEqual({
+      subscription: { plan: "free", interval: null },
+    });
+  });
+
+  it("redirects to login when the customer state is unauthorized", async () => {
+    const { calls, fetchApi } = createApi(
+      (path) => new HttpError(401, path),
+    );
+
+    const thrown = await captureThrow(() => runUpgradeLoader(fetchApi));
+
+    expect(isRedirect(thrown)).toBe(true);
+    expect((thrown as { options: { to: string } }).options.to).toBe("/login");
+    expect(calls).toEqual([CUSTOMER_STATE_PATH]);
+  });
+
+  it("redirects to login when only the fallback discovers the session is gone", async () => {
+    const { calls, fetchApi } = createApi((path) =>
+      path === CUSTOMER_STATE_PATH
+        ? new HttpError(500, path)
+        : new HttpError(401, path),
+    );
+
+    const thrown = await captureThrow(() => runUpgradeLoader(fetchApi));
+
+    expect(isRedirect(thrown)).toBe(true);
+    expect((thrown as { options: { to: string } }).options.to).toBe("/login");
+    expect(calls).toEqual([CUSTOMER_STATE_PATH, ENTITLEMENTS_PATH]);
+  });
+
+  it("does not read any plan endpoint without a session", async () => {
+    const { calls, fetchApi } = createApi(() => ({ activeSubscriptions: [] }));
+
+    const thrown = await captureThrow(() =>
+      runUpgradeLoader(fetchApi, { hasSession: false }),
+    );
+
+    expect(isRedirect(thrown)).toBe(true);
+    expect((thrown as { options: { to: string } }).options.to).toBe("/login");
+    expect(calls).toEqual([]);
+  });
+
+  it("surfaces the failure rather than presenting a paying customer as free when both reads are down", async () => {
+    const { calls, fetchApi } = createApi((path) => new HttpError(503, path));
+
+    const thrown = await captureThrow(() => runUpgradeLoader(fetchApi));
+
+    expect(isRedirect(thrown)).toBe(false);
+    expect(thrown).toBeInstanceOf(HttpError);
+    expect(calls).toEqual([CUSTOMER_STATE_PATH, ENTITLEMENTS_PATH]);
+  });
+
+  it("produces the same redirect on every repeated run while the outage persists", async () => {
+    const outcomes: string[] = [];
+    const sequences: string[][] = [];
+
+    for (let run = 0; run < 4; run += 1) {
+      const { calls, fetchApi } = createApi((path) =>
+        path === CUSTOMER_STATE_PATH ? new HttpError(500, path) : { plan: "pro" },
+      );
+      const thrown = await captureThrow(() => runUpgradeLoader(fetchApi));
+      outcomes.push((thrown as { options: { to: string } }).options.to);
+      sequences.push(calls);
+    }
+
+    expect(outcomes).toEqual(Array(4).fill("/dashboard"));
+    expect(sequences).toEqual(
+      Array(4).fill([CUSTOMER_STATE_PATH, ENTITLEMENTS_PATH]),
+    );
+  });
+
+  it("does not oscillate between the upgrade page and the dashboard as the read flaps", async () => {
+    const outcomes: string[] = [];
+
+    for (let run = 0; run < 6; run += 1) {
+      const failing = run % 2 === 1;
+      const { fetchApi } = createApi((path) => {
+        if (path === CUSTOMER_STATE_PATH) {
+          return failing
+            ? new HttpError(500, path)
+            : { activeSubscriptions: [{ recurringInterval: "year" }] };
+        }
+        return { plan: "pro" };
+      });
+      const thrown = await captureThrow(() => runUpgradeLoader(fetchApi));
+      outcomes.push((thrown as { options: { to: string } }).options.to);
+    }
+
+    expect(outcomes).toEqual(Array(6).fill("/dashboard"));
+  });
+
+  it("sends a commercial-mode-off deployment away from the upgrade page before reading anything", async () => {
+    const route = await loadUpgradeRoute();
+    const beforeLoad = route.options.beforeLoad as (args: unknown) => unknown;
+    const { calls, fetchApi } = createApi(() => ({ activeSubscriptions: [] }));
+
+    const thrown = await captureThrow(async () =>
+      beforeLoad({
+        context: {
+          auth: { hasSession: () => true },
+          fetchApi,
+          runtimeConfig: { commercialMode: false },
+        },
+      }),
+    );
+
+    expect(isRedirect(thrown)).toBe(true);
+    expect((thrown as { options: { to: string } }).options.to).toBe("/dashboard");
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("settings route loader", () => {
+  const respondWithCapabilities =
+    (respond: Responder): Responder =>
+    (path, callIndex) =>
+      path === CAPABILITIES_PATH ? capabilitiesBody : respond(path, callIndex);
+
+  it("preloads a paying customer as pro through the fallback", async () => {
+    const { calls, fetchApi } = createApi(
+      respondWithCapabilities((path) =>
+        path === CUSTOMER_STATE_PATH ? new HttpError(500, path) : { plan: "pro" },
+      ),
+    );
+
+    const data = (await runSettingsLoader(fetchApi)) as {
+      subscription: unknown;
+    };
+
+    expect(data.subscription).toEqual({ plan: "pro", interval: null });
+    expect(calls).toContain(ENTITLEMENTS_PATH);
+  });
+
+  it("never preloads a plan the fallback did not actually report", async () => {
+    const { fetchApi } = createApi(
+      respondWithCapabilities((path) =>
+        path === CUSTOMER_STATE_PATH ? new HttpError(500, path) : { plan: "enterprise" },
+      ),
+    );
+
+    const data = (await runSettingsLoader(fetchApi)) as {
+      subscription: unknown;
+    };
+
+    expect(data.subscription).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("still renders the page when both plan reads are down", async () => {
+    const { fetchApi } = createApi(
+      respondWithCapabilities((path) => new HttpError(503, path)),
+    );
+
+    const data = (await runSettingsLoader(fetchApi)) as {
+      authCapabilities: unknown;
+      subscription: unknown;
+    };
+
+    expect(data.authCapabilities).toMatchObject({ credentialMode: "email" });
+    expect(data.subscription).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("does not read the plan at all outside commercial mode", async () => {
+    const { calls, fetchApi } = createApi(respondWithCapabilities(() => ({})));
+
+    const data = (await runSettingsLoader(fetchApi, { commercialMode: false })) as {
+      subscription: unknown;
+    };
+
+    expect(data.subscription).toBeUndefined();
+    expect(calls).toEqual([CAPABILITIES_PATH]);
+  });
+
+  it("converges on the same preload across repeated runs during the outage", async () => {
+    const results: unknown[] = [];
+
+    for (let run = 0; run < 3; run += 1) {
+      const { fetchApi } = createApi(
+        respondWithCapabilities((path) =>
+          path === CUSTOMER_STATE_PATH ? new HttpError(429, path) : { plan: "pro" },
+        ),
+      );
+      const data = (await runSettingsLoader(fetchApi)) as { subscription: unknown };
+      results.push(data.subscription);
+    }
+
+    expect(results).toEqual(Array(3).fill({ plan: "pro", interval: null }));
+  });
+
+  it("does not send a paying customer to a login screen it cannot reach when the session expires", async () => {
+    const { fetchApi } = createApi(
+      respondWithCapabilities((path) => new HttpError(401, path)),
+    );
+
+    const data = (await runSettingsLoader(fetchApi)) as { subscription: unknown };
+
+    expect(data.subscription).toBeUndefined();
+  });
+});

--- a/applications/web/tests/routes/subscription-route-loaders.test.ts
+++ b/applications/web/tests/routes/subscription-route-loaders.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { isRedirect } from "@tanstack/react-router";
 import { HttpError } from "../../src/lib/fetcher";
+import { Route as UpgradeRoute } from "../../src/routes/(dashboard)/dashboard/upgrade/index";
+import { Route as SettingsRoute } from "../../src/routes/(dashboard)/dashboard/settings/index";
+
+type RouteOptions = { options: Record<string, unknown> };
+
+const upgradeRoute = UpgradeRoute as unknown as RouteOptions;
+const settingsRoute = SettingsRoute as unknown as RouteOptions;
 
 const CUSTOMER_STATE_PATH = "/api/auth/customer/state";
 const ENTITLEMENTS_PATH = "/api/entitlements";
@@ -30,22 +37,11 @@ const createApi = (respond: Responder) => {
   return { calls, fetchApi };
 };
 
-const loadUpgradeRoute = async () => {
-  const mod = await import("../../src/routes/(dashboard)/dashboard/upgrade/index");
-  return (mod as unknown as { Route: { options: Record<string, unknown> } }).Route;
-};
-
-const loadSettingsRoute = async () => {
-  const mod = await import("../../src/routes/(dashboard)/dashboard/settings/index");
-  return (mod as unknown as { Route: { options: Record<string, unknown> } }).Route;
-};
-
 const runUpgradeLoader = async (
   fetchApi: <T>(path: string) => Promise<T>,
   { hasSession = true, commercialMode = true } = {},
 ) => {
-  const route = await loadUpgradeRoute();
-  const loader = route.options.loader as (args: unknown) => Promise<unknown>;
+  const loader = upgradeRoute.options.loader as (args: unknown) => Promise<unknown>;
   return loader({
     context: {
       auth: { hasSession: () => hasSession },
@@ -59,8 +55,7 @@ const runSettingsLoader = async (
   fetchApi: <T>(path: string) => Promise<T>,
   { commercialMode = true } = {},
 ) => {
-  const route = await loadSettingsRoute();
-  const loader = route.options.loader as (args: unknown) => Promise<unknown>;
+  const loader = settingsRoute.options.loader as (args: unknown) => Promise<unknown>;
   return loader({
     context: { fetchApi, runtimeConfig: { commercialMode } },
   });
@@ -205,8 +200,7 @@ describe("upgrade route loader", () => {
   });
 
   it("sends a commercial-mode-off deployment away from the upgrade page before reading anything", async () => {
-    const route = await loadUpgradeRoute();
-    const beforeLoad = route.options.beforeLoad as (args: unknown) => unknown;
+    const beforeLoad = upgradeRoute.options.beforeLoad as (args: unknown) => unknown;
     const { calls, fetchApi } = createApi(() => ({ activeSubscriptions: [] }));
 
     const thrown = await captureThrow(async () =>

--- a/applications/web/vitest.config.ts
+++ b/applications/web/vitest.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
   test: {
     globals: true,
     include: ["./tests/**/*.test.ts", "./tests/**/*.test.tsx"],
+    onConsoleLog: (log) => (log.startsWith("[subscription]") ? false : undefined),
   },
 });


### PR DESCRIPTION
Follow-up hardening for #618, which merged before adversarial testing finished. The entitlements fallback body was cast rather than validated, so `{}`, `{plan:"enterprise"}` and `null` all resolved a paying customer to free — the same silent downgrade #619 exists to prevent, one layer down. Adversarial rounds also found the customer-state schema accepted arrays and error envelopes, and that a null recurring interval was coerced to a definite monthly.

- Assert both the fallback and customer-state payloads with an arktype `planSchema`, failing loud in line with the sibling auth-capabilities convention.
- Require `activeSubscriptions` so a 200 error envelope can no longer validate as an empty subscription list.
- Log the upstream Polar failure before falling back, so the motivating outage stops being invisible.
- Hold the last known billing interval as hook state instead of inventing `month`, ending the CTA flip between Manage Subscription and Switch Billing Period during an outage.

Refs #619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)