### PR TITLE
fix: stop pool max-lifetime retirement from killing in-flight queries

### DIFF
--- a/packages/database/src/utils/database.ts
+++ b/packages/database/src/utils/database.ts
@@ -12,7 +12,16 @@ const DEFAULT_STATEMENT_TIMEOUT_MS = 30_000;
 const DEFAULT_IDLE_IN_TRANSACTION_TIMEOUT_MS = 30_000;
 const POOL_MAX_CONNECTIONS = 10;
 const POOL_IDLE_TIMEOUT_SECONDS = 30;
-const POOL_MAX_LIFETIME_SECONDS = 1800;
+/*
+ * Bun 1.3.14 retires a connection the moment maxLifetime elapses even with a
+ * query in flight — onMaxLifetimeTimeout never checks hasQueryRunning — so the
+ * healthy query dies with ERR_POSTGRES_LIFETIME_TIMEOUT and is never retried
+ * (oven-sh/bun#30646; fix #30648 unmerged). With 1800 this killed better-auth
+ * session reads on a 30-minute cadence, turning every authed route into a 500.
+ * 0 disables age-based retirement; idle connections are still reaped by
+ * idleTimeout, so the pool does not accumulate stale connections.
+ */
+const POOL_MAX_LIFETIME_SECONDS = 0;
 /*
  * Bun 1.3.14 delivers one query's DataRows to a different query on the same
  * connection: an already-prepared query's Bind+Execute is written ahead of an

--- a/packages/database/tests/utils/database-pool-lifetime.test.ts
+++ b/packages/database/tests/utils/database-pool-lifetime.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { SQL } from "bun";
+import { closeDatabase, createDatabase } from "../../src/utils/database";
+
+const TEST_DATABASE_URL = process.env.KEEPER_TEST_DATABASE_URL;
+
+/*
+ * Bun 1.3.14 retires a pooled connection the instant maxLifetime elapses, even
+ * with a query in flight: onMaxLifetimeTimeout never consults hasQueryRunning,
+ * so the healthy query dies with ERR_POSTGRES_LIFETIME_TIMEOUT and nothing
+ * retries it (oven-sh/bun#30646; fix #30648 unmerged as of 1.3.14). Production
+ * saw this kill better-auth session reads every ~30 minutes, turning every
+ * authed route into a 500. The only safe value is 0; these tests pin both the
+ * driver defect and the production pool configuration that avoids it.
+ */
+describe.skipIf(!TEST_DATABASE_URL)("pool max lifetime with a query in flight", () => {
+  it("kills a healthy in-flight query when a non-zero maxLifetime elapses", async () => {
+    const sql = new SQL({ max: 1, maxLifetime: 2, prepare: false, url: TEST_DATABASE_URL });
+    try {
+      await sql.unsafe("select 1", []);
+      await Bun.sleep(500);
+      const failure = await sql.unsafe("select pg_sleep(3)", []).then(
+        () => null,
+        (error: unknown) => error,
+      );
+      expect(failure).not.toBeNull();
+      expect((failure as { code?: string }).code).toBe("ERR_POSTGRES_LIFETIME_TIMEOUT");
+    } finally {
+      await sql.close();
+    }
+  }, 15_000);
+
+  it("keeps connection retirement by age disabled in the production pool", async () => {
+    const database = await createDatabase(TEST_DATABASE_URL ?? "");
+    try {
+      expect(database.$client.options.maxLifetime).toBe(0);
+    } finally {
+      closeDatabase(database);
+    }
+  }, 15_000);
+
+  it("leaves in-flight queries untouched when maxLifetime is disabled", async () => {
+    const unretired = new SQL({ max: 1, maxLifetime: 0, prepare: false, url: TEST_DATABASE_URL });
+    try {
+      await unretired.unsafe("select 1", []);
+      const [row] = (await unretired.unsafe(
+        "select pg_sleep(2.5), 'survived' as outcome",
+        [],
+      )) as { outcome: string }[];
+      expect(row?.outcome).toBe("survived");
+    } finally {
+      await unretired.close();
+    }
+  }, 15_000);
+});


### PR DESCRIPTION
Bun 1.3.14's pool fails a connection the instant `maxLifetime` elapses — `onMaxLifetimeTimeout` never checks for a query in flight — so healthy queries die with `ERR_POSTGRES_LIFETIME_TIMEOUT` and nothing retries them (oven-sh/bun#30646; fix oven-sh/bun#30648 unmerged, no release changes this). With our 1800s lifetime this killed the better-auth session read on a ~30-minute cadence (500 on every authed route) plus cron ingest and worker jobs; Loki shows bursts clustered at :02/:32, matching connection cohorts aging out together. Setting the lifetime to 0 removes the failure mode entirely; idleTimeout still reaps idle connections, so nothing accumulates.

- Rejected blanket retry on `ERR_POSTGRES_LIFETIME_TIMEOUT`: unsafe for non-idempotent writes (a statement can commit server-side before the socket dies), and reads-only classification has no central choke point.
- Rejected call-site retry on the session read: leaves cron/worker failures in place and patches a symptom the config change removes at the source.
- New live test proves the mechanism (non-zero `maxLifetime` kills an in-flight `pg_sleep`), pins the shipped pool config at 0 (red before, green after), and shows 0 leaves in-flight queries untouched.

Note: the same driver race exists for `idleTimeout` (~2k worker job failures/day as `Idle timeout reached after 30s`) — left for a follow-up since disabling it changes pool capacity behavior.

Fixes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BQkcrAZNXz7au7KkkT7JV