### PR TITLE
feat(web): move competitor comparisons into a /compare silo

### DIFF
--- a/applications/web/plugins/blog.ts
+++ b/applications/web/plugins/blog.ts
@@ -232,35 +232,40 @@ export function processBlogDirectory(
   );
 }
 
-const VIRTUAL_MODULE_ID = "virtual:blog-posts";
-const RESOLVED_ID = `\0${VIRTUAL_MODULE_ID}`;
+interface ContentCollection {
+  directory: string;
+  exportName: string;
+  name: string;
+  virtualModuleId: string;
+}
 
-export function blogPlugin(): Plugin {
-  let blogDir: string;
+function contentCollectionPlugin(collection: ContentCollection): Plugin {
+  const resolvedId = `\0${collection.virtualModuleId}`;
+  let contentDir: string;
   let publicDir: string;
 
   return {
-    name: "keeper-blog",
+    name: collection.name,
 
     configResolved(config) {
-      blogDir = resolve(config.root, "src/content/blog");
+      contentDir = resolve(config.root, collection.directory);
       publicDir = config.publicDir;
     },
 
     resolveId(id) {
-      if (id === VIRTUAL_MODULE_ID) return RESOLVED_ID;
+      if (id === collection.virtualModuleId) return resolvedId;
     },
 
     load(id) {
-      if (id !== RESOLVED_ID) return;
+      if (id !== resolvedId) return;
 
-      const posts = processBlogDirectory(blogDir, publicDir);
-      return `export const blogPosts = ${JSON.stringify(posts)};`;
+      const posts = processBlogDirectory(contentDir, publicDir);
+      return `export const ${collection.exportName} = ${JSON.stringify(posts)};`;
     },
 
     handleHotUpdate({ file, server }) {
-      if (file.startsWith(blogDir) && file.endsWith(".mdx")) {
-        const module = server.moduleGraph.getModuleById(RESOLVED_ID);
+      if (file.startsWith(contentDir) && file.endsWith(".mdx")) {
+        const module = server.moduleGraph.getModuleById(resolvedId);
         if (module) {
           server.moduleGraph.invalidateModule(module);
           return [module];
@@ -268,4 +273,22 @@ export function blogPlugin(): Plugin {
       }
     },
   };
+}
+
+export function blogPlugin(): Plugin {
+  return contentCollectionPlugin({
+    directory: "src/content/blog",
+    exportName: "blogPosts",
+    name: "keeper-blog",
+    virtualModuleId: "virtual:blog-posts",
+  });
+}
+
+export function comparePlugin(): Plugin {
+  return contentCollectionPlugin({
+    directory: "src/content/compare",
+    exportName: "comparePages",
+    name: "keeper-compare",
+    virtualModuleId: "virtual:compare-pages",
+  });
 }

--- a/applications/web/plugins/sitemap.ts
+++ b/applications/web/plugins/sitemap.ts
@@ -47,18 +47,18 @@ function readStaticEntries(pagesFile: string): SitemapEntry[] {
   });
 }
 
-function buildBlogIndexEntry(blogEntries: SitemapEntry[]): SitemapEntry {
-  const [first] = blogEntries;
+function buildIndexEntry(path: string, entries: SitemapEntry[]): SitemapEntry {
+  const [first] = entries;
   if (!first) {
-    throw new Error("The blog index lastmod cannot be derived without any blog posts.");
+    throw new Error(`The "${path}" index lastmod cannot be derived without any entries.`);
   }
 
-  const lastmod = blogEntries.reduce(
+  const lastmod = entries.reduce(
     (newest, entry) => (entry.lastmod > newest ? entry.lastmod : newest),
     first.lastmod,
   );
 
-  return { loc: `${SITE_URL}/blog`, lastmod };
+  return { loc: `${SITE_URL}${path}`, lastmod };
 }
 
 function parseFrontmatter(raw: string, file: string): Record<string, unknown> {
@@ -118,6 +118,7 @@ function buildSitemapXml(entries: SitemapEntry[]): string {
 
 export function sitemapPlugin(): Plugin {
   let blogDir: string;
+  let compareDir: string;
   let pagesFile: string;
 
   return {
@@ -126,15 +127,23 @@ export function sitemapPlugin(): Plugin {
 
     configResolved(config) {
       blogDir = resolve(config.root, "src/content/blog");
+      compareDir = resolve(config.root, "src/content/compare");
       pagesFile = resolve(config.root, "src/content/pages.yaml");
     },
 
     generateBundle() {
       const blogEntries = discoverContentEntries(blogDir, "/blog", "Blog post");
+      const compareEntries = discoverContentEntries(
+        compareDir,
+        "/compare",
+        "Comparison page",
+      );
       const entries = [
         ...readStaticEntries(pagesFile),
-        buildBlogIndexEntry(blogEntries),
+        buildIndexEntry("/blog", blogEntries),
         ...blogEntries,
+        buildIndexEntry("/compare", compareEntries),
+        ...compareEntries,
       ];
 
       this.emitFile({

--- a/applications/web/public/llms-full.txt
+++ b/applications/web/public/llms-full.txt
@@ -128,6 +128,7 @@ MCP is fully optional — all related environment variables are optional across 
 
 - Homepage: https://www.keeper.sh
 - Blog: https://www.keeper.sh/blog
+- Compare: https://www.keeper.sh/compare
 - Privacy Policy: https://www.keeper.sh/privacy
 - Terms & Conditions: https://www.keeper.sh/terms
 - GitHub: https://github.com/ridafkih/keeper.sh

--- a/applications/web/public/llms.txt
+++ b/applications/web/public/llms.txt
@@ -18,6 +18,7 @@ Keeper.sh is an open-source (AGPL-3.0) calendar synchronization service that kee
 
 - [Homepage](https://www.keeper.sh)
 - [Blog](https://www.keeper.sh/blog)
+- [Compare](https://www.keeper.sh/compare)
 - [Privacy Policy](https://www.keeper.sh/privacy)
 - [Terms & Conditions](https://www.keeper.sh/terms)
 - [GitHub Repository](https://github.com/ridafkih/keeper.sh)

--- a/applications/web/src/content/compare/calendarbridge-alternative.mdx
+++ b/applications/web/src/content/compare/calendarbridge-alternative.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Keeper.sh vs CalendarBridge"
+title: "CalendarBridge Alternative: Keeper.sh vs CalendarBridge"
 description: "Eight calendars costs $40 a month on CalendarBridge and $5 on Keeper.sh. What each one connects, how fast changes land, and where CalendarBridge is still the right call."
-blurb: "Keeper.sh is $5 a month however many calendars you have, connects CalDAV servers CalendarBridge cannot write to, and runs on your own hardware. CalendarBridge owns the regulated flank. Here is how the two differ."
+blurb: "Keeper.sh is $5 a month however many calendars you have, and copies your busy time without copying your event titles. CalendarBridge owns the regulated flank. Here is how the two differ."
 createdAt: "2026-08-11"
-slug: "keeper-sh-vs-calendarbridge"
-updatedAt: "2026-08-11"
+slug: "calendarbridge-alternative"
+updatedAt: "2026-08-14"
 tags:
   - "calendar"
   - "comparison"
@@ -28,9 +28,9 @@ Both of those are paperwork about somebody else's cloud, which is the trade. Buy
 
 CalendarBridge connects Google Calendar, Microsoft 365 for Business, Microsoft personal accounts on outlook.com, hotmail.com, live.com and msn.com, and iCloud. Microsoft 365 personal and family plans cannot be supported, because those plans do not expose a calendar over the internet.
 
-For anything outside that list, [their answer](https://calendarbridge.com/) is an `.ics` link, which reads a calendar but cannot write to one.
+In August 2026 they added [CalDAV accounts](https://help.calendarbridge.com/user-docs/connecting-caldav-accounts/) covering Fastmail, Zoho, Yahoo, AOL, Nextcloud and self-hosted servers, and those accounts work across the rest of their product too.
 
-Keeper.sh connects the same big three plus Fastmail, any CalDAV server and any public `.ics` link. On Nextcloud, Fastmail, Zimbra, Radicale or a server in your own house, Keeper.sh both reads and writes.
+Keeper.sh connects the same big three plus Fastmail, any CalDAV server and any public `.ics` link.
 
 ## What happens when you change an event?
 
@@ -58,7 +58,9 @@ Keeper.sh does not price the symptom. However scattered your calendars get, unsc
 
 **You need other people to book time with you.** CalendarBridge includes up to 10 [scheduling pages](https://calendarbridge.com/scheduling-pages-for-people-with-multiple-calendars/) on every plan, built for people whose availability is spread across calendars. Keeper.sh does not ship booking links today, so it sits underneath whichever booking tool you use.
 
-**Procurement wants paperwork.** CalendarBridge lists a verified SOC 2 Type 1 and offers a [trust centre](https://calendarbridge.com/calendarbridge-security-overview/) on request. Keeper.sh answers that from the other end: read the code, or keep the calendar on your own hardware so there is no third party to audit.
+**You want an assistant that books for you.** CalendarBridge runs its own [MCP server](https://help.calendarbridge.com/user-docs/bring-your-own-agent-mcp/) on every plan, and an [AI scheduling assistant](https://calendarbridge.com/ai-scheduling/) that arranges meetings over email on Premium and Pro. Keeper.sh has no assistant that emails people on your behalf.
+
+**Procurement wants paperwork.** CalendarBridge lists a verified SOC 2 Type 1, says Type 2 is in progress, and runs a public [trust centre](https://trust.calendarbridge.com/). Keeper.sh answers that from the other end: read the code, or keep the calendar on your own hardware so there is no third party to audit.
 
 **One admin sets up the whole team.** CalendarBridge [group plans](https://calendarbridge.com/pricing-group/) let an admin manage everyone's connections on one bill, with no end-user involvement. Keeper.sh is set up one person at a time.
 
@@ -66,19 +68,19 @@ Keeper.sh does not price the symptom. However scattered your calendars get, unsc
 
 ## Where Keeper.sh fits better
 
-**Your calendar speaks CalDAV.** Fastmail and Nextcloud calendars can be written to by Keeper.sh, and only read through a link by CalendarBridge.
+**You want to start without paying.** Keeper.sh is free for two linked accounts and three connections, with no card and no countdown. CalendarBridge runs a trial, then bills from $5 a month.
 
 **Your setup is wide.** Nine client calendars, four family ones and a shared team calendar all cost $5 a month. Nothing in the price depends on how many you have.
 
-**Your event details stay put.** By default Keeper.sh copies a busy block labelled with the calendar's name, leaving the title, description and location on the original calendar. Pro can turn that off per calendar; the free plan keeps the private version and cannot change it.
+**Your event details stay put.** By default Keeper.sh copies a busy block labelled with the calendar's name, leaving the title, description and location on the original calendar. Pro can let the real detail through per calendar; the free plan keeps the private version and cannot change it.
 
 **You only want the next few months mirrored.** Pro sets how far back and how far ahead each calendar copies, anywhere from one week to two years. An old job's calendar does not drag a decade of history across.
 
 **You want to skip the noise.** Pro filters out all-day events, focus time and out-of-office blocks, so a week marked away does not black out your other calendar.
 
-**You want to automate it.** Keeper.sh has a REST API and an MCP server with 14 tools for AI assistants, free at 25 calls a day and unmetered on Pro.
+**You want your own assistant driving it.** Keeper.sh's MCP server hands an assistant 14 tools: read events, create, move, cancel, RSVP and find free time. It is free at 25 calls a day and unmetered on Pro, and the REST API does the same from a script.
 
-**You want to read the code.** Keeper.sh is AGPL-3.0, so nothing about how your events are handled is hidden from you.
+**You would rather nobody else held your calendar.** Keeper.sh is AGPL-3.0 and runs on hardware you own, so nothing about how your events are handled is hidden from you. CalendarBridge is hosted only.
 
 ## Running Keeper.sh yourself
 
@@ -100,16 +102,17 @@ Yes, as two connections. Each connection runs one way, so you create one in each
 
 ### Which one should I pick?
 
-Pick CalendarBridge for a HIPAA BAA, GCC High, mobile apps or scheduling pages. Pick Keeper.sh for CalDAV, a free tier, a flat price across a lot of calendars, or a copy you run yourself.
+Pick CalendarBridge for a HIPAA BAA, GCC High, mobile apps, scheduling pages or an assistant that emails on your behalf. Pick Keeper.sh for a free tier, a flat price across a lot of calendars, or a copy you run yourself.
 
 ## Where these facts come from
 
-Everything above about CalendarBridge comes from their own public pages, checked on 11 August 2026. Everything about Keeper.sh comes from our code and our pricing. Prices and features change, so follow the links if a detail matters to your decision.
+Everything above about CalendarBridge comes from their own public pages, checked on 14 August 2026. Everything about Keeper.sh comes from our code and our pricing. Prices and features change, so follow the links if a detail matters to your decision.
 
 - CalendarBridge supported calendars, sync speeds, apps, SOC 2 Type 1, HIPAA and GCC High: [calendarbridge.com](https://calendarbridge.com/)
 - CalendarBridge individual plans, prices, calendar counts and the HIPAA BAA tier: [calendarbridge.com/pricing-individual](https://calendarbridge.com/pricing-individual/)
 - CalendarBridge group plans and admin management: [calendarbridge.com/pricing-group](https://calendarbridge.com/pricing-group/)
 - CalendarBridge scheduling pages: [calendarbridge.com/scheduling-pages-for-people-with-multiple-calendars](https://calendarbridge.com/scheduling-pages-for-people-with-multiple-calendars/)
-- CalendarBridge security overview: [calendarbridge.com/calendarbridge-security-overview](https://calendarbridge.com/calendarbridge-security-overview/)
+- CalendarBridge trust centre, SOC 2 status and security documents: [trust.calendarbridge.com](https://trust.calendarbridge.com/)
+- CalendarBridge CalDAV accounts, and the MCP server on every plan: [help.calendarbridge.com](https://help.calendarbridge.com/user-docs/connecting-caldav-accounts/)
 - Keeper.sh plans and limits: [keeper.sh](/)
 - Keeper.sh code, licence and self-hosting guide: [github.com/ridafkih/keeper.sh](https://github.com/ridafkih/keeper.sh)

--- a/applications/web/src/content/compare/onecal-alternative.mdx
+++ b/applications/web/src/content/compare/onecal-alternative.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Keeper.sh vs OneCal"
+title: "OneCal Alternative: Keeper.sh vs OneCal"
 description: "Keeper.sh and OneCal both stop you double-booking. Which calendars each one connects, how fast changes land, what each costs, and who each one suits."
 blurb: "Keeper.sh connects Fastmail, Nextcloud and any calendar link, hides your event details by default, is free to start, and runs on your own server. OneCal is the broader scheduling suite. Here is how the two differ."
 createdAt: "2026-08-11"
-slug: "keeper-sh-vs-onecal"
-updatedAt: "2026-08-11"
+slug: "onecal-alternative"
+updatedAt: "2026-08-14"
 tags:
   - "calendar"
   - "comparison"
@@ -14,7 +14,7 @@ tags:
 
 You have a work calendar and a personal one, and you want your busy time to show up in both. Keeper.sh and OneCal both do that job.
 
-OneCal is a broad scheduling suite: sync, booking links, apps and admin tools in one subscription. Keeper.sh does the sync job only, reaches calendars OneCal does not, and is open source under AGPL-3.0 so you can run the whole thing on your own server.
+OneCal is a broad scheduling suite: sync, booking links, apps and admin tools in one subscription. Keeper.sh does the sync job only, reaches calendars OneCal does not, and is free to start. If you would rather nobody else held your calendar, it is open source under AGPL-3.0 and runs on a machine you own.
 
 ## Which calendars can you connect?
 
@@ -52,7 +52,7 @@ A connection runs one way. Mirroring work into personal and personal back into w
 
 **You are buying for a team.** OneCal has OIDC and SAML single sign-on, SCIM directory sync, audit logs and an [admin dashboard](https://www.onecal.io/pricing). Keeper.sh is set up one person at a time, though a self-hosted instance carries as many people as you put on it, with no seat count.
 
-**Your security review has teeth.** OneCal publishes a [data security page](https://www.onecal.io/data-security), a data processing addendum and a subprocessor list, states that it is GDPR compliant, and says its SOC 2 audit is in progress. Keeper.sh answers the same question from the other end: the code is public, and you can keep the whole thing on hardware you own.
+**Your security review has teeth.** OneCal publishes a [data security page](https://www.onecal.io/data-security), a data processing addendum and a subprocessor list, states that it is GDPR compliant, and is SOC 2 Type II certified. Keeper.sh answers the same question from the other end: the code is public, and you can keep the whole thing on hardware you own.
 
 ## Where Keeper.sh is the stronger buy
 
@@ -94,7 +94,7 @@ Pick OneCal for mobile apps, booking links or single sign-on for a team. Pick Ke
 
 ## Where these facts come from
 
-Everything above about OneCal comes from their own public pages, checked on 11 August 2026. Everything about Keeper.sh comes from our code and our pricing. Prices and features change, so follow the links if a detail matters to your decision.
+Everything above about OneCal comes from their own public pages, checked on 14 August 2026. Everything about Keeper.sh comes from our code and our pricing. Prices and features change, so follow the links if a detail matters to your decision.
 
 - OneCal plans, prices, calendar counts, trial, single sign-on, SCIM and audit logs: [onecal.io/pricing](https://www.onecal.io/pricing)
 - OneCal supported calendars and sync speed, including the iCloud figure: [onecal.io](https://www.onecal.io/)

--- a/applications/web/src/content/compare/syncthemcalendars-alternative.mdx
+++ b/applications/web/src/content/compare/syncthemcalendars-alternative.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Keeper.sh vs SyncThemCalendars"
-description: "Keeper.sh and SyncThemCalendars compared for calendar sync: two-way setup, update speed, pricing by sync count, supported calendars, languages, open source and self-hosting, with a link behind every figure."
+title: "SyncThemCalendars Alternative: Keeper.sh vs SyncThemCalendars"
+description: "Keeper.sh is $5 flat for unlimited connections; SyncThemCalendars meters syncs from $3.99. Update speed, which calendars each reaches, event privacy."
 blurb: "One meters how many syncs you run, the other charges $5 flat. Here is how each handles two-way mirroring, which calendars they reach, and what happens to your event details."
 createdAt: "2026-08-11"
-slug: "keeper-sh-vs-syncthemcalendars"
-updatedAt: "2026-08-11"
+slug: "syncthemcalendars-alternative"
+updatedAt: "2026-08-14"
 tags:
   - "calendar"
   - "sync"
@@ -13,7 +13,7 @@ tags:
 
 You keep a work calendar and a personal one, and neither knows about the other. Both Keeper.sh and SyncThemCalendars fix that by copying your busy time between them.
 
-They take different shapes. SyncThemCalendars is a polished, narrow product covering three providers very well. Keeper.sh is open source, covers more calendar types, and gives you an API.
+They take different shapes. SyncThemCalendars is a polished, narrow product covering three providers very well. Keeper.sh reaches more kinds of calendar, charges $5 flat however many connections you run, and copies your busy time without copying your event titles.
 
 ## Does either one sync both ways?
 
@@ -53,9 +53,11 @@ SyncThemCalendars charges by how many syncs you run, and does not charge for con
 | Entry paid plan | $5/month, unlimited connections | $3.99/month, 5 syncs |
 | Middle plan | None | $7.99/month, 16 syncs |
 | Top plan | None | $17.99/month, 36 syncs |
-| Yearly option | Not offered | $47.88, $95.88, $215.88 |
+| Yearly option | $42/year | $47.88, $95.88, $215.88 |
 
-Run five syncs or fewer and they are cheaper by a dollar. Run more than five and we are cheaper, because $5 on Keeper.sh Pro has no connection limit at all.
+Paying monthly, run five syncs or fewer and they are cheaper by a dollar. Run more than five and we are cheaper, because $5 on Keeper.sh Pro has no connection limit at all.
+
+Paying yearly there is no crossover. Keeper.sh Pro is $42 a year against their cheapest $47.88, because their yearly price is just twelve monthly ones.
 
 The other real difference is the free plan. Ours never expires, with 2 accounts and 3 connections. Theirs is 14 days, and then they ask for payment.
 
@@ -63,7 +65,7 @@ The other real difference is the free plan. Ours never expires, with 2 accounts 
 
 **Two-way mirroring as one toggle**, and **Google and Outlook copies that update "in moments"** by their own account, both covered above.
 
-**Cheaper at their smallest tier.** $3.99 a month for five syncs, against our $5.
+**Cheaper at their smallest tier, month to month.** $3.99 a month for five syncs, against our $5. Paid yearly it flips, at $47.88 against our $42.
 
 **Simpler onboarding.** They advertise "Set up your first sync in 2 minutes" and the product is built around that promise. Keeper.sh asks you to think about direction, which calendars feed which, and what to hide, which is more control and more decisions.
 
@@ -107,7 +109,7 @@ Most people should use hosted Keeper.sh at $5 a month. Self-hosting is there whe
 
 ### Which should I choose?
 
-Choose SyncThemCalendars for two-way sync as one switch, a two-minute setup, five syncs or fewer, or the product in your own language. Their Google and Outlook copies update in moments. Choose Keeper.sh if you use CalDAV or Fastmail, want open source and self-hosting, run more than five connections, or want an API and agent access.
+Choose SyncThemCalendars for two-way sync as one switch, a two-minute setup, five syncs or fewer, or the product in your own language. Their Google and Outlook copies update in moments. Choose Keeper.sh for CalDAV or Fastmail, more than five connections, event titles kept off the copy, or a copy you run yourself.
 
 ### Does Keeper.sh only sync every 30 minutes?
 

--- a/applications/web/src/features/marketing/components/article-card.tsx
+++ b/applications/web/src/features/marketing/components/article-card.tsx
@@ -1,0 +1,44 @@
+import { Link } from "@tanstack/react-router";
+import { Heading3 } from "@/components/ui/primitives/heading";
+import { Text } from "@/components/ui/primitives/text";
+import { formatIsoDate } from "@/utils/date";
+
+const ILLUSTRATION_STYLE = {
+  backgroundImage:
+    "repeating-linear-gradient(-45deg, transparent 0 14px, var(--color-illustration-stripe) 14px 15px)",
+} as const;
+
+type ArticleCardProps = {
+  blurb: string;
+  createdAt: string;
+  path: string;
+  title: string;
+};
+
+export function ArticleCard({ blurb, createdAt, path, title }: ArticleCardProps) {
+  return (
+    <Link
+      className="group block overflow-hidden rounded-2xl border border-interactive-border bg-background shadow-xs transition-colors hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      to={path}
+    >
+      <article className="grid grid-cols-1 sm:grid-cols-3 sm:items-stretch">
+        <div
+          className="bg-background h-28 sm:col-span-1 sm:h-full"
+          style={ILLUSTRATION_STYLE}
+          role="presentation"
+        />
+        <div className="flex flex-col gap-1 p-4 md:p-5 sm:col-span-2">
+          <Heading3 as="h2" className="group-hover:text-foreground-hover">
+            {title}
+          </Heading3>
+          <Text size="xs" tone="muted">
+            Created {formatIsoDate(createdAt)}
+          </Text>
+          <Text size="sm" tone="muted" className="line-clamp-3">
+            {blurb}
+          </Text>
+        </div>
+      </article>
+    </Link>
+  );
+}

--- a/applications/web/src/features/marketing/components/marketing-guides-section.tsx
+++ b/applications/web/src/features/marketing/components/marketing-guides-section.tsx
@@ -1,0 +1,41 @@
+import type { PropsWithChildren } from "react";
+import { Link } from "@tanstack/react-router";
+import { Text } from "@/components/ui/primitives/text";
+
+export function MarketingGuidesSection({ children }: PropsWithChildren) {
+  return <section className="w-full pt-16 pb-4">{children}</section>;
+}
+
+export function MarketingGuidesGrid({ children }: PropsWithChildren) {
+  return (
+    <ul className="mt-8 grid grid-cols-1 sm:grid-cols-2 gap-2 list-none">
+      {children}
+    </ul>
+  );
+}
+
+export function MarketingGuideCard({
+  blurb,
+  path,
+  title,
+}: {
+  blurb: string;
+  path: string;
+  title: string;
+}) {
+  return (
+    <li>
+      <Link
+        className="group flex h-full flex-col gap-1 rounded-2xl border border-interactive-border bg-background p-4 shadow-xs transition-colors hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        to={path}
+      >
+        <Text size="sm" tone="default" className="group-hover:text-foreground-hover">
+          {title}
+        </Text>
+        <Text size="sm" tone="muted" className="line-clamp-2">
+          {blurb}
+        </Text>
+      </Link>
+    </li>
+  );
+}

--- a/applications/web/src/features/marketing/components/related-articles.tsx
+++ b/applications/web/src/features/marketing/components/related-articles.tsx
@@ -1,0 +1,35 @@
+import { Link } from "@tanstack/react-router";
+import { Heading3 } from "@/components/ui/primitives/heading";
+import { Text } from "@/components/ui/primitives/text";
+import type { ArticleSummary } from "@/lib/related-articles";
+
+const RELATED_ARTICLES_HEADING_ID = "related-articles";
+
+export function RelatedArticles({ articles }: { articles: ArticleSummary[] }) {
+  if (articles.length === 0) return null;
+
+  return (
+    <aside aria-labelledby={RELATED_ARTICLES_HEADING_ID} className="flex flex-col gap-3">
+      <Heading3 as="h2" id={RELATED_ARTICLES_HEADING_ID}>
+        Keep reading
+      </Heading3>
+      <ul className="flex flex-col gap-2 list-none">
+        {articles.map((article) => (
+          <li key={article.path}>
+            <Link
+              className="group block rounded-2xl border border-interactive-border bg-background p-4 shadow-xs transition-colors hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              to={article.path}
+            >
+              <Text size="sm" tone="default" className="group-hover:text-foreground-hover">
+                {article.title}
+              </Text>
+              <Text size="sm" tone="muted" className="line-clamp-2">
+                {article.blurb}
+              </Text>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/applications/web/src/generated/tanstack/route-tree.generated.ts
+++ b/applications/web/src/generated/tanstack/route-tree.generated.ts
@@ -27,11 +27,13 @@ import { Route as authForgotPasswordRouteImport } from './../../routes/(auth)/fo
 import { Route as oauthDashboardRouteRouteImport } from './../../routes/(oauth)/dashboard/route'
 import { Route as oauthAuthRouteRouteImport } from './../../routes/(oauth)/auth/route'
 import { Route as marketingBlogRouteRouteImport } from './../../routes/(marketing)/blog/route'
+import { Route as marketingCompareIndexRouteImport } from './../../routes/(marketing)/compare/index'
 import { Route as marketingBlogIndexRouteImport } from './../../routes/(marketing)/blog/index'
 import { Route as dashboardDashboardIndexRouteImport } from './../../routes/(dashboard)/dashboard/index'
 import { Route as oauthOauthConsentRouteImport } from './../../routes/(oauth)/oauth/consent'
 import { Route as oauthAuthOutlookRouteImport } from './../../routes/(oauth)/auth/outlook'
 import { Route as oauthAuthGoogleRouteImport } from './../../routes/(oauth)/auth/google'
+import { Route as marketingCompareSlugRouteImport } from './../../routes/(marketing)/compare/$slug'
 import { Route as marketingBlogSlugRouteImport } from './../../routes/(marketing)/blog/$slug'
 import { Route as dashboardDashboardReportRouteImport } from './../../routes/(dashboard)/dashboard/report'
 import { Route as dashboardDashboardFeedbackRouteImport } from './../../routes/(dashboard)/dashboard/feedback'
@@ -149,6 +151,11 @@ const marketingBlogRouteRoute = marketingBlogRouteRouteImport.update({
   path: '/blog',
   getParentRoute: () => marketingRouteRoute,
 } as any)
+const marketingCompareIndexRoute = marketingCompareIndexRouteImport.update({
+  id: '/compare/',
+  path: '/compare/',
+  getParentRoute: () => marketingRouteRoute,
+} as any)
 const marketingBlogIndexRoute = marketingBlogIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -173,6 +180,11 @@ const oauthAuthGoogleRoute = oauthAuthGoogleRouteImport.update({
   id: '/google',
   path: '/google',
   getParentRoute: () => oauthAuthRouteRoute,
+} as any)
+const marketingCompareSlugRoute = marketingCompareSlugRouteImport.update({
+  id: '/compare/$slug',
+  path: '/compare/$slug',
+  getParentRoute: () => marketingRouteRoute,
 } as any)
 const marketingBlogSlugRoute = marketingBlogSlugRouteImport.update({
   id: '/$slug',
@@ -370,11 +382,13 @@ export interface FileRoutesByFullPath {
   '/dashboard/feedback': typeof dashboardDashboardFeedbackRoute
   '/dashboard/report': typeof dashboardDashboardReportRoute
   '/blog/$slug': typeof marketingBlogSlugRoute
+  '/compare/$slug': typeof marketingCompareSlugRoute
   '/auth/google': typeof oauthAuthGoogleRoute
   '/auth/outlook': typeof oauthAuthOutlookRoute
   '/oauth/consent': typeof oauthOauthConsentRoute
   '/dashboard/': typeof dashboardDashboardIndexRoute
   '/blog/': typeof marketingBlogIndexRoute
+  '/compare/': typeof marketingCompareIndexRoute
   '/dashboard/ical/$feedId': typeof dashboardDashboardIcalFeedIdRoute
   '/dashboard/settings/api-tokens': typeof dashboardDashboardSettingsApiTokensRoute
   '/dashboard/settings/change-password': typeof dashboardDashboardSettingsChangePasswordRoute
@@ -416,10 +430,12 @@ export interface FileRoutesByTo {
   '/dashboard/feedback': typeof dashboardDashboardFeedbackRoute
   '/dashboard/report': typeof dashboardDashboardReportRoute
   '/blog/$slug': typeof marketingBlogSlugRoute
+  '/compare/$slug': typeof marketingCompareSlugRoute
   '/auth/google': typeof oauthAuthGoogleRoute
   '/auth/outlook': typeof oauthAuthOutlookRoute
   '/oauth/consent': typeof oauthOauthConsentRoute
   '/blog': typeof marketingBlogIndexRoute
+  '/compare': typeof marketingCompareIndexRoute
   '/dashboard/ical/$feedId': typeof dashboardDashboardIcalFeedIdRoute
   '/dashboard/settings/api-tokens': typeof dashboardDashboardSettingsApiTokensRoute
   '/dashboard/settings/change-password': typeof dashboardDashboardSettingsChangePasswordRoute
@@ -469,11 +485,13 @@ export interface FileRoutesById {
   '/(dashboard)/dashboard/feedback': typeof dashboardDashboardFeedbackRoute
   '/(dashboard)/dashboard/report': typeof dashboardDashboardReportRoute
   '/(marketing)/blog/$slug': typeof marketingBlogSlugRoute
+  '/(marketing)/compare/$slug': typeof marketingCompareSlugRoute
   '/(oauth)/auth/google': typeof oauthAuthGoogleRoute
   '/(oauth)/auth/outlook': typeof oauthAuthOutlookRoute
   '/(oauth)/oauth/consent': typeof oauthOauthConsentRoute
   '/(dashboard)/dashboard/': typeof dashboardDashboardIndexRoute
   '/(marketing)/blog/': typeof marketingBlogIndexRoute
+  '/(marketing)/compare/': typeof marketingCompareIndexRoute
   '/(dashboard)/dashboard/ical/$feedId': typeof dashboardDashboardIcalFeedIdRoute
   '/(dashboard)/dashboard/settings/api-tokens': typeof dashboardDashboardSettingsApiTokensRoute
   '/(dashboard)/dashboard/settings/change-password': typeof dashboardDashboardSettingsChangePasswordRoute
@@ -520,11 +538,13 @@ export interface FileRouteTypes {
     | '/dashboard/feedback'
     | '/dashboard/report'
     | '/blog/$slug'
+    | '/compare/$slug'
     | '/auth/google'
     | '/auth/outlook'
     | '/oauth/consent'
     | '/dashboard/'
     | '/blog/'
+    | '/compare/'
     | '/dashboard/ical/$feedId'
     | '/dashboard/settings/api-tokens'
     | '/dashboard/settings/change-password'
@@ -566,10 +586,12 @@ export interface FileRouteTypes {
     | '/dashboard/feedback'
     | '/dashboard/report'
     | '/blog/$slug'
+    | '/compare/$slug'
     | '/auth/google'
     | '/auth/outlook'
     | '/oauth/consent'
     | '/blog'
+    | '/compare'
     | '/dashboard/ical/$feedId'
     | '/dashboard/settings/api-tokens'
     | '/dashboard/settings/change-password'
@@ -618,11 +640,13 @@ export interface FileRouteTypes {
     | '/(dashboard)/dashboard/feedback'
     | '/(dashboard)/dashboard/report'
     | '/(marketing)/blog/$slug'
+    | '/(marketing)/compare/$slug'
     | '/(oauth)/auth/google'
     | '/(oauth)/auth/outlook'
     | '/(oauth)/oauth/consent'
     | '/(dashboard)/dashboard/'
     | '/(marketing)/blog/'
+    | '/(marketing)/compare/'
     | '/(dashboard)/dashboard/ical/$feedId'
     | '/(dashboard)/dashboard/settings/api-tokens'
     | '/(dashboard)/dashboard/settings/change-password'
@@ -781,6 +805,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof marketingBlogRouteRouteImport
       parentRoute: typeof marketingRouteRoute
     }
+    '/(marketing)/compare/': {
+      id: '/(marketing)/compare/'
+      path: '/compare'
+      fullPath: '/compare/'
+      preLoaderRoute: typeof marketingCompareIndexRouteImport
+      parentRoute: typeof marketingRouteRoute
+    }
     '/(marketing)/blog/': {
       id: '/(marketing)/blog/'
       path: '/'
@@ -815,6 +846,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/auth/google'
       preLoaderRoute: typeof oauthAuthGoogleRouteImport
       parentRoute: typeof oauthAuthRouteRoute
+    }
+    '/(marketing)/compare/$slug': {
+      id: '/(marketing)/compare/$slug'
+      path: '/compare/$slug'
+      fullPath: '/compare/$slug'
+      preLoaderRoute: typeof marketingCompareSlugRouteImport
+      parentRoute: typeof marketingRouteRoute
     }
     '/(marketing)/blog/$slug': {
       id: '/(marketing)/blog/$slug'
@@ -1173,6 +1211,8 @@ interface marketingRouteRouteChildren {
   marketingPrivacyRoute: typeof marketingPrivacyRoute
   marketingTermsRoute: typeof marketingTermsRoute
   marketingIndexRoute: typeof marketingIndexRoute
+  marketingCompareSlugRoute: typeof marketingCompareSlugRoute
+  marketingCompareIndexRoute: typeof marketingCompareIndexRoute
 }
 
 const marketingRouteRouteChildren: marketingRouteRouteChildren = {
@@ -1182,6 +1222,8 @@ const marketingRouteRouteChildren: marketingRouteRouteChildren = {
   marketingPrivacyRoute: marketingPrivacyRoute,
   marketingTermsRoute: marketingTermsRoute,
   marketingIndexRoute: marketingIndexRoute,
+  marketingCompareSlugRoute: marketingCompareSlugRoute,
+  marketingCompareIndexRoute: marketingCompareIndexRoute,
 }
 
 const marketingRouteRouteWithChildren = marketingRouteRoute._addFileChildren(

--- a/applications/web/src/lib/article-library.ts
+++ b/applications/web/src/lib/article-library.ts
@@ -1,0 +1,33 @@
+import { blogPosts, type BlogPost } from "./blog-posts";
+import { comparePages } from "./compare-pages";
+import { selectLatestArticles, type ArticleSummary } from "./related-articles";
+
+const LATEST_GUIDE_COUNT = 6;
+
+function toArticleSummary(page: BlogPost, basePath: string): ArticleSummary {
+  return {
+    blurb: page.metadata.blurb,
+    createdAt: page.metadata.createdAt,
+    path: `${basePath}/${page.slug}`,
+    tags: page.metadata.tags,
+    title: page.metadata.title,
+  };
+}
+
+/* Every article shares a createdAt, so byRecency returns 0 throughout and a
+ * stable sort hands the whole ordering to this array. Compare pages are titled
+ * after the rival, so putting them first leads every related list with a
+ * competitor's brand name. */
+export const articleLibrary: ArticleSummary[] = [
+  ...blogPosts.map((blogPost) => toArticleSummary(blogPost, "/blog")),
+  ...comparePages.map((comparePage) => toArticleSummary(comparePage, "/compare")),
+];
+
+const COMPARE_PATH_PREFIX = "/compare/";
+
+/* The homepage block is headed "Latest Guides", and a guide is what a reader
+ * clicking it expects — not three pages named after other products. */
+export const latestGuides: ArticleSummary[] = selectLatestArticles(
+  articleLibrary.filter((article) => !article.path.startsWith(COMPARE_PATH_PREFIX)),
+  LATEST_GUIDE_COUNT,
+);

--- a/applications/web/src/lib/cacheable-paths.ts
+++ b/applications/web/src/lib/cacheable-paths.ts
@@ -1,8 +1,10 @@
 import { blogPosts } from "./blog-posts";
+import { comparePages } from "./compare-pages";
 
-const marketingPaths = ["/", "/blog", "/privacy", "/terms"];
+const marketingPaths = ["/", "/blog", "/compare", "/privacy", "/terms"];
 
 export const cacheableHtmlPaths: string[] = [
   ...marketingPaths,
   ...blogPosts.map((blogPost) => `/blog/${blogPost.slug}`),
+  ...comparePages.map((comparePage) => `/compare/${comparePage.slug}`),
 ];

--- a/applications/web/src/lib/compare-pages.ts
+++ b/applications/web/src/lib/compare-pages.ts
@@ -1,0 +1,11 @@
+// @ts-expect-error - virtual module provided by plugins/blog.ts
+import { comparePages as processedPages } from "virtual:compare-pages";
+import type { BlogPost } from "./blog-posts";
+
+export type ComparePage = BlogPost;
+
+export const comparePages: ComparePage[] = processedPages;
+
+export function findComparePageBySlug(slug: string): ComparePage | undefined {
+  return comparePages.find((comparePage) => comparePage.slug === slug);
+}

--- a/applications/web/src/lib/moved-paths.ts
+++ b/applications/web/src/lib/moved-paths.ts
@@ -1,0 +1,9 @@
+const MOVED_PATHS: Record<string, string> = {
+  "/blog/keeper-sh-vs-calendarbridge": "/compare/calendarbridge-alternative",
+  "/blog/keeper-sh-vs-onecal": "/compare/onecal-alternative",
+  "/blog/keeper-sh-vs-syncthemcalendars": "/compare/syncthemcalendars-alternative",
+};
+
+export function resolveMovedPath(pathname: string): string | null {
+  return MOVED_PATHS[pathname] ?? null;
+}

--- a/applications/web/src/lib/related-articles.ts
+++ b/applications/web/src/lib/related-articles.ts
@@ -1,0 +1,41 @@
+export interface ArticleSummary {
+  blurb: string;
+  createdAt: string;
+  path: string;
+  tags: string[];
+  title: string;
+}
+
+const RELATED_ARTICLE_COUNT = 3;
+
+function countSharedTags(tags: string[], otherTags: string[]): number {
+  return tags.filter((tag) => otherTags.includes(tag)).length;
+}
+
+function byRecency(article: ArticleSummary, other: ArticleSummary): number {
+  return other.createdAt.localeCompare(article.createdAt);
+}
+
+export function selectLatestArticles(
+  articles: ArticleSummary[],
+  count: number,
+): ArticleSummary[] {
+  return [...articles].sort(byRecency).slice(0, count);
+}
+
+export function selectRelatedArticles(
+  currentPath: string,
+  articles: ArticleSummary[],
+  count = RELATED_ARTICLE_COUNT,
+): ArticleSummary[] {
+  const currentTags = articles.find((article) => article.path === currentPath)?.tags ?? [];
+
+  return articles
+    .filter((article) => article.path !== currentPath)
+    .sort((article, other) => {
+      const sharedTagDifference =
+        countSharedTags(other.tags, currentTags) - countSharedTags(article.tags, currentTags);
+      return sharedTagDifference !== 0 ? sharedTagDifference : byRecency(article, other);
+    })
+    .slice(0, count);
+}

--- a/applications/web/src/lib/seo.ts
+++ b/applications/web/src/lib/seo.ts
@@ -219,21 +219,25 @@ export function faqSchema(
   };
 }
 
-export function collectionPageSchema(posts: Array<{ slug: string; metadata: { title: string } }>) {
+export function collectionPageSchema(
+  path: string,
+  name: string,
+  entries: Array<{ slug: string; metadata: { title: string } }>,
+) {
   return {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
-    "@id": entityId("/blog", "collectionpage"),
-    name: "Blog",
-    url: canonicalUrl("/blog"),
+    "@id": entityId(path, "collectionpage"),
+    name,
+    url: canonicalUrl(path),
     isPartOf: { "@id": `${SITE_URL}/#website` },
     mainEntity: {
       "@type": "ItemList",
-      itemListElement: posts.map((post, index) => ({
+      itemListElement: entries.map((entry, index) => ({
         "@type": "ListItem",
         position: index + 1,
-        url: canonicalUrl(`/blog/${post.slug}`),
-        name: post.metadata.title,
+        url: canonicalUrl(`${path}/${entry.slug}`),
+        name: entry.metadata.title,
       })),
     },
   };
@@ -250,17 +254,17 @@ export const authorPersonSchema = {
 export function blogPostingSchema(post: {
   title: string;
   description: string;
-  slug: string;
+  path: string;
   createdAt: string;
   updatedAt: string;
   tags: string[];
   imagePath?: string;
 }) {
-  const url = canonicalUrl(`/blog/${post.slug}`);
+  const url = canonicalUrl(post.path);
   return {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
-    "@id": entityId(`/blog/${post.slug}`, "blogposting"),
+    "@id": entityId(post.path, "blogposting"),
     headline: post.title,
     description: post.description,
     image: canonicalUrl(post.imagePath ?? DEFAULT_IMAGE_PATH),

--- a/applications/web/src/routes/(marketing)/blog/index.tsx
+++ b/applications/web/src/routes/(marketing)/blog/index.tsx
@@ -1,17 +1,13 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { Heading1, Heading3 } from "@/components/ui/primitives/heading";
+import { createFileRoute } from "@tanstack/react-router";
+import { Heading1 } from "@/components/ui/primitives/heading";
 import { Text } from "@/components/ui/primitives/text";
+import { TextLink } from "@/components/ui/primitives/text-link";
+import { ArticleCard } from "@/features/marketing/components/article-card";
 import { blogPosts } from "@/lib/blog-posts";
-import { formatIsoDate } from "@/utils/date";
 import { canonicalUrl, jsonLdScript, seoMeta, breadcrumbSchema, breadcrumbTrail, collectionPageSchema } from "@/lib/seo";
 import { Breadcrumb } from "@/components/ui/primitives/breadcrumb";
 
 const breadcrumbs = breadcrumbTrail({ name: "Blog", path: "/blog" });
-
-const BLOG_ILLUSTRATION_STYLE = {
-  backgroundImage:
-    "repeating-linear-gradient(-45deg, transparent 0 14px, var(--color-illustration-stripe) 14px 15px)",
-} as const;
 
 export const Route = createFileRoute("/(marketing)/blog/")({
   component: BlogDirectoryPage,
@@ -24,7 +20,7 @@ export const Route = createFileRoute("/(marketing)/blog/")({
     }),
     scripts: [
       jsonLdScript(breadcrumbSchema(breadcrumbs)),
-      jsonLdScript(collectionPageSchema(blogPosts)),
+      jsonLdScript(collectionPageSchema("/blog", "Blog", blogPosts)),
     ],
   }),
 });
@@ -37,36 +33,20 @@ function BlogDirectoryPage() {
         <Heading1>Blog</Heading1>
         <Text size="base" tone="muted" className="leading-6">
           Product updates, engineering deep-dives, and calendar syncing tips from the Keeper.sh team.
+          Weighing Keeper.sh against another tool? Read the{" "}
+          <TextLink align="left" size="base" to="/compare">comparison pages</TextLink>.
         </Text>
       </header>
 
       <div className="flex flex-col gap-3">
         {blogPosts.map((blogPost) => (
-          <Link
+          <ArticleCard
             key={blogPost.slug}
-            className="group block overflow-hidden rounded-2xl border border-interactive-border bg-background shadow-xs transition-colors hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            params={{ slug: blogPost.slug }}
-            to="/blog/$slug"
-          >
-            <article className="grid grid-cols-1 sm:grid-cols-3 sm:items-stretch">
-              <div
-                className="bg-background h-28 sm:col-span-1 sm:h-full"
-                style={BLOG_ILLUSTRATION_STYLE}
-                role="presentation"
-              />
-              <div className="flex flex-col gap-1 p-4 md:p-5 sm:col-span-2">
-                <Heading3 as="h2" className="group-hover:text-foreground-hover">
-                  {blogPost.metadata.title}
-                </Heading3>
-                <Text size="xs" tone="muted">
-                  Created {formatIsoDate(blogPost.metadata.createdAt)}
-                </Text>
-                <Text size="sm" tone="muted" className="line-clamp-3">
-                  {blogPost.metadata.blurb}
-                </Text>
-              </div>
-            </article>
-          </Link>
+            blurb={blogPost.metadata.blurb}
+            createdAt={blogPost.metadata.createdAt}
+            path={`/blog/${blogPost.slug}`}
+            title={blogPost.metadata.title}
+          />
         ))}
       </div>
     </div>

--- a/applications/web/src/routes/(marketing)/compare/$slug.tsx
+++ b/applications/web/src/routes/(marketing)/compare/$slug.tsx
@@ -9,7 +9,7 @@ import { ArticleCta } from "@/features/marketing/components/article-cta";
 import { MarkdownFaq, MarkdownFaqItem } from "@/features/marketing/components/markdown-faq";
 import { RelatedArticles } from "@/features/marketing/components/related-articles";
 import { articleLibrary } from "@/lib/article-library";
-import { findBlogPostBySlug } from "@/lib/blog-posts";
+import { findComparePageBySlug } from "@/lib/compare-pages";
 import { selectRelatedArticles } from "@/lib/related-articles";
 import { formatIsoDate } from "@/utils/date";
 import { canonicalUrl, jsonLdScript, seoMeta, blogPostingSchema, breadcrumbSchema, breadcrumbTrail, faqPageSchema } from "@/lib/seo";
@@ -25,82 +25,82 @@ const MARKDOWN_FAQ_COMPONENTS = {
   "faq-item": MarkdownFaqItem,
 } as Components;
 
-const blogPostBreadcrumbs = (title: string, slug: string) =>
-  breadcrumbTrail({ name: "Blog", path: "/blog" }, { name: title, path: `/blog/${slug}` });
+const comparePageBreadcrumbs = (title: string, slug: string) =>
+  breadcrumbTrail({ name: "Compare", path: "/compare" }, { name: title, path: `/compare/${slug}` });
 
-export const Route = createFileRoute("/(marketing)/blog/$slug")({
+export const Route = createFileRoute("/(marketing)/compare/$slug")({
   loader: ({ params }) => {
-    if (!findBlogPostBySlug(params.slug)) {
+    if (!findComparePageBySlug(params.slug)) {
       throw notFound();
     }
   },
-  component: BlogPostPage,
+  component: ComparePage,
   notFoundComponent: NotFoundState,
   head: ({ params }) => {
-    const blogPost = findBlogPostBySlug(params.slug);
-    if (!blogPost) {
+    const comparePage = findComparePageBySlug(params.slug);
+    if (!comparePage) {
       return {
         meta: [
-          { title: "Blog Post · Keeper.sh" },
+          { title: "Compare · Keeper.sh" },
           { content: "noindex", name: "robots" },
         ],
       };
     }
 
-    const postUrl = `/blog/${params.slug}`;
+    const pageUrl = `/compare/${params.slug}`;
     return {
-      links: [{ rel: "canonical", href: canonicalUrl(postUrl) }],
+      links: [{ rel: "canonical", href: canonicalUrl(pageUrl) }],
       meta: [
         ...seoMeta({
-          title: blogPost.metadata.title,
-          description: blogPost.metadata.description,
-          path: postUrl,
+          title: comparePage.metadata.title,
+          description: comparePage.metadata.description,
+          path: pageUrl,
           type: "article",
-          imagePath: blogPost.metadata.image,
+          imagePath: comparePage.metadata.image,
         }),
-        { content: blogPost.metadata.tags.join(", "), name: "keywords" },
-        { content: blogPost.metadata.createdAt, property: "article:published_time" },
-        { content: blogPost.metadata.updatedAt, property: "article:modified_time" },
-        ...blogPost.metadata.tags.map((tag) => ({
+        { content: comparePage.metadata.tags.join(", "), name: "keywords" },
+        { content: comparePage.metadata.createdAt, property: "article:published_time" },
+        { content: comparePage.metadata.updatedAt, property: "article:modified_time" },
+        ...comparePage.metadata.tags.map((tag) => ({
           content: tag,
           property: "article:tag",
         })),
       ],
       scripts: [
         jsonLdScript(blogPostingSchema({
-          title: blogPost.metadata.title,
-          description: blogPost.metadata.description,
-          path: postUrl,
-          createdAt: blogPost.metadata.createdAt,
-          updatedAt: blogPost.metadata.updatedAt,
-          tags: blogPost.metadata.tags,
-          imagePath: blogPost.metadata.image,
+          title: comparePage.metadata.title,
+          description: comparePage.metadata.description,
+          path: pageUrl,
+          createdAt: comparePage.metadata.createdAt,
+          updatedAt: comparePage.metadata.updatedAt,
+          tags: comparePage.metadata.tags,
+          imagePath: comparePage.metadata.image,
         })),
-        jsonLdScript(breadcrumbSchema(blogPostBreadcrumbs(blogPost.metadata.title, params.slug))),
-        ...(blogPost.faq.length > 0
-          ? [jsonLdScript(faqPageSchema(postUrl, blogPost.faq))]
+        jsonLdScript(breadcrumbSchema(comparePageBreadcrumbs(comparePage.metadata.title, params.slug))),
+        ...(comparePage.faq.length > 0
+          ? [jsonLdScript(faqPageSchema(pageUrl, comparePage.faq))]
           : []),
       ],
     };
   },
 });
 
-function BlogPostPage() {
+function ComparePage() {
   const { slug } = Route.useParams();
-  const blogPost = findBlogPostBySlug(slug);
-  if (!blogPost) {
+  const comparePage = findComparePageBySlug(slug);
+  if (!comparePage) {
     throw notFound();
   }
 
-  const createdDate = formatIsoDate(blogPost.metadata.createdAt);
-  const updatedDate = formatIsoDate(blogPost.metadata.updatedAt);
-  const showUpdated = blogPost.metadata.updatedAt !== blogPost.metadata.createdAt;
+  const createdDate = formatIsoDate(comparePage.metadata.createdAt);
+  const updatedDate = formatIsoDate(comparePage.metadata.updatedAt);
+  const showUpdated = comparePage.metadata.updatedAt !== comparePage.metadata.createdAt;
 
   return (
     <div className="flex flex-col gap-6 py-16">
-      <Breadcrumb items={blogPostBreadcrumbs(blogPost.metadata.title, slug)} />
+      <Breadcrumb items={comparePageBreadcrumbs(comparePage.metadata.title, slug)} />
       <header className="flex flex-col gap-2">
-        <Heading1>{blogPost.metadata.title}</Heading1>
+        <Heading1>{comparePage.metadata.title}</Heading1>
         <div className="flex flex-col">
           <Text size="sm" tone="muted" align="left">
             By{" "}
@@ -121,10 +121,10 @@ function BlogPostPage() {
       </header>
 
       <Prose allowedTags={MARKDOWN_FAQ_TAGS} components={MARKDOWN_FAQ_COMPONENTS}>
-        {blogPost.content}
+        {comparePage.content}
       </Prose>
 
-      <RelatedArticles articles={selectRelatedArticles(`/blog/${slug}`, articleLibrary)} />
+      <RelatedArticles articles={selectRelatedArticles(`/compare/${slug}`, articleLibrary)} />
 
       <ArticleCta />
     </div>

--- a/applications/web/src/routes/(marketing)/compare/index.tsx
+++ b/applications/web/src/routes/(marketing)/compare/index.tsx
@@ -1,0 +1,60 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Heading1 } from "@/components/ui/primitives/heading";
+import { Text } from "@/components/ui/primitives/text";
+import { TextLink } from "@/components/ui/primitives/text-link";
+import { ArticleCard } from "@/features/marketing/components/article-card";
+import { ArticleCta } from "@/features/marketing/components/article-cta";
+import { comparePages } from "@/lib/compare-pages";
+import { canonicalUrl, jsonLdScript, seoMeta, breadcrumbSchema, breadcrumbTrail, collectionPageSchema } from "@/lib/seo";
+import { Breadcrumb } from "@/components/ui/primitives/breadcrumb";
+
+const breadcrumbs = breadcrumbTrail({ name: "Compare", path: "/compare" });
+
+const PAGE_DESCRIPTION =
+  "How Keeper.sh compares to the other calendar sync tools: which calendars each one connects, how fast changes land, what each costs, and who each one suits.";
+
+export const Route = createFileRoute("/(marketing)/compare/")({
+  component: CompareDirectoryPage,
+  head: () => ({
+    links: [{ rel: "canonical", href: canonicalUrl("/compare") }],
+    meta: seoMeta({
+      title: "Compare Keeper.sh With Other Calendar Sync Tools",
+      description: PAGE_DESCRIPTION,
+      path: "/compare",
+    }),
+    scripts: [
+      jsonLdScript(breadcrumbSchema(breadcrumbs)),
+      jsonLdScript(collectionPageSchema("/compare", "Compare", comparePages)),
+    ],
+  }),
+});
+
+function CompareDirectoryPage() {
+  return (
+    <div className="flex flex-col gap-8 py-16">
+      <Breadcrumb items={breadcrumbs} />
+      <header className="flex flex-col gap-1.5">
+        <Heading1>Compare</Heading1>
+        <Text size="base" tone="muted" className="leading-6">
+          {PAGE_DESCRIPTION} Every figure links back to the source it came from. For the
+          longer guides on syncing calendars, read the{" "}
+          <TextLink align="left" size="base" to="/blog">blog</TextLink>.
+        </Text>
+      </header>
+
+      <div className="flex flex-col gap-3">
+        {comparePages.map((comparePage) => (
+          <ArticleCard
+            key={comparePage.slug}
+            blurb={comparePage.metadata.blurb}
+            createdAt={comparePage.metadata.createdAt}
+            path={`/compare/${comparePage.slug}`}
+            title={comparePage.metadata.title}
+          />
+        ))}
+      </div>
+
+      <ArticleCta />
+    </div>
+  );
+}

--- a/applications/web/src/routes/(marketing)/index.tsx
+++ b/applications/web/src/routes/(marketing)/index.tsx
@@ -11,9 +11,11 @@ import {
   MarketingHowItWorksStepIllustration,
 } from '../../features/marketing/components/marketing-how-it-works'
 import { MarketingFaqSection, MarketingFaqList, MarketingFaqItem, MarketingFaqQuestion } from '../../features/marketing/components/marketing-faq'
+import { MarketingGuideCard, MarketingGuidesGrid, MarketingGuidesSection } from '../../features/marketing/components/marketing-guides-section'
 import { MarketingCtaSection, MarketingCtaCard } from '../../features/marketing/components/marketing-cta'
 import { Collapsible } from '../../components/ui/primitives/collapsible'
 import { ButtonIcon, ButtonText, ExternalLinkButton, LinkButton } from '../../components/ui/primitives/button'
+import { TextLink } from '../../components/ui/primitives/text-link'
 import { MarketingIllustrationCalendar, MarketingIllustrationCalendarCard, type Skew, type SkewTuple } from '../../features/marketing/components/marketing-illustration-calendar'
 import {
   MarketingFeatureBentoBody,
@@ -42,6 +44,7 @@ import {
   MarketingPricingSection,
 } from '../../features/marketing/components/marketing-pricing-section'
 import { PRICING_FEATURES, PRICING_PLANS } from '../../features/marketing/pricing-plans'
+import { latestGuides } from '../../lib/article-library'
 import { calendarEmphasizedAtom } from '../../state/calendar-emphasized'
 import { ANALYTICS_EVENTS } from '../../lib/analytics'
 import ArrowRightIcon from "lucide-react/dist/esm/icons/arrow-right";
@@ -337,6 +340,26 @@ function MarketingPage() {
               </MarketingHowItWorksRow>
             </MarketingHowItWorksCard>
           </MarketingHowItWorksSection>
+
+          <MarketingGuidesSection>
+            <Heading2 className="text-center">Latest Guides</Heading2>
+            <Text size="sm" align="center" className="mt-2 max-w-[48ch] mx-auto">
+              Step-by-step guides for the calendars you use, and comparisons with the other
+              sync tools. Browse them all on the{' '}
+              <TextLink size="sm" to="/blog">blog</TextLink> and the{' '}
+              <TextLink size="sm" to="/compare">comparison pages</TextLink>.
+            </Text>
+            <MarketingGuidesGrid>
+              {latestGuides.map((guide) => (
+                <MarketingGuideCard
+                  key={guide.path}
+                  blurb={guide.blurb}
+                  path={guide.path}
+                  title={guide.title}
+                />
+              ))}
+            </MarketingGuidesGrid>
+          </MarketingGuidesSection>
 
           <MarketingFaqSection>
             <Heading2 className="text-center">Frequently Asked Questions</Heading2>

--- a/applications/web/src/routes/(marketing)/route.tsx
+++ b/applications/web/src/routes/(marketing)/route.tsx
@@ -100,6 +100,7 @@ function MarketingLayout() {
             <MarketingFooterNavGroup>
               <MarketingFooterNavGroupLabel>Resources</MarketingFooterNavGroupLabel>
               <MarketingFooterNavItem to="/blog">Blog</MarketingFooterNavItem>
+              <MarketingFooterNavItem to="/compare">Compare</MarketingFooterNavItem>
               <MarketingFooterNavItem href="https://github.com/ridafkih/keeper.sh">GitHub</MarketingFooterNavItem>
             </MarketingFooterNavGroup>
             <MarketingFooterNavGroup>

--- a/applications/web/src/server/http-handler.ts
+++ b/applications/web/src/server/http-handler.ts
@@ -2,6 +2,7 @@ import { withCompression } from "./compression";
 import { isApiRequest, isMcpRequest, proxyRequest } from "./proxy/http";
 import { handleInternalRoute } from "./internal-routes";
 import { hasSessionCookie } from "@/lib/session-cookie";
+import { resolveMovedPath } from "@/lib/moved-paths";
 import type { Runtime, ServerConfig } from "./types";
 
 const HTML_CACHE_TTL_MS = 60_000;
@@ -94,9 +95,18 @@ export function resolveCanonicalRedirect(requestUrl: URL): Response | null {
     return permanentRedirect(`/${requestUrl.search}`);
   }
 
-  if (pathname.length > 1 && pathname.endsWith("/")) {
-    const normalizedPath = pathname.replace(/\/+$/, "");
-    return permanentRedirect(`${normalizedPath || "/"}${requestUrl.search}`);
+  const trimmedPath =
+    pathname.length > 1 && pathname.endsWith("/")
+      ? pathname.replace(/\/+$/, "") || "/"
+      : pathname;
+
+  const movedPath = resolveMovedPath(trimmedPath);
+  if (movedPath) {
+    return permanentRedirect(`${movedPath}${requestUrl.search}`);
+  }
+
+  if (trimmedPath !== pathname) {
+    return permanentRedirect(`${trimmedPath}${requestUrl.search}`);
   }
 
   return null;

--- a/applications/web/tests/content/blog-links.test.ts
+++ b/applications/web/tests/content/blog-links.test.ts
@@ -2,18 +2,24 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-const BLOG_DIRECTORY = join(import.meta.dirname, "../../src/content/blog");
+const CONTENT_DIRECTORIES = ["blog", "compare"].map((collection) =>
+  join(import.meta.dirname, "../../src/content", collection),
+);
 const ABSOLUTE_SELF_LINK = /]\(https?:\/\/(?:www\.)?keeper\.sh(?![\w.-])[^)]*\)/g;
 
-const posts = readdirSync(BLOG_DIRECTORY).filter((entry) => entry.endsWith(".mdx"));
+const posts = CONTENT_DIRECTORIES.flatMap((directory) =>
+  readdirSync(directory)
+    .filter((entry) => entry.endsWith(".mdx"))
+    .map((entry) => join(directory, entry)),
+);
 
-describe("blog post links", () => {
+describe("content links", () => {
   it("has posts to check", () => {
     expect(posts.length).toBeGreaterThan(0);
   });
 
   it.each(posts)("links to keeper.sh with root-relative paths in %s", (post) => {
-    const content = readFileSync(join(BLOG_DIRECTORY, post), "utf8");
+    const content = readFileSync(post, "utf8");
 
     expect(content.match(ABSOLUTE_SELF_LINK)).toBeNull();
   });

--- a/applications/web/tests/lib/related-articles.test.ts
+++ b/applications/web/tests/lib/related-articles.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  selectLatestArticles,
+  selectRelatedArticles,
+  type ArticleSummary,
+} from "@/lib/related-articles";
+
+const articles: ArticleSummary[] = [
+  {
+    blurb: "How Keeper.sh and CalendarBridge differ.",
+    createdAt: "2026-08-11",
+    path: "/compare/calendarbridge-alternative",
+    tags: ["calendar", "comparison", "calendarbridge"],
+    title: "CalendarBridge Alternative",
+  },
+  {
+    blurb: "How Keeper.sh and OneCal differ.",
+    createdAt: "2026-08-10",
+    path: "/compare/onecal-alternative",
+    tags: ["calendar", "comparison", "onecal"],
+    title: "OneCal Alternative",
+  },
+  {
+    blurb: "Why syncing calendars is harder than it looks.",
+    createdAt: "2026-08-09",
+    path: "/blog/how-calendar-sync-actually-works",
+    tags: ["calendar", "engineering"],
+    title: "How Calendar Sync Actually Works",
+  },
+  {
+    blurb: "Connecting Google Calendar to Outlook.",
+    createdAt: "2026-08-08",
+    path: "/blog/how-to-sync-google-calendar-with-outlook",
+    tags: ["google", "outlook"],
+    title: "How To Sync Google Calendar With Outlook",
+  },
+];
+
+describe("selectRelatedArticles", () => {
+  it("leaves the current article out of its own suggestions", () => {
+    const related = selectRelatedArticles("/compare/calendarbridge-alternative", articles);
+
+    expect(related.map((article) => article.path)).not.toContain(
+      "/compare/calendarbridge-alternative",
+    );
+  });
+
+  it("puts the articles sharing the most tags first", () => {
+    const related = selectRelatedArticles("/compare/calendarbridge-alternative", articles);
+
+    expect(related.map((article) => article.path)).toEqual([
+      "/compare/onecal-alternative",
+      "/blog/how-calendar-sync-actually-works",
+      "/blog/how-to-sync-google-calendar-with-outlook",
+    ]);
+  });
+
+  it("falls back to the newest articles for a path outside the library", () => {
+    const related = selectRelatedArticles("/compare/unknown", articles, 2);
+
+    expect(related.map((article) => article.path)).toEqual([
+      "/compare/calendarbridge-alternative",
+      "/compare/onecal-alternative",
+    ]);
+  });
+});
+
+describe("selectLatestArticles", () => {
+  it("returns the newest articles first without mutating the library", () => {
+    const latest = selectLatestArticles([...articles].reverse(), 2);
+
+    expect(latest.map((article) => article.path)).toEqual([
+      "/compare/calendarbridge-alternative",
+      "/compare/onecal-alternative",
+    ]);
+    expect(articles[0].path).toBe("/compare/calendarbridge-alternative");
+  });
+});

--- a/applications/web/tests/lib/seo.test.ts
+++ b/applications/web/tests/lib/seo.test.ts
@@ -12,7 +12,7 @@ const GENERIC_IMAGE_URL = "https://www.keeper.sh/open-graph.png";
 const post = {
   title: "How Calendar Sync Actually Works",
   description: "A long-form explainer.",
-  slug: "how-calendar-sync-actually-works",
+  path: "/blog/how-calendar-sync-actually-works",
   createdAt: "2026-08-01",
   updatedAt: "2026-08-02",
   tags: ["calendar"],
@@ -130,7 +130,7 @@ describe("blogPostingSchema", () => {
     const schema = blogPostingSchema({
       title: "Why Keeper",
       description: "A post",
-      slug: "why-keeper",
+      path: "/blog/why-keeper",
       createdAt: "2026-01-01",
       updatedAt: "2026-01-02",
       tags: ["calendar"],
@@ -142,6 +142,19 @@ describe("blogPostingSchema", () => {
 
 describe("collectionPageSchema", () => {
   it("keeps the published identifier", () => {
-    expect(collectionPageSchema([])["@id"]).toBe("https://www.keeper.sh/blog/#collectionpage");
+    expect(collectionPageSchema("/blog", "Blog", [])["@id"]).toBe(
+      "https://www.keeper.sh/blog/#collectionpage",
+    );
+  });
+
+  it("lists every entry under the collection it belongs to", () => {
+    const schema = collectionPageSchema("/compare", "Compare", [
+      { slug: "onecal-alternative", metadata: { title: "OneCal Alternative" } },
+    ]);
+
+    expect(schema.name).toBe("Compare");
+    expect(schema.mainEntity.itemListElement[0].url).toBe(
+      "https://www.keeper.sh/compare/onecal-alternative",
+    );
   });
 });

--- a/applications/web/tests/server/http-handler.test.ts
+++ b/applications/web/tests/server/http-handler.test.ts
@@ -226,6 +226,25 @@ describe("resolveCanonicalRedirect", () => {
   it("leaves canonical paths untouched", () => {
     expect(resolveCanonicalRedirect(new URL("https://www.keeper.sh/blog"))).toBeNull();
   });
+
+  it("permanently redirects a moved comparison post to its /compare path", () => {
+    const response = resolveCanonicalRedirect(
+      new URL("https://www.keeper.sh/blog/keeper-sh-vs-calendarbridge"),
+    );
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe("/compare/calendarbridge-alternative");
+  });
+
+  it("reaches the moved comparison post in one hop from a trailing slash", () => {
+    const response = resolveCanonicalRedirect(
+      new URL("https://www.keeper.sh/blog/keeper-sh-vs-onecal/?ref=newsletter"),
+    );
+
+    expect(response?.headers.get("location")).toBe(
+      "/compare/onecal-alternative?ref=newsletter",
+    );
+  });
 });
 
 function cspDirectives(header: string): Map<string, string[]> {

--- a/applications/web/vite.config.ts
+++ b/applications/web/vite.config.ts
@@ -5,7 +5,7 @@ import tailwindcss from "@tailwindcss/vite";
 import svgr from "vite-plugin-svgr";
 import react, { reactCompilerPreset } from '@vitejs/plugin-react'
 import babel from '@rolldown/plugin-babel'
-import { blogPlugin } from "./plugins/blog";
+import { blogPlugin, comparePlugin } from "./plugins/blog";
 import { feedPlugin } from "./plugins/feed";
 import { sitemapPlugin } from "./plugins/sitemap";
 
@@ -17,6 +17,7 @@ export default defineConfig(({ isSsrBuild }) => ({
   },
   plugins: [
     blogPlugin(),
+    comparePlugin(),
     tailwindcss(),
     tanstackRouter({
       autoCodeSplitting: true,


### PR DESCRIPTION
The old `/blog` comparison paths now permanently redirect to the new `/compare` routes, so existing links and search results keep resolving.