### PR TITLE
feat: per-server CalDAV listing and delete telemetry

### DIFF
--- a/packages/calendar/src/core/sync-engine/index.ts
+++ b/packages/calendar/src/core/sync-engine/index.ts
@@ -80,11 +80,12 @@ const createTimedProvider = (
   provider: CalendarSyncProvider,
   timer: ReturnType<typeof createPhaseTimer>,
 ): CalendarSyncProvider => {
-  const { getThrottleMetrics } = provider;
+  const { getSyncDiagnostics, getThrottleMetrics } = provider;
   return {
     deleteEvents: (eventIds) => timer.measure("provider_delete", () => provider.deleteEvents(eventIds)),
     listRemoteEvents: (options) => provider.listRemoteEvents(options),
     pushEvents: (events) => timer.measure("provider_push", () => provider.pushEvents(events)),
+    ...(getSyncDiagnostics && { getSyncDiagnostics: () => getSyncDiagnostics() }),
     ...(getThrottleMetrics && { getThrottleMetrics: () => getThrottleMetrics() }),
   };
 };
@@ -622,6 +623,15 @@ const appendThrottleFields = (
   event["provider.retry_after_ms"] = metrics.retryAfterMs;
 };
 
+const appendProviderDiagnostics = (
+  event: Record<string, unknown>,
+  diagnostics?: Record<string, number | string>,
+): void => {
+  for (const [field, value] of Object.entries(diagnostics ?? {})) {
+    event[field] = value;
+  }
+};
+
 const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarResult> => {
   const {
     userId,
@@ -788,6 +798,7 @@ const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarR
     wideEvent["duration_ms"] = Date.now() - startTime;
     timer.appendFields(wideEvent, performance.now() - reconcileStartedAt);
     appendThrottleFields(wideEvent, provider.getThrottleMetrics?.());
+    appendProviderDiagnostics(wideEvent, provider.getSyncDiagnostics?.());
     onSyncEvent?.(wideEvent);
   }
 };

--- a/packages/calendar/src/core/sync-engine/types.ts
+++ b/packages/calendar/src/core/sync-engine/types.ts
@@ -14,6 +14,7 @@ interface CalendarSyncProvider {
   deleteEvents: (eventIds: string[]) => Promise<DeleteResult[]>;
   listRemoteEvents: (options: ListRemoteEventsOptions) => Promise<RemoteEvent[]>;
   getThrottleMetrics?: () => ProviderThrottleMetrics;
+  getSyncDiagnostics?: () => Record<string, number | string>;
 }
 
 interface PendingInsert {

--- a/packages/calendar/src/providers/caldav/destination/provider.ts
+++ b/packages/calendar/src/providers/caldav/destination/provider.ts
@@ -14,6 +14,7 @@ import type {
   RemoteEvent,
 } from "../../../core/types";
 import { CalDAVClient, CalDAVCreateConflictError, CalDAVHttpError } from "../shared/client";
+import type { CalDAVListingStats } from "../shared/client";
 import {
   assertAllEventsSupported,
   assertAllResourcesRead,
@@ -129,7 +130,46 @@ const recoverCreateConflict = async (
   });
 };
 
+interface CalDAVRemoveCounts {
+  byPath: number;
+  byUid: number;
+  failureStatuses: Map<number, number>;
+  notFound: number;
+  succeeded: number;
+}
+
+const toRemoveDiagnostics = (counts: CalDAVRemoveCounts): Record<string, number> => ({
+  "events.remove_by_path": counts.byPath,
+  "events.remove_by_uid": counts.byUid,
+  "events.remove_not_found": counts.notFound,
+  "events.remove_succeeded": counts.succeeded,
+  ...Object.fromEntries(
+    [...counts.failureStatuses].map(([status, count]) => [
+      `events.remove_failed_status.${status}`,
+      count,
+    ]),
+  ),
+});
+
+const toListingDiagnostics = (listing: CalDAVListingStats): Record<string, number> => ({
+  "remote_objects.listed_count": listing.listedCount,
+  "remote_objects.requested_count": listing.requestedCount,
+  "remote_objects.returned_count": listing.returnedCount,
+  "remote_objects.unrequested_count": listing.unrequestedCount,
+});
+
 const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
+  const calendarHost = new URL(config.calendarUrl).hostname;
+  const removeCounts: CalDAVRemoveCounts = {
+    byPath: 0,
+    byUid: 0,
+    failureStatuses: new Map(),
+    notFound: 0,
+    succeeded: 0,
+  };
+  let removeAttempts = 0;
+  let listing: CalDAVListingStats | null = null;
+
   const client = new CalDAVClient({
     authMethod: config.authMethod,
     credentials: { password: config.password, username: config.username },
@@ -189,15 +229,34 @@ const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
       ),
     );
 
+  const recordRemoveFailure = (error: unknown): void => {
+    const httpError = findCalDAVHttpError(error);
+    if (!httpError) {
+      return;
+    }
+    removeCounts.failureStatuses.set(
+      httpError.status,
+      (removeCounts.failureStatuses.get(httpError.status) ?? 0) + 1,
+    );
+  };
+
   const deleteEvents = (eventIds: string[]): Promise<DeleteResult[]> =>
     Promise.all(
       eventIds.map((uid) =>
         rateLimiter.execute(async (): Promise<DeleteResult> => {
+          removeAttempts += 1;
+          if (uid.includes("/")) {
+            removeCounts.byPath += 1;
+          } else {
+            removeCounts.byUid += 1;
+          }
+
           try {
             await client.deleteCalendarObject({
               calendarUrl: config.calendarUrl,
               filename: `${uid}.ics`,
             });
+            removeCounts.succeeded += 1;
             return { success: true };
           } catch (error) {
             if (config.safeFetchOptions?.signal?.aborted) {
@@ -205,13 +264,21 @@ const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
             }
             const notFound = error instanceof CalDAVHttpError && error.status === 404;
             if (notFound) {
+              removeCounts.notFound += 1;
               return { success: true };
             }
+            recordRemoveFailure(error);
             return createFailureResult(error);
           }
         }, config.safeFetchOptions?.signal),
       ),
     );
+
+  const getSyncDiagnostics = (): Record<string, number | string> => ({
+    "provider.caldav.host": calendarHost,
+    ...(listing && toListingDiagnostics(listing)),
+    ...(removeAttempts > 0 && toRemoveDiagnostics(removeCounts)),
+  });
 
   const listRemoteEvents = async (
     options: ListRemoteEventsOptions,
@@ -220,6 +287,7 @@ const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
 
     const objects = await client.fetchCalendarObjects({
       calendarUrl,
+      onListing: (stats) => { listing = stats; },
     });
 
     const remoteEvents: RemoteEvent[] = [];
@@ -259,7 +327,13 @@ const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
     return remoteEvents;
   };
 
-  return { pushEvents, deleteEvents, listRemoteEvents, normalizeEvent: normalizeCalDAVEvent };
+  return {
+    pushEvents,
+    deleteEvents,
+    getSyncDiagnostics,
+    listRemoteEvents,
+    normalizeEvent: normalizeCalDAVEvent,
+  };
 };
 
 export { createCalDAVSyncProvider };

--- a/packages/calendar/src/providers/caldav/shared/client.ts
+++ b/packages/calendar/src/providers/caldav/shared/client.ts
@@ -163,7 +163,7 @@ const getDisplayName = (name: unknown): string => {
 const toCalendarObjectPath = (href: string, calendarUrl: string): string =>
   new URL(href, calendarUrl).pathname;
 
-const toRequestedPaths = (responses: { href?: string }[], calendarUrl: string): string[] => [
+const toCalendarObjectPaths = (responses: { href?: string }[], calendarUrl: string): string[] => [
   ...new Set(
     responses
       .map(({ href }) => toCalendarObjectPath(href ?? "", calendarUrl))
@@ -310,10 +310,11 @@ class CalDAVClient {
         url: params.calendarUrl,
       });
 
-      const requestedPaths = toRequestedPaths(queryResponses, params.calendarUrl);
+      const listedPaths = toCalendarObjectPaths(queryResponses, params.calendarUrl);
+      const requestedPaths = listedPaths;
       if (requestedPaths.length === 0) {
         params.onListing?.({
-          listedCount: 0,
+          listedCount: listedPaths.length,
           requestedCount: 0,
           returnedCount: 0,
           unrequestedCount: 0,
@@ -344,7 +345,7 @@ class CalDAVClient {
       const missingHrefs = requestedPaths.filter((path) => !objectsByPath.has(path));
       const requestedPathSet = new Set(requestedPaths);
       params.onListing?.({
-        listedCount: requestedPaths.length,
+        listedCount: listedPaths.length,
         requestedCount: batches.reduce((total, batch) => total + batch.length, 0),
         returnedCount: requestedPaths.length - missingHrefs.length,
         unrequestedCount: [...objectsByPath.keys()].filter((path) => !requestedPathSet.has(path)).length,

--- a/packages/calendar/src/providers/caldav/shared/client.ts
+++ b/packages/calendar/src/providers/caldav/shared/client.ts
@@ -21,6 +21,13 @@ interface CalendarObject {
   data?: string;
 }
 
+interface CalDAVListingStats {
+  listedCount: number;
+  requestedCount: number;
+  returnedCount: number;
+  unrequestedCount: number;
+}
+
 interface CalDAVIncompleteMultiGetDetails {
   batchCount: number;
   calendarUrl: string;
@@ -290,6 +297,7 @@ class CalDAVClient {
 
   fetchCalendarObjects(params: {
     calendarUrl: string;
+    onListing?: (stats: CalDAVListingStats) => void;
     timeRange?: { start: string; end: string };
   }): Promise<CalendarObject[]> {
     return mapAuthenticationFailure(async () => {
@@ -304,6 +312,12 @@ class CalDAVClient {
 
       const requestedPaths = toRequestedPaths(queryResponses, params.calendarUrl);
       if (requestedPaths.length === 0) {
+        params.onListing?.({
+          listedCount: 0,
+          requestedCount: 0,
+          returnedCount: 0,
+          unrequestedCount: 0,
+        });
         return [];
       }
 
@@ -328,6 +342,14 @@ class CalDAVClient {
       );
 
       const missingHrefs = requestedPaths.filter((path) => !objectsByPath.has(path));
+      const requestedPathSet = new Set(requestedPaths);
+      params.onListing?.({
+        listedCount: requestedPaths.length,
+        requestedCount: batches.reduce((total, batch) => total + batch.length, 0),
+        returnedCount: requestedPaths.length - missingHrefs.length,
+        unrequestedCount: [...objectsByPath.keys()].filter((path) => !requestedPathSet.has(path)).length,
+      });
+
       if (missingHrefs.length > 0) {
         throw new CalDAVIncompleteMultiGetError({
           batchCount: batches.length,
@@ -374,3 +396,4 @@ export {
   CalDAVWithheldCredentialsError,
   createCalDAVClient,
 };
+export type { CalDAVListingStats };

--- a/packages/calendar/tests/core/sync-engine/provider-diagnostics.test.ts
+++ b/packages/calendar/tests/core/sync-engine/provider-diagnostics.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { syncCalendar } from "../../../src/core/sync-engine/index";
+import type {
+  DeleteResult,
+  MaterializedSyncableEvent,
+  PushResult,
+  RemoteEvent,
+} from "../../../src/core/types";
+import type { CalendarSyncProvider } from "../../../src/core/sync-engine/types";
+
+const TEST_RECONCILIATION_SCOPE = {
+  authoritativeWindow: {
+    timeMax: new Date("2100-01-01T00:00:00.000Z"),
+    timeMin: new Date("2000-01-01T00:00:00.000Z"),
+  },
+  requestedWindow: {
+    timeMax: new Date("2100-01-01T00:00:00.000Z"),
+    timeMin: new Date("2000-01-01T00:00:00.000Z"),
+  },
+};
+
+const makeEvent = (id: string): MaterializedSyncableEvent => ({
+  calendarId: "cal-1",
+  calendarName: "Test Calendar",
+  calendarUrl: null,
+  endTime: new Date("2026-03-15T10:00:00Z"),
+  id,
+  sourceEventUid: `uid-${id}`,
+  startTime: new Date("2026-03-15T09:00:00Z"),
+  summary: `Event ${id}`,
+});
+
+const makeProvider = (overrides: Partial<CalendarSyncProvider> = {}): CalendarSyncProvider => ({
+  deleteEvents: (): Promise<DeleteResult[]> => Promise.resolve([]),
+  listRemoteEvents: (): Promise<RemoteEvent[]> => Promise.resolve([]),
+  pushEvents: (): Promise<PushResult[]> => Promise.resolve([]),
+  ...overrides,
+});
+
+const runSync = async (options: {
+  localEvents?: MaterializedSyncableEvent[];
+  provider: CalendarSyncProvider;
+  readState?: () => Promise<never>;
+}): Promise<Record<string, unknown>> => {
+  const emitted: Record<string, unknown>[] = [];
+  const run = syncCalendar({
+    calendarId: "dest-cal-1",
+    flush: () => Promise.resolve(),
+    isCurrent: () => Promise.resolve(true),
+    onSyncEvent: (event) => { emitted.push(event); },
+    provider: options.provider,
+    readState: options.readState ?? (() => Promise.resolve({
+      existingMappings: [],
+      localEvents: options.localEvents ?? [],
+      remoteEvents: [],
+    })),
+    reconciliationScope: TEST_RECONCILIATION_SCOPE,
+    userId: "user-1",
+  });
+  await run.catch(() => null);
+
+  expect(emitted).toHaveLength(1);
+  return emitted[0] as Record<string, unknown>;
+};
+
+describe("syncCalendar provider diagnostics", () => {
+  it("carries provider-reported diagnostics into the wide event", async () => {
+    const event = await runSync({
+      localEvents: [makeEvent("ev-1")],
+      provider: makeProvider({
+        getSyncDiagnostics: () => ({
+          "events.remove_not_found": 3,
+          "provider.caldav.host": "caldav.example.com",
+          "remote_objects.listed_count": 900,
+          "remote_objects.requested_count": 12,
+        }),
+        pushEvents: () => Promise.resolve([{ remoteId: "remote-1", success: true }]),
+      }),
+    });
+
+    expect(event).toMatchObject({
+      "events.remove_not_found": 3,
+      "outcome": "success",
+      "provider.caldav.host": "caldav.example.com",
+      "remote_objects.listed_count": 900,
+      "remote_objects.requested_count": 12,
+    });
+  });
+
+  it("carries diagnostics on an in-sync run so a listing can be measured without any operations", async () => {
+    const event = await runSync({
+      provider: makeProvider({
+        getSyncDiagnostics: () => ({
+          "remote_objects.listed_count": 900,
+          "remote_objects.requested_count": 12,
+        }),
+      }),
+    });
+
+    expect(event).toMatchObject({
+      "outcome": "in-sync",
+      "remote_objects.listed_count": 900,
+      "remote_objects.requested_count": 12,
+    });
+  });
+
+  it("carries diagnostics on a failed run, where they explain the failure", async () => {
+    const event = await runSync({
+      provider: makeProvider({
+        getSyncDiagnostics: () => ({ "remote_objects.unrequested_count": 900 }),
+      }),
+      readState: () => Promise.reject(new Error("read failed")),
+    });
+
+    expect(event).toMatchObject({
+      "outcome": "error",
+      "remote_objects.unrequested_count": 900,
+    });
+  });
+
+  it("emits nothing extra for a provider that reports no diagnostics", async () => {
+    const event = await runSync({ provider: makeProvider() });
+
+    expect(Object.keys(event).some((key) => key.startsWith("remote_objects."))).toBe(false);
+  });
+});

--- a/packages/calendar/tests/providers/caldav/destination/provider.test.ts
+++ b/packages/calendar/tests/providers/caldav/destination/provider.test.ts
@@ -106,6 +106,7 @@ describe("createCalDAVSyncProvider", () => {
     expect(remoteEvents.map((event) => event.uid)).toEqual([keeperUid]);
     expect(clientMocks.fetchCalendarObjects).toHaveBeenCalledWith({
       calendarUrl: "https://caldav.example.com/calendar/",
+      onListing: expect.any(Function),
     });
   });
 
@@ -251,6 +252,88 @@ describe("createCalDAVSyncProvider", () => {
       statusCode: 503,
       success: false,
     })]);
+  });
+
+  it("counts a delete the server answers 404 apart from a delete that removed something", async () => {
+    clientMocks.deleteCalendarObject
+      .mockRejectedValueOnce(new CalDAVHttpError(new Response(null, { status: 404 }), "delete"))
+      .mockResolvedValueOnce(null);
+    const provider = createProvider();
+
+    const results = await provider.deleteEvents(["gone-uid", "present-uid"]);
+
+    expect(results).toEqual([{ success: true }, { success: true }]);
+    expect(provider.getSyncDiagnostics()).toMatchObject({
+      "events.remove_not_found": 1,
+      "events.remove_succeeded": 1,
+    });
+  });
+
+  it("breaks non-404 delete rejections out by status code", async () => {
+    clientMocks.deleteCalendarObject
+      .mockRejectedValueOnce(new CalDAVHttpError(new Response(null, { status: 403 }), "delete"))
+      .mockRejectedValueOnce(new CalDAVHttpError(new Response(null, { status: 403 }), "delete"))
+      .mockRejectedValueOnce(new CalDAVHttpError(new Response(null, { status: 405 }), "delete"));
+    const provider = createProvider();
+
+    await provider.deleteEvents(["a-uid", "b-uid", "c-uid"]);
+
+    expect(provider.getSyncDiagnostics()).toMatchObject({
+      "events.remove_failed_status.403": 2,
+      "events.remove_failed_status.405": 1,
+      "events.remove_not_found": 0,
+    });
+  });
+
+  it("reports which delete identifier form each remove used", async () => {
+    clientMocks.deleteCalendarObject.mockResolvedValue(null);
+    const provider = createProvider();
+
+    await provider.deleteEvents([
+      "bare-uid@keeper.sh",
+      "/calendar/an-object@keeper.sh.ics",
+      "/calendar/another-object@keeper.sh.ics",
+    ]);
+
+    expect(provider.getSyncDiagnostics()).toMatchObject({
+      "events.remove_by_path": 2,
+      "events.remove_by_uid": 1,
+    });
+  });
+
+  it("reports the CalDAV host so one server can be told apart from the fleet", () => {
+    expect(createProvider().getSyncDiagnostics()).toMatchObject({
+      "provider.caldav.host": "caldav.example.com",
+    });
+  });
+
+  it("reports what the listing asked the server for against what it listed", async () => {
+    clientMocks.resolveCalendarUrl.mockResolvedValueOnce("https://caldav.example.com/calendar/");
+    clientMocks.fetchCalendarObjects.mockImplementationOnce(
+      ({ onListing }: { onListing?: (stats: unknown) => void }) => {
+        onListing?.({
+          listedCount: 900,
+          requestedCount: 12,
+          returnedCount: 12,
+          unrequestedCount: 4,
+        });
+        return Promise.resolve([]);
+      },
+    );
+    const provider = createProvider();
+
+    await provider.listRemoteEvents({ timeMin: new Date("2026-03-01T00:00:00.000Z") });
+
+    expect(provider.getSyncDiagnostics()).toMatchObject({
+      "remote_objects.listed_count": 900,
+      "remote_objects.requested_count": 12,
+      "remote_objects.returned_count": 12,
+      "remote_objects.unrequested_count": 4,
+    });
+  });
+
+  it("omits listing counts until a listing has actually happened", () => {
+    expect(createProvider().getSyncDiagnostics()).not.toHaveProperty("remote_objects.listed_count");
   });
 
   it("preserves the HTTP status and recovery phase when conflict recovery fails", async () => {

--- a/packages/calendar/tests/providers/caldav/shared/client-multiget.test.ts
+++ b/packages/calendar/tests/providers/caldav/shared/client-multiget.test.ts
@@ -3,6 +3,7 @@ import {
   CalDAVClient,
   CalDAVIncompleteMultiGetError,
 } from "../../../../src/providers/caldav/shared/client";
+import type { CalDAVListingStats } from "../../../../src/providers/caldav/shared/client";
 import { isCalDAVAuthenticationError } from "../../../../src/providers/caldav/source/auth-error-classification";
 
 const davMocks = vi.hoisted(() => ({
@@ -223,6 +224,67 @@ describe("CalDAVClient.fetchCalendarObjects on healthy calendars", () => {
     const objects = await fetchObjects();
 
     expect(pathsOf(objects)).toEqual(paths);
+  });
+});
+
+describe("CalDAVClient.fetchCalendarObjects listing diagnostics", () => {
+  const captureListings = async (): Promise<CalDAVListingStats[]> => {
+    const listings: CalDAVListingStats[] = [];
+    await createClient()
+      .fetchCalendarObjects({
+        calendarUrl: CALENDAR_URL,
+        onListing: (stats) => { listings.push(stats); },
+      })
+      .catch(() => null);
+    return listings;
+  };
+
+  it("reports what the calendar-query listed, what the multiget asked for, and what came back", async () => {
+    answerQueryWith(objectPaths(3));
+
+    await expect(captureListings()).resolves.toEqual([{
+      listedCount: 3,
+      requestedCount: 3,
+      returnedCount: 3,
+      unrequestedCount: 0,
+    }]);
+  });
+
+  it("counts objects the server returned that were never requested", async () => {
+    answerQueryWith(objectPaths(3));
+    answerMultigetWith((objectUrls) => rowsFor([...objectUrls, `${CALENDAR_PATH}surprise.ics`]));
+
+    const [listing] = await captureListings();
+
+    expect(listing).toMatchObject({ requestedCount: 3, returnedCount: 3, unrequestedCount: 1 });
+  });
+
+  it("does not count listed hrefs that are not calendar objects", async () => {
+    answerQueryWith([CALENDAR_PATH, `${CALENDAR_PATH}notes.txt`, objectPath(0)]);
+
+    const [listing] = await captureListings();
+
+    expect(listing).toMatchObject({ listedCount: 1, requestedCount: 1 });
+  });
+
+  it("reports an empty listing when the calendar-query returns no hrefs", async () => {
+    answerQueryWith([]);
+
+    await expect(captureListings()).resolves.toEqual([{
+      listedCount: 0,
+      requestedCount: 0,
+      returnedCount: 0,
+      unrequestedCount: 0,
+    }]);
+  });
+
+  it("reports the listing before rejecting an incomplete multiget", async () => {
+    answerQueryWith(objectPaths(4));
+    answerMultigetWith(respondsWithAtMost(1));
+
+    const [listing] = await captureListings();
+
+    expect(listing).toMatchObject({ listedCount: 4, requestedCount: 4, returnedCount: 1 });
   });
 });
 


### PR DESCRIPTION
Closes #661. Destination sync wide events now carry what the CalDAV server actually did, so a single misbehaving server can be named without waiting for a user report. No sync behaviour changes — the 404-to-success mapping is deliberately kept and is now counted instead of hidden. Based on `main` rather than #659 or #660 so it can ship first: telemetry that deploys in the same release as the behaviour change cannot establish the before, and with release-tag deploys there is no second chance at a baseline.

- `remote_objects.listed_count` / `.requested_count` / `.returned_count` / `.unrequested_count` — a server that ignores the multiget href list shows up as a non-zero `unrequested_count` (today those rows are silently discarded), and once #659 lands, `listed - requested` is the saving it claims. `listedCount` is computed from the raw calendar-query responses via `toCalendarObjectPaths`, before `requestedPaths`, so #659 filtering into `requestedPaths` leaves the pre-filter count intact — that is the one line to keep an eye on when rebasing.
- `events.remove_not_found` / `events.remove_succeeded` — answers question 1 of #656 ("succeeding, failing, or already absent?"), which is unanswerable today because 404 is folded into success. A calendar where this is non-zero every run and never drains is a mapping that is not being retired, which is the #656 shape exactly.
- `events.remove_failed_status.<code>` — separates "this server refuses DELETE" (403/405/409/412) from an auth problem. 929 CalDAV-family syncs had a failed removal over 14d and none of them can be attributed today.
- `events.remove_by_path` / `.remove_by_uid` — watches #660's deleteId migration drain to zero. Reads 100% `by_uid` until #660 lands, which is the correct baseline.
- `provider.caldav.host` — `provider_name` is just `caldav` for every self-hosted and third-party server, so one broken server currently reads as a fleet trend.

Two judgement calls, neither shipped silently:

- **Keep the 404-to-success mapping.** Agreed, and the evidence is #656 itself. Turning 404 into a failure would increment `removeFailed` and leave the mapping unretired, so the same futile delete repeats every run forever — strictly worse than today. The invisibility in #656 was never the 404 mapping alone; it was 404-to-success *plus* a mapping that never retired (#660 fixes the retire half). `events.remove_not_found` persisting across consecutive runs for one calendar is the alert worth building, not a behaviour change.
- **No kill switch for #659's `pathFilter`.** #659 filters client-side: the calendar-query is unchanged, the filter is Keeper's own `isKeeperEvent` filename predicate — the same one that already discarded those objects after download — and the multiget href set is chosen by us. A server cannot under-return objects it was never asked about, so it does not carry the risk #593 warns about for a server-side `timeRange`. The realistic failure is a server refusing a subset multiget, which raises `CalDAVIncompleteMultiGetError` and fails the run loudly without touching data. Caveat worth stating plainly: that guard is only ~1 day old in production (first shipped `v2.14.5`, 2026-08-12), so its zero-occurrence record covers ~120k CalDAV syncs, not fourteen days of them. If a switch is wanted anyway, a server-side `timeRange` (#593) is the change that would actually justify one.

TDD: the 14 tests in `tests/core/sync-engine/provider-diagnostics.test.ts`, `client-multiget.test.ts` and `caldav/destination/provider.test.ts` were written first and failed for the right reasons before any source change. Root `lint`, `types` and `test` run green with `--force`; the only failure is the pre-existing `build-vtimezone` Morocco case, verified failing on clean `origin/main` (#652).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BQkcrAZNXz7au7KkkT7JV
