### PR TITLE
fix: stop serving bun's development error page in production

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -141,6 +141,7 @@
     "packages/database": {
       "name": "@keeper.sh/database",
       "dependencies": {
+        "@keeper.sh/data-schemas": "workspace:*",
         "drizzle-orm": "0.45.1",
         "pg": "8.16.3",
         "tweetnacl": "^1.0.3",
@@ -221,6 +222,7 @@
       "dependencies": {
         "@keeper.sh/calendar": "workspace:*",
         "@keeper.sh/constants": "workspace:*",
+        "@keeper.sh/data-schemas": "workspace:*",
         "@keeper.sh/database": "workspace:*",
         "drizzle-orm": "^0.45.1",
         "ioredis": "^5.6.1",

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -25,6 +25,7 @@ const router = new Bun.FileSystemRouter({
 await entry({
   main: async () => {
     const server = Bun.serve<BroadcastData>({
+      development: false,
       port: env.API_PORT,
       websocket: websocketHandler,
       fetch: withCors(async (request) => {

--- a/services/api/tests/server-error-page-leak.test.ts
+++ b/services/api/tests/server-error-page-leak.test.ts
@@ -1,0 +1,139 @@
+import { readFileSync } from "node:fs";
+import { DrizzleQueryError } from "drizzle-orm/errors";
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string): string =>
+  readFileSync(new URL(relativePath, import.meta.url), "utf8");
+
+const indexSource = readSource("../src/index.ts");
+
+const readServeOptionsSource = (source: string): string => {
+  const start = source.indexOf("Bun.serve");
+  const end = source.indexOf("await broadcastService", start);
+  return source.slice(start, end);
+};
+
+const serveOptionsSource = readServeOptionsSource(indexSource);
+
+const suppressesDevelopmentErrorPage = (options: string): boolean =>
+  /\bdevelopment\s*:\s*false\b/.test(options) || /(^|[\s{,])error\s*:/m.test(options);
+
+const SELECT_SQL =
+  'select "username", "server_url", "encrypted_password" from "caldav_credentials" '
+  + 'where "user_id" = $1';
+
+const USERNAME = "rida@fastmail.com";
+const SERVER_URL = "https://caldav.fastmail.com";
+const ENCRYPTED_PASSWORD = "nacl:9f0c2a41d0";
+
+const poolFailure = (): DrizzleQueryError =>
+  new DrizzleQueryError(
+    SELECT_SQL,
+    ["user-1", USERNAME, SERVER_URL, ENCRYPTED_PASSWORD],
+    Object.assign(new Error("Connection closed"), {
+      code: "ERR_POSTGRES_CONNECTION_CLOSED",
+      name: "PostgresError",
+    }),
+  );
+
+const serverFailure = (): DrizzleQueryError =>
+  new DrizzleQueryError(
+    SELECT_SQL,
+    ["user-1", USERNAME, SERVER_URL, ENCRYPTED_PASSWORD],
+    Object.assign(new Error('relation "caldav_credentials" does not exist'), {
+      code: "ERR_POSTGRES_SERVER_ERROR",
+      errno: "42P01",
+      name: "PostgresError",
+    }),
+  );
+
+const decodeFallbackPayload = (body: string): string => {
+  const match = body.match(/<script id="__bunfallback"[^>]*>([\s\S]*?)<\/script>/);
+  if (!match?.[1]) {
+    return "";
+  }
+  return Buffer.from(match[1].trim(), "base64").toString("latin1");
+};
+
+const readResponseSurface = async (response: Response): Promise<string> => {
+  const body = await response.text();
+  return `${body}\n${decodeFallbackPayload(body)}`;
+};
+
+const readDevelopmentOverride = (): { development?: false } => {
+  if (suppressesDevelopmentErrorPage(serveOptionsSource)) {
+    return { development: false };
+  }
+  return {};
+};
+
+const serveLikeApi = (fetchHandler: () => Response): ReturnType<typeof Bun.serve> =>
+  Bun.serve({
+    fetch: fetchHandler,
+    port: 0,
+    ...readDevelopmentOverride(),
+  });
+
+const requestFailureSurface = async (
+  buildError: () => Error,
+  requestCount: number,
+): Promise<string[]> => {
+  const server = serveLikeApi(() => {
+    throw buildError();
+  });
+  const surfaces: string[] = [];
+  try {
+    for (let attempt = 0; attempt < requestCount; attempt += 1) {
+      surfaces.push(await readResponseSurface(await fetch(server.url)));
+    }
+  } finally {
+    server.stop(true);
+  }
+  return surfaces;
+};
+
+describe("api server configuration", () => {
+  it("suppresses Bun's development error page so thrown errors are never rendered", () => {
+    expect(suppressesDevelopmentErrorPage(serveOptionsSource)).toBe(true);
+  });
+
+  it("keeps the error page off even though no runtime pins NODE_ENV to production", () => {
+    const runScript = readSource(
+      "../../../docker/standalone/rootfs/etc/s6-overlay/s6-rc.d/api/run",
+    );
+    const pinsProductionEnvironment = /NODE_ENV\s*=\s*["']?production/.test(runScript);
+    expect(suppressesDevelopmentErrorPage(serveOptionsSource) || pinsProductionEnvironment)
+      .toBe(true);
+  });
+});
+
+describe("uncaught database failures reaching the Bun server", () => {
+  it("never returns the failing SQL to the caller", async () => {
+    const [surface] = await requestFailureSurface(poolFailure, 1);
+    expect(surface).not.toContain("caldav_credentials");
+  });
+
+  it("never returns bound parameters to the caller", async () => {
+    const [surface] = await requestFailureSurface(poolFailure, 1);
+    expect([
+      surface?.includes(USERNAME),
+      surface?.includes(SERVER_URL),
+      surface?.includes(ENCRYPTED_PASSWORD),
+    ]).toEqual([false, false, false]);
+  });
+
+  it("stays leak free for ordinary server-side failures as well as pool failures", async () => {
+    const [surface] = await requestFailureSurface(serverFailure, 1);
+    expect([surface?.includes("caldav_credentials"), surface?.includes(USERNAME)])
+      .toEqual([false, false]);
+  });
+
+  it("stays leak free across repeated requests during a sustained outage", async () => {
+    const surfaces = await requestFailureSurface(poolFailure, 3);
+    expect(surfaces.map((surface) => surface.includes(USERNAME))).toEqual([
+      false,
+      false,
+      false,
+    ]);
+  });
+});

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -22,6 +22,7 @@ const router = new Bun.FileSystemRouter({
 await entry({
   main: () => {
     const server = Bun.serve({
+      development: false,
       port: env.MCP_PORT,
       fetch: async (request) => {
         const match = router.match(request);


### PR DESCRIPTION
Bun defaults `development` to on and `NODE_ENV` is set nowhere, so every uncaught error returns a 68KB page whose base64 `__bunfallback` payload contains the failing query and its bound parameters — including on unauthenticated `/api/auth/*` routes, and on the MCP server. Two one-line changes, extracted from #622 so they ship without waiting on thirteen rounds of error-classification work.

- `development: false` on both `Bun.serve` sites, which are the only two in the repo.
- Test boots a real server, throws a `DrizzleQueryError` carrying a CalDAV username, server URL and encrypted-password parameter, and asserts neither the body nor the base64 fallback payload contains them — with `NODE_ENV` unset.
- Root `bun run lint` and `bun run types` are 17/17; tests pass apart from the known ICU failure in #492.

Refs #622.

🤖 Generated with [Claude Code](https://claude.com/claude-code)