### PR TITLE
fix(caldav): download only Keeper-named objects on destination reconciliation

### DIFF
--- a/packages/calendar/src/providers/caldav/destination/provider.ts
+++ b/packages/calendar/src/providers/caldav/destination/provider.ts
@@ -182,14 +182,21 @@ const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
 
   const rateLimiter = new RateLimiter({ concurrency: CALDAV_RATE_LIMIT_CONCURRENCY });
 
-  const isKeeperCalendarObjectUrl = (objectUrl: string): boolean => {
+  const isKeeperCalendarObjectPath = (path: string): boolean => {
     try {
-      const url = new URL(objectUrl, config.calendarUrl);
-      const filename = decodeURIComponent(url.pathname.split("/").at(-1) ?? "");
+      const filename = decodeURIComponent(path.split("/").at(-1) ?? "");
       if (!filename.endsWith(".ics")) {
         return false;
       }
       return isKeeperEvent(filename.slice(0, -4));
+    } catch {
+      return false;
+    }
+  };
+
+  const isKeeperCalendarObjectUrl = (objectUrl: string): boolean => {
+    try {
+      return isKeeperCalendarObjectPath(new URL(objectUrl, config.calendarUrl).pathname);
     } catch {
       return false;
     }
@@ -298,6 +305,7 @@ const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
     const objects = await client.fetchCalendarObjects({
       calendarUrl,
       onListing: (stats) => { listing = stats; },
+      pathFilter: isKeeperCalendarObjectPath,
     });
 
     const remoteEvents: RemoteEvent[] = [];

--- a/packages/calendar/src/providers/caldav/shared/client.ts
+++ b/packages/calendar/src/providers/caldav/shared/client.ts
@@ -298,6 +298,7 @@ class CalDAVClient {
   fetchCalendarObjects(params: {
     calendarUrl: string;
     onListing?: (stats: CalDAVListingStats) => void;
+    pathFilter?: (path: string) => boolean;
     timeRange?: { start: string; end: string };
   }): Promise<CalendarObject[]> {
     return mapAuthenticationFailure(async () => {
@@ -311,7 +312,7 @@ class CalDAVClient {
       });
 
       const listedPaths = toCalendarObjectPaths(queryResponses, params.calendarUrl);
-      const requestedPaths = listedPaths;
+      const requestedPaths = listedPaths.filter((path) => params.pathFilter?.(path) ?? true);
       if (requestedPaths.length === 0) {
         params.onListing?.({
           listedCount: listedPaths.length,

--- a/packages/calendar/tests/providers/caldav/destination/provider.test.ts
+++ b/packages/calendar/tests/providers/caldav/destination/provider.test.ts
@@ -116,7 +116,26 @@ describe("createCalDAVSyncProvider", () => {
     expect(clientMocks.fetchCalendarObjects).toHaveBeenCalledWith({
       calendarUrl: "https://caldav.example.com/calendar/",
       onListing: expect.any(Function),
+      pathFilter: expect.any(Function),
     });
+  });
+
+  it("asks the server for Keeper-named objects only", async () => {
+    const keeperUid = generateDeterministicEventUid("any-event-id");
+    clientMocks.resolveCalendarUrl.mockResolvedValueOnce(
+      "https://caldav.example.com/calendar/",
+    );
+    clientMocks.fetchCalendarObjects.mockResolvedValueOnce([]);
+
+    await createProvider().listRemoteEvents({
+      timeMin: new Date("2026-07-10T00:00:00.000Z"),
+    });
+
+    const { pathFilter } = clientMocks.fetchCalendarObjects.mock.calls[0]?.[0] ?? {};
+    expect(pathFilter(`/calendar/${keeperUid}.ics`)).toBe(true);
+    expect(pathFilter(`/calendar/${encodeURIComponent(keeperUid)}.ics`)).toBe(true);
+    expect(pathFilter("/calendar/user-owned.ics")).toBe(false);
+    expect(pathFilter(`/calendar/${keeperUid}.txt`)).toBe(false);
   });
 
   it("does not let an unrelated user RDATE abort Keeper reconciliation", async () => {

--- a/packages/calendar/tests/providers/caldav/shared/client-multiget.test.ts
+++ b/packages/calendar/tests/providers/caldav/shared/client-multiget.test.ts
@@ -288,6 +288,51 @@ describe("CalDAVClient.fetchCalendarObjects listing diagnostics", () => {
   });
 });
 
+describe("CalDAVClient.fetchCalendarObjects with a path filter", () => {
+  const acceptedPath = `${CALENDAR_PATH}accepted.ics`;
+  const rejectedPath = `${CALENDAR_PATH}rejected.ics`;
+  const acceptOnly = (path: string): boolean => path === acceptedPath;
+
+  const fetchFilteredObjects = () =>
+    createClient().fetchCalendarObjects({ calendarUrl: CALENDAR_URL, pathFilter: acceptOnly });
+
+  it("downloads only the hrefs the filter accepts", async () => {
+    answerQueryWith([rejectedPath, acceptedPath]);
+
+    const objects = await fetchFilteredObjects();
+
+    expect(requestedBatches()).toEqual([[acceptedPath]]);
+    expect(pathsOf(objects)).toEqual([acceptedPath]);
+  });
+
+  it("issues no multiget when the filter rejects every href", async () => {
+    answerQueryWith([rejectedPath]);
+
+    await expect(fetchFilteredObjects()).resolves.toEqual([]);
+    expect(davMocks.fetchCalendarObjects).not.toHaveBeenCalled();
+  });
+
+  it("does not count filtered-out hrefs as missing", async () => {
+    answerQueryWith([rejectedPath, acceptedPath]);
+    answerMultigetWith((objectUrls) => rowsFor(objectUrls));
+
+    await expect(fetchFilteredObjects()).resolves.toHaveLength(1);
+  });
+
+  it("still rejects when an accepted href is never returned", async () => {
+    answerQueryWith([rejectedPath, acceptedPath]);
+    answerMultigetWith(() => []);
+
+    const error = await captureRejection(fetchFilteredObjects);
+
+    expect(error).toMatchObject({
+      hrefsRequested: 1,
+      name: "CalDAVIncompleteMultiGetError",
+    });
+    expect((error as { missingHrefs: string[] }).missingHrefs).toEqual([acceptedPath]);
+  });
+});
+
 describe("CalDAVIncompleteMultiGetError", () => {
   const createError = () =>
     new CalDAVIncompleteMultiGetError({


### PR DESCRIPTION
Fixes #593. The CalDAV destination read must stay unbounded in time to find every object Keeper ever wrote, but it was downloading the entire calendar and only then discarding non-Keeper objects in memory. Keeper filenames are recognisable from the calendar-query hrefs alone, so `fetchCalendarObjects` now takes a `pathFilter` and the destination multigets only its own objects — the etag listing still sees the whole collection, and the incomplete-multiget guard still covers everything actually requested.

- Production (last 24h): 65 CalDAV destination calendars, ~15.6k destination runs/day, remote read median 4.3s / p90 14.1s, ~25.5h/day of remote-read wall time — and the median run keeps **zero** Keeper events after downloading everything.
- No `time-range` added anywhere, per the analysis on #593: completeness over Keeper's own objects is preserved because the filter is by filename, not by time.
- Red-first tests: client-level (filtered hrefs are never requested, filtered-out hrefs don't trip the completeness guard, missing accepted hrefs still do) and destination-level (the filter accepts Keeper-named `.ics` paths, including percent-encoded, and nothing else).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BQkcrAZNXz7au7KkkT7JV
