### PR TITLE
test: home description projection suite with its cross-provider neighbours

### DIFF
--- a/packages/calendar/tests/core/events/description-projection-destination-convergence.test.ts
+++ b/packages/calendar/tests/core/events/description-projection-destination-convergence.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { eventToICalString, parseICalToRemoteEvent } from "../../src/providers/caldav/shared/ics";
-import { normalizeCalDAVEvent } from "../../src/providers/caldav/destination/normalize-event";
-import { normalizeGoogleEvent } from "../../src/providers/google/destination/normalize-event";
-import { normalizeOutlookEvent } from "../../src/providers/outlook/destination/normalize-event";
-import { serializeGoogleEvent } from "../../src/providers/google/destination/serialize-event";
-import { createEditableEventContentHash } from "../../src/core/events/content-hash";
-import type { MaterializedSyncableEvent } from "../../src/core/types";
+import { eventToICalString, parseICalToRemoteEvent } from "../../../src/providers/caldav/shared/ics";
+import { normalizeCalDAVEvent } from "../../../src/providers/caldav/destination/normalize-event";
+import { normalizeGoogleEvent } from "../../../src/providers/google/destination/normalize-event";
+import { normalizeOutlookEvent } from "../../../src/providers/outlook/destination/normalize-event";
+import { serializeGoogleEvent } from "../../../src/providers/google/destination/serialize-event";
+import { createEditableEventContentHash } from "../../../src/core/events/content-hash";
+import type { MaterializedSyncableEvent } from "../../../src/core/types";
 
 const CONFERENCE_DELIMITER =
   "-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-";


### PR DESCRIPTION
`tests/providers/destination-description-projection.test.ts` was the only file sitting directly under `tests/providers/` — every other provider test lives under `tests/providers/{caldav,google,outlook}/{source,destination,shared}/`. It does not belong there: it exercises all three destination normalizers plus `core/events/content-hash` to pin one invariant, exactly like its new neighbour `tests/core/events/vfy-shaping-fixed-point.test.ts`. Move and rename only, no behavioural change.

- Moved to `packages/calendar/tests/core/events/description-projection-destination-convergence.test.ts`
- Renamed to match the neighbouring `all-day-series-destination-convergence` / `representable-range-idempotence` pattern, which names the property rather than the topic
- Relative imports rewritten `../../` → `../../../`; no config references the old path (vitest include is a glob, knip ignores `tests/**`)
- 13 tests before, 13 tests after; calendar suite 161 files / 1667 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BQkcrAZNXz7au7KkkT7JV