### PR TITLE
fix(oauth): persist provider account ids, and stop withholding push channels that never needed them

### DIFF
--- a/packages/calendar/src/core/source/push-channel.ts
+++ b/packages/calendar/src/core/source/push-channel.ts
@@ -5,6 +5,7 @@ import {
   resolveRenewalLeadMs,
   resolveStaggerPeriodMs,
   type PushChannelRenewalMode,
+  type PushProviderProfile,
 } from "./push-provider-profile";
 
 const FULL_POLL_INTERVAL_MS = 60_000;
@@ -63,7 +64,7 @@ type PushChannelScope =
     calendarId: string;
     externalCalendarId: string;
     kind: "calendar";
-    providerAccountId: string;
+    providerAccountId: string | null;
     userId: string;
   }
   | {
@@ -155,11 +156,25 @@ interface PushChannelHealth {
   reason: string | null;
 }
 
+type PushPlanSkipReason =
+  | "existing-channel"
+  | "free-plan"
+  | "missing-external-calendar-id"
+  | "missing-provider-account-id"
+  | "needs-reauthentication"
+  | "not-pull"
+  | "plan-unresolved"
+  | "unsupported-provider";
+
+type CalendarPlanDecision =
+  | { kind: "register"; profile: PushProviderProfile; scope: PushChannelScope }
+  | { kind: "skip"; reason: PushPlanSkipReason };
+
 interface PlanPushChannelActionsInput {
   calendars: EligibleSourceCalendar[];
   channels: StoredPushChannel[];
   now: Date;
-  onFreeCalendarSkipped?: (calendar: EligibleSourceCalendar) => void;
+  onCalendarSkipped?: (calendar: EligibleSourceCalendar, reason: PushPlanSkipReason) => void;
   onPlanError: (userId: string, error: unknown) => void;
   resolvePlan: (userId: string) => Promise<"free" | "pro">;
   webhookPublicUrl: string | null;
@@ -248,7 +263,7 @@ const resolveRequestedExpiresAt = (
 };
 
 const buildCalendarScope = (calendar: EligibleSourceCalendar): PushChannelScope | null => {
-  if (calendar.externalCalendarId === null || calendar.providerAccountId === null) {
+  if (calendar.externalCalendarId === null) {
     return null;
   }
   return {
@@ -268,12 +283,58 @@ const buildChannelScope = (channel: StoredPushChannel): PushChannelScope => ({
   userId: channel.userId,
 });
 
-const isRegistrationEligible = (calendar: EligibleSourceCalendar): boolean =>
-  isPullCalendar(calendar)
-  && !calendar.needsReauthentication
-  && calendar.externalCalendarId !== null
-  && calendar.providerAccountId !== null
-  && resolvePushProviderProfile(calendar.provider) !== null;
+const isRegistrationEligible = (calendar: EligibleSourceCalendar): boolean => {
+  const profile = resolvePushProviderProfile(calendar.provider);
+  if (!profile) {
+    return false;
+  }
+  if (profile.requiresProviderAccountId && calendar.providerAccountId === null) {
+    return false;
+  }
+  return isPullCalendar(calendar)
+    && !calendar.needsReauthentication
+    && calendar.externalCalendarId !== null;
+};
+
+const resolveCalendarPlanDecision = (
+  calendar: EligibleSourceCalendar,
+  hasLiveChannel: boolean,
+  plan: "free" | "pro" | null,
+): CalendarPlanDecision => {
+  if (hasLiveChannel) {
+    return { kind: "skip", reason: "existing-channel" };
+  }
+  if (!isPullCalendar(calendar)) {
+    return { kind: "skip", reason: "not-pull" };
+  }
+  if (calendar.needsReauthentication) {
+    return { kind: "skip", reason: "needs-reauthentication" };
+  }
+
+  const profile = resolvePushProviderProfile(calendar.provider);
+  if (!profile) {
+    return { kind: "skip", reason: "unsupported-provider" };
+  }
+  if (calendar.externalCalendarId === null) {
+    return { kind: "skip", reason: "missing-external-calendar-id" };
+  }
+  if (profile.requiresProviderAccountId && calendar.providerAccountId === null) {
+    return { kind: "skip", reason: "missing-provider-account-id" };
+  }
+
+  const scope = buildCalendarScope(calendar);
+  if (!scope) {
+    return { kind: "skip", reason: "missing-external-calendar-id" };
+  }
+  if (plan === null) {
+    return { kind: "skip", reason: "plan-unresolved" };
+  }
+  if (plan === "free") {
+    return { kind: "skip", reason: "free-plan" };
+  }
+
+  return { kind: "register", profile, scope };
+};
 
 const isRenewalDue = (
   channel: StoredPushChannel,
@@ -460,22 +521,14 @@ const planPushChannelActions = async (
   }
 
   for (const calendar of input.calendars) {
-    if (liveChannelsByCalendarId.has(calendar.calendarId)) {
-      continue;
-    }
-    if (!isRegistrationEligible(calendar)) {
-      continue;
-    }
-    const profile = resolvePushProviderProfile(calendar.provider);
-    const scope = buildCalendarScope(calendar);
-    if (!profile || !scope) {
-      continue;
-    }
-    if (plansByUserId.get(calendar.userId) === "free") {
-      input.onFreeCalendarSkipped?.(calendar);
-      continue;
-    }
-    if (plansByUserId.get(calendar.userId) !== "pro") {
+    const decision = resolveCalendarPlanDecision(
+      calendar,
+      liveChannelsByCalendarId.has(calendar.calendarId),
+      plansByUserId.get(calendar.userId) ?? null,
+    );
+
+    if (decision.kind === "skip") {
+      input.onCalendarSkipped?.(calendar, decision.reason);
       continue;
     }
 
@@ -484,13 +537,13 @@ const planPushChannelActions = async (
       previousProviderChannelId: null,
       previousProviderResourceId: null,
       provider: calendar.provider,
-      renewalMode: profile.renewalMode,
+      renewalMode: decision.profile.renewalMode,
       requestedExpiresAt: resolveRequestedExpiresAt(
         `${calendar.provider}:${calendar.calendarId}`,
-        profile.maxLifetimeMs,
+        decision.profile.maxLifetimeMs,
         input.now,
       ),
-      scope,
+      scope: decision.scope,
       type: "register",
     });
   }
@@ -552,6 +605,7 @@ export type {
   PushChannelScope,
   PushChannelState,
   PushClaimKind,
+  PushPlanSkipReason,
   PushRateLimiter,
   RegistrarContext,
   SourcePushRegistrar,

--- a/packages/calendar/src/core/source/push-provider-profile.ts
+++ b/packages/calendar/src/core/source/push-provider-profile.ts
@@ -11,6 +11,7 @@ interface PushProviderProfile {
   maxLifetimeMs: number;
   provider: string;
   renewalMode: PushChannelRenewalMode;
+  requiresProviderAccountId: boolean;
   scopeKind: "calendar";
   supportsList: boolean;
 }
@@ -19,6 +20,7 @@ const GOOGLE_PUSH_PROFILE: PushProviderProfile = {
   maxLifetimeMs: GOOGLE_WATCH_MAX_LIFETIME_MS,
   provider: "google",
   renewalMode: "recreate",
+  requiresProviderAccountId: false,
   scopeKind: "calendar",
   supportsList: false,
 };
@@ -27,6 +29,7 @@ const OUTLOOK_PUSH_PROFILE: PushProviderProfile = {
   maxLifetimeMs: GRAPH_SUBSCRIPTION_MAX_LIFETIME_MS,
   provider: "outlook",
   renewalMode: "extend",
+  requiresProviderAccountId: true,
   scopeKind: "calendar",
   supportsList: true,
 };

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -71,6 +71,7 @@ export type {
   PushChannelScope,
   PushChannelState,
   PushClaimKind,
+  PushPlanSkipReason,
   PushRateLimiter,
   RegistrarContext,
   SourcePushRegistrar,

--- a/packages/calendar/src/providers/outlook/push/subscription.ts
+++ b/packages/calendar/src/providers/outlook/push/subscription.ts
@@ -108,6 +108,13 @@ const registerOutlookSubscription = async (
     );
   }
 
+  if (scope.providerAccountId === null) {
+    throw new GraphSubscriptionError(
+      "Outlook push registration requires a provider account id on the calendar scope",
+      0,
+    );
+  }
+
   const resourcePath = buildCalendarResourcePath(
     scope.providerAccountId,
     scope.externalCalendarId,

--- a/packages/calendar/tests/core/source/push-channel-plan.test.ts
+++ b/packages/calendar/tests/core/source/push-channel-plan.test.ts
@@ -110,8 +110,8 @@ describe("planPushChannelActions eligibility", () => {
     })).resolves.toEqual([]);
   });
 
-  it("skips calendars whose account carries no provider account id", async () => {
-    await expect(plan({
+  it("skips only the providers that need a provider account id when it is absent", async () => {
+    const actions = await plan({
       calendars: [
         makeCalendar({ providerAccountId: null }),
         makeCalendar({
@@ -120,7 +120,11 @@ describe("planPushChannelActions eligibility", () => {
           providerAccountId: null,
         }),
       ],
-    })).resolves.toEqual([]);
+    });
+
+    expect(actions.map((action) => [action.provider, action.type])).toEqual([
+      ["google", "register"],
+    ]);
   });
 
   it("deregisters a channel whose calendar became disabled or lost pull", async () => {

--- a/packages/database/drizzle/0085_fixed_kat_farrell.sql
+++ b/packages/database/drizzle/0085_fixed_kat_farrell.sql
@@ -1,0 +1,14 @@
+UPDATE "calendar_accounts"
+SET "accountId" = NULL
+WHERE "accountId" = '';
+--> statement-breakpoint
+UPDATE "calendar_accounts" AS target
+SET "accountId" = donor."accountId"
+FROM "calendar_accounts" AS donor
+WHERE target."accountId" IS NULL
+  AND donor."accountId" IS NOT NULL
+  AND donor."id" <> target."id"
+  AND donor."userId" = target."userId"
+  AND donor."provider" = target."provider"
+  AND donor."email" IS NOT NULL
+  AND donor."email" = target."email";

--- a/packages/database/drizzle/meta/0085_snapshot.json
+++ b/packages/database/drizzle/meta/0085_snapshot.json
@@ -1,0 +1,3837 @@
+{
+  "id": "38fe910b-81fd-4355-8702-ed15aa405187",
+  "prevId": "cb9ec7fc-01a9-4d60-91d0-b71a07230324",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_tokens_user_idx": {
+          "name": "api_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "api_tokens_hash_idx": {
+          "name": "api_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_userId_user_id_fk": {
+          "name": "api_tokens_userId_user_id_fk",
+          "tableFrom": "api_tokens",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_tokenHash_unique": {
+          "name": "api_tokens_tokenHash_unique",
+          "columns": [
+            "tokenHash"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caldav_credentials": {
+      "name": "caldav_credentials",
+      "schema": "",
+      "columns": {
+        "authMethod": {
+          "name": "authMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'basic'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "encryptedPassword": {
+          "name": "encryptedPassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "serverUrl": {
+          "name": "serverUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_accounts": {
+      "name": "calendar_accounts",
+      "schema": "",
+      "columns": {
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authType": {
+          "name": "authType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caldavCredentialId": {
+          "name": "caldavCredentialId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendarsRefreshAttemptedAt": {
+          "name": "calendarsRefreshAttemptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendarsRefreshedAt": {
+          "name": "calendarsRefreshedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "needsReauthentication": {
+          "name": "needsReauthentication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "oauthCredentialId": {
+          "name": "oauthCredentialId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reauthenticationSource": {
+          "name": "reauthenticationSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_accounts_user_idx": {
+          "name": "calendar_accounts_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "calendar_accounts_provider_idx": {
+          "name": "calendar_accounts_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "calendar_accounts_needs_reauth_idx": {
+          "name": "calendar_accounts_needs_reauth_idx",
+          "columns": [
+            {
+              "expression": "needsReauthentication",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "calendar_accounts_provider_account_idx": {
+          "name": "calendar_accounts_provider_account_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "calendar_accounts_caldavCredentialId_caldav_credentials_id_fk": {
+          "name": "calendar_accounts_caldavCredentialId_caldav_credentials_id_fk",
+          "tableFrom": "calendar_accounts",
+          "columnsFrom": [
+            "caldavCredentialId"
+          ],
+          "tableTo": "caldav_credentials",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "calendar_accounts_oauthCredentialId_oauth_credentials_id_fk": {
+          "name": "calendar_accounts_oauthCredentialId_oauth_credentials_id_fk",
+          "tableFrom": "calendar_accounts",
+          "columnsFrom": [
+            "oauthCredentialId"
+          ],
+          "tableTo": "oauth_credentials",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "calendar_accounts_userId_user_id_fk": {
+          "name": "calendar_accounts_userId_user_id_fk",
+          "tableFrom": "calendar_accounts",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_push_channels": {
+      "name": "calendar_push_channels",
+      "schema": "",
+      "columns": {
+        "accountId": {
+          "name": "accountId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failureCount": {
+          "name": "failureCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lastFailureAt": {
+          "name": "lastFailureAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastNotificationAt": {
+          "name": "lastNotificationAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextAttemptAt": {
+          "name": "nextAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerChannelId": {
+          "name": "providerChannelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerResourceId": {
+          "name": "providerResourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauthorizeRequestedAt": {
+          "name": "reauthorizeRequestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourcePath": {
+          "name": "resourcePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secretHash": {
+          "name": "secretHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registering'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "calendar_push_channels_account_idx": {
+          "name": "calendar_push_channels_account_idx",
+          "columns": [
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "calendar_push_channels_expiry_idx": {
+          "name": "calendar_push_channels_expiry_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "calendar_push_channels_provider_channel_idx": {
+          "name": "calendar_push_channels_provider_channel_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerChannelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"calendar_push_channels\".\"providerChannelId\" is not null",
+          "concurrently": false
+        },
+        "calendar_push_channels_scope_idx": {
+          "name": "calendar_push_channels_scope_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"calendar_push_channels\".\"calendarId\" is not null and \"calendar_push_channels\".\"state\" in ('registering', 'active', 'degraded')",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "calendar_push_channels_accountId_calendar_accounts_id_fk": {
+          "name": "calendar_push_channels_accountId_calendar_accounts_id_fk",
+          "tableFrom": "calendar_push_channels",
+          "columnsFrom": [
+            "accountId"
+          ],
+          "tableTo": "calendar_accounts",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "calendar_push_channels_calendarId_calendars_id_fk": {
+          "name": "calendar_push_channels_calendarId_calendars_id_fk",
+          "tableFrom": "calendar_push_channels",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "tableTo": "calendars",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "calendar_push_channels_userId_user_id_fk": {
+          "name": "calendar_push_channels_userId_user_id_fk",
+          "tableFrom": "calendar_push_channels",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_snapshots": {
+      "name": "calendar_snapshots",
+      "schema": "",
+      "columns": {
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ical": {
+          "name": "ical",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "calendar_snapshots_calendarId_calendars_id_fk": {
+          "name": "calendar_snapshots_calendarId_calendars_id_fk",
+          "tableFrom": "calendar_snapshots",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "tableTo": "calendars",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_snapshots_calendarId_unique": {
+          "name": "calendar_snapshots_calendarId_unique",
+          "columns": [
+            "calendarId"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendars": {
+      "name": "calendars",
+      "schema": "",
+      "columns": {
+        "accountId": {
+          "name": "accountId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarType": {
+          "name": "calendarType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarUrl": {
+          "name": "calendarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "excludeAllDayEvents": {
+          "name": "excludeAllDayEvents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeEventDescription": {
+          "name": "excludeEventDescription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "excludeEventLocation": {
+          "name": "excludeEventLocation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "excludeEventName": {
+          "name": "excludeEventName",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "excludeFocusTime": {
+          "name": "excludeFocusTime",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeOutOfOffice": {
+          "name": "excludeOutOfOffice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeInIcalFeed": {
+          "name": "includeInIcalFeed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "treatFullDayTimedEventsAsAllDay": {
+          "name": "treatFullDayTimedEventsAsAllDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customEventName": {
+          "name": "customEventName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{{calendar_name}}'"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "failureCount": {
+          "name": "failureCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastFailureAt": {
+          "name": "lastFailureAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextAttemptAt": {
+          "name": "nextAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestFailureCount": {
+          "name": "ingestFailureCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ingestLastFailureAt": {
+          "name": "ingestLastFailureAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestNextAttemptAt": {
+          "name": "ingestNextAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestFutureRange": {
+          "name": "ingestFutureRange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2_years'"
+        },
+        "ingestHistoricRange": {
+          "name": "ingestHistoricRange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1_month'"
+        },
+        "ingestWindowEnd": {
+          "name": "ingestWindowEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestWindowRecordedAt": {
+          "name": "ingestWindowRecordedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestWindowStart": {
+          "name": "ingestWindowStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalCalendarId": {
+          "name": "externalCalendarId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"pull\"}'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalName": {
+          "name": "originalName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncToken": {
+          "name": "syncToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncFutureRange": {
+          "name": "syncFutureRange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2_years'"
+        },
+        "syncHistoricRange": {
+          "name": "syncHistoricRange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1_month'"
+        },
+        "unavailableSince": {
+          "name": "unavailableSince",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendars_user_idx": {
+          "name": "calendars_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "calendars_account_idx": {
+          "name": "calendars_account_idx",
+          "columns": [
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "calendars_capabilities_idx": {
+          "name": "calendars_capabilities_idx",
+          "columns": [
+            {
+              "expression": "capabilities",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "calendars_type_idx": {
+          "name": "calendars_type_idx",
+          "columns": [
+            {
+              "expression": "calendarType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "calendars_accountId_calendar_accounts_id_fk": {
+          "name": "calendars_accountId_calendar_accounts_id_fk",
+          "tableFrom": "calendars",
+          "columnsFrom": [
+            "accountId"
+          ],
+          "tableTo": "calendar_accounts",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "calendars_userId_user_id_fk": {
+          "name": "calendars_userId_user_id_fk",
+          "tableFrom": "calendars",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "calendars_sync_ranges_check": {
+          "name": "calendars_sync_ranges_check",
+          "value": "\"syncHistoricRange\" IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years') AND \"syncFutureRange\" IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years')"
+        },
+        "calendars_ingest_coverage_check": {
+          "name": "calendars_ingest_coverage_check",
+          "value": "\"ingestHistoricRange\" IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years') AND \"ingestFutureRange\" IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years') AND ((\"ingestWindowStart\" IS NULL AND \"ingestWindowEnd\" IS NULL AND \"ingestWindowRecordedAt\" IS NULL) OR (\"ingestWindowStart\" IS NOT NULL AND \"ingestWindowEnd\" IS NOT NULL AND \"ingestWindowRecordedAt\" IS NOT NULL AND \"ingestWindowStart\" < \"ingestWindowEnd\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.event_mappings": {
+      "name": "event_mappings",
+      "schema": "",
+      "columns": {
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleteIdentifier": {
+          "name": "deleteIdentifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destinationEventUid": {
+          "name": "destinationEventUid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventStateId": {
+          "name": "eventStateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "syncEventId": {
+          "name": "syncEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncEventHash": {
+          "name": "syncEventHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceCalendarId": {
+          "name": "sourceCalendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "event_mappings_sync_event_cal_idx": {
+          "name": "event_mappings_sync_event_cal_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "syncEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"event_mappings\".\"syncEventId\" is not null",
+          "concurrently": false
+        },
+        "event_mappings_calendar_idx": {
+          "name": "event_mappings_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "event_mappings_event_state_idx": {
+          "name": "event_mappings_event_state_idx",
+          "columns": [
+            {
+              "expression": "eventStateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "event_mappings_source_calendar_idx": {
+          "name": "event_mappings_source_calendar_idx",
+          "columns": [
+            {
+              "expression": "sourceCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "event_mappings_missing_sync_event_idx": {
+          "name": "event_mappings_missing_sync_event_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"event_mappings\".\"syncEventId\" is null",
+          "concurrently": false
+        },
+        "event_mappings_sync_hash_idx": {
+          "name": "event_mappings_sync_hash_idx",
+          "columns": [
+            {
+              "expression": "syncEventHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "event_mappings_calendarId_calendars_id_fk": {
+          "name": "event_mappings_calendarId_calendars_id_fk",
+          "tableFrom": "event_mappings",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "tableTo": "calendars",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "event_mappings_eventStateId_event_states_id_fk": {
+          "name": "event_mappings_eventStateId_event_states_id_fk",
+          "tableFrom": "event_mappings",
+          "columnsFrom": [
+            "eventStateId"
+          ],
+          "tableTo": "event_states",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "event_mappings_identity_check": {
+          "name": "event_mappings_identity_check",
+          "value": "\"event_mappings\".\"eventStateId\" is not null or \"event_mappings\".\"syncEventId\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.event_states": {
+      "name": "event_states",
+      "schema": "",
+      "columns": {
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrenceRule": {
+          "name": "recurrenceRule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exceptionDates": {
+          "name": "exceptionDates",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrenceId": {
+          "name": "recurrenceId",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAllDay": {
+          "name": "isAllDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceEventId": {
+          "name": "sourceEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceEventType": {
+          "name": "sourceEventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceEventUid": {
+          "name": "sourceEventUid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startTimeZone": {
+          "name": "startTimeZone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_states_start_time_idx": {
+          "name": "event_states_start_time_idx",
+          "columns": [
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "event_states_end_time_idx": {
+          "name": "event_states_end_time_idx",
+          "columns": [
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "event_states_calendar_idx": {
+          "name": "event_states_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "event_states_source_event_idx": {
+          "name": "event_states_source_event_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"event_states\".\"sourceEventId\" is not null",
+          "concurrently": false
+        },
+        "event_states_recurring_instance_idx": {
+          "name": "event_states_recurring_instance_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceEventUid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurrenceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"event_states\".\"sourceEventId\" is null and \"event_states\".\"recurrenceId\" is not null",
+          "concurrently": false
+        },
+        "event_states_non_recurring_instance_idx": {
+          "name": "event_states_non_recurring_instance_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceEventUid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"event_states\".\"sourceEventId\" is null and \"event_states\".\"recurrenceId\" is null",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "event_states_calendarId_calendars_id_fk": {
+          "name": "event_states_calendarId_calendars_id_fk",
+          "tableFrom": "event_states",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "tableTo": "calendars",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wantsFollowUp": {
+          "name": "wantsFollowUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "feedback_user_idx": {
+          "name": "feedback_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "feedback_userId_user_id_fk": {
+          "name": "feedback_userId_user_id_fk",
+          "tableFrom": "feedback",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ical_feed_calendars": {
+      "name": "ical_feed_calendars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feedId": {
+          "name": "feedId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ical_feed_calendar_idx": {
+          "name": "ical_feed_calendar_idx",
+          "columns": [
+            {
+              "expression": "feedId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ical_feed_calendars_feed_idx": {
+          "name": "ical_feed_calendars_feed_idx",
+          "columns": [
+            {
+              "expression": "feedId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ical_feed_calendars_calendar_idx": {
+          "name": "ical_feed_calendars_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "ical_feed_calendars_feedId_ical_feeds_id_fk": {
+          "name": "ical_feed_calendars_feedId_ical_feeds_id_fk",
+          "tableFrom": "ical_feed_calendars",
+          "columnsFrom": [
+            "feedId"
+          ],
+          "tableTo": "ical_feeds",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "ical_feed_calendars_calendarId_calendars_id_fk": {
+          "name": "ical_feed_calendars_calendarId_calendars_id_fk",
+          "tableFrom": "ical_feed_calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "tableTo": "calendars",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ical_feed_settings": {
+      "name": "ical_feed_settings",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "includeEventName": {
+          "name": "includeEventName",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeEventDescription": {
+          "name": "includeEventDescription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeEventLocation": {
+          "name": "includeEventLocation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeAllDayEvents": {
+          "name": "excludeAllDayEvents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customEventName": {
+          "name": "customEventName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Busy'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ical_feed_settings_userId_user_id_fk": {
+          "name": "ical_feed_settings_userId_user_id_fk",
+          "tableFrom": "ical_feed_settings",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ical_feeds": {
+      "name": "ical_feeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'My Calendar'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "legacyAlias": {
+          "name": "legacyAlias",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeEventName": {
+          "name": "includeEventName",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeEventDescription": {
+          "name": "includeEventDescription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeEventLocation": {
+          "name": "includeEventLocation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeAllDayEvents": {
+          "name": "excludeAllDayEvents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeFocusTime": {
+          "name": "excludeFocusTime",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeOutOfOffice": {
+          "name": "excludeOutOfOffice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customEventName": {
+          "name": "customEventName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Busy'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ical_feeds_user_idx": {
+          "name": "ical_feeds_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ical_feeds_token_idx": {
+          "name": "ical_feeds_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ical_feeds_default_idx": {
+          "name": "ical_feeds_default_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"ical_feeds\".\"isDefault\" = true",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "ical_feeds_userId_user_id_fk": {
+          "name": "ical_feeds_userId_user_id_fk",
+          "tableFrom": "ical_feeds",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_credentials": {
+      "name": "oauth_credentials",
+      "schema": "",
+      "columns": {
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "needsReauthentication": {
+          "name": "needsReauthentication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_credentials_user_idx": {
+          "name": "oauth_credentials_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "oauth_credentials_provider_idx": {
+          "name": "oauth_credentials_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "oauth_credentials_expires_at_idx": {
+          "name": "oauth_credentials_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_credentials_userId_user_id_fk": {
+          "name": "oauth_credentials_userId_user_id_fk",
+          "tableFrom": "oauth_credentials",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_destination_mappings": {
+      "name": "source_destination_mappings",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "destinationCalendarId": {
+          "name": "destinationCalendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sourceCalendarId": {
+          "name": "sourceCalendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "source_destination_mapping_idx": {
+          "name": "source_destination_mapping_idx",
+          "columns": [
+            {
+              "expression": "sourceCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destinationCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "source_destination_mappings_source_idx": {
+          "name": "source_destination_mappings_source_idx",
+          "columns": [
+            {
+              "expression": "sourceCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "source_destination_mappings_destination_idx": {
+          "name": "source_destination_mappings_destination_idx",
+          "columns": [
+            {
+              "expression": "destinationCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "source_destination_mappings_destinationCalendarId_calendars_id_fk": {
+          "name": "source_destination_mappings_destinationCalendarId_calendars_id_fk",
+          "tableFrom": "source_destination_mappings",
+          "columnsFrom": [
+            "destinationCalendarId"
+          ],
+          "tableTo": "calendars",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "source_destination_mappings_sourceCalendarId_calendars_id_fk": {
+          "name": "source_destination_mappings_sourceCalendarId_calendars_id_fk",
+          "tableFrom": "source_destination_mappings",
+          "columnsFrom": [
+            "sourceCalendarId"
+          ],
+          "tableTo": "calendars",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "",
+      "columns": {
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "localEventCount": {
+          "name": "localEventCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remoteEventCount": {
+          "name": "remoteEventCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_status_calendar_idx": {
+          "name": "sync_status_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sync_status_calendarId_calendars_id_fk": {
+          "name": "sync_status_calendarId_calendars_id_fk",
+          "tableFrom": "sync_status",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "tableTo": "calendars",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_events": {
+      "name": "user_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceEventUid": {
+          "name": "sourceEventUid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAllDay": {
+          "name": "isAllDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startTimeZone": {
+          "name": "startTimeZone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_events_user_idx": {
+          "name": "user_events_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_events_calendar_idx": {
+          "name": "user_events_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_events_start_time_idx": {
+          "name": "user_events_start_time_idx",
+          "columns": [
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_events_end_time_idx": {
+          "name": "user_events_end_time_idx",
+          "columns": [
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_events_calendarId_calendars_id_fk": {
+          "name": "user_events_calendarId_calendars_id_fk",
+          "tableFrom": "user_events",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "tableTo": "calendars",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_events_userId_user_id_fk": {
+          "name": "user_events_userId_user_id_fk",
+          "tableFrom": "user_events",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscriptions": {
+      "name": "user_subscriptions",
+      "schema": "",
+      "columns": {
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "polarSubscriptionId": {
+          "name": "polarSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_subscriptions_userId_user_id_fk": {
+          "name": "user_subscriptions_userId_user_id_fk",
+          "tableFrom": "user_subscriptions",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sync_requests": {
+      "name": "user_sync_requests",
+      "schema": "",
+      "columns": {
+        "requestId": {
+          "name": "requestId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "requestedAt": {
+          "name": "requestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sync_requests_userId_user_id_fk": {
+          "name": "user_sync_requests_userId_user_id_fk",
+          "tableFrom": "user_sync_requests",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshId": {
+          "name": "refreshId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_idx": {
+          "name": "oauth_access_token_client_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "oauth_access_token_session_idx": {
+          "name": "oauth_access_token_session_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "oauth_access_token_user_idx": {
+          "name": "oauth_access_token_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "oauth_access_token_refresh_idx": {
+          "name": "oauth_access_token_refresh_idx",
+          "columns": [
+            {
+              "expression": "refreshId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_clientId_oauth_application_clientId_fk": {
+          "name": "oauth_access_token_clientId_oauth_application_clientId_fk",
+          "tableFrom": "oauth_access_token",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "tableTo": "oauth_application",
+          "columnsTo": [
+            "clientId"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "oauth_access_token_sessionId_session_id_fk": {
+          "name": "oauth_access_token_sessionId_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "tableTo": "session",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "oauth_access_token_userId_user_id_fk": {
+          "name": "oauth_access_token_userId_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "oauth_access_token_refreshId_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refreshId_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "columnsFrom": [
+            "refreshId"
+          ],
+          "tableTo": "oauth_refresh_token",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientSecret": {
+          "name": "clientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "skipConsent": {
+          "name": "skipConsent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enableEndSession": {
+          "name": "enableEndSession",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjectType": {
+          "name": "subjectType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "softwareId": {
+          "name": "softwareId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "softwareVersion": {
+          "name": "softwareVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "softwareStatement": {
+          "name": "softwareStatement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirectUris": {
+          "name": "redirectUris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postLogoutRedirectUris": {
+          "name": "postLogoutRedirectUris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenEndpointAuthMethod": {
+          "name": "tokenEndpointAuthMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grantTypes": {
+          "name": "grantTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTypes": {
+          "name": "responseTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirePKCE": {
+          "name": "requirePKCE",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_application_user_idx": {
+          "name": "oauth_application_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_application_userId_user_id_fk": {
+          "name": "oauth_application_userId_user_id_fk",
+          "tableFrom": "oauth_application",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_clientId_unique": {
+          "name": "oauth_application_clientId_unique",
+          "columns": [
+            "clientId"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_idx": {
+          "name": "oauth_consent_client_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "oauth_consent_user_idx": {
+          "name": "oauth_consent_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "oauth_consent_reference_idx": {
+          "name": "oauth_consent_reference_idx",
+          "columns": [
+            {
+              "expression": "referenceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_clientId_oauth_application_clientId_fk": {
+          "name": "oauth_consent_clientId_oauth_application_clientId_fk",
+          "tableFrom": "oauth_consent",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "tableTo": "oauth_application",
+          "columnsTo": [
+            "clientId"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "oauth_consent_userId_user_id_fk": {
+          "name": "oauth_consent_userId_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authTime": {
+          "name": "authTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_client_idx": {
+          "name": "oauth_refresh_token_client_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "oauth_refresh_token_session_idx": {
+          "name": "oauth_refresh_token_session_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "oauth_refresh_token_user_idx": {
+          "name": "oauth_refresh_token_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_clientId_oauth_application_clientId_fk": {
+          "name": "oauth_refresh_token_clientId_oauth_application_clientId_fk",
+          "tableFrom": "oauth_refresh_token",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "tableTo": "oauth_application",
+          "columnsTo": [
+            "clientId"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "oauth_refresh_token_sessionId_session_id_fk": {
+          "name": "oauth_refresh_token_sessionId_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "tableTo": "session",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "oauth_refresh_token_userId_user_id_fk": {
+          "name": "oauth_refresh_token_userId_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passkey_userId_user_id_fk": {
+          "name": "passkey_userId_user_id_fk",
+          "tableFrom": "passkey",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -596,6 +596,13 @@
       "when": 1786668304728,
       "tag": "0084_abandoned_tombstone",
       "breakpoints": true
+    },
+    {
+      "idx": 85,
+      "version": "7",
+      "when": 1786818618563,
+      "tag": "0085_fixed_kat_farrell",
+      "breakpoints": true
     }
   ]
 }

--- a/services/api/scripts/backfill-provider-account-ids.ts
+++ b/services/api/scripts/backfill-provider-account-ids.ts
@@ -1,0 +1,124 @@
+import { calendarAccountsTable, oauthCredentialsTable } from "@keeper.sh/database/schema";
+import { and, eq, inArray, isNull, or } from "drizzle-orm";
+import { database, oauthProviders } from "@/context";
+
+const PUSH_PROVIDERS = ["google", "outlook"];
+const EXPIRY_SKEW_MS = 60_000;
+
+interface BackfillRow {
+  accountRowId: string;
+  provider: string;
+  email: string | null;
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: Date;
+  credentialNeedsReauthentication: boolean;
+  accountNeedsReauthentication: boolean;
+}
+
+interface BackfillTally {
+  updated: number;
+  skippedReauth: number;
+  failed: number;
+  unchanged: number;
+}
+
+const selectCandidates = (): Promise<BackfillRow[]> =>
+  database
+    .select({
+      accountRowId: calendarAccountsTable.id,
+      provider: calendarAccountsTable.provider,
+      email: calendarAccountsTable.email,
+      accessToken: oauthCredentialsTable.accessToken,
+      refreshToken: oauthCredentialsTable.refreshToken,
+      expiresAt: oauthCredentialsTable.expiresAt,
+      credentialNeedsReauthentication: oauthCredentialsTable.needsReauthentication,
+      accountNeedsReauthentication: calendarAccountsTable.needsReauthentication,
+    })
+    .from(calendarAccountsTable)
+    .innerJoin(
+      oauthCredentialsTable,
+      eq(calendarAccountsTable.oauthCredentialId, oauthCredentialsTable.id),
+    )
+    .where(and(
+      inArray(calendarAccountsTable.provider, PUSH_PROVIDERS),
+      or(
+        isNull(calendarAccountsTable.accountId),
+        eq(calendarAccountsTable.accountId, ""),
+      ),
+    ));
+
+const resolveAccessToken = async (row: BackfillRow): Promise<string> => {
+  if (row.expiresAt.getTime() - EXPIRY_SKEW_MS > Date.now()) {
+    return row.accessToken;
+  }
+
+  const provider = oauthProviders.getProvider(row.provider);
+  if (!provider) {
+    throw new Error(`No OAuth provider registered for ${row.provider}`);
+  }
+
+  const refreshed = await provider.refreshAccessToken(row.refreshToken);
+  return refreshed.access_token;
+};
+
+const resolveProviderAccountId = async (row: BackfillRow): Promise<string> => {
+  const provider = oauthProviders.getProvider(row.provider);
+  if (!provider) {
+    throw new Error(`No OAuth provider registered for ${row.provider}`);
+  }
+
+  const accessToken = await resolveAccessToken(row);
+  const userInfo = await provider.fetchUserInfo(accessToken);
+
+  if (!userInfo.id) {
+    throw new Error(`${row.provider} returned no account id for ${row.email ?? row.accountRowId}`);
+  }
+
+  return userInfo.id;
+};
+
+const backfillRow = async (row: BackfillRow, tally: BackfillTally): Promise<void> => {
+  if (row.accountNeedsReauthentication || row.credentialNeedsReauthentication) {
+    tally.skippedReauth += 1;
+    console.log(`skip ${row.provider} ${row.email ?? row.accountRowId}: needs reauthentication`);
+    return;
+  }
+
+  try {
+    const providerAccountId = await resolveProviderAccountId(row);
+
+    await database
+      .update(calendarAccountsTable)
+      .set({ accountId: providerAccountId })
+      .where(eq(calendarAccountsTable.id, row.accountRowId));
+
+    tally.updated += 1;
+    console.log(`ok   ${row.provider} ${row.email ?? row.accountRowId} -> ${providerAccountId}`);
+  } catch (error) {
+    tally.failed += 1;
+    const reason = error instanceof Error ? error.message : String(error);
+    console.error(`fail ${row.provider} ${row.email ?? row.accountRowId}: ${reason}`);
+  }
+};
+
+const run = async (): Promise<void> => {
+  const rows = await selectCandidates();
+  console.log(`found ${rows.length} account(s) missing a provider account id`);
+
+  const tally: BackfillTally = { updated: 0, skippedReauth: 0, failed: 0, unchanged: 0 };
+
+  for (const row of rows) {
+    await backfillRow(row, tally);
+  }
+
+  console.log(
+    `done: ${tally.updated} updated, ${tally.skippedReauth} skipped (reauth), ${tally.failed} failed`,
+  );
+
+  if (tally.failed > 0) {
+    process.exitCode = 1;
+  }
+};
+
+await run();

--- a/services/api/scripts/backfill-provider-account-ids.ts
+++ b/services/api/scripts/backfill-provider-account-ids.ts
@@ -1,6 +1,7 @@
 import { calendarAccountsTable, oauthCredentialsTable } from "@keeper.sh/database/schema";
 import { and, eq, inArray, isNull, or } from "drizzle-orm";
 import { database, oauthProviders } from "@/context";
+import { context, destroy, widelog } from "@/utils/logging";
 
 const PUSH_PROVIDERS = ["google", "outlook"];
 const EXPIRY_SKEW_MS = 60_000;
@@ -20,7 +21,6 @@ interface BackfillTally {
   updated: number;
   skippedReauth: number;
   failed: number;
-  unchanged: number;
 }
 
 const selectCandidates = (): Promise<BackfillRow[]> =>
@@ -72,53 +72,76 @@ const resolveProviderAccountId = async (row: BackfillRow): Promise<string> => {
   const userInfo = await provider.fetchUserInfo(accessToken);
 
   if (!userInfo.id) {
-    throw new Error(`${row.provider} returned no account id for ${row.email ?? row.accountRowId}`);
+    throw new Error(`${row.provider} returned no account id for account ${row.accountRowId}`);
   }
 
   return userInfo.id;
 };
 
-const backfillRow = async (row: BackfillRow, tally: BackfillTally): Promise<void> => {
-  if (row.accountNeedsReauthentication || row.credentialNeedsReauthentication) {
-    tally.skippedReauth += 1;
-    console.log(`skip ${row.provider} ${row.email ?? row.accountRowId}: needs reauthentication`);
-    return;
+const backfillRow = (row: BackfillRow, tally: BackfillTally): Promise<void> =>
+  context(async () => {
+    widelog.set("operation.name", "backfill-provider-account-id");
+    widelog.set("operation.type", "script");
+    widelog.set("provider.name", row.provider);
+    widelog.set("account.id", row.accountRowId);
+
+    if (row.accountNeedsReauthentication || row.credentialNeedsReauthentication) {
+      tally.skippedReauth += 1;
+      widelog.set("outcome", "skipped");
+      widelog.set("skip.reason", "needs-reauthentication");
+      widelog.flush();
+      return;
+    }
+
+    try {
+      const providerAccountId = await resolveProviderAccountId(row);
+
+      await database
+        .update(calendarAccountsTable)
+        .set({ accountId: providerAccountId })
+        .where(eq(calendarAccountsTable.id, row.accountRowId));
+
+      tally.updated += 1;
+      widelog.set("provider.account_id", providerAccountId);
+      widelog.set("outcome", "success");
+    } catch (error) {
+      tally.failed += 1;
+      widelog.set("outcome", "error");
+      widelog.errorFields(error, { slug: "backfill-provider-account-id-failed" });
+    } finally {
+      widelog.flush();
+    }
+  });
+
+const resolveOutcome = (failed: number): "partial" | "success" => {
+  if (failed > 0) {
+    return "partial";
   }
-
-  try {
-    const providerAccountId = await resolveProviderAccountId(row);
-
-    await database
-      .update(calendarAccountsTable)
-      .set({ accountId: providerAccountId })
-      .where(eq(calendarAccountsTable.id, row.accountRowId));
-
-    tally.updated += 1;
-    console.log(`ok   ${row.provider} ${row.email ?? row.accountRowId} -> ${providerAccountId}`);
-  } catch (error) {
-    tally.failed += 1;
-    const reason = error instanceof Error ? error.message : String(error);
-    console.error(`fail ${row.provider} ${row.email ?? row.accountRowId}: ${reason}`);
-  }
+  return "success";
 };
 
-const run = async (): Promise<void> => {
-  const rows = await selectCandidates();
-  console.log(`found ${rows.length} account(s) missing a provider account id`);
+const run = (): Promise<void> =>
+  context(async () => {
+    const rows = await selectCandidates();
+    const tally: BackfillTally = { updated: 0, skippedReauth: 0, failed: 0 };
 
-  const tally: BackfillTally = { updated: 0, skippedReauth: 0, failed: 0, unchanged: 0 };
+    for (const row of rows) {
+      await backfillRow(row, tally);
+    }
 
-  for (const row of rows) {
-    await backfillRow(row, tally);
-  }
+    widelog.set("operation.name", "backfill-provider-account-ids");
+    widelog.set("operation.type", "script");
+    widelog.set("backfill.candidate_count", rows.length);
+    widelog.set("backfill.updated_count", tally.updated);
+    widelog.set("backfill.skipped_reauth_count", tally.skippedReauth);
+    widelog.set("backfill.failed_count", tally.failed);
+    widelog.set("outcome", resolveOutcome(tally.failed));
+    widelog.flush();
 
-  console.log(
-    `done: ${tally.updated} updated, ${tally.skippedReauth} skipped (reauth), ${tally.failed} failed`,
-  );
-
-  if (tally.failed > 0) {
-    process.exitCode = 1;
-  }
-};
+    if (tally.failed > 0) {
+      process.exitCode = 1;
+    }
+  });
 
 await run();
+await destroy();

--- a/services/api/src/routes/api/sources/callback/[provider].ts
+++ b/services/api/src/routes/api/sources/callback/[provider].ts
@@ -78,6 +78,7 @@ const GET = withWideEvent(async ({ request, params }) => {
       email: userInfo.email,
       oauthCredentialId: credentialId,
       provider,
+      providerAccountId: userInfo.id,
       userId,
     });
 

--- a/services/api/src/utils/oauth-sources.ts
+++ b/services/api/src/utils/oauth-sources.ts
@@ -588,7 +588,10 @@ interface ImportOAuthAccountDependencies {
   canAddAccount: (userId: string, currentCount: number) => Promise<boolean>;
   countUserAccounts: (userId: string) => Promise<number>;
   createAccountId: (
-    options: Pick<ImportOAuthAccountOptions, "userId" | "provider" | "oauthCredentialId" | "email">,
+    options: Pick<
+      ImportOAuthAccountOptions,
+      "userId" | "provider" | "oauthCredentialId" | "email" | "providerAccountId"
+    >,
   ) => Promise<string>;
   findExistingAccountId: (options: {
     userId: string;
@@ -615,11 +618,12 @@ const createDefaultImportOAuthAccountDependencies = (): ImportOAuthAccountDepend
     return premiumService.canAddAccount(userId, currentCount);
   },
   countUserAccounts,
-  createAccountId: async ({ userId, provider, oauthCredentialId, email }) => {
+  createAccountId: async ({ userId, provider, oauthCredentialId, email, providerAccountId }) => {
     const { database } = await import("@/context");
     const [insertedAccount] = await database
       .insert(calendarAccountsTable)
       .values({
+        accountId: providerAccountId,
         authType: "oauth",
         displayName: email,
         email,
@@ -710,7 +714,7 @@ const importOAuthAccountCalendarsWithDependencies = async (
   options: ImportOAuthAccountOptions,
   dependencies: ImportOAuthAccountDependencies,
 ): Promise<string> => {
-  const { userId, provider, oauthCredentialId, accessToken, email } = options;
+  const { userId, provider, oauthCredentialId, accessToken, email, providerAccountId } = options;
 
   const existingAccountId = await dependencies.findExistingAccountId({
     oauthCredentialId,
@@ -730,6 +734,7 @@ const importOAuthAccountCalendarsWithDependencies = async (
       email,
       oauthCredentialId,
       provider,
+      providerAccountId,
       userId,
     });
   }
@@ -762,17 +767,22 @@ interface ImportOAuthAccountOptions {
   oauthCredentialId: string;
   accessToken: string;
   email: string | null;
+  providerAccountId: string | null;
 }
 
 const createOAuthAccountIdWithDatabase = async (
   databaseClient: OAuthSourceDatabase,
-  options: Pick<ImportOAuthAccountOptions, "userId" | "provider" | "oauthCredentialId" | "email">,
+  options: Pick<
+    ImportOAuthAccountOptions,
+    "userId" | "provider" | "oauthCredentialId" | "email" | "providerAccountId"
+  >,
 ): Promise<string> => {
-  const { userId, provider, oauthCredentialId, email } = options;
+  const { userId, provider, oauthCredentialId, email, providerAccountId } = options;
 
   const [insertedAccount] = await databaseClient
     .insert(calendarAccountsTable)
     .values({
+      accountId: providerAccountId,
       authType: "oauth",
       displayName: email,
       email,

--- a/services/api/tests/utils/account-locks.test.ts
+++ b/services/api/tests/utils/account-locks.test.ts
@@ -417,6 +417,7 @@ describe("Account locks", () => {
       email: "person@example.com",
       oauthCredentialId: "credential-1",
       provider: "google",
+      providerAccountId: "google-account-1",
       userId: "user-1",
     });
 

--- a/services/api/tests/utils/oauth-sources.test.ts
+++ b/services/api/tests/utils/oauth-sources.test.ts
@@ -33,6 +33,7 @@ describe("importOAuthAccountCalendarsWithDependencies", () => {
           email: "person@example.com",
           oauthCredentialId: "credential-1",
           provider: "google",
+          providerAccountId: "google-account-1",
           userId: "user-1",
         },
         {
@@ -65,6 +66,7 @@ describe("importOAuthAccountCalendarsWithDependencies", () => {
         email: "person@example.com",
         oauthCredentialId: "credential-1",
         provider: "google",
+        providerAccountId: "google-account-1",
         userId: "user-1",
       },
       {

--- a/services/cron/src/utils/manage-push-channels-core.ts
+++ b/services/cron/src/utils/manage-push-channels-core.ts
@@ -13,6 +13,7 @@ import type {
   PushChannelAction,
   PushChannelRegistration,
   PushChannelScope,
+  PushPlanSkipReason,
   RegistrarContext,
   SourcePushRegistrar,
   StoredPushChannel,
@@ -54,6 +55,17 @@ interface ManagePushChannelsDependencies {
   webhookPublicUrl: string | null;
 }
 
+const PUSH_PLAN_SKIP_REASONS = [
+  "existing-channel",
+  "free-plan",
+  "missing-external-calendar-id",
+  "missing-provider-account-id",
+  "needs-reauthentication",
+  "not-pull",
+  "plan-unresolved",
+  "unsupported-provider",
+] as const satisfies readonly PushPlanSkipReason[];
+
 interface ManageCounters {
   activatedProviderChannelIds: Set<string>;
   deregistered: number;
@@ -64,8 +76,29 @@ interface ManageCounters {
   planErrors: number;
   registered: number;
   renewed: number;
-  skippedFree: number;
+  skipped: Record<PushPlanSkipReason, number>;
 }
+
+const createSkipCounters = (): Record<PushPlanSkipReason, number> => ({
+  "existing-channel": 0,
+  "free-plan": 0,
+  "missing-external-calendar-id": 0,
+  "missing-provider-account-id": 0,
+  "needs-reauthentication": 0,
+  "not-pull": 0,
+  "plan-unresolved": 0,
+  "unsupported-provider": 0,
+});
+
+const toSkipFields = (
+  skipped: Record<PushPlanSkipReason, number>,
+): Record<string, number> =>
+  Object.fromEntries(
+    PUSH_PLAN_SKIP_REASONS.map((reason) => [
+      `push_channel.skipped.${reason.replaceAll("-", "_")}_count`,
+      skipped[reason] ?? 0,
+    ]),
+  );
 
 const createCounters = (): ManageCounters => ({
   activatedProviderChannelIds: new Set<string>(),
@@ -77,7 +110,7 @@ const createCounters = (): ManageCounters => ({
   planErrors: 0,
   registered: 0,
   renewed: 0,
-  skippedFree: 0,
+  skipped: createSkipCounters(),
 });
 
 const resolveScopeLockKey = (action: PushChannelAction): string => {
@@ -642,8 +675,8 @@ const runManagePushChannels = async (
       calendars,
       channels,
       now: dependencies.now(),
-      onFreeCalendarSkipped: () => {
-        counters.skippedFree += 1;
+      onCalendarSkipped: (_calendar, reason) => {
+        counters.skipped[reason] = (counters.skipped[reason] ?? 0) + 1;
       },
       onPlanError: (_userId, error) => {
         counters.planErrors += 1;
@@ -677,7 +710,7 @@ const runManagePushChannels = async (
       "push_channel.plan_error_count": counters.planErrors,
       "push_channel.registered_count": counters.registered,
       "push_channel.renewed_count": counters.renewed,
-      "push_channel.skipped_free_count": counters.skippedFree,
+      ...toSkipFields(counters.skipped),
     });
     await dependencies.releaseLock(TICK_LOCK_KEY);
   }

--- a/services/cron/tests/utils/manage-push-channels-core.test.ts
+++ b/services/cron/tests/utils/manage-push-channels-core.test.ts
@@ -530,7 +530,61 @@ describe("runManagePushChannels teardown", () => {
 
     await runManagePushChannels(dependencies);
 
-    expect(observedFields(dependencies.observe)["push_channel.skipped_free_count"]).toBe(2);
+    expect(observedFields(dependencies.observe)["push_channel.skipped.free_plan_count"]).toBe(2);
+    expect(dependencies.registrar.register).not.toHaveBeenCalled();
+  });
+
+  it("registers a Google calendar whose account carries no provider account id", async () => {
+    const callLog: string[] = [];
+    const dependencies = makeDependencies(callLog, {
+      selectEligibleCalendars: vi.fn(() => Promise.resolve([
+        makeCalendar({ providerAccountId: null }),
+      ])),
+    });
+
+    await runManagePushChannels(dependencies);
+
+    expect(dependencies.registrar.register).toHaveBeenCalledOnce();
+    const fields = observedFields(dependencies.observe);
+    expect(fields["push_channel.registered_count"]).toBe(1);
+    expect(fields["push_channel.skipped.missing_provider_account_id_count"]).toBe(0);
+  });
+
+  it("withholds an Outlook calendar whose account carries no provider account id", async () => {
+    const callLog: string[] = [];
+    const dependencies = makeDependencies(callLog, {
+      selectEligibleCalendars: vi.fn(() => Promise.resolve([
+        makeCalendar({ provider: "outlook", providerAccountId: null }),
+      ])),
+    });
+
+    await runManagePushChannels(dependencies);
+
+    expect(dependencies.registrar.register).not.toHaveBeenCalled();
+    const fields = observedFields(dependencies.observe);
+    expect(fields["push_channel.skipped.missing_provider_account_id_count"]).toBe(1);
+  });
+
+  it("attributes a withheld calendar to the reason that withheld it", async () => {
+    const callLog: string[] = [];
+    const dependencies = makeDependencies(callLog, {
+      selectEligibleCalendars: vi.fn(() => Promise.resolve([
+        makeCalendar({ calendarId: "cal-1", externalCalendarId: null }),
+        makeCalendar({ calendarId: "cal-2", externalCalendarId: "external-2", provider: "outlook", providerAccountId: null }),
+        makeCalendar({ calendarId: "cal-3", externalCalendarId: "external-3", needsReauthentication: true }),
+        makeCalendar({ calendarId: "cal-4", externalCalendarId: "external-4", provider: "caldav" }),
+        makeCalendar({ calendarId: "cal-5", externalCalendarId: "external-5", disabled: true }),
+      ])),
+    });
+
+    await runManagePushChannels(dependencies);
+
+    const fields = observedFields(dependencies.observe);
+    expect(fields["push_channel.skipped.missing_external_calendar_id_count"]).toBe(1);
+    expect(fields["push_channel.skipped.missing_provider_account_id_count"]).toBe(1);
+    expect(fields["push_channel.skipped.needs_reauthentication_count"]).toBe(1);
+    expect(fields["push_channel.skipped.unsupported_provider_count"]).toBe(1);
+    expect(fields["push_channel.skipped.not_pull_count"]).toBe(1);
     expect(dependencies.registrar.register).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Push channels covered 7 of 1866 eligible calendars in production. Two independent causes, one of which reaches beyond push.

**The source OAuth flow never recorded `calendar_accounts.accountId`.** Only `persistCalendarDestination` wrote it, so every account created by adding a *source* had it NULL — which is precisely the population push channels target. Verified against production: 1673 calendars across 245 users withheld for a missing provider account id, and 0 of 312 Google / 0 of 37 Outlook source accounts had the column populated. This was never a case of old rows missing a backfill; the value had never been written.

**The eligibility gate demanded that column for every provider.** Only Outlook reads it — its Graph subscription resource is `/users/{id}/calendars/{id}/events`, while Google's watch builds `/calendars/{externalCalendarId}/events` and never touches it. So 1529 Google calendars across 232 users were blocked by a field their registrar does not use.

## Changes

- Give each push provider profile a `requiresProviderAccountId` flag, so the planner only withholds calendars whose registrar actually needs it. `PushChannelScope.providerAccountId` becomes nullable and Outlook's registrar throws rather than building a `/users/null/...` path.
- Thread `providerAccountId` from `userInfo.id` — already fetched and discarded by the source callback — through `importOAuthAccountCalendars` into the `calendar_accounts` insert.
- Attribute every planner skip to a named reason, emitted as `push_channel.skipped.*`. The previous single free-plan counter left 1673 withheld calendars invisible; that blind spot is why this took production forensics to find rather than showing up in a dashboard.
- Migration `0085` normalises `accountId = ''` to NULL and copies the real id from a sibling row where the destination flow already recorded it.
- `services/api/scripts/backfill-provider-account-ids.ts` reads the true id per account from the provider for whatever the migration cannot reach, emitting a wide event per account.

## Why the backfill is not pure SQL

`accountId` holds an opaque provider identifier — Google's `sub`, Microsoft's directory GUID — which exists nowhere in our database. Deriving it from `email` was tempting since every Google and Outlook account has one, but Outlook's `email` is `mail ?? userPrincipalName`, so it is not reliably a UPN, and personal Microsoft accounts have no directory entry to resolve against. That would have written plausible-looking wrong data that only failed later at registration. The migration therefore does only what SQL can do correctly, and the script fetches the rest from the provider.

## This is not only a push problem

`oauth.ts:163` guards reauthentication with `if (existingAccountId && existingAccountId !== userInfo.id)`. That short-circuits on NULL, so for every account missing the id the "reauthenticate with the same account" check has silently not been running. The backfill covers both providers — ~245 accounts, not just the 33 Outlook ones — which closes that gap too.

## Note on tests

Two pre-existing tests asserted the old blanket rule and now assert the provider-specific behaviour instead. That is a deliberate semantic change rather than a weakened assertion: Google with a null provider account id must now register, Outlook must still be withheld, and both are asserted explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWminUmH2kMq6fQShPLgvE