### PR TITLE
feat: emit wide events on reauthentication demand raises and clears

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -110,6 +110,7 @@
         "tldts": "^7.0.27",
         "ts-ics": "^2.4.3",
         "tsdav": "^2.1.8",
+        "widelogger": "^0.7.0",
       },
       "devDependencies": {
         "@keeper.sh/fixtures": "workspace:*",

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -30,7 +30,8 @@
     "rrule": "^2.8.1",
     "tldts": "^7.0.27",
     "ts-ics": "^2.4.3",
-    "tsdav": "^2.1.8"
+    "tsdav": "^2.1.8",
+    "widelogger": "^0.7.0"
   },
   "devDependencies": {
     "@keeper.sh/fixtures": "workspace:*",

--- a/packages/calendar/src/core/oauth/coordinated-refresher.ts
+++ b/packages/calendar/src/core/oauth/coordinated-refresher.ts
@@ -2,6 +2,10 @@ import type { RefreshLockStore } from "./refresh-coordinator";
 import { runWithCredentialRefreshLock } from "./refresh-coordinator";
 import { isOAuthReauthRequiredError } from "./error-classification";
 import {
+  readPriorReauthenticationState,
+  recordReauthenticationDemand,
+} from "../reauthentication/demand-telemetry";
+import {
   calendarAccountsTable,
   oauthCredentialsTable,
 } from "@keeper.sh/database/schema";
@@ -47,6 +51,7 @@ const createCoordinatedRefresher = (options: CoordinatedRefresherOptions) => {
           return result;
         } catch (error) {
           if (isOAuthReauthRequiredError(error)) {
+            const prior = await readPriorReauthenticationState(database, calendarAccountId);
             await database
               .update(calendarAccountsTable)
               .set({
@@ -54,6 +59,14 @@ const createCoordinatedRefresher = (options: CoordinatedRefresherOptions) => {
                 reauthenticationSource: REAUTHENTICATION_TOKEN_REFRESH,
               })
               .where(eq(calendarAccountsTable.id, calendarAccountId));
+            recordReauthenticationDemand({
+              accountId: calendarAccountId,
+              action: "raise",
+              previous: prior?.needsReauthentication ?? null,
+              provenance: REAUTHENTICATION_TOKEN_REFRESH,
+              recordedProvenance: prior?.reauthenticationSource,
+              signal: "oauth-refresh-rejected",
+            });
           }
           throw error;
         }

--- a/packages/calendar/src/core/reauthentication/demand-telemetry.ts
+++ b/packages/calendar/src/core/reauthentication/demand-telemetry.ts
@@ -1,0 +1,115 @@
+import { widelog } from "widelogger";
+import { calendarAccountsTable } from "@keeper.sh/database/schema";
+import { eq } from "drizzle-orm";
+import type { BunSQLDatabase } from "drizzle-orm/bun-sql";
+import { getErrorMessage } from "../utils/error";
+
+const FIRST_RESULT_LIMIT = 1;
+
+type ReauthenticationDemandAction = "raise" | "clear";
+
+interface ReauthenticationDemandFieldsParams {
+  accountId: string;
+  action: ReauthenticationDemandAction;
+  provenance: string;
+  previous: boolean | null;
+  signal?: string;
+  recordedProvenance?: string | null;
+}
+
+type ReauthenticationDemandFields = Record<string, string | number | boolean>;
+
+const buildPreviousFields = (
+  action: ReauthenticationDemandAction,
+  previous: boolean | null,
+): ReauthenticationDemandFields => {
+  if (previous === null) {
+    return {};
+  }
+  return {
+    "reauth.previous": previous,
+    "reauth.transitioned": previous !== (action === "raise"),
+  };
+};
+
+const buildSignalFields = (signal?: string): ReauthenticationDemandFields => {
+  if (!signal) {
+    return {};
+  }
+  return { "reauth.signal": signal };
+};
+
+const buildRecordedProvenanceFields = (
+  recordedProvenance?: string | null,
+): ReauthenticationDemandFields => {
+  if (!recordedProvenance) {
+    return {};
+  }
+  return { "reauth.recorded_provenance": recordedProvenance };
+};
+
+const resolveReauthenticationDemandAction = (
+  needsReauthentication: boolean,
+): ReauthenticationDemandAction => {
+  if (needsReauthentication) {
+    return "raise";
+  }
+  return "clear";
+};
+
+const buildReauthenticationDemandFields = (
+  params: ReauthenticationDemandFieldsParams,
+): ReauthenticationDemandFields => ({
+  "provider.account_id": params.accountId,
+  "reauth.action": params.action,
+  "reauth.provenance": params.provenance,
+  ...buildPreviousFields(params.action, params.previous),
+  ...buildSignalFields(params.signal),
+  ...buildRecordedProvenanceFields(params.recordedProvenance),
+});
+
+const recordReauthenticationDemand = (
+  params: ReauthenticationDemandFieldsParams,
+): void => {
+  for (const [key, value] of Object.entries(buildReauthenticationDemandFields(params))) {
+    widelog.set(key, value);
+  }
+};
+
+interface PriorReauthenticationState {
+  needsReauthentication: boolean;
+  reauthenticationSource: string | null;
+}
+
+const readPriorReauthenticationState = async (
+  database: Pick<BunSQLDatabase, "select">,
+  accountId: string,
+): Promise<PriorReauthenticationState | null> => {
+  try {
+    const [account] = await database
+      .select({
+        needsReauthentication: calendarAccountsTable.needsReauthentication,
+        reauthenticationSource: calendarAccountsTable.reauthenticationSource,
+      })
+      .from(calendarAccountsTable)
+      .where(eq(calendarAccountsTable.id, accountId))
+      .limit(FIRST_RESULT_LIMIT);
+    return account ?? null;
+  } catch (error) {
+    widelog.set("reauth.previous_read_failed", true);
+    widelog.set("reauth.previous_read_error", getErrorMessage(error));
+    return null;
+  }
+};
+
+export {
+  buildReauthenticationDemandFields,
+  readPriorReauthenticationState,
+  recordReauthenticationDemand,
+  resolveReauthenticationDemandAction,
+};
+export type {
+  ReauthenticationDemandAction,
+  ReauthenticationDemandFields,
+  ReauthenticationDemandFieldsParams,
+};

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -30,6 +30,13 @@ export {
 } from "./core/oauth/refresh-coordinator";
 export { isOAuthReauthRequiredError } from "./core/oauth/error-classification";
 export {
+  buildReauthenticationDemandFields,
+  resolveReauthenticationDemandAction,
+  type ReauthenticationDemandAction,
+  type ReauthenticationDemandFields,
+  type ReauthenticationDemandFieldsParams,
+} from "./core/reauthentication/demand-telemetry";
+export {
   createCoordinatedRefresher,
   type CoordinatedRefresherOptions,
 } from "./core/oauth/coordinated-refresher";

--- a/packages/calendar/src/providers/caldav/source/provider.ts
+++ b/packages/calendar/src/providers/caldav/source/provider.ts
@@ -24,6 +24,10 @@ import {
   parseICalCalendarsToRemoteEvents,
 } from "../shared/ics";
 import { isCalDAVAuthenticationError } from "./auth-error-classification";
+import {
+  readPriorReauthenticationState,
+  recordReauthenticationDemand,
+} from "../../../core/reauthentication/demand-telemetry";
 import { createCalDAVSourceService } from "./sync";
 import {
   DEFAULT_FUTURE_SYNC_RANGE,
@@ -207,6 +211,7 @@ const createCalDAVSourceProvider = (
       });
     } catch (error) {
       if (isCalDAVAuthenticationError(error)) {
+        const prior = await readPriorReauthenticationState(database, account.calendarAccountId);
         await database
           .update(calendarAccountsTable)
           .set({
@@ -214,6 +219,14 @@ const createCalDAVSourceProvider = (
             reauthenticationSource: REAUTHENTICATION_SOURCE_CREDENTIALS,
           })
           .where(eq(calendarAccountsTable.id, account.calendarAccountId));
+        recordReauthenticationDemand({
+          accountId: account.calendarAccountId,
+          action: "raise",
+          previous: prior?.needsReauthentication ?? null,
+          provenance: REAUTHENTICATION_SOURCE_CREDENTIALS,
+          recordedProvenance: prior?.reauthenticationSource,
+          signal: "caldav-authentication-error",
+        });
       }
 
       return {

--- a/packages/calendar/tests/core/oauth/coordinated-refresher-demand-telemetry.test.ts
+++ b/packages/calendar/tests/core/oauth/coordinated-refresher-demand-telemetry.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { widelog, widelogger } from "widelogger";
+import type { BunSQLDatabase } from "drizzle-orm/bun-sql";
+import { createCoordinatedRefresher } from "../../../src/core/oauth/coordinated-refresher";
+
+interface EmittedEvent {
+  provider?: { account_id?: string };
+  reauth?: {
+    action?: string;
+    previous?: boolean;
+    previous_read_failed?: boolean;
+    provenance?: string;
+    recorded_provenance?: string;
+    signal?: string;
+    transitioned?: boolean;
+  };
+}
+
+interface PriorRow {
+  needsReauthentication: boolean;
+  reauthenticationSource: string | null;
+}
+
+const { context } = widelogger({
+  defaultEventName: "wide_event",
+  environment: "production",
+  service: "calendar-test",
+});
+
+const emitted: EmittedEvent[] = [];
+const originalWrite = process.stdout.write.bind(process.stdout);
+
+const captureLine = (chunk: unknown): void => {
+  for (const line of String(chunk).split("\n")) {
+    if (line.trim().length === 0) {
+      continue;
+    }
+    emitted.push(JSON.parse(line) as EmittedEvent);
+  }
+};
+
+beforeEach(() => {
+  emitted.length = 0;
+  process.stdout.write = ((chunk: unknown) => {
+    captureLine(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+});
+
+afterEach(() => {
+  process.stdout.write = originalWrite;
+});
+
+const createChain = (resolve: () => unknown): unknown => {
+  const chain: Record<string, unknown> = {};
+  return new Proxy(chain, {
+    get(_target, property) {
+      if (property === "then") {
+        return (onFulfilled: (value: unknown) => unknown, onRejected: (reason: unknown) => unknown) =>
+          Promise.resolve().then(resolve).then(onFulfilled).catch(onRejected);
+      }
+      return () => createChain(resolve);
+    },
+  });
+};
+
+interface FakeDatabase {
+  database: BunSQLDatabase;
+  updates: Record<string, unknown>[];
+}
+
+const createFakeDatabase = (
+  readPrior: () => PriorRow[],
+): FakeDatabase => {
+  const updates: Record<string, unknown>[] = [];
+  const database = {
+    select: () => createChain(() => readPrior()),
+    update: () => ({
+      set: (values: Record<string, unknown>) => ({
+        where: () => {
+          updates.push(values);
+          return Promise.resolve([]);
+        },
+      }),
+    }),
+  } as unknown as BunSQLDatabase;
+  return { database, updates };
+};
+
+let credentialSequence = 0;
+
+const refreshOnce = async (
+  fake: FakeDatabase,
+  rawRefresh: () => Promise<never>,
+): Promise<void> => {
+  credentialSequence += 1;
+  const refresher = createCoordinatedRefresher({
+    calendarAccountId: "account-1",
+    database: fake.database,
+    oauthCredentialId: `credential-${String(credentialSequence)}`,
+    rawRefresh,
+    refreshLockStore: null,
+  });
+  await context(async () => {
+    try {
+      await refresher("refresh-token");
+    } catch {
+      widelog.set("outcome", "error");
+    } finally {
+      widelog.flush();
+    }
+  });
+};
+
+const rejectedGrant = (): Promise<never> =>
+  Promise.reject(new Error("invalid_grant: token revoked"));
+
+const demandEvent = (): EmittedEvent => {
+  const event = emitted.find(({ reauth }) => Boolean(reauth));
+  if (!event) {
+    throw new Error("expected a wide event carrying reauth fields");
+  }
+  return event;
+};
+
+describe("a token refresh rejected by the identity provider", () => {
+  it("logs the raise with its provenance and deciding signal on the active wide event", async () => {
+    const fake = createFakeDatabase(() => [
+      { needsReauthentication: false, reauthenticationSource: null },
+    ]);
+
+    await refreshOnce(fake, rejectedGrant);
+
+    const event = demandEvent();
+    expect(event.provider?.account_id).toBe("account-1");
+    expect(event.reauth?.action).toBe("raise");
+    expect(event.reauth?.provenance).toBe("token-refresh");
+    expect(event.reauth?.signal).toBe("oauth-refresh-rejected");
+    expect(event.reauth?.previous).toBe(false);
+    expect(event.reauth?.transitioned).toBe(true);
+    expect(fake.updates).toEqual([
+      { needsReauthentication: true, reauthenticationSource: "token-refresh" },
+    ]);
+  });
+
+  it("distinguishes a re-raise over an already-standing demand from a real transition", async () => {
+    const fake = createFakeDatabase(() => [
+      { needsReauthentication: true, reauthenticationSource: "destination-grant" },
+    ]);
+
+    await refreshOnce(fake, rejectedGrant);
+
+    const event = demandEvent();
+    expect(event.reauth?.previous).toBe(true);
+    expect(event.reauth?.transitioned).toBe(false);
+    expect(event.reauth?.recorded_provenance).toBe("destination-grant");
+  });
+
+  it("still raises and logs when the prior-state read fails, marking the state unknown", async () => {
+    const fake = createFakeDatabase(() => {
+      throw new Error("connection reset");
+    });
+
+    await refreshOnce(fake, rejectedGrant);
+
+    const event = demandEvent();
+    expect(event.reauth?.action).toBe("raise");
+    expect(event.reauth?.previous).toBeUndefined();
+    expect(event.reauth?.transitioned).toBeUndefined();
+    expect(event.reauth?.previous_read_failed).toBe(true);
+    expect(fake.updates).toEqual([
+      { needsReauthentication: true, reauthenticationSource: "token-refresh" },
+    ]);
+  });
+
+  it("logs nothing and writes nothing for a refresh failure that does not demand reauthentication", async () => {
+    const fake = createFakeDatabase(() => [
+      { needsReauthentication: false, reauthenticationSource: null },
+    ]);
+
+    await refreshOnce(fake, () => Promise.reject(new Error("provider returned 503")));
+
+    expect(emitted.find(({ reauth }) => Boolean(reauth))).toBeUndefined();
+    expect(fake.updates).toEqual([]);
+  });
+});

--- a/packages/calendar/tests/providers/caldav/source/provider-demand-telemetry.test.ts
+++ b/packages/calendar/tests/providers/caldav/source/provider-demand-telemetry.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { widelog, widelogger } from "widelogger";
+import type { BunSQLDatabase } from "drizzle-orm/bun-sql";
+
+interface EmittedEvent {
+  provider?: { account_id?: string };
+  reauth?: {
+    action?: string;
+    previous?: boolean;
+    provenance?: string;
+    recorded_provenance?: string;
+    signal?: string;
+    transitioned?: boolean;
+  };
+}
+
+interface PriorRow {
+  needsReauthentication: boolean;
+  reauthenticationSource: string | null;
+}
+
+let clientFailure: () => never = () => {
+  throw Object.assign(new Error("Unauthorized"), { status: 401 });
+};
+
+const createFailingClient = (): Record<string, unknown> => ({
+  fetchCalendarDisplayName: () => Promise.resolve(null),
+  fetchCalendarObjects: () => Promise.resolve().then(() => clientFailure()),
+  resolveCalendarUrl: () => Promise.resolve().then(() => clientFailure()),
+});
+
+vi.mock("../../../../src/providers/caldav/shared/client", () => ({
+  CalDAVClient: function CalDAVClient() {
+    return createFailingClient();
+  },
+}));
+
+vi.mock("@keeper.sh/database", async (importOriginal) => ({
+  ...await importOriginal<Record<string, unknown>>(),
+  decryptPassword: () => "plaintext",
+}));
+
+const { createCalDAVSourceProvider } = await import(
+  "../../../../src/providers/caldav/source/provider"
+);
+
+const { context } = widelogger({
+  defaultEventName: "wide_event",
+  environment: "production",
+  service: "calendar-test",
+});
+
+const emitted: EmittedEvent[] = [];
+const originalWrite = process.stdout.write.bind(process.stdout);
+
+const captureLine = (chunk: unknown): void => {
+  for (const line of String(chunk).split("\n")) {
+    if (line.trim().length === 0) {
+      continue;
+    }
+    emitted.push(JSON.parse(line) as EmittedEvent);
+  }
+};
+
+beforeEach(() => {
+  emitted.length = 0;
+  clientFailure = () => {
+    throw Object.assign(new Error("Unauthorized"), { status: 401 });
+  };
+  process.stdout.write = ((chunk: unknown) => {
+    captureLine(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+});
+
+afterEach(() => {
+  process.stdout.write = originalWrite;
+});
+
+const SOURCE_ROW = {
+  authMethod: "basic",
+  calendarAccountId: "account-1",
+  calendarId: "calendar-1",
+  calendarUrl: "https://dav.example.com/cal/",
+  encryptedPassword: "cipher",
+  name: "Calendar",
+  originalName: "Calendar",
+  provider: "caldav",
+  serverUrl: "https://dav.example.com/",
+  syncToken: null,
+  userId: "user-1",
+};
+
+const createChain = (resolve: () => unknown): unknown => {
+  const chain: Record<string, unknown> = {};
+  return new Proxy(chain, {
+    get(_target, property) {
+      if (property === "then") {
+        return (onFulfilled: (value: unknown) => unknown, onRejected: (reason: unknown) => unknown) =>
+          Promise.resolve().then(resolve).then(onFulfilled).catch(onRejected);
+      }
+      return () => createChain(resolve);
+    },
+  });
+};
+
+interface FakeDatabase {
+  database: BunSQLDatabase;
+  updates: Record<string, unknown>[];
+}
+
+const createFakeDatabase = (readPrior: () => PriorRow[]): FakeDatabase => {
+  const updates: Record<string, unknown>[] = [];
+  const resolveSelect = (projection: Record<string, unknown>): unknown[] => {
+    const keys = new Set(Object.keys(projection));
+    if (keys.has("calendarAccountId")) {
+      return [SOURCE_ROW];
+    }
+    if (keys.has("needsReauthentication")) {
+      return readPrior();
+    }
+    throw new Error(`unexpected select projection: ${[...keys].join(",")}`);
+  };
+  const database = {
+    select: (projection: Record<string, unknown>) =>
+      createChain(() => resolveSelect(projection)),
+    transaction: (work: (transaction: unknown) => Promise<unknown>) =>
+      work({
+        execute: () => Promise.resolve(null),
+        select: (projection: Record<string, unknown>) =>
+          createChain(() => resolveSelect(projection)),
+      }),
+    update: () => ({
+      set: (values: Record<string, unknown>) => ({
+        where: () => {
+          updates.push(values);
+          return Promise.resolve([]);
+        },
+      }),
+    }),
+  } as unknown as BunSQLDatabase;
+  return { database, updates };
+};
+
+const syncOnce = async (fake: FakeDatabase): Promise<void> => {
+  const provider = createCalDAVSourceProvider({
+    database: fake.database,
+    encryptionKey: "0".repeat(64),
+  });
+  await context(async () => {
+    await provider.syncSource("calendar-1");
+    widelog.flush();
+  });
+};
+
+const demandEvent = (): EmittedEvent => {
+  const event = emitted.find(({ reauth }) => Boolean(reauth));
+  if (!event) {
+    throw new Error("expected a wide event carrying reauth fields");
+  }
+  return event;
+};
+
+describe("a CalDAV source pull rejected as unauthenticated", () => {
+  it("logs the raise with its provenance and deciding signal on the active wide event", async () => {
+    const fake = createFakeDatabase(() => [
+      { needsReauthentication: false, reauthenticationSource: null },
+    ]);
+
+    await syncOnce(fake);
+
+    const event = demandEvent();
+    expect(event.provider?.account_id).toBe("account-1");
+    expect(event.reauth?.action).toBe("raise");
+    expect(event.reauth?.provenance).toBe("source-credentials");
+    expect(event.reauth?.signal).toBe("caldav-authentication-error");
+    expect(event.reauth?.previous).toBe(false);
+    expect(event.reauth?.transitioned).toBe(true);
+    expect(fake.updates).toEqual([
+      { needsReauthentication: true, reauthenticationSource: "source-credentials" },
+    ]);
+  });
+
+  it("distinguishes a re-raise over an already-standing demand from a real transition", async () => {
+    const fake = createFakeDatabase(() => [
+      { needsReauthentication: true, reauthenticationSource: "token-refresh" },
+    ]);
+
+    await syncOnce(fake);
+
+    const event = demandEvent();
+    expect(event.reauth?.previous).toBe(true);
+    expect(event.reauth?.transitioned).toBe(false);
+    expect(event.reauth?.recorded_provenance).toBe("token-refresh");
+  });
+
+  it("logs nothing and writes nothing for a non-authentication failure", async () => {
+    clientFailure = () => {
+      throw Object.assign(new Error("Service Unavailable"), { status: 503 });
+    };
+    const fake = createFakeDatabase(() => [
+      { needsReauthentication: false, reauthenticationSource: null },
+    ]);
+
+    await syncOnce(fake);
+
+    expect(emitted.find(({ reauth }) => Boolean(reauth))).toBeUndefined();
+    expect(fake.updates).toEqual([]);
+  });
+});

--- a/services/api/src/utils/destinations.ts
+++ b/services/api/src/utils/destinations.ts
@@ -8,6 +8,11 @@ import {
 } from "@keeper.sh/database/schema";
 import { REAUTHENTICATION_DESTINATION_GRANT } from "@keeper.sh/constants";
 import { and, eq, inArray } from "drizzle-orm";
+import {
+  buildReauthenticationDemandFields,
+  getErrorMessage,
+  resolveReauthenticationDemandAction,
+} from "@keeper.sh/calendar";
 import type {
   AuthorizationUrlOptions,
   OAuthTokens,
@@ -15,6 +20,7 @@ import type {
   ValidatedState,
 } from "@keeper.sh/calendar";
 import { database, oauthProviders } from "@/context";
+import { widelog } from "@/utils/logging";
 import { getCalendarsAffectedByAccountMutation } from "@/utils/invalidate-calendars";
 import {
   requestUserSync,
@@ -72,6 +78,8 @@ interface ExistingAccount {
   userId: string;
   oauthCredentialId: string | null;
   caldavCredentialId: string | null;
+  needsReauthentication: boolean;
+  reauthenticationSource: string | null;
 }
 
 const findExistingAccount = async (
@@ -83,7 +91,9 @@ const findExistingAccount = async (
     .select({
       caldavCredentialId: calendarAccountsTable.caldavCredentialId,
       id: calendarAccountsTable.id,
+      needsReauthentication: calendarAccountsTable.needsReauthentication,
       oauthCredentialId: calendarAccountsTable.oauthCredentialId,
+      reauthenticationSource: calendarAccountsTable.reauthenticationSource,
       userId: calendarAccountsTable.userId,
     })
     .from(calendarAccountsTable)
@@ -138,11 +148,77 @@ const resolveGrantDemandSource = (needsReauthentication: boolean): string | null
   return null;
 };
 
+interface PriorGrantDemandState {
+  needsReauthentication: boolean;
+  reauthenticationSource: string | null;
+}
+
+const resolveGrantDemandSignal = (needsReauthentication: boolean): string | undefined => {
+  if (!needsReauthentication) {
+    return;
+  }
+  return "grant-missing-scopes";
+};
+
+const recordGrantDemand = (
+  accountId: string,
+  needsReauthentication: boolean,
+  prior: PriorGrantDemandState | null,
+): void => {
+  const fields = buildReauthenticationDemandFields({
+    accountId,
+    action: resolveReauthenticationDemandAction(needsReauthentication),
+    previous: prior?.needsReauthentication ?? null,
+    provenance: REAUTHENTICATION_DESTINATION_GRANT,
+    recordedProvenance: prior?.reauthenticationSource,
+    signal: resolveGrantDemandSignal(needsReauthentication),
+  });
+  for (const [key, value] of Object.entries(fields)) {
+    widelog.set(key, value);
+  }
+};
+
+const readPriorGrantDemandState = async (
+  databaseClient: DestinationDatabase,
+  provider: string,
+  accountId: string,
+): Promise<PriorGrantDemandState | null> => {
+  try {
+    const [account] = await databaseClient
+      .select({
+        needsReauthentication: calendarAccountsTable.needsReauthentication,
+        reauthenticationSource: calendarAccountsTable.reauthenticationSource,
+      })
+      .from(calendarAccountsTable)
+      .where(
+        and(
+          eq(calendarAccountsTable.provider, provider),
+          eq(calendarAccountsTable.accountId, accountId),
+        ),
+      )
+      .limit(FIRST_RESULT_LIMIT);
+    return account ?? { needsReauthentication: false, reauthenticationSource: null };
+  } catch (error) {
+    widelog.set("reauth.previous_read_failed", true);
+    widelog.set("reauth.previous_read_error", getErrorMessage(error));
+    return null;
+  }
+};
+
 const upsertAccountAndCalendarWithDatabase = async (
   databaseClient: DestinationDatabase,
   data: AccountInsertData,
 ): Promise<string | undefined> => {
   const { oauthCredentialId, caldavCredentialId, needsReauthentication, ...base } = data;
+
+  let priorGrantDemandState: PriorGrantDemandState | null = null;
+  if (oauthCredentialId) {
+    priorGrantDemandState = await readPriorGrantDemandState(
+      databaseClient,
+      base.provider,
+      base.accountId,
+    );
+  }
 
   const setClause: Record<string, unknown> = { email: base.email };
 
@@ -182,6 +258,10 @@ const upsertAccountAndCalendarWithDatabase = async (
 
   if (!account) {
     throw new Error("This account is already linked to another user");
+  }
+
+  if (oauthCredentialId) {
+    recordGrantDemand(account.id, needsReauthentication ?? false, priorGrantDemandState);
   }
 
   const [existingCalendar] = await databaseClient
@@ -244,6 +324,8 @@ const saveCalendarDestinationWithDatabase = async (
         reauthenticationSource: resolveGrantDemandSource(needsReauthentication),
       })
       .where(eq(calendarAccountsTable.id, existingAccount.id));
+
+    recordGrantDemand(existingAccount.id, needsReauthentication, existingAccount);
 
     const [existingCalendar] = await databaseClient
       .select({ id: calendarsTable.id })

--- a/services/api/tests/utils/destination-reauth-telemetry.test.ts
+++ b/services/api/tests/utils/destination-reauth-telemetry.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const captured = vi.hoisted(() => ({
+  setCalls: [] as [string, unknown][],
+}));
+
+vi.mock("@/utils/logging", () => ({
+  context: (callback: () => unknown) => callback(),
+  widelog: {
+    errorFields: () => null,
+    flush: () => null,
+    set: (key: string, value: unknown) => {
+      captured.setCalls.push([key, value]);
+    },
+    setFields: () => null,
+    time: { measure: (_key: string, callback: () => unknown) => callback() },
+  },
+}));
+
+vi.mock("@/context", () => ({
+  database: {},
+  oauthProviders: {
+    getProvider: () => null,
+    hasRequiredScopes: () => true,
+    isOAuthProvider: () => true,
+  },
+}));
+
+const destinationsModule = await import("../../src/utils/destinations");
+const { saveCalendarDestinationWithDatabase, upsertAccountAndCalendarWithDatabase } = destinationsModule;
+
+interface AccountRow {
+  caldavCredentialId: string | null;
+  id: string;
+  needsReauthentication: boolean;
+  oauthCredentialId: string | null;
+  reauthenticationSource: string | null;
+  userId: string;
+}
+
+const updates: Record<string, unknown>[] = [];
+let existingAccountRow: AccountRow | null = null;
+
+const createSelectQuery = (rows: unknown[]): unknown => {
+  const chain: Record<string, unknown> = {};
+  return new Proxy(chain, {
+    get(_target, property) {
+      if (property === "then") {
+        return (onFulfilled: (value: unknown) => unknown) =>
+          Promise.resolve(rows).then(onFulfilled);
+      }
+      return () => createSelectQuery(rows);
+    },
+  });
+};
+
+const resolveSelect = (projection: Record<string, unknown>): unknown[] => {
+  const keys = new Set(Object.keys(projection));
+  if (keys.has("oauthCredentialId") || keys.has("needsReauthentication")) {
+    if (!existingAccountRow) {
+      return [];
+    }
+    return [existingAccountRow];
+  }
+  return [];
+};
+
+const createInsertQuery = (rows: unknown[]): unknown => {
+  const chain: Record<string, unknown> = {};
+  return new Proxy(chain, {
+    get(_target, property) {
+      if (property === "then") {
+        return (onFulfilled: (value: unknown) => unknown) =>
+          Promise.resolve(rows).then(onFulfilled);
+      }
+      return () => createInsertQuery(rows);
+    },
+  });
+};
+
+let insertSequence = 0;
+
+const createDatabase = (): Parameters<typeof saveCalendarDestinationWithDatabase>[0] => ({
+  delete: () => createSelectQuery([]),
+  insert: () => ({
+    values: () => {
+      insertSequence += 1;
+      return createInsertQuery([{ id: `row-${String(insertSequence)}` }]);
+    },
+  }),
+  select: (projection: Record<string, unknown>) =>
+    createSelectQuery(resolveSelect(projection)),
+  selectDistinct: () => createSelectQuery([]),
+  update: () => ({
+    set: (values: Record<string, unknown>) => {
+      updates.push(values);
+      return createSelectQuery([]);
+    },
+  }),
+} as unknown as Parameters<typeof saveCalendarDestinationWithDatabase>[0]);
+
+const reauthFields = (): Record<string, unknown> =>
+  Object.fromEntries(captured.setCalls.filter(([key]) =>
+    key.startsWith("reauth.") || key === "provider.account_id"));
+
+const relinkDestination = (needsReauthentication: boolean): Promise<void> =>
+  saveCalendarDestinationWithDatabase(
+    createDatabase(),
+    "user-1",
+    "google",
+    "external-account-1",
+    "user@example.com",
+    "access-token",
+    "refresh-token",
+    new Date(Date.now() + 3_600_000),
+    needsReauthentication,
+  );
+
+const linkFreshDestination = async (needsReauthentication: boolean): Promise<void> => {
+  await upsertAccountAndCalendarWithDatabase(createDatabase(), {
+    accountId: "external-account-1",
+    email: "user@example.com",
+    needsReauthentication,
+    oauthCredentialId: "credential-1",
+    provider: "google",
+    userId: "user-1",
+  });
+};
+
+describe("re-authentication demand telemetry on the destination grant path", () => {
+  beforeEach(() => {
+    captured.setCalls.length = 0;
+    updates.length = 0;
+    insertSequence = 0;
+    existingAccountRow = null;
+  });
+
+  describe("re-linking an existing destination account", () => {
+    it("logs a raise when the fresh grant is missing required scopes", async () => {
+      existingAccountRow = {
+        caldavCredentialId: null,
+        id: "account-1",
+        needsReauthentication: false,
+        oauthCredentialId: "credential-1",
+        reauthenticationSource: null,
+        userId: "user-1",
+      };
+
+      await relinkDestination(true);
+
+      expect(reauthFields()).toEqual({
+        "provider.account_id": "account-1",
+        "reauth.action": "raise",
+        "reauth.previous": false,
+        "reauth.provenance": "destination-grant",
+        "reauth.signal": "grant-missing-scopes",
+        "reauth.transitioned": true,
+      });
+    });
+
+    it("logs a clear carrying the provenance the demand was raised under", async () => {
+      existingAccountRow = {
+        caldavCredentialId: null,
+        id: "account-1",
+        needsReauthentication: true,
+        oauthCredentialId: "credential-1",
+        reauthenticationSource: "token-refresh",
+        userId: "user-1",
+      };
+
+      await relinkDestination(false);
+
+      expect(reauthFields()).toEqual({
+        "provider.account_id": "account-1",
+        "reauth.action": "clear",
+        "reauth.previous": true,
+        "reauth.provenance": "destination-grant",
+        "reauth.recorded_provenance": "token-refresh",
+        "reauth.transitioned": true,
+      });
+    });
+
+    it("distinguishes a no-op clear over an already-clear flag from a real transition", async () => {
+      existingAccountRow = {
+        caldavCredentialId: null,
+        id: "account-1",
+        needsReauthentication: false,
+        oauthCredentialId: "credential-1",
+        reauthenticationSource: null,
+        userId: "user-1",
+      };
+
+      await relinkDestination(false);
+
+      expect(reauthFields()).toEqual({
+        "provider.account_id": "account-1",
+        "reauth.action": "clear",
+        "reauth.previous": false,
+        "reauth.provenance": "destination-grant",
+        "reauth.transitioned": false,
+      });
+    });
+  });
+
+  describe("linking a destination account for the first time", () => {
+    it("logs a scope-deficient grant as a raise over a clear prior state", async () => {
+      await linkFreshDestination(true);
+
+      expect(reauthFields()).toEqual({
+        "provider.account_id": "row-1",
+        "reauth.action": "raise",
+        "reauth.previous": false,
+        "reauth.provenance": "destination-grant",
+        "reauth.signal": "grant-missing-scopes",
+        "reauth.transitioned": true,
+      });
+    });
+
+    it("logs a fully-scoped grant as a no-op clear", async () => {
+      await linkFreshDestination(false);
+
+      expect(reauthFields()).toEqual({
+        "provider.account_id": "row-1",
+        "reauth.action": "clear",
+        "reauth.previous": false,
+        "reauth.provenance": "destination-grant",
+        "reauth.transitioned": false,
+      });
+    });
+  });
+});

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -11,6 +11,8 @@ import {
   ensureValidToken,
   isTimeoutError,
   buildCalendarBackoffState,
+  buildReauthenticationDemandFields,
+  resolveReauthenticationDemandAction,
   SOURCE_INGEST_LOCK_NAMESPACE,
   createRequiredSourceRanges,
   createSourceIngestionPlan,
@@ -468,32 +470,113 @@ const resolveReauthenticationDemands = (
   );
 };
 
+const REAUTHENTICATION_VOTE_FIELDS: [ReauthenticationDemand, string][] = [
+  ["credential-rejected", "reauth.votes.credential_rejected"],
+  ["authenticated", "reauth.votes.authenticated"],
+  ["request-rejected", "reauth.votes.request_rejected"],
+  ["abstain", "reauth.votes.abstain"],
+];
+
+const recordReauthenticationDemandVotes = (
+  cast: ReauthenticationDemand[],
+): ReauthenticationDemand | undefined => {
+  for (const [demand, field] of REAUTHENTICATION_VOTE_FIELDS) {
+    widelog.set(field, cast.filter((vote) => vote === demand).length);
+  }
+  const decidingVote = REAUTHENTICATION_DEMAND_PRECEDENCE.find(
+    (demand) => cast.includes(demand),
+  );
+  if (decidingVote) {
+    widelog.set("reauth.deciding_vote", decidingVote);
+  }
+  return decidingVote;
+};
+
+const recordReauthenticationDemandFields = (
+  fields: Record<string, string | number | boolean>,
+): void => {
+  for (const [key, value] of Object.entries(fields)) {
+    widelog.set(key, value);
+  }
+};
+
+const resolvePreviousFlag = (
+  transitioned: boolean,
+  needsReauthentication: boolean,
+): boolean => {
+  if (transitioned) {
+    return !needsReauthentication;
+  }
+  return needsReauthentication;
+};
+
+const resolveRaiseSignal = (
+  needsReauthentication: boolean,
+  decidingVote: ReauthenticationDemand | undefined,
+): string | undefined => {
+  if (!needsReauthentication || !decidingVote) {
+    return;
+  }
+  return decidingVote;
+};
+
 const applyReauthenticationDemands = async (
   demands: ReauthenticationDemandRecord[],
   recordedDemandSources: Map<string, string | null>,
 ): Promise<void> => {
   for (const [accountId, needsReauthentication] of resolveReauthenticationDemands(demands)) {
     const recordedDemandSource = recordedDemandSources.get(accountId) ?? null;
-    if (!needsReauthentication && !isIngestAdjudicableDemand(recordedDemandSource)) {
-      continue;
-    }
-    try {
-      await database
-        .update(calendarAccountsTable)
-        .set({
-          needsReauthentication,
-          reauthenticationSource: resolveRecordedDemandSource(needsReauthentication),
-        })
-        .where(and(
-          eq(calendarAccountsTable.id, accountId),
-          ne(calendarAccountsTable.needsReauthentication, needsReauthentication),
-        ));
-    } catch (error) {
-      widelog.errorFields(error, {
-        retriable: true,
-        slug: resolveDatabaseIngestErrorSlug(error) ?? "reauthentication-demand-write-failed",
-      });
-    }
+    const cast = demands
+      .filter((record) => record.accountId === accountId)
+      .map(({ demand }) => demand);
+    await context(async () => {
+      widelog.set("operation.name", "reauthentication-demand");
+      widelog.set("operation.type", "job");
+      const decidingVote = recordReauthenticationDemandVotes(cast);
+      try {
+        if (!needsReauthentication && !isIngestAdjudicableDemand(recordedDemandSource)) {
+          recordReauthenticationDemandFields(buildReauthenticationDemandFields({
+            accountId,
+            action: "clear",
+            previous: null,
+            provenance: REAUTHENTICATION_SOURCE_INGEST,
+            recordedProvenance: recordedDemandSource,
+          }));
+          widelog.set("reauth.suppressed", true);
+          widelog.set("outcome", "skipped");
+          return;
+        }
+        const written = await database
+          .update(calendarAccountsTable)
+          .set({
+            needsReauthentication,
+            reauthenticationSource: resolveRecordedDemandSource(needsReauthentication),
+          })
+          .where(and(
+            eq(calendarAccountsTable.id, accountId),
+            ne(calendarAccountsTable.needsReauthentication, needsReauthentication),
+          ))
+          .returning({ id: calendarAccountsTable.id });
+        const transitioned = written.length > 0;
+        recordReauthenticationDemandFields(buildReauthenticationDemandFields({
+          accountId,
+          action: resolveReauthenticationDemandAction(needsReauthentication),
+          previous: resolvePreviousFlag(transitioned, needsReauthentication),
+          provenance: REAUTHENTICATION_SOURCE_INGEST,
+          recordedProvenance: recordedDemandSource,
+          signal: resolveRaiseSignal(needsReauthentication, decidingVote),
+        }));
+        widelog.set("outcome", "success");
+      } catch (error) {
+        widelog.set("outcome", "error");
+        widelog.errorFields(error, {
+          retriable: true,
+          slug: resolveDatabaseIngestErrorSlug(error) ?? "reauthentication-demand-write-failed",
+        });
+      } finally {
+        widelog.flush();
+      }
+    });
   }
 };
 

--- a/services/cron/tests/jobs/reauth-demand-log-emission.test.ts
+++ b/services/cron/tests/jobs/reauth-demand-log-emission.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface EmittedEvent {
+  event_name?: string;
+  operation?: { name?: string; type?: string };
+  outcome?: string;
+  provider?: { account_id?: string };
+  reauth?: {
+    action?: string;
+    deciding_vote?: string;
+    previous?: boolean;
+    provenance?: string;
+    signal?: string;
+    transitioned?: boolean;
+    votes?: Record<string, number>;
+  };
+}
+
+vi.mock("@/env", () => ({
+  default: {
+    BLOCK_PRIVATE_RESOLUTION: false,
+    ENCRYPTION_KEY: "0".repeat(64),
+    WORKER_JOB_QUEUE_ENABLED: false,
+  },
+}));
+
+vi.mock("@/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: () => Promise.resolve(null),
+}));
+
+let accountNeedsReauthentication = false;
+let accountDemandSource: string | null = null;
+
+const baseSource = {
+  accessToken: "access-token",
+  accountId: "account-1",
+  expiresAt: new Date(Date.now() + 3_600_000),
+  ingestFutureRange: "P90D",
+  ingestHistoricRange: "P30D",
+  ingestWindowEnd: null,
+  ingestWindowRecordedAt: null,
+  ingestWindowStart: null,
+  oauthCredentialId: "credential-1",
+  provider: "google",
+  refreshToken: "refresh-token",
+  syncToken: null,
+  userId: "user-1",
+};
+
+const resolveSelect = (projection: Record<string, unknown>): unknown[] => {
+  const keys = new Set(Object.keys(projection));
+  if (keys.has("encryptedPassword") || keys.has("treatFullDayTimedEventsAsAllDay")) {
+    return [];
+  }
+  if (keys.has("failureCount") && keys.has("nextAttemptAt")) {
+    return [{ failureCount: 0, nextAttemptAt: null }];
+  }
+  if (keys.has("syncFutureRange") && keys.has("syncHistoricRange")) {
+    return [];
+  }
+  if (keys.has("oauthCredentialId")) {
+    return [{
+      ...baseSource,
+      calendarId: "calendar-primary",
+      externalCalendarId: "primary",
+      reauthenticationSource: accountDemandSource,
+    }];
+  }
+  throw new Error(`unexpected select projection: ${[...keys].join(",")}`);
+};
+
+const createQuery = (resolve: () => unknown): unknown => {
+  const chain: Record<string, unknown> = {};
+  return new Proxy(chain, {
+    get(_target, property) {
+      if (property === "then") {
+        return (onFulfilled: (value: unknown) => unknown, onRejected: (reason: unknown) => unknown) =>
+          Promise.resolve().then(resolve).then(onFulfilled).catch(onRejected);
+      }
+      return () => createQuery(resolve);
+    },
+  });
+};
+
+const applyDemandWrite = (values: Record<string, unknown>): unknown[] => {
+  if (!("needsReauthentication" in values)) {
+    return [];
+  }
+  const next = values.needsReauthentication === true;
+  if (next === accountNeedsReauthentication) {
+    return [];
+  }
+  accountNeedsReauthentication = next;
+  return [{ id: "account-1" }];
+};
+
+const createUpdateQuery = (pending?: Record<string, unknown>): unknown => {
+  const chain: Record<string, unknown> = {};
+  return new Proxy(chain, {
+    get(_target, property) {
+      if (property === "then") {
+        return (onFulfilled: (value: unknown) => unknown, onRejected: (reason: unknown) => unknown) =>
+          Promise.resolve()
+            .then(() => {
+              if (pending) {
+                return applyDemandWrite(pending);
+              }
+              return [];
+            })
+            .then(onFulfilled)
+            .catch(onRejected);
+      }
+      if (property === "set") {
+        return (values: Record<string, unknown>) => createUpdateQuery(values);
+      }
+      return () => createUpdateQuery(pending);
+    },
+  });
+};
+
+vi.mock("@/context", () => ({
+  database: {
+    select: (projection: Record<string, unknown>) =>
+      createQuery(() => resolveSelect(projection)),
+    transaction: (work: (transaction: unknown) => Promise<unknown>) => work({}),
+    update: () => createUpdateQuery(),
+  },
+  refreshLockRedis: {},
+  refreshLockStore: {},
+}));
+
+vi.mock("@keeper.sh/sync", async (importOriginal) => ({
+  ...await importOriginal<Record<string, unknown>>(),
+  createSyncLock: () => ({
+    acquire: () => Promise.resolve({
+      acquired: true,
+      handle: {
+        isCurrent: () => Promise.resolve(true),
+        release: () => Promise.resolve(null),
+      },
+    }),
+  }),
+}));
+
+vi.mock("@keeper.sh/database", async (importOriginal) => ({
+  ...await importOriginal<Record<string, unknown>>(),
+  createDatabase: () => Promise.resolve({}),
+  decryptPassword: () => "plaintext",
+}));
+
+let sourcePullSucceeds = true;
+
+vi.mock("@keeper.sh/calendar", async (importOriginal) => ({
+  ...await importOriginal<Record<string, unknown>>(),
+  ingestSource: (): Promise<{ eventsAdded: number; eventsRemoved: number }> =>
+    Promise.resolve().then(() => {
+      if (sourcePullSucceeds) {
+        return { eventsAdded: 1, eventsRemoved: 0 };
+      }
+      throw Object.assign(new Error("Failed to fetch events: 401"), {
+        authRequired: true,
+        status: 401,
+      });
+    }),
+}));
+
+const ingestSourcesModule = await import("../../src/jobs/ingest-sources");
+const ingestSourcesJob = ingestSourcesModule.default;
+
+const emitted: EmittedEvent[] = [];
+const originalWrite = process.stdout.write.bind(process.stdout);
+
+const captureLine = (chunk: unknown): void => {
+  for (const line of String(chunk).split("\n")) {
+    if (line.trim().length === 0) {
+      continue;
+    }
+    emitted.push(JSON.parse(line) as EmittedEvent);
+  }
+};
+
+beforeEach(() => {
+  emitted.length = 0;
+  accountNeedsReauthentication = false;
+  accountDemandSource = null;
+  sourcePullSucceeds = true;
+  process.stdout.write = ((chunk: unknown) => {
+    captureLine(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+});
+
+afterEach(() => {
+  process.stdout.write = originalWrite;
+});
+
+const runTick = async (): Promise<void> => {
+  await Promise.resolve(ingestSourcesJob.callback()).catch(() => null);
+};
+
+const demandEvents = (): EmittedEvent[] =>
+  emitted.filter((event) => event.operation?.name === "reauthentication-demand");
+
+describe("re-authentication demand events through the real logging stack", () => {
+  it("lands a raise decision as its own parseable log line", async () => {
+    sourcePullSucceeds = false;
+
+    await runTick();
+
+    const [event] = demandEvents();
+    if (!event) {
+      throw new Error("no reauthentication-demand log line was emitted");
+    }
+    expect(event.event_name).toBe("wide_event");
+    expect(event.operation).toEqual({ name: "reauthentication-demand", type: "job" });
+    expect(event.provider).toEqual({ account_id: "account-1" });
+    expect(event.outcome).toBe("success");
+    expect(event.reauth).toEqual({
+      action: "raise",
+      deciding_vote: "request-rejected",
+      previous: false,
+      provenance: "source-ingest",
+      signal: "request-rejected",
+      transitioned: true,
+      votes: {
+        abstain: 0,
+        authenticated: 0,
+        credential_rejected: 0,
+        request_rejected: 1,
+      },
+    });
+  });
+
+  it("lands a clear decision as its own parseable log line", async () => {
+    accountNeedsReauthentication = true;
+    accountDemandSource = "source-ingest";
+
+    await runTick();
+
+    const [event] = demandEvents();
+    if (!event) {
+      throw new Error("no reauthentication-demand log line was emitted");
+    }
+    expect(event.reauth).toEqual({
+      action: "clear",
+      deciding_vote: "authenticated",
+      previous: true,
+      provenance: "source-ingest",
+      recorded_provenance: "source-ingest",
+      transitioned: true,
+      votes: {
+        abstain: 0,
+        authenticated: 1,
+        credential_rejected: 0,
+        request_rejected: 0,
+      },
+    });
+  });
+});

--- a/services/cron/tests/jobs/reauth-demand-telemetry.test.ts
+++ b/services/cron/tests/jobs/reauth-demand-telemetry.test.ts
@@ -1,0 +1,323 @@
+import { DrizzleQueryError } from "drizzle-orm/errors";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface WideEvent {
+  fields: Record<string, unknown>;
+  values: Record<string, unknown>;
+}
+
+const emitted: WideEvent[] = [];
+const writes: Record<string, unknown>[] = [];
+let current: WideEvent = { fields: {}, values: {} };
+let accountNeedsReauthentication = false;
+let accountDemandSource: string | null = null;
+let demandWriteFails = false;
+
+vi.mock("@/utils/logging", () => ({
+  context: (run: () => Promise<unknown>) => run(),
+  widelog: {
+    append: () => null,
+    error: () => null,
+    errorFields: (_error: unknown, fields: Record<string, unknown>) => {
+      current.fields = { ...current.fields, ...fields };
+    },
+    flush: () => {
+      emitted.push(current);
+      current = { fields: {}, values: {} };
+    },
+    set: (key: string, value: unknown) => {
+      current.values[key] = value;
+    },
+    time: {
+      measure: <TResult>(_key: string, run: () => Promise<TResult>) => run(),
+    },
+  },
+}));
+
+vi.mock("@/env", () => ({
+  default: {
+    BLOCK_PRIVATE_RESOLUTION: false,
+    ENCRYPTION_KEY: "0".repeat(64),
+    WORKER_JOB_QUEUE_ENABLED: false,
+  },
+}));
+
+vi.mock("@/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: () => Promise.resolve(null),
+}));
+
+const baseSource = {
+  accessToken: "access-token",
+  accountId: "account-1",
+  expiresAt: new Date(Date.now() + 3_600_000),
+  ingestFutureRange: "P90D",
+  ingestHistoricRange: "P30D",
+  ingestWindowEnd: null,
+  ingestWindowRecordedAt: null,
+  ingestWindowStart: null,
+  oauthCredentialId: "credential-1",
+  provider: "google",
+  refreshToken: "refresh-token",
+  syncToken: null,
+  userId: "user-1",
+};
+
+const readSource = (): Record<string, unknown> => ({
+  ...baseSource,
+  calendarId: "calendar-primary",
+  externalCalendarId: "primary",
+  reauthenticationSource: accountDemandSource,
+});
+
+const resolveSelect = (projection: Record<string, unknown>): unknown[] => {
+  const keys = new Set(Object.keys(projection));
+  if (keys.has("encryptedPassword")) {
+    return [];
+  }
+  if (keys.has("treatFullDayTimedEventsAsAllDay")) {
+    return [];
+  }
+  if (keys.has("failureCount") && keys.has("nextAttemptAt")) {
+    return [{ failureCount: 0, nextAttemptAt: null }];
+  }
+  if (keys.has("syncFutureRange") && keys.has("syncHistoricRange")) {
+    return [];
+  }
+  if (keys.has("oauthCredentialId")) {
+    return [readSource()];
+  }
+  throw new Error(`unexpected select projection: ${[...keys].join(",")}`);
+};
+
+const createQuery = (resolve: () => unknown): unknown => {
+  const chain: Record<string, unknown> = {};
+  return new Proxy(chain, {
+    get(_target, property) {
+      if (property === "then") {
+        return (onFulfilled: (value: unknown) => unknown, onRejected: (reason: unknown) => unknown) =>
+          Promise.resolve().then(resolve).then(onFulfilled).catch(onRejected);
+      }
+      return () => createQuery(resolve);
+    },
+  });
+};
+
+const postgresError = (
+  message: string,
+  fields: Record<string, unknown>,
+): Error & Record<string, unknown> =>
+  Object.assign(new Error(message), { name: "PostgresError" }, fields);
+
+const demandWriteDeadlock = (): DrizzleQueryError =>
+  new DrizzleQueryError(
+    "update \"calendar_accounts\" set \"needs_reauthentication\" = $1",
+    [],
+    postgresError("deadlock detected", {
+      code: "ERR_POSTGRES_SERVER_ERROR",
+      errno: "40P01",
+    }),
+  );
+
+const applyDemandWrite = (values: Record<string, unknown>): unknown[] => {
+  if (!("needsReauthentication" in values)) {
+    return [];
+  }
+  if (demandWriteFails) {
+    throw demandWriteDeadlock();
+  }
+  const next = values.needsReauthentication === true;
+  if (next === accountNeedsReauthentication) {
+    return [];
+  }
+  writes.push(values);
+  accountNeedsReauthentication = next;
+  accountDemandSource = null;
+  if (typeof values.reauthenticationSource === "string") {
+    accountDemandSource = values.reauthenticationSource;
+  }
+  return [{ id: "account-1" }];
+};
+
+const createUpdateQuery = (pending?: Record<string, unknown>): unknown => {
+  const chain: Record<string, unknown> = {};
+  return new Proxy(chain, {
+    get(_target, property) {
+      if (property === "then") {
+        return (
+          onFulfilled: (value: unknown) => unknown,
+          onRejected: (reason: unknown) => unknown,
+        ) =>
+          Promise.resolve()
+            .then(() => {
+              if (pending) {
+                return applyDemandWrite(pending);
+              }
+              return [];
+            })
+            .then(onFulfilled)
+            .catch(onRejected);
+      }
+      if (property === "set") {
+        return (values: Record<string, unknown>) => createUpdateQuery(values);
+      }
+      return () => createUpdateQuery(pending);
+    },
+  });
+};
+
+vi.mock("@/context", () => ({
+  database: {
+    select: (projection: Record<string, unknown>) =>
+      createQuery(() => resolveSelect(projection)),
+    transaction: (work: (transaction: unknown) => Promise<unknown>) => work({}),
+    update: () => createUpdateQuery(),
+  },
+  refreshLockRedis: {},
+  refreshLockStore: {},
+}));
+
+vi.mock("@keeper.sh/sync", async (importOriginal) => ({
+  ...await importOriginal<Record<string, unknown>>(),
+  createSyncLock: () => ({
+    acquire: () => Promise.resolve({
+      acquired: true,
+      handle: {
+        isCurrent: () => Promise.resolve(true),
+        release: () => Promise.resolve(null),
+      },
+    }),
+  }),
+}));
+
+vi.mock("@keeper.sh/database", async (importOriginal) => ({
+  ...await importOriginal<Record<string, unknown>>(),
+  createDatabase: () => Promise.resolve({}),
+  decryptPassword: () => "plaintext",
+}));
+
+let sourcePullSucceeds = true;
+
+vi.mock("@keeper.sh/calendar", async (importOriginal) => ({
+  ...await importOriginal<Record<string, unknown>>(),
+  ingestSource: (): Promise<{ eventsAdded: number; eventsRemoved: number }> =>
+    Promise.resolve().then(() => {
+      if (sourcePullSucceeds) {
+        return { eventsAdded: 1, eventsRemoved: 0 };
+      }
+      throw Object.assign(new Error("Failed to fetch events: 401"), {
+        authRequired: true,
+        status: 401,
+      });
+    }),
+}));
+
+const ingestSourcesModule = await import("../../src/jobs/ingest-sources");
+const ingestSourcesJob = ingestSourcesModule.default;
+
+const runTick = async (): Promise<void> => {
+  emitted.length = 0;
+  await Promise.resolve(ingestSourcesJob.callback()).catch(() => null);
+};
+
+const demandEvent = (): WideEvent => {
+  const event = emitted.find(
+    ({ values }) => values["operation.name"] === "reauthentication-demand",
+  );
+  if (!event) {
+    throw new Error("no reauthentication-demand wide event was emitted");
+  }
+  return event;
+};
+
+describe("re-authentication demand telemetry at ingest vote resolution", () => {
+  beforeEach(() => {
+    emitted.length = 0;
+    writes.length = 0;
+    current = { fields: {}, values: {} };
+    accountNeedsReauthentication = false;
+    accountDemandSource = null;
+    demandWriteFails = false;
+    sourcePullSucceeds = true;
+  });
+
+  it("logs an unopposed single-calendar rejection as such when it raises", async () => {
+    sourcePullSucceeds = false;
+
+    await runTick();
+
+    const { values } = demandEvent();
+    expect(values["operation.type"]).toBe("job");
+    expect(values["provider.account_id"]).toBe("account-1");
+    expect(values["reauth.action"]).toBe("raise");
+    expect(values["reauth.provenance"]).toBe("source-ingest");
+    expect(values["reauth.deciding_vote"]).toBe("request-rejected");
+    expect(values["reauth.signal"]).toBe("request-rejected");
+    expect(values["reauth.votes.request_rejected"]).toBe(1);
+    expect(values["reauth.votes.credential_rejected"]).toBe(0);
+    expect(values["reauth.votes.authenticated"]).toBe(0);
+    expect(values["reauth.votes.abstain"]).toBe(0);
+    expect(values["reauth.previous"]).toBe(false);
+    expect(values["reauth.transitioned"]).toBe(true);
+    expect(values.outcome).toBe("success");
+    expect(accountNeedsReauthentication).toBe(true);
+  });
+
+  it("logs a clear carrying the provenance the demand was standing under", async () => {
+    accountNeedsReauthentication = true;
+    accountDemandSource = "token-refresh";
+
+    await runTick();
+
+    const { values } = demandEvent();
+    expect(values["reauth.action"]).toBe("clear");
+    expect(values["reauth.provenance"]).toBe("source-ingest");
+    expect(values["reauth.recorded_provenance"]).toBe("token-refresh");
+    expect(values["reauth.deciding_vote"]).toBe("authenticated");
+    expect(values["reauth.votes.authenticated"]).toBe(1);
+    expect(values["reauth.previous"]).toBe(true);
+    expect(values["reauth.transitioned"]).toBe(true);
+    expect(accountNeedsReauthentication).toBe(false);
+  });
+
+  it("logs a suppressed clear when the standing demand is not ingest-adjudicable", async () => {
+    accountNeedsReauthentication = true;
+    accountDemandSource = "destination-grant";
+
+    await runTick();
+
+    const { values } = demandEvent();
+    expect(values["reauth.action"]).toBe("clear");
+    expect(values["reauth.suppressed"]).toBe(true);
+    expect(values["reauth.recorded_provenance"]).toBe("destination-grant");
+    expect(values.outcome).toBe("skipped");
+    expect(writes).toEqual([]);
+    expect(accountNeedsReauthentication).toBe(true);
+  });
+
+  it("distinguishes a no-op raise over an already-raised flag from a real transition", async () => {
+    accountNeedsReauthentication = true;
+    accountDemandSource = "source-ingest";
+    sourcePullSucceeds = false;
+
+    await runTick();
+
+    const { values } = demandEvent();
+    expect(values["reauth.action"]).toBe("raise");
+    expect(values["reauth.previous"]).toBe(true);
+    expect(values["reauth.transitioned"]).toBe(false);
+    expect(writes).toEqual([]);
+  });
+
+  it("reports a failing demand write on the demand event without failing the tick", async () => {
+    accountNeedsReauthentication = true;
+    accountDemandSource = "source-ingest";
+    demandWriteFails = true;
+
+    await runTick();
+
+    const event = demandEvent();
+    expect(event.values.outcome).toBe("error");
+    expect(event.fields.slug).toBe("db-query-failed");
+    expect(accountNeedsReauthentication).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes the telemetry gap from the #643 reauth false-positive audit (see also #626): every writer of the account reauthentication flag now records the decision on its active wide event, so "did we tell a customer to reconnect working credentials?" is answerable straight from the logs instead of by reconstructing votes from ingest outcomes. Telemetry only — no write is added, removed, or re-ordered, and the cron vote resolution now lands as its own `reauthentication-demand` event per account. Note: `services/cron/src/jobs/ingest-sources.ts` is also touched by open PRs #625 and #634; the hunk here is confined to `applyReauthenticationDemands` and new helpers beside it.

- Fields: `reauth.action`, `reauth.provenance`, `reauth.previous`, `reauth.transitioned`, `reauth.signal`, `reauth.recorded_provenance`, plus `reauth.votes.*`, `reauth.deciding_vote`, and `reauth.suppressed` at vote resolution — an unopposed single-calendar rejection is visible as such
- Covers all four writers: destination-grant (API oauth callback request event), token-refresh (coordinated refresher, via `widelog` in whatever context runs it: cron per-source, worker job, API request), source-credentials (CalDAV source provider — currently has no production caller, so instrumented but unreachable until one exists), and source-ingest incl. suppressed clears over unadjudicable demands
- Prior flag state comes from the guarded update's `RETURNING` (cron) or a contained pre-read that degrades to `reauth.previous_read_failed` rather than altering the write path; a consecutive-failure count is not emitted because no writer tracks one for auth failures (ingest backoff deliberately excludes them)
- Proven red-first per writer, then re-proven by gutting the field builder (all five new test files fail); the cron and packages/calendar tests assert on JSON lines parsed from the real widelogger/pino stdout stream, not a mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)