### PR TITLE
fix(oauth): accept resource-qualified Microsoft scope grants

### DIFF
--- a/packages/calendar/src/core/oauth/microsoft.ts
+++ b/packages/calendar/src/core/oauth/microsoft.ts
@@ -144,12 +144,19 @@ const fetchUserInfo = async (accessToken: string): Promise<MicrosoftUserInfo> =>
   return microsoftUserInfoSchema.assert(body);
 };
 
-/**
- * Checks if the granted scopes include all required scopes for calendar operations.
- * Microsoft returns scopes as a space-separated string.
- */
+const MICROSOFT_GRAPH_RESOURCE_PREFIX = "https://graph.microsoft.com/";
+
+// The v2.0 token response returns Graph scopes short-form (Calendars.ReadWrite) or resource-qualified (https://graph.microsoft.com/Calendars.ReadWrite).
+const normalizeGrantedScope = (scope: string): string => {
+  const lowered = scope.toLowerCase();
+  if (lowered.startsWith(MICROSOFT_GRAPH_RESOURCE_PREFIX.toLowerCase())) {
+    return lowered.slice(MICROSOFT_GRAPH_RESOURCE_PREFIX.length);
+  }
+  return lowered;
+};
+
 const hasRequiredScopes = (grantedScopes: string): boolean => {
-  const scopes = grantedScopes.toLowerCase().split(" ");
+  const scopes = grantedScopes.split(" ").map((scope) => normalizeGrantedScope(scope));
   return scopes.includes(MICROSOFT_CALENDAR_SCOPE.toLowerCase());
 };
 

--- a/packages/calendar/tests/core/oauth/scope-validation.test.ts
+++ b/packages/calendar/tests/core/oauth/scope-validation.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { hasRequiredScopes as hasRequiredMicrosoftScopes } from "../../../src/core/oauth/microsoft";
+import { hasRequiredScopes as hasRequiredGoogleScopes } from "../../../src/core/oauth/google";
+
+describe("microsoft hasRequiredScopes", () => {
+  it("accepts a short-form grant", () => {
+    expect(hasRequiredMicrosoftScopes("Calendars.ReadWrite User.Read offline_access")).toBe(true);
+  });
+
+  it("accepts a fully-qualified grant", () => {
+    expect(
+      hasRequiredMicrosoftScopes(
+        "https://graph.microsoft.com/Calendars.ReadWrite https://graph.microsoft.com/User.Read offline_access",
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts a fully-qualified grant regardless of casing", () => {
+    expect(
+      hasRequiredMicrosoftScopes("https://graph.microsoft.com/calendars.readwrite offline_access"),
+    ).toBe(true);
+  });
+
+  it("rejects a read-only grant in short form", () => {
+    expect(hasRequiredMicrosoftScopes("Calendars.Read User.Read offline_access")).toBe(false);
+  });
+
+  it("rejects a read-only grant in fully-qualified form", () => {
+    expect(
+      hasRequiredMicrosoftScopes(
+        "https://graph.microsoft.com/Calendars.Read https://graph.microsoft.com/User.Read",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a grant whose scope merely contains the required name", () => {
+    expect(hasRequiredMicrosoftScopes("NotCalendars.ReadWrite User.Read")).toBe(false);
+    expect(hasRequiredMicrosoftScopes("https://contoso.example/Calendars.ReadWrite")).toBe(false);
+  });
+
+  it("rejects an empty grant", () => {
+    expect(hasRequiredMicrosoftScopes("")).toBe(false);
+  });
+});
+
+describe("google hasRequiredScopes", () => {
+  it("accepts a grant containing the calendar events scope", () => {
+    expect(
+      hasRequiredGoogleScopes(
+        "https://www.googleapis.com/auth/calendar.events https://www.googleapis.com/auth/userinfo.email",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a read-only grant", () => {
+    expect(
+      hasRequiredGoogleScopes(
+        "https://www.googleapis.com/auth/calendar.events.readonly https://www.googleapis.com/auth/userinfo.email",
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Microsoft's v2.0 token endpoint returns Graph scopes in the response `scope` field either short-form (`Calendars.ReadWrite`, [Graph tutorial example](https://learn.microsoft.com/en-us/graph/auth-v2-user#token-response)) or resource-qualified (`https://graph.microsoft.com/mail.read`, [Entra protocol reference example](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#successful-response-1)). `hasRequiredScopes` only matched the short form, so a fully-qualified grant was rejected and the account flagged `destination-grant` — the one demand a source pull cannot clear (#643). The fix normalizes the Graph resource prefix off each granted scope before the exact match; read-only or foreign-resource grants are still rejected in both forms, covered by tests that drive the real implementation.

- Red test first: fully-qualified `Calendars.ReadWrite` failed against the old implementation, passes after
- Google's check already compares the canonical fully-qualified URI Google returns, so it is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)