### PR TITLE
fix: delete CalDAV mirrors at their listed object URL

### DIFF
--- a/packages/calendar/src/core/sync-engine/index.ts
+++ b/packages/calendar/src/core/sync-engine/index.ts
@@ -268,9 +268,10 @@ const processDeleteResults = (
     }
 
     removed += 1;
-    const mapping = mappingsByRemoteIdentity.get(`${operation.uid}\u0000${operation.deleteId}`);
-    if (mapping) {
-      deleteIds.push(mapping.id);
+    const mappingId = operation.mappingId
+      ?? mappingsByRemoteIdentity.get(`${operation.uid}\u0000${operation.deleteId}`)?.id;
+    if (mappingId) {
+      deleteIds.push(mappingId);
     }
   }
 

--- a/packages/calendar/src/core/sync/operations.ts
+++ b/packages/calendar/src/core/sync/operations.ts
@@ -419,6 +419,7 @@ const buildAddOperations = (
 const buildRemoveOperationsForMappings = (mappings: EventMapping[]): SyncOperation[] =>
   mappings.map((mapping) => ({
     deleteId: mapping.deleteIdentifier,
+    mappingId: mapping.id,
     startTime: mapping.startTime,
     type: "remove",
     uid: mapping.destinationEventUid,
@@ -525,6 +526,7 @@ const buildRemoveOperations = (
     ) {
       operations.push({
         deleteId: resolveMappingDeleteId(mapping, remoteEventsByMappingId),
+        mappingId: mapping.id,
         startTime: mapping.startTime,
         type: "remove",
         uid: mapping.destinationEventUid,

--- a/packages/calendar/src/core/types.ts
+++ b/packages/calendar/src/core/types.ts
@@ -142,7 +142,7 @@ interface RemoteEvent {
 
 type SyncOperation =
   | { type: "add"; event: MaterializedSyncableEvent; staleMappingId?: string }
-  | { type: "remove"; uid: string; deleteId: string; startTime: Date }
+  | { type: "remove"; uid: string; deleteId: string; startTime: Date; mappingId?: string }
   | {
     type: "replace";
     event: MaterializedSyncableEvent;

--- a/packages/calendar/src/providers/caldav/destination/provider.ts
+++ b/packages/calendar/src/providers/caldav/destination/provider.ts
@@ -250,22 +250,32 @@ const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
     );
   };
 
+  /* Listed deleteIds are object paths; deleteIds stored before path recording are bare UIDs. */
+  const deleteEventObject = (deleteId: string): Promise<void> => {
+    if (deleteId.includes("/")) {
+      return client.deleteCalendarObjectByUrl({
+        objectUrl: new URL(deleteId, config.calendarUrl).href,
+      });
+    }
+    return client.deleteCalendarObject({
+      calendarUrl: config.calendarUrl,
+      filename: `${deleteId}.ics`,
+    });
+  };
+
   const deleteEvents = (eventIds: string[]): Promise<DeleteResult[]> =>
     Promise.all(
-      eventIds.map((uid) =>
+      eventIds.map((deleteId) =>
         rateLimiter.execute(async (): Promise<DeleteResult> => {
           removeAttempts += 1;
-          if (uid.includes("/")) {
+          if (deleteId.includes("/")) {
             removeCounts.byPath += 1;
           } else {
             removeCounts.byUid += 1;
           }
 
           try {
-            await client.deleteCalendarObject({
-              calendarUrl: config.calendarUrl,
-              filename: `${uid}.ics`,
-            });
+            await deleteEventObject(deleteId);
             removeCounts.succeeded += 1;
             return { success: true };
           } catch (error) {
@@ -302,38 +312,43 @@ const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
 
     const remoteEvents: RemoteEvent[] = [];
 
-    const resources = parseICalCalendarsToRemoteEvents(
-      objects.flatMap(({ data, url }) => {
-        if (!data || !isKeeperCalendarObjectUrl(url)) {
-          return [];
-        }
-        return [data];
-      }),
-      { rejectUnsupportedRecurrenceDates: false },
-    );
-    assertAllResourcesRead(resources);
-    assertAllEventsSupported(resources);
-    for (const parsed of resources.events) {
-      if (!isKeeperEvent(parsed.uid) || resolveTimeRangeEnd(parsed) < options.timeMin) {
-        continue;
+    const keeperObjects = objects.flatMap(({ data, url }) => {
+      if (!data || !isKeeperCalendarObjectUrl(url)) {
+        return [];
       }
+      return [{ data, url }];
+    });
+    for (const { data, url } of keeperObjects) {
+      const resources = parseICalCalendarsToRemoteEvents(
+        [data],
+        { rejectUnsupportedRecurrenceDates: false },
+      );
+      assertAllResourcesRead(resources);
+      assertAllEventsSupported(resources);
+      const objectPath = new URL(url, calendarUrl).pathname;
+      for (const parsed of resources.events) {
+        if (!isKeeperEvent(parsed.uid) || resolveTimeRangeEnd(parsed) < options.timeMin) {
+          continue;
+        }
 
-      const editableContent = createEditableEventContentSnapshot({
-        availability: parsed.availability,
-        description: parsed.description,
-        endTime: parsed.endTime,
-        isAllDay: parsed.isAllDay,
-        location: parsed.location,
-        startTime: parsed.startTime,
-        summary: parsed.title ?? "",
-      });
-      remoteEvents.push({
-        ...parsed,
-        editableAvailability: parsed.availability,
-        editableContent,
-        editableContentHash: hashEditableEventContentSnapshot(editableContent),
-        supportedAvailabilities: ["busy", "free"],
-      });
+        const editableContent = createEditableEventContentSnapshot({
+          availability: parsed.availability,
+          description: parsed.description,
+          endTime: parsed.endTime,
+          isAllDay: parsed.isAllDay,
+          location: parsed.location,
+          startTime: parsed.startTime,
+          summary: parsed.title ?? "",
+        });
+        remoteEvents.push({
+          ...parsed,
+          deleteId: objectPath,
+          editableAvailability: parsed.availability,
+          editableContent,
+          editableContentHash: hashEditableEventContentSnapshot(editableContent),
+          supportedAvailabilities: ["busy", "free"],
+        });
+      }
     }
 
     return remoteEvents;

--- a/packages/calendar/src/providers/caldav/shared/client.ts
+++ b/packages/calendar/src/providers/caldav/shared/client.ts
@@ -269,11 +269,20 @@ class CalDAVClient {
     filename: string;
     etag?: string;
   }): Promise<void> {
+    await this.deleteCalendarObjectByUrl({
+      etag: params.etag,
+      objectUrl: CalDAVClient.normalizeUrl(params.calendarUrl, params.filename),
+    });
+  }
+
+  async deleteCalendarObjectByUrl(params: {
+    objectUrl: string;
+    etag?: string;
+  }): Promise<void> {
     const client = await this.getClient();
-    const objectUrl = CalDAVClient.normalizeUrl(params.calendarUrl, params.filename);
 
     const response = await client.deleteCalendarObject({
-      calendarObject: { url: objectUrl, etag: params.etag },
+      calendarObject: { url: params.objectUrl, etag: params.etag },
     });
 
     await assertSuccessfulResponse(response, "delete");

--- a/packages/calendar/tests/core/sync-engine/index.test.ts
+++ b/packages/calendar/tests/core/sync-engine/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { executeRemoteOperations, OPERATION_ERROR_SAMPLE_SIZE } from "../../../src/core/sync-engine/index";
+import { computeSyncOperations } from "../../../src/core/sync/operations";
 import type {
   DeleteResult,
   MaterializedSyncableEvent,
@@ -67,6 +68,35 @@ const makeProvider = (overrides: Partial<{
 });
 
 describe("executeRemoteOperations", () => {
+  it("retires a mapping whose remove targeted the listed object path instead of the stored delete identifier", async () => {
+    const mapping = makeMapping("map-1", "ev-1", "abc123@keeper.sh");
+    const remoteEvent = {
+      deleteId: "/calendar/renamed-object@keeper.sh.ics",
+      endTime: mapping.endTime,
+      isKeeperEvent: true,
+      startTime: mapping.startTime,
+      uid: mapping.destinationEventUid,
+    };
+    const { operations } = computeSyncOperations(
+      [],
+      [mapping],
+      [remoteEvent],
+      TEST_RECONCILIATION_SCOPE,
+    );
+    expect(operations).toEqual([expect.objectContaining({
+      deleteId: "/calendar/renamed-object@keeper.sh.ics",
+      type: "remove",
+    })]);
+    const provider = makeProvider({
+      deleteEvents: (ids) => Promise.resolve(ids.map(() => ({ success: true }))),
+    });
+
+    const outcome = await executeRemoteOperations(operations, [mapping], "dest-cal-1", provider);
+
+    expect(outcome.result.removed).toBe(1);
+    expect(outcome.changes.deletes).toEqual(["map-1"]);
+  });
+
   it("accumulates mapping inserts from successful pushes", async () => {
     const event = makeEvent("ev-1", new Date("2026-03-15T09:00:00Z"), new Date("2026-03-15T10:00:00Z"));
     const operations: SyncOperation[] = [{ type: "add", event }];

--- a/packages/calendar/tests/core/sync/operations.test.ts
+++ b/packages/calendar/tests/core/sync/operations.test.ts
@@ -178,6 +178,7 @@ describe("buildRemoveOperations", () => {
     expect(operations).toHaveLength(1);
     expect(operations[0]).toEqual({
       deleteId: "future-delete-id",
+      mappingId: "future-mapping-id",
       startTime: new Date("2026-03-08T13:00:00.000Z"),
       type: "remove",
       uid: "future-uid",
@@ -268,6 +269,7 @@ describe("buildRemoveOperations", () => {
       { syncWindowStart: new Date("2026-03-01T00:00:00.000Z") },
     )).toEqual([{
       deleteId: mapping.deleteIdentifier,
+      mappingId: "mapping-id-1",
       startTime: mapping.startTime,
       type: "remove",
       uid: mapping.destinationEventUid,
@@ -340,6 +342,7 @@ describe("computeSyncOperations", () => {
     expect(operations).toEqual([
       {
         deleteId: "google-event-id",
+        mappingId: "mapping-id-1",
         startTime: mapping.startTime,
         type: "remove",
         uid: "legacy-uid@google.com",
@@ -454,6 +457,7 @@ describe("computeSyncOperations", () => {
       mappingUpdates: [],
       operations: [{
         deleteId: mapping.deleteIdentifier,
+        mappingId: "expired-occurrence-mapping",
         startTime: mapping.startTime,
         type: "remove",
         uid: mapping.destinationEventUid,
@@ -933,6 +937,7 @@ describe("computeSyncOperations", () => {
     ]);
     expect(result.operations).toEqual([{
       deleteId: "google-provider-id-1",
+      mappingId: "legacy-mapping-1",
       startTime: removedSlot.startTime,
       type: "remove",
       uid: "legacy-1@keeper.sh",
@@ -1054,6 +1059,7 @@ describe("computeSyncOperations", () => {
 
     expect(result.operations).toEqual([{
       deleteId: outsideMapping.deleteIdentifier,
+      mappingId: "outside-mapping",
       startTime: outsideMapping.startTime,
       type: "remove",
       uid: outsideMapping.destinationEventUid,
@@ -1147,6 +1153,7 @@ describe("computeSyncOperations", () => {
 
     expect(result.operations).toEqual([{
       deleteId: deletedSourceMapping.deleteIdentifier,
+      mappingId: "deleted-source-mapping",
       startTime: deletedSourceMapping.startTime,
       type: "remove",
       uid: deletedSourceMapping.destinationEventUid,
@@ -1179,6 +1186,7 @@ describe("computeSyncOperations", () => {
 
     expect(result.operations).toEqual([{
       deleteId: deletedSourceMapping.deleteIdentifier,
+      mappingId: "migration-window-tombstone",
       startTime: deletedSourceMapping.startTime,
       type: "remove",
       uid: deletedSourceMapping.destinationEventUid,
@@ -1208,6 +1216,7 @@ describe("computeSyncOperations", () => {
 
     expect(result.operations).toEqual([{
       deleteId: farFutureMapping.deleteIdentifier,
+      mappingId: "far-future-mapping",
       startTime: farFutureMapping.startTime,
       type: "remove",
       uid: farFutureMapping.destinationEventUid,
@@ -1235,6 +1244,7 @@ describe("computeSyncOperations", () => {
 
     expect(result.operations).toEqual([{
       deleteId: beyondEdgeMapping.deleteIdentifier,
+      mappingId: "beyond-edge-mapping",
       startTime: beyondEdgeMapping.startTime,
       type: "remove",
       uid: beyondEdgeMapping.destinationEventUid,
@@ -1284,6 +1294,7 @@ describe("computeSyncOperations", () => {
 
     expect(result.operations).toEqual([{
       deleteId: withheldOutsideMapping.deleteIdentifier,
+      mappingId: "over-budget-outside-mapping",
       startTime: withheldOutsideMapping.startTime,
       type: "remove",
       uid: withheldOutsideMapping.destinationEventUid,

--- a/packages/calendar/tests/providers/caldav/destination/provider.test.ts
+++ b/packages/calendar/tests/providers/caldav/destination/provider.test.ts
@@ -8,6 +8,7 @@ import { eventToICalString } from "../../../../src/providers/caldav/shared/ics";
 const clientMocks = vi.hoisted(() => ({
   createCalendarObject: vi.fn(),
   deleteCalendarObject: vi.fn(),
+  deleteCalendarObjectByUrl: vi.fn(),
   fetchCalendarObject: vi.fn(),
   fetchCalendarObjects: vi.fn(),
   resolveCalendarUrl: vi.fn(),
@@ -34,6 +35,7 @@ vi.mock("../../../../src/providers/caldav/shared/client", () => {
   class CalDAVClient {
     createCalendarObject = clientMocks.createCalendarObject;
     deleteCalendarObject = clientMocks.deleteCalendarObject;
+    deleteCalendarObjectByUrl = clientMocks.deleteCalendarObjectByUrl;
     fetchCalendarObject = clientMocks.fetchCalendarObject;
     fetchCalendarObjects = clientMocks.fetchCalendarObjects;
     resolveCalendarUrl = clientMocks.resolveCalendarUrl;
@@ -245,6 +247,68 @@ describe("createCalDAVSyncProvider", () => {
       etag: "etag-1",
     }));
     expect(clientMocks.createCalendarObject).toHaveBeenCalledTimes(2);
+  });
+
+  it("lists a remote object's own path as its deleteId when the filename differs from the embedded UID", async () => {
+    const event = createEvent();
+    const embeddedUid = generateDeterministicEventUid(event.id);
+    const fileUid = generateDeterministicEventUid("a-different-event");
+    clientMocks.resolveCalendarUrl.mockResolvedValueOnce(
+      "https://caldav.example.com/calendar/",
+    );
+    clientMocks.fetchCalendarObjects.mockResolvedValueOnce([{
+      data: eventToICalString(event, embeddedUid),
+      url: `https://caldav.example.com/calendar/${fileUid}.ics`,
+    }]);
+
+    const remoteEvents = await createProvider().listRemoteEvents({
+      timeMin: new Date("2026-03-01T00:00:00.000Z"),
+    });
+
+    expect(remoteEvents).toHaveLength(1);
+    expect(remoteEvents[0]?.uid).toBe(embeddedUid);
+    expect(remoteEvents[0]?.deleteId).toBe(`/calendar/${fileUid}.ics`);
+  });
+
+  it("deletes a swept remote object at its listed URL rather than a UID-derived filename", async () => {
+    const event = createEvent();
+    const embeddedUid = generateDeterministicEventUid(event.id);
+    const fileUid = generateDeterministicEventUid("a-different-event");
+    clientMocks.resolveCalendarUrl.mockResolvedValueOnce(
+      "https://caldav.example.com/calendar/",
+    );
+    clientMocks.fetchCalendarObjects.mockResolvedValueOnce([{
+      data: eventToICalString(event, embeddedUid),
+      url: `https://caldav.example.com/calendar/${fileUid}.ics`,
+    }]);
+    clientMocks.deleteCalendarObjectByUrl.mockImplementationOnce(() => Promise.resolve());
+    const provider = createProvider();
+    const remoteEvents = await provider.listRemoteEvents({
+      timeMin: new Date("2026-03-01T00:00:00.000Z"),
+    });
+    const deleteId = remoteEvents[0]?.deleteId ?? "";
+
+    const results = await provider.deleteEvents([deleteId]);
+
+    expect(results).toEqual([{ success: true }]);
+    expect(clientMocks.deleteCalendarObjectByUrl).toHaveBeenCalledWith({
+      objectUrl: `https://caldav.example.com/calendar/${fileUid}.ics`,
+    });
+    expect(clientMocks.deleteCalendarObject).not.toHaveBeenCalled();
+  });
+
+  it("deletes a legacy UID deleteId at the calendar's UID-derived filename", async () => {
+    const uid = generateDeterministicEventUid("legacy-event");
+    clientMocks.deleteCalendarObject.mockImplementationOnce(() => Promise.resolve());
+    const provider = createProvider();
+
+    const results = await provider.deleteEvents([uid]);
+
+    expect(results).toEqual([{ success: true }]);
+    expect(clientMocks.deleteCalendarObject).toHaveBeenCalledWith({
+      calendarUrl: "https://caldav.example.com/calendar/",
+      filename: `${uid}.ics`,
+    });
   });
 
   it("returns structured diagnostics for a failed CalDAV write", async () => {


### PR DESCRIPTION
Fixes the #656 remove-only loop: the CalDAV destination deleted objects at a UID-derived filename, so any Keeper-tagged object whose filename differs from its embedded VEVENT UID got a 404 that was reported as success, and the same set was swept again every sync. Telemetry pinned it to the orphan-sweep path — every run lists the same Keeper-tagged remote events with zero mappings and zero local events, reports all removes succeeded, and the next run lists the identical set, so these are futile deletes (#617's shape), not silent data loss. The listing already had each object's real href; it now flows through `RemoteEvent.deleteId` and removes delete at that path.

- Bare-UID delete identifiers from stored mappings still resolve to `{uid}.ics`; the existing `mappingUpdates` machinery migrates them to object paths on the next matched sync, mirroring the Google delete-id migration.
- Remove operations now carry `mappingId` so mapping retirement no longer depends on reconstructing the remote identity from a stored delete identifier the listing has superseded.
- Red-first tests: destination provider path/UID mismatch listing + delete, legacy-UID delete, and engine-level mapping retirement; the one failing test in the calendar suite is the pre-existing Morocco VTIMEZONE case #652 fixes.

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BQkcrAZNXz7au7KkkT7JV