### PR TITLE
fix(accounts): scope provider account identity to the owning user

### DIFF
--- a/packages/database/drizzle/0085_fixed_kat_farrell.sql
+++ b/packages/database/drizzle/0085_fixed_kat_farrell.sql
@@ -1,14 +1,3 @@
 UPDATE "calendar_accounts"
 SET "accountId" = NULL
 WHERE "accountId" = '';
---> statement-breakpoint
-UPDATE "calendar_accounts" AS target
-SET "accountId" = donor."accountId"
-FROM "calendar_accounts" AS donor
-WHERE target."accountId" IS NULL
-  AND donor."accountId" IS NOT NULL
-  AND donor."id" <> target."id"
-  AND donor."userId" = target."userId"
-  AND donor."provider" = target."provider"
-  AND donor."email" IS NOT NULL
-  AND donor."email" = target."email";

--- a/packages/database/drizzle/0085_fixed_kat_farrell.sql
+++ b/packages/database/drizzle/0085_fixed_kat_farrell.sql
@@ -1,3 +1,9 @@
+-- A second statement shipped here and ran in production, where it matched no rows.
+-- It copied a sibling row's "accountId" onto a row holding NULL, which always produces
+-- two rows sharing ("provider", "accountId") and violates the unique index in both its
+-- pre-0086 and post-0086 form. It could only ever match nothing or abort the migration,
+-- so it was removed rather than left to break databases that had not yet applied 0085.
+-- Adopting a provider account id onto an existing row is handled by adoptProviderAccountId.
 UPDATE "calendar_accounts"
 SET "accountId" = NULL
 WHERE "accountId" = '';

--- a/packages/database/drizzle/0086_scope_provider_account_identity_to_user.sql
+++ b/packages/database/drizzle/0086_scope_provider_account_identity_to_user.sql
@@ -1,0 +1,2 @@
+DROP INDEX "calendar_accounts_provider_account_idx";--> statement-breakpoint
+CREATE UNIQUE INDEX "calendar_accounts_provider_account_idx" ON "calendar_accounts" USING btree ("userId","provider","accountId");

--- a/packages/database/drizzle/meta/0086_snapshot.json
+++ b/packages/database/drizzle/meta/0086_snapshot.json
@@ -1,0 +1,3843 @@
+{
+  "id": "1bd69000-dc6d-4e05-9bd0-8b276b528651",
+  "prevId": "38fe910b-81fd-4355-8702-ed15aa405187",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_tokens_user_idx": {
+          "name": "api_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_hash_idx": {
+          "name": "api_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_userId_user_id_fk": {
+          "name": "api_tokens_userId_user_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_tokenHash_unique": {
+          "name": "api_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caldav_credentials": {
+      "name": "caldav_credentials",
+      "schema": "",
+      "columns": {
+        "authMethod": {
+          "name": "authMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'basic'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "encryptedPassword": {
+          "name": "encryptedPassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "serverUrl": {
+          "name": "serverUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_accounts": {
+      "name": "calendar_accounts",
+      "schema": "",
+      "columns": {
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authType": {
+          "name": "authType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caldavCredentialId": {
+          "name": "caldavCredentialId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendarsRefreshAttemptedAt": {
+          "name": "calendarsRefreshAttemptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendarsRefreshedAt": {
+          "name": "calendarsRefreshedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "needsReauthentication": {
+          "name": "needsReauthentication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "oauthCredentialId": {
+          "name": "oauthCredentialId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reauthenticationSource": {
+          "name": "reauthenticationSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_accounts_user_idx": {
+          "name": "calendar_accounts_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_accounts_provider_idx": {
+          "name": "calendar_accounts_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_accounts_needs_reauth_idx": {
+          "name": "calendar_accounts_needs_reauth_idx",
+          "columns": [
+            {
+              "expression": "needsReauthentication",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_accounts_provider_account_idx": {
+          "name": "calendar_accounts_provider_account_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_accounts_caldavCredentialId_caldav_credentials_id_fk": {
+          "name": "calendar_accounts_caldavCredentialId_caldav_credentials_id_fk",
+          "tableFrom": "calendar_accounts",
+          "tableTo": "caldav_credentials",
+          "columnsFrom": [
+            "caldavCredentialId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_accounts_oauthCredentialId_oauth_credentials_id_fk": {
+          "name": "calendar_accounts_oauthCredentialId_oauth_credentials_id_fk",
+          "tableFrom": "calendar_accounts",
+          "tableTo": "oauth_credentials",
+          "columnsFrom": [
+            "oauthCredentialId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_accounts_userId_user_id_fk": {
+          "name": "calendar_accounts_userId_user_id_fk",
+          "tableFrom": "calendar_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_push_channels": {
+      "name": "calendar_push_channels",
+      "schema": "",
+      "columns": {
+        "accountId": {
+          "name": "accountId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failureCount": {
+          "name": "failureCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lastFailureAt": {
+          "name": "lastFailureAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastNotificationAt": {
+          "name": "lastNotificationAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextAttemptAt": {
+          "name": "nextAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerChannelId": {
+          "name": "providerChannelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerResourceId": {
+          "name": "providerResourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauthorizeRequestedAt": {
+          "name": "reauthorizeRequestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourcePath": {
+          "name": "resourcePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secretHash": {
+          "name": "secretHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registering'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "calendar_push_channels_account_idx": {
+          "name": "calendar_push_channels_account_idx",
+          "columns": [
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_push_channels_expiry_idx": {
+          "name": "calendar_push_channels_expiry_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_push_channels_provider_channel_idx": {
+          "name": "calendar_push_channels_provider_channel_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerChannelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_push_channels\".\"providerChannelId\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_push_channels_scope_idx": {
+          "name": "calendar_push_channels_scope_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendar_push_channels\".\"calendarId\" is not null and \"calendar_push_channels\".\"state\" in ('registering', 'active', 'degraded')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_push_channels_accountId_calendar_accounts_id_fk": {
+          "name": "calendar_push_channels_accountId_calendar_accounts_id_fk",
+          "tableFrom": "calendar_push_channels",
+          "tableTo": "calendar_accounts",
+          "columnsFrom": [
+            "accountId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_push_channels_calendarId_calendars_id_fk": {
+          "name": "calendar_push_channels_calendarId_calendars_id_fk",
+          "tableFrom": "calendar_push_channels",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_push_channels_userId_user_id_fk": {
+          "name": "calendar_push_channels_userId_user_id_fk",
+          "tableFrom": "calendar_push_channels",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_snapshots": {
+      "name": "calendar_snapshots",
+      "schema": "",
+      "columns": {
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ical": {
+          "name": "ical",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "calendar_snapshots_calendarId_calendars_id_fk": {
+          "name": "calendar_snapshots_calendarId_calendars_id_fk",
+          "tableFrom": "calendar_snapshots",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_snapshots_calendarId_unique": {
+          "name": "calendar_snapshots_calendarId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendarId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendars": {
+      "name": "calendars",
+      "schema": "",
+      "columns": {
+        "accountId": {
+          "name": "accountId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarType": {
+          "name": "calendarType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarUrl": {
+          "name": "calendarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "excludeAllDayEvents": {
+          "name": "excludeAllDayEvents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeEventDescription": {
+          "name": "excludeEventDescription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "excludeEventLocation": {
+          "name": "excludeEventLocation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "excludeEventName": {
+          "name": "excludeEventName",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "excludeFocusTime": {
+          "name": "excludeFocusTime",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeOutOfOffice": {
+          "name": "excludeOutOfOffice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeInIcalFeed": {
+          "name": "includeInIcalFeed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "treatFullDayTimedEventsAsAllDay": {
+          "name": "treatFullDayTimedEventsAsAllDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customEventName": {
+          "name": "customEventName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{{calendar_name}}'"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "failureCount": {
+          "name": "failureCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastFailureAt": {
+          "name": "lastFailureAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextAttemptAt": {
+          "name": "nextAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestFailureCount": {
+          "name": "ingestFailureCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ingestLastFailureAt": {
+          "name": "ingestLastFailureAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestNextAttemptAt": {
+          "name": "ingestNextAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestFutureRange": {
+          "name": "ingestFutureRange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2_years'"
+        },
+        "ingestHistoricRange": {
+          "name": "ingestHistoricRange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1_month'"
+        },
+        "ingestWindowEnd": {
+          "name": "ingestWindowEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestWindowRecordedAt": {
+          "name": "ingestWindowRecordedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestWindowStart": {
+          "name": "ingestWindowStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalCalendarId": {
+          "name": "externalCalendarId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"pull\"}'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalName": {
+          "name": "originalName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncToken": {
+          "name": "syncToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncFutureRange": {
+          "name": "syncFutureRange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2_years'"
+        },
+        "syncHistoricRange": {
+          "name": "syncHistoricRange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1_month'"
+        },
+        "unavailableSince": {
+          "name": "unavailableSince",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendars_user_idx": {
+          "name": "calendars_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_account_idx": {
+          "name": "calendars_account_idx",
+          "columns": [
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_capabilities_idx": {
+          "name": "calendars_capabilities_idx",
+          "columns": [
+            {
+              "expression": "capabilities",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_type_idx": {
+          "name": "calendars_type_idx",
+          "columns": [
+            {
+              "expression": "calendarType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendars_accountId_calendar_accounts_id_fk": {
+          "name": "calendars_accountId_calendar_accounts_id_fk",
+          "tableFrom": "calendars",
+          "tableTo": "calendar_accounts",
+          "columnsFrom": [
+            "accountId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendars_userId_user_id_fk": {
+          "name": "calendars_userId_user_id_fk",
+          "tableFrom": "calendars",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "calendars_sync_ranges_check": {
+          "name": "calendars_sync_ranges_check",
+          "value": "\"syncHistoricRange\" IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years') AND \"syncFutureRange\" IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years')"
+        },
+        "calendars_ingest_coverage_check": {
+          "name": "calendars_ingest_coverage_check",
+          "value": "\"ingestHistoricRange\" IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years') AND \"ingestFutureRange\" IN ('1_week', '1_month', '3_months', '6_months', '12_months', '2_years') AND ((\"ingestWindowStart\" IS NULL AND \"ingestWindowEnd\" IS NULL AND \"ingestWindowRecordedAt\" IS NULL) OR (\"ingestWindowStart\" IS NOT NULL AND \"ingestWindowEnd\" IS NOT NULL AND \"ingestWindowRecordedAt\" IS NOT NULL AND \"ingestWindowStart\" < \"ingestWindowEnd\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.event_mappings": {
+      "name": "event_mappings",
+      "schema": "",
+      "columns": {
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleteIdentifier": {
+          "name": "deleteIdentifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destinationEventUid": {
+          "name": "destinationEventUid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventStateId": {
+          "name": "eventStateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "syncEventId": {
+          "name": "syncEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncEventHash": {
+          "name": "syncEventHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceCalendarId": {
+          "name": "sourceCalendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "event_mappings_sync_event_cal_idx": {
+          "name": "event_mappings_sync_event_cal_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "syncEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_mappings\".\"syncEventId\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_mappings_calendar_idx": {
+          "name": "event_mappings_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_mappings_event_state_idx": {
+          "name": "event_mappings_event_state_idx",
+          "columns": [
+            {
+              "expression": "eventStateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_mappings_source_calendar_idx": {
+          "name": "event_mappings_source_calendar_idx",
+          "columns": [
+            {
+              "expression": "sourceCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_mappings_missing_sync_event_idx": {
+          "name": "event_mappings_missing_sync_event_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"event_mappings\".\"syncEventId\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_mappings_sync_hash_idx": {
+          "name": "event_mappings_sync_hash_idx",
+          "columns": [
+            {
+              "expression": "syncEventHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_mappings_calendarId_calendars_id_fk": {
+          "name": "event_mappings_calendarId_calendars_id_fk",
+          "tableFrom": "event_mappings",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_mappings_eventStateId_event_states_id_fk": {
+          "name": "event_mappings_eventStateId_event_states_id_fk",
+          "tableFrom": "event_mappings",
+          "tableTo": "event_states",
+          "columnsFrom": [
+            "eventStateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "event_mappings_identity_check": {
+          "name": "event_mappings_identity_check",
+          "value": "\"event_mappings\".\"eventStateId\" is not null or \"event_mappings\".\"syncEventId\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.event_states": {
+      "name": "event_states",
+      "schema": "",
+      "columns": {
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrenceRule": {
+          "name": "recurrenceRule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exceptionDates": {
+          "name": "exceptionDates",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrenceId": {
+          "name": "recurrenceId",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAllDay": {
+          "name": "isAllDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceEventId": {
+          "name": "sourceEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceEventType": {
+          "name": "sourceEventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceEventUid": {
+          "name": "sourceEventUid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startTimeZone": {
+          "name": "startTimeZone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_states_start_time_idx": {
+          "name": "event_states_start_time_idx",
+          "columns": [
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_states_end_time_idx": {
+          "name": "event_states_end_time_idx",
+          "columns": [
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_states_calendar_idx": {
+          "name": "event_states_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_states_source_event_idx": {
+          "name": "event_states_source_event_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_states\".\"sourceEventId\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_states_recurring_instance_idx": {
+          "name": "event_states_recurring_instance_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceEventUid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurrenceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_states\".\"sourceEventId\" is null and \"event_states\".\"recurrenceId\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_states_non_recurring_instance_idx": {
+          "name": "event_states_non_recurring_instance_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceEventUid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_states\".\"sourceEventId\" is null and \"event_states\".\"recurrenceId\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_states_calendarId_calendars_id_fk": {
+          "name": "event_states_calendarId_calendars_id_fk",
+          "tableFrom": "event_states",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wantsFollowUp": {
+          "name": "wantsFollowUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "feedback_user_idx": {
+          "name": "feedback_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_userId_user_id_fk": {
+          "name": "feedback_userId_user_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ical_feed_calendars": {
+      "name": "ical_feed_calendars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feedId": {
+          "name": "feedId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ical_feed_calendar_idx": {
+          "name": "ical_feed_calendar_idx",
+          "columns": [
+            {
+              "expression": "feedId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ical_feed_calendars_feed_idx": {
+          "name": "ical_feed_calendars_feed_idx",
+          "columns": [
+            {
+              "expression": "feedId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ical_feed_calendars_calendar_idx": {
+          "name": "ical_feed_calendars_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ical_feed_calendars_feedId_ical_feeds_id_fk": {
+          "name": "ical_feed_calendars_feedId_ical_feeds_id_fk",
+          "tableFrom": "ical_feed_calendars",
+          "tableTo": "ical_feeds",
+          "columnsFrom": [
+            "feedId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ical_feed_calendars_calendarId_calendars_id_fk": {
+          "name": "ical_feed_calendars_calendarId_calendars_id_fk",
+          "tableFrom": "ical_feed_calendars",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ical_feed_settings": {
+      "name": "ical_feed_settings",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "includeEventName": {
+          "name": "includeEventName",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeEventDescription": {
+          "name": "includeEventDescription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeEventLocation": {
+          "name": "includeEventLocation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeAllDayEvents": {
+          "name": "excludeAllDayEvents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customEventName": {
+          "name": "customEventName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Busy'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ical_feed_settings_userId_user_id_fk": {
+          "name": "ical_feed_settings_userId_user_id_fk",
+          "tableFrom": "ical_feed_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ical_feeds": {
+      "name": "ical_feeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'My Calendar'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "legacyAlias": {
+          "name": "legacyAlias",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeEventName": {
+          "name": "includeEventName",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeEventDescription": {
+          "name": "includeEventDescription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "includeEventLocation": {
+          "name": "includeEventLocation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeAllDayEvents": {
+          "name": "excludeAllDayEvents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeFocusTime": {
+          "name": "excludeFocusTime",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excludeOutOfOffice": {
+          "name": "excludeOutOfOffice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customEventName": {
+          "name": "customEventName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Busy'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ical_feeds_user_idx": {
+          "name": "ical_feeds_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ical_feeds_token_idx": {
+          "name": "ical_feeds_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ical_feeds_default_idx": {
+          "name": "ical_feeds_default_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ical_feeds\".\"isDefault\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ical_feeds_userId_user_id_fk": {
+          "name": "ical_feeds_userId_user_id_fk",
+          "tableFrom": "ical_feeds",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_credentials": {
+      "name": "oauth_credentials",
+      "schema": "",
+      "columns": {
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "needsReauthentication": {
+          "name": "needsReauthentication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_credentials_user_idx": {
+          "name": "oauth_credentials_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_credentials_provider_idx": {
+          "name": "oauth_credentials_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_credentials_expires_at_idx": {
+          "name": "oauth_credentials_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_credentials_userId_user_id_fk": {
+          "name": "oauth_credentials_userId_user_id_fk",
+          "tableFrom": "oauth_credentials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_destination_mappings": {
+      "name": "source_destination_mappings",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "destinationCalendarId": {
+          "name": "destinationCalendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sourceCalendarId": {
+          "name": "sourceCalendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "source_destination_mapping_idx": {
+          "name": "source_destination_mapping_idx",
+          "columns": [
+            {
+              "expression": "sourceCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destinationCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_destination_mappings_source_idx": {
+          "name": "source_destination_mappings_source_idx",
+          "columns": [
+            {
+              "expression": "sourceCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_destination_mappings_destination_idx": {
+          "name": "source_destination_mappings_destination_idx",
+          "columns": [
+            {
+              "expression": "destinationCalendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_destination_mappings_destinationCalendarId_calendars_id_fk": {
+          "name": "source_destination_mappings_destinationCalendarId_calendars_id_fk",
+          "tableFrom": "source_destination_mappings",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "destinationCalendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_destination_mappings_sourceCalendarId_calendars_id_fk": {
+          "name": "source_destination_mappings_sourceCalendarId_calendars_id_fk",
+          "tableFrom": "source_destination_mappings",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "sourceCalendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "",
+      "columns": {
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "localEventCount": {
+          "name": "localEventCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remoteEventCount": {
+          "name": "remoteEventCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_status_calendar_idx": {
+          "name": "sync_status_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_status_calendarId_calendars_id_fk": {
+          "name": "sync_status_calendarId_calendars_id_fk",
+          "tableFrom": "sync_status",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_events": {
+      "name": "user_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "calendarId": {
+          "name": "calendarId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceEventUid": {
+          "name": "sourceEventUid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAllDay": {
+          "name": "isAllDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startTimeZone": {
+          "name": "startTimeZone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_events_user_idx": {
+          "name": "user_events_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_events_calendar_idx": {
+          "name": "user_events_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendarId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_events_start_time_idx": {
+          "name": "user_events_start_time_idx",
+          "columns": [
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_events_end_time_idx": {
+          "name": "user_events_end_time_idx",
+          "columns": [
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_events_calendarId_calendars_id_fk": {
+          "name": "user_events_calendarId_calendars_id_fk",
+          "tableFrom": "user_events",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendarId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_events_userId_user_id_fk": {
+          "name": "user_events_userId_user_id_fk",
+          "tableFrom": "user_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscriptions": {
+      "name": "user_subscriptions",
+      "schema": "",
+      "columns": {
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "polarSubscriptionId": {
+          "name": "polarSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_subscriptions_userId_user_id_fk": {
+          "name": "user_subscriptions_userId_user_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sync_requests": {
+      "name": "user_sync_requests",
+      "schema": "",
+      "columns": {
+        "requestId": {
+          "name": "requestId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "requestedAt": {
+          "name": "requestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sync_requests_userId_user_id_fk": {
+          "name": "user_sync_requests_userId_user_id_fk",
+          "tableFrom": "user_sync_requests",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshId": {
+          "name": "refreshId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_idx": {
+          "name": "oauth_access_token_client_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_session_idx": {
+          "name": "oauth_access_token_session_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_idx": {
+          "name": "oauth_access_token_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_refresh_idx": {
+          "name": "oauth_access_token_refresh_idx",
+          "columns": [
+            {
+              "expression": "refreshId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_clientId_oauth_application_clientId_fk": {
+          "name": "oauth_access_token_clientId_oauth_application_clientId_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_sessionId_session_id_fk": {
+          "name": "oauth_access_token_sessionId_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_userId_user_id_fk": {
+          "name": "oauth_access_token_userId_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refreshId_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refreshId_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refreshId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientSecret": {
+          "name": "clientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "skipConsent": {
+          "name": "skipConsent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enableEndSession": {
+          "name": "enableEndSession",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjectType": {
+          "name": "subjectType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "softwareId": {
+          "name": "softwareId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "softwareVersion": {
+          "name": "softwareVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "softwareStatement": {
+          "name": "softwareStatement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirectUris": {
+          "name": "redirectUris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postLogoutRedirectUris": {
+          "name": "postLogoutRedirectUris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenEndpointAuthMethod": {
+          "name": "tokenEndpointAuthMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grantTypes": {
+          "name": "grantTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTypes": {
+          "name": "responseTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirePKCE": {
+          "name": "requirePKCE",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_application_user_idx": {
+          "name": "oauth_application_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_application_userId_user_id_fk": {
+          "name": "oauth_application_userId_user_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_clientId_unique": {
+          "name": "oauth_application_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clientId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_idx": {
+          "name": "oauth_consent_client_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_idx": {
+          "name": "oauth_consent_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_reference_idx": {
+          "name": "oauth_consent_reference_idx",
+          "columns": [
+            {
+              "expression": "referenceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_clientId_oauth_application_clientId_fk": {
+          "name": "oauth_consent_clientId_oauth_application_clientId_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_userId_user_id_fk": {
+          "name": "oauth_consent_userId_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authTime": {
+          "name": "authTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_client_idx": {
+          "name": "oauth_refresh_token_client_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_session_idx": {
+          "name": "oauth_refresh_token_session_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_user_idx": {
+          "name": "oauth_refresh_token_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_clientId_oauth_application_clientId_fk": {
+          "name": "oauth_refresh_token_clientId_oauth_application_clientId_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_sessionId_session_id_fk": {
+          "name": "oauth_refresh_token_sessionId_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_userId_user_id_fk": {
+          "name": "oauth_refresh_token_userId_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passkey_userId_user_id_fk": {
+          "name": "passkey_userId_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -603,6 +603,13 @@
       "when": 1786818618563,
       "tag": "0085_fixed_kat_farrell",
       "breakpoints": true
+    },
+    {
+      "idx": 86,
+      "version": "7",
+      "when": 1786824381678,
+      "tag": "0086_scope_provider_account_identity_to_user",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/database/schema.ts
+++ b/packages/database/src/database/schema.ts
@@ -96,7 +96,11 @@ const calendarAccountsTable = pgTable(
     index("calendar_accounts_user_idx").on(table.userId),
     index("calendar_accounts_provider_idx").on(table.provider),
     index("calendar_accounts_needs_reauth_idx").on(table.needsReauthentication),
-    uniqueIndex("calendar_accounts_provider_account_idx").on(table.provider, table.accountId),
+    uniqueIndex("calendar_accounts_provider_account_idx").on(
+      table.userId,
+      table.provider,
+      table.accountId,
+    ),
   ],
 );
 

--- a/packages/database/tests/database/calendar-account-identity.test.ts
+++ b/packages/database/tests/database/calendar-account-identity.test.ts
@@ -1,0 +1,208 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Client } from "pg";
+
+const administrativeUrl = process.env.KEEPER_TEST_DATABASE_URL;
+const migrationScript = `${import.meta.dirname}/../../scripts/migrate.ts`;
+const drizzleDirectory = `${import.meta.dirname}/../../drizzle`;
+const templateName = `keeper_account_identity_template_${process.pid}`;
+const scratchNames: string[] = [];
+
+const withAdministrativeClient = async <Result>(
+  run: (client: Client) => Promise<Result>,
+): Promise<Result> => {
+  const client = new Client({ connectionString: administrativeUrl });
+  await client.connect();
+  try {
+    return await run(client);
+  } finally {
+    await client.end();
+  }
+};
+
+const withDatabaseClient = async <Result>(
+  databaseName: string,
+  run: (client: Client) => Promise<Result>,
+): Promise<Result> => {
+  const url = new URL(administrativeUrl ?? "postgres://localhost");
+  url.pathname = `/${databaseName}`;
+  const client = new Client({ connectionString: url.toString() });
+  await client.connect();
+  try {
+    return await run(client);
+  } finally {
+    await client.end();
+  }
+};
+
+const runMigrations = async (databaseName: string): Promise<void> => {
+  const url = new URL(administrativeUrl ?? "postgres://localhost");
+  url.pathname = `/${databaseName}`;
+  const result = await Bun.$`bun ${migrationScript}`
+    .env({ ...process.env, DATABASE_URL: url.toString() })
+    .quiet()
+    .nothrow();
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Migration failed for ${databaseName}: ${result.stdout.toString()}${result.stderr.toString()}`,
+    );
+  }
+};
+
+const createScratchDatabase = async (label: string): Promise<string> => {
+  const name = `keeper_account_identity_${label}_${process.pid}`;
+  scratchNames.push(name);
+  await withAdministrativeClient(async (client) => {
+    await client.query(`DROP DATABASE IF EXISTS "${name}"`);
+    await client.query(`CREATE DATABASE "${name}" TEMPLATE "${templateName}"`);
+  });
+  return name;
+};
+
+const seedUser = async (client: Client, userId: string): Promise<void> => {
+  await client.query(
+    `INSERT INTO "user" ("id", "email", "name") VALUES ($1, $2, $3)`,
+    [userId, `${userId}@example.com`, "Account Identity Fixture"],
+  );
+};
+
+const insertAccount = async (
+  client: Client,
+  values: {
+    userId: string;
+    provider: string;
+    accountId: string | null;
+    email?: string | null;
+  },
+): Promise<string> => {
+  const result = await client.query<{ id: string }>(
+    `INSERT INTO "calendar_accounts" ("authType", "provider", "userId", "accountId", "email")
+     VALUES ('oauth', $1, $2, $3, $4) RETURNING "id"`,
+    [values.provider, values.userId, values.accountId, values.email ?? null],
+  );
+  const id = result.rows[0]?.id;
+  if (!id) {
+    throw new Error("Failed to seed a calendar account");
+  }
+  return id;
+};
+
+const readDuplicateProviderIdentities = async (
+  client: Client,
+): Promise<{ count: number }[]> => {
+  const result = await client.query<{ count: string }>(
+    `SELECT count(*)::text AS count
+     FROM "calendar_accounts"
+     WHERE "accountId" IS NOT NULL
+     GROUP BY "userId", "provider", "accountId"
+     HAVING count(*) > 1`,
+  );
+  return result.rows.map((row) => ({ count: Number(row.count) }));
+};
+
+const readMigrationStatements = async (tag: string): Promise<string[]> => {
+  const contents = await Bun.file(`${drizzleDirectory}/${tag}.sql`).text();
+  return contents
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0);
+};
+
+describe.skipIf(!administrativeUrl)("calendar account provider identity", () => {
+  beforeAll(async () => {
+    await withAdministrativeClient(async (client) => {
+      await client.query(`DROP DATABASE IF EXISTS "${templateName}"`);
+      await client.query(`CREATE DATABASE "${templateName}"`);
+    });
+    await runMigrations(templateName);
+  }, 300_000);
+
+  afterAll(async () => {
+    await withAdministrativeClient(async (client) => {
+      for (const name of [...scratchNames, templateName]) {
+        await client.query(`DROP DATABASE IF EXISTS "${name}"`);
+      }
+    });
+  }, 120_000);
+
+  it("lets two users hold the same provider account", async () => {
+    const databaseName = await createScratchDatabase("cross_user");
+    await withDatabaseClient(databaseName, async (client) => {
+      await seedUser(client, "identity-user-a");
+      await seedUser(client, "identity-user-b");
+      await insertAccount(client, {
+        accountId: "shared-provider-account",
+        provider: "google",
+        userId: "identity-user-a",
+      });
+
+      await expect(insertAccount(client, {
+        accountId: "shared-provider-account",
+        provider: "google",
+        userId: "identity-user-b",
+      })).resolves.toEqual(expect.any(String));
+    });
+  }, 120_000);
+
+  it("still refuses a second row for one user's provider account", async () => {
+    const databaseName = await createScratchDatabase("same_user");
+    await withDatabaseClient(databaseName, async (client) => {
+      await seedUser(client, "identity-user-c");
+      await insertAccount(client, {
+        accountId: "one-provider-account",
+        provider: "google",
+        userId: "identity-user-c",
+      });
+
+      await expect(insertAccount(client, {
+        accountId: "one-provider-account",
+        provider: "google",
+        userId: "identity-user-c",
+      })).rejects.toThrow();
+    });
+  }, 120_000);
+
+  it("keeps unlinked accounts free to coexist while their id is unknown", async () => {
+    const databaseName = await createScratchDatabase("null_ids");
+    await withDatabaseClient(databaseName, async (client) => {
+      await seedUser(client, "identity-user-d");
+      await insertAccount(client, {
+        accountId: null,
+        provider: "google",
+        userId: "identity-user-d",
+      });
+
+      await expect(insertAccount(client, {
+        accountId: null,
+        provider: "google",
+        userId: "identity-user-d",
+      })).resolves.toEqual(expect.any(String));
+    });
+  }, 120_000);
+
+  it("replays 0085 over a sibling pair without aborting or duplicating an identity", async () => {
+    const databaseName = await createScratchDatabase("sibling_backfill");
+    const statements = await readMigrationStatements("0085_fixed_kat_farrell");
+
+    await withDatabaseClient(databaseName, async (client) => {
+      await seedUser(client, "identity-user-e");
+      await insertAccount(client, {
+        accountId: "donor-provider-account",
+        email: "person@example.com",
+        provider: "google",
+        userId: "identity-user-e",
+      });
+      await insertAccount(client, {
+        accountId: null,
+        email: "person@example.com",
+        provider: "google",
+        userId: "identity-user-e",
+      });
+
+      for (const statement of statements) {
+        await client.query(statement);
+      }
+
+      expect(await readDuplicateProviderIdentities(client)).toEqual([]);
+    });
+  }, 120_000);
+});

--- a/packages/database/tests/database/schema.test.ts
+++ b/packages/database/tests/database/schema.test.ts
@@ -13,7 +13,7 @@ import {
 } from "../../src/database/schema";
 
 describe("calendar account schema", () => {
-  it("enforces provider account identity for OAuth upserts", () => {
+  it("enforces one row per user for a provider account", () => {
     const tableConfig = getTableConfig(calendarAccountsTable);
     const identityIndex = tableConfig.indexes.find(
       (index) => index.config.name === "calendar_accounts_provider_account_idx",
@@ -27,6 +27,7 @@ describe("calendar account schema", () => {
       return null;
     });
     expect(columnNames).toEqual([
+      "userId",
       "provider",
       "accountId",
     ]);

--- a/services/api/src/utils/destinations.ts
+++ b/services/api/src/utils/destinations.ts
@@ -7,7 +7,7 @@ import {
   syncStatusTable,
 } from "@keeper.sh/database/schema";
 import { REAUTHENTICATION_DESTINATION_GRANT } from "@keeper.sh/constants";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import {
   buildReauthenticationDemandFields,
   getErrorMessage,
@@ -79,6 +79,7 @@ interface ExistingAccount {
 
 const findExistingAccount = async (
   databaseClient: DestinationDatabase,
+  userId: string,
   provider: string,
   accountId: string,
 ): Promise<ExistingAccount | undefined> => {
@@ -98,6 +99,7 @@ const findExistingAccount = async (
         eq(calendarAccountsTable.accountId, accountId),
       ),
     )
+    .orderBy(desc(sql`${calendarAccountsTable.userId} = ${userId}`))
     .limit(FIRST_RESULT_LIMIT);
 
   return account;
@@ -246,13 +248,16 @@ const upsertAccountAndCalendarWithDatabase = async (
     })
     .onConflictDoUpdate({
       set: setClause,
-      setWhere: eq(calendarAccountsTable.userId, base.userId),
-      target: [calendarAccountsTable.provider, calendarAccountsTable.accountId],
+      target: [
+        calendarAccountsTable.userId,
+        calendarAccountsTable.provider,
+        calendarAccountsTable.accountId,
+      ],
     })
     .returning({ id: calendarAccountsTable.id });
 
   if (!account) {
-    throw new Error("This account is already linked to another user");
+    throw new Error("Failed to find or create the calendar account");
   }
 
   if (oauthCredentialId) {
@@ -291,19 +296,21 @@ const upsertAccountAndCalendarWithDatabase = async (
   return calendar?.id;
 };
 
-const saveCalendarDestinationWithDatabase = async (
+interface DestinationCredentialPayload {
+  accessToken: string;
+  email: string | null;
+  expiresAt: Date;
+  provider: string;
+  refreshToken: string;
+  userId: string;
+}
+
+const resolveDestinationCredentialId = async (
   databaseClient: DestinationDatabase,
-  userId: string,
-  provider: string,
-  accountId: string,
-  email: string | null,
-  accessToken: string,
-  refreshToken: string,
-  expiresAt: Date,
-  needsReauthentication = false,
-): Promise<void> => {
-  const existingAccount = await findExistingAccount(databaseClient, provider, accountId);
-  validateAccountOwnership(existingAccount, userId);
+  existingAccount: ExistingAccount | undefined,
+  payload: DestinationCredentialPayload,
+): Promise<string> => {
+  const { accessToken, email, expiresAt, provider, refreshToken, userId } = payload;
 
   if (existingAccount?.oauthCredentialId) {
     await databaseClient
@@ -311,39 +318,7 @@ const saveCalendarDestinationWithDatabase = async (
       .set({ accessToken, expiresAt, refreshToken })
       .where(eq(oauthCredentialsTable.id, existingAccount.oauthCredentialId));
 
-    await databaseClient
-      .update(calendarAccountsTable)
-      .set({
-        email,
-        needsReauthentication,
-        reauthenticationSource: resolveGrantDemandSource(needsReauthentication),
-      })
-      .where(eq(calendarAccountsTable.id, existingAccount.id));
-
-    recordGrantDemand(existingAccount.id, needsReauthentication, existingAccount);
-
-    const [existingCalendar] = await databaseClient
-      .select({ id: calendarsTable.id })
-      .from(calendarsTable)
-      .where(
-        and(
-          eq(calendarsTable.accountId, existingAccount.id),
-          inArray(calendarsTable.id,
-            databaseClient.selectDistinct({ id: sourceDestinationMappingsTable.destinationCalendarId })
-              .from(sourceDestinationMappingsTable)
-          ),
-        ),
-      )
-      .limit(FIRST_RESULT_LIMIT);
-
-    if (existingCalendar) {
-      await databaseClient
-        .update(calendarsTable)
-        .set(RECONNECTED_CALENDAR_STATE)
-        .where(eq(calendarsTable.id, existingCalendar.id));
-      await initializeSyncStatusWithDatabase(databaseClient, existingCalendar.id);
-    }
-    return;
+    return existingAccount.oauthCredentialId;
   }
 
   const [credential] = await databaseClient
@@ -355,18 +330,50 @@ const saveCalendarDestinationWithDatabase = async (
     throw new Error("Failed to create OAuth credentials");
   }
 
+  return credential.id;
+};
+
+const saveCalendarDestinationWithDatabase = async (
+  databaseClient: DestinationDatabase,
+  userId: string,
+  provider: string,
+  accountId: string,
+  email: string | null,
+  accessToken: string,
+  refreshToken: string,
+  expiresAt: Date,
+  needsReauthentication = false,
+): Promise<void> => {
+  const existingAccount = await findExistingAccount(databaseClient, userId, provider, accountId);
+  validateAccountOwnership(existingAccount, userId);
+
+  const oauthCredentialId = await resolveDestinationCredentialId(databaseClient, existingAccount, {
+    accessToken,
+    email,
+    expiresAt,
+    provider,
+    refreshToken,
+    userId,
+  });
+
   const calendarId = await upsertAccountAndCalendarWithDatabase(databaseClient, {
     accountId,
     email,
     needsReauthentication,
-    oauthCredentialId: credential.id,
+    oauthCredentialId,
     provider,
     userId,
   });
 
-  if (calendarId) {
-    await setupNewDestinationWithDatabase(databaseClient, calendarId);
+  if (!calendarId) {
+    return;
   }
+
+  await databaseClient
+    .update(calendarsTable)
+    .set(RECONNECTED_CALENDAR_STATE)
+    .where(eq(calendarsTable.id, calendarId));
+  await setupNewDestinationWithDatabase(databaseClient, calendarId);
 };
 
 const saveCalendarDestination = (
@@ -453,7 +460,7 @@ const saveCalDAVDestinationWithDatabase = async (
   encryptedPassword: string,
   authMethod: string,
 ): Promise<void> => {
-  const existingAccount = await findExistingAccount(databaseClient, provider, accountId);
+  const existingAccount = await findExistingAccount(databaseClient, userId, provider, accountId);
   validateAccountOwnership(existingAccount, userId);
 
   if (existingAccount?.caldavCredentialId) {

--- a/services/api/src/utils/oauth-sources.ts
+++ b/services/api/src/utils/oauth-sources.ts
@@ -4,7 +4,7 @@ import {
   oauthCredentialsTable,
   sourceDestinationMappingsTable,
 } from "@keeper.sh/database/schema";
-import { and, count, eq, inArray, sql } from "drizzle-orm";
+import { and, count, eq, inArray, isNull, sql } from "drizzle-orm";
 import { listUserCalendars as listGoogleCalendars } from "@keeper.sh/calendar/google";
 import { listUserCalendars as listOutlookCalendars } from "@keeper.sh/calendar/outlook";
 import type { database as contextDatabase } from "@/context";
@@ -19,7 +19,7 @@ import { enqueuePushSync } from "./enqueue-push-sync";
 const FIRST_RESULT_LIMIT = 1;
 const OAUTH_CALENDAR_TYPE = "oauth";
 const USER_ACCOUNT_LOCK_NAMESPACE = 9002;
-type OAuthSourceDatabase = Pick<typeof contextDatabase, "insert" | "select" | "selectDistinct">;
+type OAuthSourceDatabase = Pick<typeof contextDatabase, "insert" | "select" | "selectDistinct" | "update">;
 
 class OAuthSourceLimitError extends Error {
   constructor() {
@@ -292,15 +292,47 @@ const countUserAccounts = async (userId: string): Promise<number> => {
   return countUserAccountsWithDatabase(database, userId);
 };
 
+interface FindOAuthAccountOptions {
+  userId: string;
+  provider: string;
+  oauthCredentialId: string;
+  providerAccountId?: string | null;
+}
+
+const findOAuthAccountIdByProviderIdentity = async (
+  databaseClient: OAuthSourceDatabase,
+  options: FindOAuthAccountOptions,
+): Promise<string | null> => {
+  const { userId, provider, providerAccountId } = options;
+  if (!providerAccountId) {
+    return null;
+  }
+
+  const [existingAccount] = await databaseClient
+    .select({ id: calendarAccountsTable.id })
+    .from(calendarAccountsTable)
+    .where(
+      and(
+        eq(calendarAccountsTable.userId, userId),
+        eq(calendarAccountsTable.provider, provider),
+        eq(calendarAccountsTable.accountId, providerAccountId),
+      ),
+    )
+    .limit(FIRST_RESULT_LIMIT);
+
+  return existingAccount?.id ?? null;
+};
+
 const findOAuthAccountIdWithDatabase = async (
   databaseClient: OAuthSourceDatabase,
-  options: {
-    userId: string;
-    provider: string;
-    oauthCredentialId: string;
-  },
+  options: FindOAuthAccountOptions,
 ): Promise<string | null> => {
   const { userId, provider, oauthCredentialId } = options;
+
+  const identityMatch = await findOAuthAccountIdByProviderIdentity(databaseClient, options);
+  if (identityMatch) {
+    return identityMatch;
+  }
 
   const [existingAccount] = await databaseClient
     .select({ id: calendarAccountsTable.id })
@@ -318,14 +350,29 @@ const findOAuthAccountIdWithDatabase = async (
 };
 
 const findOAuthAccountId = async (
-  options: {
-    userId: string;
-    provider: string;
-    oauthCredentialId: string;
-  },
+  options: FindOAuthAccountOptions,
 ): Promise<string | null> => {
   const { database } = await import("@/context");
   return findOAuthAccountIdWithDatabase(database, options);
+};
+
+const adoptProviderAccountIdWithDatabase = async (
+  databaseClient: OAuthSourceDatabase,
+  options: { accountRowId: string; providerAccountId: string | null },
+): Promise<void> => {
+  if (!options.providerAccountId) {
+    return;
+  }
+
+  await databaseClient
+    .update(calendarAccountsTable)
+    .set({ accountId: options.providerAccountId })
+    .where(
+      and(
+        eq(calendarAccountsTable.id, options.accountRowId),
+        isNull(calendarAccountsTable.accountId),
+      ),
+    );
 };
 
 const hasExistingOAuthCalendarWithDatabase = async (
@@ -593,11 +640,10 @@ interface ImportOAuthAccountDependencies {
       "userId" | "provider" | "oauthCredentialId" | "email" | "providerAccountId"
     >,
   ) => Promise<string>;
-  findExistingAccountId: (options: {
-    userId: string;
-    provider: string;
-    oauthCredentialId: string;
-  }) => Promise<string | null>;
+  adoptProviderAccountId: (
+    options: { accountRowId: string; providerAccountId: string | null },
+  ) => Promise<void>;
+  findExistingAccountId: (options: FindOAuthAccountOptions) => Promise<string | null>;
   getUnimportedExternalCalendars: (
     userId: string,
     accountId: string,
@@ -613,6 +659,10 @@ interface ImportOAuthAccountDependencies {
 }
 
 const createDefaultImportOAuthAccountDependencies = (): ImportOAuthAccountDependencies => ({
+  adoptProviderAccountId: async (options) => {
+    const { database } = await import("@/context");
+    await adoptProviderAccountIdWithDatabase(database, options);
+  },
   canAddAccount: async (userId, currentCount) => {
     const { premiumService } = await import("@/context");
     return premiumService.canAddAccount(userId, currentCount);
@@ -719,9 +769,14 @@ const importOAuthAccountCalendarsWithDependencies = async (
   const existingAccountId = await dependencies.findExistingAccountId({
     oauthCredentialId,
     provider,
+    providerAccountId,
     userId,
   });
   let accountId = existingAccountId;
+
+  if (accountId) {
+    await dependencies.adoptProviderAccountId({ accountRowId: accountId, providerAccountId });
+  }
 
   if (!accountId) {
     const existingAccountCount = await dependencies.countUserAccounts(userId);
@@ -866,6 +921,8 @@ const importOAuthAccountCalendars = async (
 
     return importOAuthAccountCalendarsWithDependencies(options, {
       ...dependencies,
+      adoptProviderAccountId: (accountOptions) =>
+        adoptProviderAccountIdWithDatabase(tx, accountOptions),
       canAddAccount: (_userId, currentCount) =>
         Promise.resolve(currentCount < premiumService.getAccountLimit(plan)),
       listCalendars: () => Promise.resolve(externalCalendars),
@@ -893,6 +950,8 @@ export {
   getOAuthSourceCredentials,
   createOAuthSource,
   createOAuthSourceWithDependencies,
+  createOAuthAccountIdWithDatabase,
+  findOAuthAccountIdWithDatabase,
   importOAuthAccountCalendars,
   importOAuthAccountCalendarsWithDependencies,
 };

--- a/services/api/tests/utils/destination-reauth-telemetry.test.ts
+++ b/services/api/tests/utils/destination-reauth-telemetry.test.ts
@@ -80,12 +80,19 @@ const createInsertQuery = (rows: unknown[]): unknown => {
 
 let insertSequence = 0;
 
+const resolveInsertedId = (values: Record<string, unknown>): string => {
+  if (existingAccountRow && "accountId" in values && "provider" in values) {
+    return existingAccountRow.id;
+  }
+  return `row-${String(insertSequence)}`;
+};
+
 const createDatabase = (): Parameters<typeof saveCalendarDestinationWithDatabase>[0] => ({
   delete: () => createSelectQuery([]),
   insert: () => ({
-    values: () => {
+    values: (values: Record<string, unknown>) => {
       insertSequence += 1;
-      return createInsertQuery([{ id: `row-${String(insertSequence)}` }]);
+      return createInsertQuery([{ id: resolveInsertedId(values) }]);
     },
   }),
   select: (projection: Record<string, unknown>) =>

--- a/services/api/tests/utils/oauth-account-identity.test.ts
+++ b/services/api/tests/utils/oauth-account-identity.test.ts
@@ -1,0 +1,246 @@
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const client = new PGlite();
+const database = drizzle(client);
+
+vi.mock("@/context", () => ({
+  database,
+  encryptionKey: "encryption-key",
+  oauthProviders: {
+    getProvider: () => null,
+    hasRequiredScopes: () => true,
+    isOAuthProvider: () => true,
+  },
+}));
+
+vi.mock("@/utils/logging", () => ({
+  widelog: {
+    error: () => null,
+    errorFields: () => null,
+    set: () => null,
+  },
+}));
+
+const { saveCalendarDestinationWithDatabase } = await import("../../src/utils/destinations");
+const { createOAuthAccountIdWithDatabase, findOAuthAccountIdWithDatabase } = await import(
+  "../../src/utils/oauth-sources"
+);
+
+type DestinationClient = Parameters<typeof saveCalendarDestinationWithDatabase>[0];
+type SourceClient = Parameters<typeof findOAuthAccountIdWithDatabase>[0];
+
+const destinationClient = database as unknown as DestinationClient;
+const sourceClient = database as unknown as SourceClient;
+
+const DDL = `
+create table oauth_credentials (
+  "id" uuid primary key default gen_random_uuid(),
+  "accessToken" text not null,
+  "createdAt" timestamp not null default now(),
+  "email" text,
+  "expiresAt" timestamp not null,
+  "needsReauthentication" boolean not null default false,
+  "provider" text not null,
+  "refreshToken" text not null,
+  "updatedAt" timestamp not null default now(),
+  "userId" text not null
+);
+create table caldav_credentials (
+  "id" uuid primary key default gen_random_uuid(),
+  "authMethod" text not null default 'basic',
+  "encryptedPassword" text not null,
+  "serverUrl" text not null,
+  "username" text not null
+);
+create table calendar_accounts (
+  "id" uuid primary key default gen_random_uuid(),
+  "accountId" text,
+  "authType" text not null,
+  "caldavCredentialId" uuid,
+  "calendarsRefreshAttemptedAt" timestamp,
+  "calendarsRefreshedAt" timestamp,
+  "createdAt" timestamp not null default now(),
+  "displayName" text,
+  "email" text,
+  "needsReauthentication" boolean not null default false,
+  "oauthCredentialId" uuid,
+  "provider" text not null,
+  "reauthenticationSource" text,
+  "updatedAt" timestamp not null default now(),
+  "userId" text not null
+);
+create unique index "calendar_accounts_provider_account_idx"
+  on "calendar_accounts" ("userId", "provider", "accountId");
+create table calendars (
+  "id" uuid primary key default gen_random_uuid(),
+  "accountId" uuid not null,
+  "calendarType" text not null,
+  "calendarUrl" text,
+  "capabilities" text[] not null default array['pull'],
+  "createdAt" timestamp not null default now(),
+  "customEventName" text not null default '{{calendar_name}}',
+  "disabled" boolean not null default false,
+  "excludeAllDayEvents" boolean not null default false,
+  "excludeEventDescription" boolean not null default true,
+  "excludeEventLocation" boolean not null default true,
+  "excludeEventName" boolean not null default true,
+  "excludeFocusTime" boolean not null default false,
+  "excludeOutOfOffice" boolean not null default false,
+  "externalCalendarId" text,
+  "failureCount" integer not null default 0,
+  "includeInIcalFeed" boolean not null default false,
+  "ingestFailureCount" integer not null default 0,
+  "ingestFutureRange" text not null default '2_years',
+  "ingestHistoricRange" text not null default '1_month',
+  "ingestLastFailureAt" timestamp,
+  "ingestNextAttemptAt" timestamp,
+  "ingestWindowEnd" timestamp,
+  "ingestWindowRecordedAt" timestamp,
+  "ingestWindowStart" timestamp,
+  "lastFailureAt" timestamp,
+  "name" text not null,
+  "nextAttemptAt" timestamp,
+  "originalName" text,
+  "syncFutureRange" text not null default '2_years',
+  "syncHistoricRange" text not null default '1_month',
+  "syncToken" text,
+  "treatFullDayTimedEventsAsAllDay" boolean not null default false,
+  "unavailableSince" timestamp,
+  "updatedAt" timestamp not null default now(),
+  "url" text,
+  "userId" text not null
+);
+create table source_destination_mappings (
+  "id" uuid primary key default gen_random_uuid(),
+  "createdAt" timestamp not null default now(),
+  "destinationCalendarId" uuid not null,
+  "sourceCalendarId" uuid not null
+);
+create table sync_status (
+  "id" uuid primary key default gen_random_uuid(),
+  "calendarId" uuid not null,
+  "lastSyncedAt" timestamp,
+  "localEventCount" integer not null default 0,
+  "remoteEventCount" integer not null default 0,
+  "updatedAt" timestamp not null default now()
+);
+create unique index "sync_status_calendar_idx" on "sync_status" ("calendarId");
+`;
+
+const PROVIDER_ACCOUNT_ID = "116651453584579904080";
+const USER_ID = "user-1";
+const EXPIRES_AT = new Date("2027-01-01T00:00:00.000Z");
+
+const resetDatabase = async (): Promise<void> => {
+  await client.exec(`
+    drop table if exists sync_status, source_destination_mappings, calendars,
+      calendar_accounts, oauth_credentials, caldav_credentials cascade;
+  `);
+  await client.exec(DDL);
+};
+
+const seedSourceAccount = async (options: {
+  accountId: string | null;
+  email: string | null;
+}): Promise<{ accountRowId: string; credentialId: string }> => {
+  const credential = await client.query<{ id: string }>(
+    `insert into oauth_credentials
+       ("accessToken", "email", "expiresAt", "provider", "refreshToken", "userId")
+     values ('source-access', $1, $2, 'google', 'source-refresh', $3)
+     returning "id"`,
+    [options.email, EXPIRES_AT, USER_ID],
+  );
+  const credentialId = credential.rows[0]?.id;
+  if (!credentialId) {
+    throw new Error("Failed to seed an OAuth credential");
+  }
+
+  const account = await client.query<{ id: string }>(
+    `insert into calendar_accounts
+       ("accountId", "authType", "email", "oauthCredentialId", "provider", "userId")
+     values ($1, 'oauth', $2, $3, 'google', $4)
+     returning "id"`,
+    [options.accountId, options.email, credentialId, USER_ID],
+  );
+  const accountRowId = account.rows[0]?.id;
+  if (!accountRowId) {
+    throw new Error("Failed to seed a calendar account");
+  }
+
+  return { accountRowId, credentialId };
+};
+
+const countCalendars = async (accountRowId: string): Promise<number> => {
+  const result = await client.query<{ count: string }>(
+    `select count(*)::text as count from calendars where "accountId" = $1`,
+    [accountRowId],
+  );
+  return Number(result.rows[0]?.count ?? "0");
+};
+
+const countAccounts = async (): Promise<number> => {
+  const result = await client.query<{ count: string }>(
+    `select count(*)::text as count from calendar_accounts`,
+  );
+  return Number(result.rows[0]?.count ?? "0");
+};
+
+describe("linking a provider account that the user already holds", () => {
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  it("creates the destination calendar when the account already exists as a source", async () => {
+    const { accountRowId } = await seedSourceAccount({
+      accountId: PROVIDER_ACCOUNT_ID,
+      email: "person@example.com",
+    });
+
+    await saveCalendarDestinationWithDatabase(
+      destinationClient,
+      USER_ID,
+      "google",
+      PROVIDER_ACCOUNT_ID,
+      "person@example.com",
+      "destination-access",
+      "destination-refresh",
+      EXPIRES_AT,
+    );
+
+    expect(await countAccounts()).toBe(1);
+    expect(await countCalendars(accountRowId)).toBe(1);
+  });
+
+  it("reuses the existing row when the source flow arrives on a different credential", async () => {
+    const { accountRowId } = await seedSourceAccount({
+      accountId: PROVIDER_ACCOUNT_ID,
+      email: "person@example.com",
+    });
+
+    const found = await findOAuthAccountIdWithDatabase(sourceClient, {
+      oauthCredentialId: "00000000-0000-4000-8000-0000000000ff",
+      provider: "google",
+      providerAccountId: PROVIDER_ACCOUNT_ID,
+      userId: USER_ID,
+    });
+
+    expect(found).toBe(accountRowId);
+  });
+
+  it("refuses to insert a second row for a provider account the user already holds", async () => {
+    await seedSourceAccount({
+      accountId: PROVIDER_ACCOUNT_ID,
+      email: "person@example.com",
+    });
+
+    await expect(createOAuthAccountIdWithDatabase(sourceClient, {
+      email: "person@example.com",
+      oauthCredentialId: "00000000-0000-4000-8000-0000000000ff",
+      provider: "google",
+      providerAccountId: PROVIDER_ACCOUNT_ID,
+      userId: USER_ID,
+    })).rejects.toThrow();
+  });
+});

--- a/services/api/tests/utils/oauth-account-identity.test.ts
+++ b/services/api/tests/utils/oauth-account-identity.test.ts
@@ -213,6 +213,51 @@ describe("linking a provider account that the user already holds", () => {
     expect(await countCalendars(accountRowId)).toBe(1);
   });
 
+  it("lets a second user link the same provider account as a source", async () => {
+    await seedSourceAccount({
+      accountId: PROVIDER_ACCOUNT_ID,
+      email: "person@example.com",
+    });
+
+    await expect(createOAuthAccountIdWithDatabase(sourceClient, {
+      email: "person@example.com",
+      oauthCredentialId: "00000000-0000-4000-8000-0000000000ff",
+      provider: "google",
+      providerAccountId: PROVIDER_ACCOUNT_ID,
+      userId: "user-2",
+    })).resolves.toEqual(expect.any(String));
+  });
+
+  it("resolves a destination against the caller's row, not another holder's", async () => {
+    await seedSourceAccount({
+      accountId: PROVIDER_ACCOUNT_ID,
+      email: "person@example.com",
+    });
+    const secondHolder = await client.query<{ id: string }>(
+      `insert into calendar_accounts ("accountId", "authType", "provider", "userId")
+       values ($1, 'oauth', 'google', 'user-2') returning "id"`,
+      [PROVIDER_ACCOUNT_ID],
+    );
+    const secondHolderRowId = secondHolder.rows[0]?.id;
+    if (!secondHolderRowId) {
+      throw new Error("Failed to seed the second holder");
+    }
+
+    await saveCalendarDestinationWithDatabase(
+      destinationClient,
+      "user-2",
+      "google",
+      PROVIDER_ACCOUNT_ID,
+      "person@example.com",
+      "destination-access",
+      "destination-refresh",
+      EXPIRES_AT,
+    );
+
+    expect(await countAccounts()).toBe(2);
+    expect(await countCalendars(secondHolderRowId)).toBe(1);
+  });
+
   it("reuses the existing row when the source flow arrives on a different credential", async () => {
     const { accountRowId } = await seedSourceAccount({
       accountId: PROVIDER_ACCOUNT_ID,

--- a/services/api/tests/utils/oauth-sources.test.ts
+++ b/services/api/tests/utils/oauth-sources.test.ts
@@ -37,6 +37,7 @@ describe("importOAuthAccountCalendarsWithDependencies", () => {
           userId: "user-1",
         },
         {
+          adoptProviderAccountId: () => Promise.resolve(),
           canAddAccount: (userId, currentCount) => {
             canAddAccountCalls.push([userId, currentCount]);
             return Promise.resolve(canAddAccountResult);
@@ -70,6 +71,7 @@ describe("importOAuthAccountCalendarsWithDependencies", () => {
         userId: "user-1",
       },
       {
+        adoptProviderAccountId: () => Promise.resolve(),
         canAddAccount: (userId, currentCount) => {
           canAddAccountCalls.push([userId, currentCount]);
           return Promise.resolve(false);


### PR DESCRIPTION
Follow-up to #805. The production backfill it enabled ran 349 candidates: 316 updated, 32 skipped for reauthentication, and **1 hard failure** on a unique constraint. That failure exposed three defects, each proven here with a test that fails before its fix.

## 1. The unique index was global, not per-user

`calendar_accounts_provider_account_idx` was on `(provider, accountId)` across the whole table. It only ever held because every source row was NULL, and Postgres permits unlimited NULLs in a unique index. Writing real values made it bite — two rows resolved to the same Google account and the second `UPDATE` was rejected.

Two distinct users can legitimately hold one provider account, and could before #805. Migration `0086` scopes the index to `(userId, provider, accountId)`, **and** the source flow now reuses the user's existing row rather than inserting a second. Both were needed; either alone leaves a hole.

## 2. Destination connect silently created nothing — regression from #805

Once a source row carries `accountId`, `saveCalendarDestinationWithDatabase` found it, took the "existing account" branch, found no mapped destination calendar, and returned having created nothing. The user was redirected to `?destination=connected` with no destination. Both paths now route through `upsertAccountAndCalendarWithDatabase`, which already handled create-or-reconnect correctly; the early-return branch was a strictly worse duplicate.

## 3. Migration `0085`'s sibling backfill could only abort

It copied a donor row's `accountId` onto a NULL sibling, which always produces two rows sharing `(provider, accountId)` — violating the index in both its old and new form. Demonstrated against Postgres 17:

```
ERROR:  duplicate key value violates unique constraint "calendar_accounts_provider_account_idx"
DETAIL:  Key (provider, "accountId")=(google, 116651453584579904080) already exists.
```

It matched nothing in production, which is why that deploy survived. The statement is removed and the file carries a comment recording that it ran in production and why it was taken out — a later migration cannot fix this, because drizzle runs all pending migrations in one transaction, so a database that has not yet applied `0085` would roll the whole batch back before any fix-up ran. The intent is now served by `adoptProviderAccountId`, which adopts the id onto an existing row on reconnect.

## Deliberately left undecided

The cross-user ownership check on the destination path is still global. If user A holds a Google account **as a source**, user B is now refused when linking it as a destination — allowed pre-#805, because source rows were invisible to that lookup. Restoring the exact prior meaning needs a reliable "is a destination" predicate, and the obvious one (a row in `source_destination_mappings`) is wrong for a freshly created destination that has no mapping yet. This fails loudly with a clear message rather than corrupting anything, but it is a real behaviour tightening and wants a decision rather than a silent choice.

`0086` does a non-concurrent index swap — sub-second `ACCESS EXCLUSIVE` at this table size, under the migrator's 10s `lock_timeout`.

## Not proven, flagged rather than dropped

`saveCalDAVDestinationWithDatabase` appears to have the identical "no destination created" hole, and `deleteCalendarDestination` deletes the whole `calendar_accounts` row, so removing a destination on a row that also serves as a source may cascade the source calendars away. Both are static reads with no test behind them; #805 did not touch either path.

## Production data

No urgent action. The surviving duplicate pair is Google, which does not need `accountId` for push, so the NULL row still gets channels. Remaining Outlook rows drain on their own as users reconnect.

```sql
SELECT a.id AS holder, b.id AS orphan, a."userId", a.provider, a."accountId", a.email
FROM calendar_accounts a
JOIN calendar_accounts b ON b."userId" = a."userId" AND b.provider = a.provider
                        AND b.id <> a.id AND b."accountId" IS NULL
WHERE a."accountId" IS NOT NULL AND a.provider IN ('google','outlook');
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWminUmH2kMq6fQShPLgvE