### PR TITLE
perf(tests): stop the backoff and tzdata suites burning real wall time

### DIFF
--- a/packages/calendar/src/core/utils/backoff.ts
+++ b/packages/calendar/src/core/utils/backoff.ts
@@ -37,7 +37,7 @@ const abortableSleep = (delayMs: number, signal?: AbortSignal): Promise<void> =>
     return Promise.reject(signal.reason);
   }
   if (!signal) {
-    return Bun.sleep(delayMs);
+    return new Promise((resolve) => { setTimeout(resolve, delayMs); });
   }
   return new Promise((resolve, reject) => {
     createAbortableTimer(delayMs, signal, resolve, reject);

--- a/packages/calendar/tests/core/utils/backoff.test.ts
+++ b/packages/calendar/tests/core/utils/backoff.test.ts
@@ -8,7 +8,7 @@ const flushAsync = async (): Promise<void> => {
 };
 
 const advanceBackoff = async (): Promise<void> => {
-  vi.advanceTimersByTime(65_000);
+  await vi.advanceTimersToNextTimerAsync();
   await flushAsync();
 };
 
@@ -136,11 +136,12 @@ describe("withBackoff", () => {
       maxRetries: 2,
       shouldRetry: () => true,
     });
+    const rejection = expect(promise).rejects.toThrow("rate limited");
 
     await advanceBackoff();
     await advanceBackoff();
 
-    await expect(promise).rejects.toThrow("rate limited");
+    await rejection;
 
     expect(callCount).toBe(3);
   });
@@ -162,7 +163,7 @@ describe("withBackoff", () => {
       shouldRetry: () => true,
     });
 
-    vi.advanceTimersByTime(250);
+    await vi.advanceTimersToNextTimerAsync();
     await flushAsync();
 
     expect(await promise).toBe("recovered");

--- a/packages/calendar/tests/ics/utils/tz-sweep-support.ts
+++ b/packages/calendar/tests/ics/utils/tz-sweep-support.ts
@@ -1,0 +1,20 @@
+const ALL_TIME_ZONES = Intl.supportedValuesOf("timeZone");
+
+// Sweeping every IANA zone at daily or sub-daily granularity across decades
+// Is CPU-bound and takes tens of seconds per test. These suites assert
+// Properties that hold for *every* zone (no minimum-count thresholds), so a
+// Stride sample still exercises the full breadth of offset families while
+// Running in a fraction of the time. Set CALENDAR_TZ_SWEEP_EXHAUSTIVE=1 to
+// Run every zone, e.g. before a tzdata upgrade or when touching the
+// Wall-time resolution code directly.
+const EXHAUSTIVE = process.env.CALENDAR_TZ_SWEEP_EXHAUSTIVE === "1";
+const SAMPLE_STRIDE = 4;
+
+const sweepTimeZones = (): string[] => {
+  if (EXHAUSTIVE) {
+    return ALL_TIME_ZONES;
+  }
+  return ALL_TIME_ZONES.filter((_zone, index) => index % SAMPLE_STRIDE === 0);
+};
+
+export { ALL_TIME_ZONES, EXHAUSTIVE, sweepTimeZones };

--- a/packages/calendar/tests/ics/utils/wall-time-bracket-premise.test.ts
+++ b/packages/calendar/tests/ics/utils/wall-time-bracket-premise.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { instantToWallTime, wallTimeToInstant } from "../../../src/ics/utils/timezone-instant";
+import { sweepTimeZones } from "./tz-sweep-support";
 
 const MS_PER_HOUR = 60 * 60 * 1000;
 const MS_PER_DAY = 24 * MS_PER_HOUR;
@@ -8,7 +9,7 @@ const SCAN_START = Date.UTC(2015, 0, 1);
 const SCAN_END = Date.UTC(2045, 0, 1);
 const SUITE_TIMEOUT_MS = 300_000;
 
-const ZONES = Intl.supportedValuesOf("timeZone");
+const ZONES = sweepTimeZones();
 
 interface Transition {
   from: number;

--- a/packages/calendar/tests/ics/utils/wall-time-historical-differential.test.ts
+++ b/packages/calendar/tests/ics/utils/wall-time-historical-differential.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { instantToWallTime, wallTimeToInstant } from "../../../src/ics/utils/timezone-instant";
+import { sweepTimeZones } from "./tz-sweep-support";
 
 const MS_PER_MINUTE = 60 * 1000;
 const MS_PER_HOUR = 60 * MS_PER_MINUTE;
@@ -13,7 +14,7 @@ const DAILY_STEP_MS = MS_PER_DAY;
 const SWEEP_RADIUS_MS = 30 * MS_PER_HOUR;
 const SWEEP_STEP_MS = 5 * MS_PER_MINUTE;
 
-const ZONES = Intl.supportedValuesOf("timeZone");
+const ZONES = sweepTimeZones();
 
 interface Transition {
   from: number;

--- a/packages/calendar/tests/ics/utils/wall-time-zone-sweep.test.ts
+++ b/packages/calendar/tests/ics/utils/wall-time-zone-sweep.test.ts
@@ -4,6 +4,7 @@ import {
   instantToWallTime,
   wallTimeToInstant,
 } from "../../../src/ics/utils/timezone-instant";
+import { sweepTimeZones } from "./tz-sweep-support";
 
 const MS_PER_MINUTE = 60_000;
 const MS_PER_HOUR = 60 * MS_PER_MINUTE;
@@ -185,7 +186,7 @@ describe("resolving a wall time near every transition IANA declares", () => {
   it("finds no zone that changes offset twice within two days", () => {
     const closePairs: string[] = [];
 
-    for (const timeZone of ALL_TIME_ZONES) {
+    for (const timeZone of sweepTimeZones()) {
       const transitions = collectTransitions(timeZone, Date.UTC(1970, 0, 1), Date.UTC(2038, 0, 1));
       for (let index = 1; index < transitions.length; index += 1) {
         const previous = transitions[index - 1];


### PR DESCRIPTION
The suite regressed to minutes on CI. Two independent causes, neither of them a deliberately awaited timeout.

`abortableSleep` took a `Bun.sleep` fast path when given no `AbortSignal`, and `Bun.sleep` is a native primitive that `vi.useFakeTimers()` cannot patch — so `advanceTimersByTime` was a silent no-op and the two `withBackoff` tests slept through the real 1s+2s+4s retry ladder. The signal branch went through `setTimeout` and was always instant, which is why it looked inconsistent. Separately, the tzdata sweeps added in b057d2e0 walk all 445 IANA zones on every run.

- Route `abortableSleep` through `setTimeout` on both paths, and advance the backoff tests one timer at a time.
- Sample every fourth zone by default, with `CALENDAR_TZ_SWEEP_EXHAUSTIVE=1` restoring the full walk. Applied only where the assertion is an empty-set check that sampling cannot silently weaken; the test with a `> 100` threshold still runs the full list.

`packages/calendar` 31.2s → ~10s, full suite 38.5s → 17.3s locally, test counts unchanged (1830/1830).

Worth a careful look at the sampling tradeoff before merging. Also flagged and **not** fixed here: `packages/sync/src/sync-lock.ts` has the same `Bun.sleep`-under-fake-timers bug, costing ~4.5s, but it involves racing lock-acquisition flows and needs more care than the sequential backoff case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWminUmH2kMq6fQShPLgvE