### PR TITLE
ci: run the database-gated tests against postgres

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,11 +30,25 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres@sha256:ef257d85f76e48da1c64832459b59fcaba1a4dac97bf5d7450c77753542eee94 # 17.6-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - run: bun install --frozen-lockfile
       - run: bun run test
+        env:
+          KEEPER_TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
 
   migrations:
     runs-on: ubuntu-latest

--- a/bun.lock
+++ b/bun.lock
@@ -141,6 +141,7 @@
     "packages/database": {
       "name": "@keeper.sh/database",
       "dependencies": {
+        "@keeper.sh/data-schemas": "workspace:*",
         "drizzle-orm": "0.45.1",
         "pg": "8.16.3",
         "tweetnacl": "^1.0.3",
@@ -221,6 +222,7 @@
       "dependencies": {
         "@keeper.sh/calendar": "workspace:*",
         "@keeper.sh/constants": "workspace:*",
+        "@keeper.sh/data-schemas": "workspace:*",
         "@keeper.sh/database": "workspace:*",
         "drizzle-orm": "^0.45.1",
         "ioredis": "^5.6.1",

--- a/turbo.json
+++ b/turbo.json
@@ -26,10 +26,8 @@
       "cache": false
     },
     "test": {
-      "cache": false
-    },
-    "test": {
-      "cache": false
+      "cache": false,
+      "passThroughEnv": ["KEEPER_TEST_DATABASE_URL"]
     },
     "lint": {
       "inputs": ["src/**", ".oxlintrc.json", "../../.oxlintrc.json"],

--- a/turbo.json
+++ b/turbo.json
@@ -30,7 +30,7 @@
       "passThroughEnv": ["KEEPER_TEST_DATABASE_URL"]
     },
     "lint": {
-      "inputs": ["src/**", ".oxlintrc.json", "../../.oxlintrc.json"],
+      "inputs": ["src/**", "tests/**", ".oxlintrc.json", "../../.oxlintrc.json"],
       "cache": true
     }
   }


### PR DESCRIPTION
The `test` job provisions no database, so every suite guarded on `KEEPER_TEST_DATABASE_URL` skips and `bun run test` still exits 0 — between 8 and 89 tests are invisible depending on which packages are in scope. This reuses the `migrations` job's existing Postgres service so those tests actually run.

- A skipped test is not a passing test; every recent "all green" CI result was partly hollow.
- The prepared-statement corruption pin (#610) is one of the suites that never ran.
- A microsecond-versus-millisecond timestamp comparison found during hardening was caught only by a live-Postgres test — unit stubs passed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)