### PR TITLE
test(caldav): regression guard for the fall-back repeated hour (#608)

### DIFF
--- a/packages/calendar/tests/core/sync-engine/degenerate-range-caldav-convergence.test.ts
+++ b/packages/calendar/tests/core/sync-engine/degenerate-range-caldav-convergence.test.ts
@@ -275,6 +275,22 @@ describe("caldav convergence near a dst transition", () => {
     },
     {
       event: buildEvent({
+        endTime: new Date("2026-11-01T06:00:00.000Z"),
+        startTime: new Date("2026-11-01T05:30:00.000Z"),
+        startTimeZone: "America/New_York",
+      }),
+      name: "thirty-minute event on the first pass of a fall-back repeated hour",
+    },
+    {
+      event: buildEvent({
+        endTime: new Date("2026-11-01T07:00:00.000Z"),
+        startTime: new Date("2026-11-01T06:30:00.000Z"),
+        startTimeZone: "America/New_York",
+      }),
+      name: "thirty-minute event on the second pass of a fall-back repeated hour",
+    },
+    {
+      event: buildEvent({
         endTime: new Date("2027-03-14T06:59:30.000Z"),
         startTime: new Date("2027-03-14T06:59:30.000Z"),
         startTimeZone: "America/New_York",


### PR DESCRIPTION
Issue #608 no longer reproduces on main: #616's UTC fall-back for ambiguous wall times plus IANA-authoritative TZID resolution fixed it incidentally, and production CalDAV delete/re-create churn went to zero within two runs of v2.14.9. Since the fix was a side effect rather than targeted, this pins the reconciler-level convergence for both passes of the repeated hour — the issue's exact America/New_York instants — so it cannot regress silently.

- Both cases pass on main; the first-pass case (write 05:30Z, read back 06:30Z — #608's repro) fails when run against pre-#616 source
- ICS-level coverage for both passes already exists in `zoned-instant-resolution.test.ts`; this adds the missing reconciler-level second-pass and New York cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BQkcrAZNXz7au7KkkT7JV