### PR TITLE
fix: deflake pool-telemetry burst and overhead tests on contended runners

### DIFF
--- a/packages/database/tests/utils/pool-telemetry-burst.test.ts
+++ b/packages/database/tests/utils/pool-telemetry-burst.test.ts
@@ -47,11 +47,14 @@ describe.skipIf(!TEST_DATABASE_URL)("database pool telemetry under a burst of tr
         const sample = window();
 
         const waited = burst.startOffsetsMs.filter((offset) => offset > STATEMENT_SECONDS * 500);
+        // Scheduling stalls on a contended runner can push any start past the threshold, so only the pool-derived lower bound is deterministic.
+        const mustHaveWaited = 6 - POOL_MAX;
 
-        expect(waited.length).toBe(4);
+        expect(waited.length).toBeGreaterThanOrEqual(mustHaveWaited);
         expect(burst.wallMs).toBeGreaterThan(STATEMENT_SECONDS * 1000 * 2);
         expect(sample.queryCount).toBe(6);
-        expect(sample.queuedQueryCount).toBeGreaterThanOrEqual(waited.length);
+        expect(sample.queuedQueryCount).toBeGreaterThanOrEqual(mustHaveWaited);
+        expect(sample.queuedQueryCount).toBeLessThanOrEqual(6);
       });
     } finally {
       await sql.end();

--- a/packages/database/tests/utils/pool-telemetry-demand.test.ts
+++ b/packages/database/tests/utils/pool-telemetry-demand.test.ts
@@ -102,36 +102,45 @@ describe("database pool telemetry demand accounting", () => {
     expect(samples).toEqual([0, 0, 0, 0, 0]);
   });
 
-  it("adds well under a microsecond of overhead per query", async () => {
-    const { client, pending } = createDeferredClient();
-    const iterations = 5000;
+  /*
+   * A single involuntary preemption on a contended CI runner adds tens of milliseconds
+   * to a two-millisecond batch, which reads as ~10µs/query of phantom overhead — any
+   * budget loose enough to absorb that would no longer prove the instrumentation is
+   * cheap. Opt in on quiet hardware; CI reports it as skipped, never silently absent.
+   */
+  it.runIf(Boolean(process.env.KEEPER_PERF_TESTS))(
+    "adds well under a microsecond of overhead per query",
+    async () => {
+      const { client, pending } = createDeferredClient();
+      const iterations = 5000;
 
-    const runBatch = async (): Promise<number> => {
-      const startedAt = performance.now();
-      for (let index = 0; index < iterations; index += 1) {
-        const query = client.unsafe("select 1") as { values: () => Promise<unknown> };
-        pending.at(-1)?.resolve([]);
-        await query.values();
-      }
-      return performance.now() - startedAt;
-    };
+      const runBatch = async (): Promise<number> => {
+        const startedAt = performance.now();
+        for (let index = 0; index < iterations; index += 1) {
+          const query = client.unsafe("select 1") as { values: () => Promise<unknown> };
+          pending.at(-1)?.resolve([]);
+          await query.values();
+        }
+        return performance.now() - startedAt;
+      };
 
-    // Fastest of several batches: a single batch is swamped by JIT warm-up and GC.
-    const runFastestBatch = async (): Promise<number> => {
-      let fastestMs = Number.POSITIVE_INFINITY;
-      for (let round = 0; round < 4; round += 1) {
-        fastestMs = Math.min(fastestMs, await runBatch());
-      }
-      return fastestMs;
-    };
+      // Fastest of several batches: a single batch is swamped by JIT warm-up and GC.
+      const runFastestBatch = async (): Promise<number> => {
+        let fastestMs = Number.POSITIVE_INFINITY;
+        for (let round = 0; round < 4; round += 1) {
+          fastestMs = Math.min(fastestMs, await runBatch());
+        }
+        return fastestMs;
+      };
 
-    const plainMs = await runFastestBatch();
-    instrumentDatabasePool(client, 10);
-    const instrumentedMs = await runFastestBatch();
+      const plainMs = await runFastestBatch();
+      instrumentDatabasePool(client, 10);
+      const instrumentedMs = await runFastestBatch();
 
-    const overheadPerQueryUs = ((instrumentedMs - plainMs) / iterations) * 1000;
-    expect(overheadPerQueryUs).toBeLessThan(5);
-  });
+      const overheadPerQueryUs = ((instrumentedMs - plainMs) / iterations) * 1000;
+      expect(overheadPerQueryUs).toBeLessThan(5);
+    },
+  );
 });
 
 describe.skipIf(!TEST_DATABASE_URL)("database pool telemetry against postgres", () => {


### PR DESCRIPTION
Two timing-sensitive assertions from #629 started flaking on unrelated PRs once #638 made CI actually run the database suites on a contended two-core runner. Both reproduce in a 1-CPU container with competing load: the burst test fails with all 6 offsets past the threshold (waited 5-6 instead of exactly 4), and the overhead microbenchmark reads 17-19µs of phantom per-query cost from a single preemption. Reproduced pre-fix at 9/15 passing under that contention; post-fix 25/25.

- Burst: exact `waited.length === 4` becomes the pool-derived bound `>= 6 - max`; telemetry must report `queuedQueryCount` between that bound and 6, so undercounting and double-instrumentation both still fail.
- Overhead: a wall-clock microbenchmark cannot gate on shared CI, so it is opt-in via `KEEPER_PERF_TESTS` and reported as skipped otherwise, with the 5µs budget unchanged locally.
- Root lint/types green; only expected failure repo-wide is build-vtimezone (#492).

🤖 Generated with [Claude Code](https://claude.com/claude-code)