### PR TITLE
fix(destinations): stop reconnect creating a duplicate destination calendar

### DIFF
--- a/services/api/src/utils/destinations.ts
+++ b/services/api/src/utils/destinations.ts
@@ -7,7 +7,7 @@ import {
   syncStatusTable,
 } from "@keeper.sh/database/schema";
 import { REAUTHENTICATION_DESTINATION_GRANT } from "@keeper.sh/constants";
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 import {
   buildReauthenticationDemandFields,
   getErrorMessage,
@@ -270,10 +270,7 @@ const upsertAccountAndCalendarWithDatabase = async (
     .where(
       and(
         eq(calendarsTable.accountId, account.id),
-        inArray(calendarsTable.id,
-          databaseClient.selectDistinct({ id: sourceDestinationMappingsTable.destinationCalendarId })
-            .from(sourceDestinationMappingsTable)
-        ),
+        isNull(calendarsTable.externalCalendarId),
       ),
     )
     .limit(FIRST_RESULT_LIMIT);

--- a/services/api/tests/utils/destination-reconnect-duplicate.test.ts
+++ b/services/api/tests/utils/destination-reconnect-duplicate.test.ts
@@ -1,0 +1,184 @@
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const client = new PGlite();
+const database = drizzle(client);
+
+vi.mock("@/context", () => ({
+  database,
+  encryptionKey: "encryption-key",
+  oauthProviders: {
+    getProvider: () => null,
+    hasRequiredScopes: () => true,
+    isOAuthProvider: () => true,
+  },
+}));
+
+vi.mock("@/utils/logging", () => ({
+  widelog: {
+    error: () => null,
+    errorFields: () => null,
+    set: () => null,
+  },
+}));
+
+const { saveCalendarDestinationWithDatabase } = await import("../../src/utils/destinations");
+type DestinationClient = Parameters<typeof saveCalendarDestinationWithDatabase>[0];
+
+const destinationClient = database as unknown as DestinationClient;
+
+const DDL = `
+create table oauth_credentials (
+  "id" uuid primary key default gen_random_uuid(),
+  "accessToken" text not null,
+  "createdAt" timestamp not null default now(),
+  "email" text,
+  "expiresAt" timestamp not null,
+  "needsReauthentication" boolean not null default false,
+  "provider" text not null,
+  "refreshToken" text not null,
+  "updatedAt" timestamp not null default now(),
+  "userId" text not null
+);
+create table caldav_credentials (
+  "id" uuid primary key default gen_random_uuid(),
+  "authMethod" text not null default 'basic',
+  "encryptedPassword" text not null,
+  "serverUrl" text not null,
+  "username" text not null
+);
+create table calendar_accounts (
+  "id" uuid primary key default gen_random_uuid(),
+  "accountId" text,
+  "authType" text not null,
+  "caldavCredentialId" uuid,
+  "calendarsRefreshAttemptedAt" timestamp,
+  "calendarsRefreshedAt" timestamp,
+  "createdAt" timestamp not null default now(),
+  "displayName" text,
+  "email" text,
+  "needsReauthentication" boolean not null default false,
+  "oauthCredentialId" uuid,
+  "provider" text not null,
+  "reauthenticationSource" text,
+  "updatedAt" timestamp not null default now(),
+  "userId" text not null
+);
+create unique index "calendar_accounts_provider_account_idx"
+  on "calendar_accounts" ("userId", "provider", "accountId");
+create table calendars (
+  "id" uuid primary key default gen_random_uuid(),
+  "accountId" uuid not null,
+  "calendarType" text not null,
+  "calendarUrl" text,
+  "capabilities" text[] not null default array['pull'],
+  "createdAt" timestamp not null default now(),
+  "customEventName" text not null default '{{calendar_name}}',
+  "disabled" boolean not null default false,
+  "excludeAllDayEvents" boolean not null default false,
+  "excludeEventDescription" boolean not null default true,
+  "excludeEventLocation" boolean not null default true,
+  "excludeEventName" boolean not null default true,
+  "excludeFocusTime" boolean not null default false,
+  "excludeOutOfOffice" boolean not null default false,
+  "externalCalendarId" text,
+  "failureCount" integer not null default 0,
+  "includeInIcalFeed" boolean not null default false,
+  "ingestFailureCount" integer not null default 0,
+  "ingestFutureRange" text not null default '2_years',
+  "ingestHistoricRange" text not null default '1_month',
+  "ingestLastFailureAt" timestamp,
+  "ingestNextAttemptAt" timestamp,
+  "ingestWindowEnd" timestamp,
+  "ingestWindowRecordedAt" timestamp,
+  "ingestWindowStart" timestamp,
+  "lastFailureAt" timestamp,
+  "name" text not null,
+  "nextAttemptAt" timestamp,
+  "originalName" text,
+  "syncFutureRange" text not null default '2_years',
+  "syncHistoricRange" text not null default '1_month',
+  "syncToken" text,
+  "treatFullDayTimedEventsAsAllDay" boolean not null default false,
+  "unavailableSince" timestamp,
+  "updatedAt" timestamp not null default now(),
+  "url" text,
+  "userId" text not null
+);
+create table source_destination_mappings (
+  "id" uuid primary key default gen_random_uuid(),
+  "createdAt" timestamp not null default now(),
+  "destinationCalendarId" uuid not null,
+  "sourceCalendarId" uuid not null
+);
+create table sync_status (
+  "id" uuid primary key default gen_random_uuid(),
+  "calendarId" uuid not null,
+  "lastSyncedAt" timestamp,
+  "localEventCount" integer not null default 0,
+  "remoteEventCount" integer not null default 0,
+  "updatedAt" timestamp not null default now()
+);
+create unique index "sync_status_calendar_idx" on "sync_status" ("calendarId");
+`;
+
+const PROVIDER_ACCOUNT_ID = "116651453584579904080";
+const USER_ID = "user-1";
+const EXPIRES_AT = new Date("2027-01-01T00:00:00.000Z");
+
+const resetDatabase = async (): Promise<void> => {
+  await client.exec(`
+    drop table if exists sync_status, source_destination_mappings, calendars,
+      calendar_accounts, oauth_credentials, caldav_credentials cascade;
+  `);
+  await client.exec(DDL);
+};
+
+const countCalendars = async (accountRowId: string): Promise<number> => {
+  const result = await client.query<{ count: string }>(
+    `select count(*)::text as count from calendars where "accountId" = $1`,
+    [accountRowId],
+  );
+  return Number(result.rows[0]?.count ?? "0");
+};
+
+const countAccounts = async (): Promise<number> => {
+  const result = await client.query<{ count: string }>(
+    `select count(*)::text as count from calendar_accounts`,
+  );
+  return Number(result.rows[0]?.count ?? "0");
+};
+
+describe("reconnecting a destination that has no mapping yet", () => {
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  it("does not create a second destination calendar", async () => {
+    const connect = () => saveCalendarDestinationWithDatabase(
+      destinationClient,
+      USER_ID,
+      "google",
+      PROVIDER_ACCOUNT_ID,
+      "person@example.com",
+      "destination-access",
+      "destination-refresh",
+      EXPIRES_AT,
+    );
+
+    await connect();
+    await connect();
+
+    const accountRow = await client.query<{ id: string }>(
+      `select "id" from calendar_accounts limit 1`,
+    );
+    const accountRowId = accountRow.rows[0]?.id;
+    if (!accountRowId) {
+      throw new Error("Expected a calendar account");
+    }
+
+    expect(await countAccounts()).toBe(1);
+    expect(await countCalendars(accountRowId)).toBe(1);
+  });
+});


### PR DESCRIPTION
Regression from #809, already on `main`. Found by an adversarial review of that PR after it merged.

#809 routed both destination paths through `upsertAccountAndCalendarWithDatabase` — correct, since the old early-return branch created nothing at all. But that function treats a calendar as existing only when it already appears in `source_destination_mappings.destinationCalendarId`. A destination that has been connected but not yet wired to a source is invisible to that lookup, so **every reconnect inserts another `<provider> destination` calendar**.

The normal state between connecting a destination and configuring a mapping is exactly that window. Re-running the destination OAuth in it — a scope re-grant, a reconnect, a retried callback — adds a row each time. They stay hidden from `listCalendarDestinations` (which also requires a mapping), so they accumulate silently and then all become live destinations the moment one mapping is created.

## The fix

Match the destination placeholder by its null `externalCalendarId` rather than by mapping membership. Source calendars always set `externalCalendarId` (`oauth-sources.ts:726`, `:899`); the destination placeholder never does. A mapped destination was created by this same insert, so it also has a null value — the new predicate is a superset of the old one and keeps the mapped case working.

## Verification

Reproduced against `main` before fixing, with a pglite test that drives `saveCalendarDestinationWithDatabase` twice:

```
expected 2 to be 1     ← calendars under the account after a second connect
```

It passes with this change. Full suite uncached: **45/45 tasks**, api 716 tests across 87 files.

I also trimmed unused scaffolding from the test as authored (an unused import, client alias and seed helper) so it passes oxlint's `no-unused-vars`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWminUmH2kMq6fQShPLgvE