### PR TITLE
feat(sync-kit): the adapter contract for the new sync engine

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -240,6 +240,15 @@
         "vitest": "^4.1.4",
       },
     },
+    "packages/sync-kit/protocol": {
+      "name": "@keeper.sh/sync-protocol",
+      "devDependencies": {
+        "@keeper.sh/typescript-config": "workspace:*",
+        "@types/bun": "latest",
+        "typescript": "5.9.3",
+        "vitest": "^4.1.4",
+      },
+    },
     "packages/typescript-config": {
       "name": "@keeper.sh/typescript-config",
       "devDependencies": {
@@ -596,6 +605,8 @@
     "@keeper.sh/queue": ["@keeper.sh/queue@workspace:packages/queue"],
 
     "@keeper.sh/sync": ["@keeper.sh/sync@workspace:packages/sync"],
+
+    "@keeper.sh/sync-protocol": ["@keeper.sh/sync-protocol@workspace:packages/sync-kit/protocol"],
 
     "@keeper.sh/typescript-config": ["@keeper.sh/typescript-config@workspace:packages/typescript-config"],
 

--- a/knip.json
+++ b/knip.json
@@ -10,16 +10,28 @@
     "applications/web/src/generated/**/*"
   ],
   "ignoreBinaries": [],
-  "ignoreDependencies": ["@keeper.sh/otelemetry", "@keeper.sh/fixtures"],
-  "ignoreWorkspaces": ["packages/typescript-config"],
+  "ignoreDependencies": [
+    "@keeper.sh/otelemetry",
+    "@keeper.sh/fixtures"
+  ],
+  "ignoreWorkspaces": [
+    "packages/typescript-config"
+  ],
   "ignoreExportsUsedInFile": true,
   "workspaces": {
     "packages/*": {
-      "entry": ["src/{index.ts,api.ts,cron.ts}"],
+      "entry": [
+        "src/{index.ts,api.ts,cron.ts}"
+      ],
       "project": "src/**/*.{ts,tsx}"
     },
+    "packages/sync-kit/*": {
+      "project": "src/**/*.ts"
+    },
     "applications/*": {
-      "entry": ["src/{index.ts,main.tsx,server.tsx}"],
+      "entry": [
+        "src/{index.ts,main.tsx,server.tsx}"
+      ],
       "project": "src/**/*.{ts,tsx}"
     },
     "applications/web": {
@@ -29,22 +41,35 @@
         "plugins/**/*.ts",
         "scripts/**/*.ts"
       ],
-      "project": ["src/**/*.{ts,tsx}", "plugins/**/*.ts", "scripts/**/*.ts"],
-      "ignoreDependencies": ["@babel/preset-typescript"]
+      "project": [
+        "src/**/*.{ts,tsx}",
+        "plugins/**/*.ts",
+        "scripts/**/*.ts"
+      ],
+      "ignoreDependencies": [
+        "@babel/preset-typescript"
+      ]
     },
     "services/*": {
       "project": "src/**/*.{ts,tsx}"
     },
     "services/api": {
-      "entry": ["src/routes/**/*.ts", "src/scripts/**/*.ts"],
+      "entry": [
+        "src/routes/**/*.ts",
+        "src/scripts/**/*.ts"
+      ],
       "project": "src/**/*.{ts,tsx}"
     },
     "services/cron": {
-      "entry": ["src/jobs/*.ts"],
+      "entry": [
+        "src/jobs/*.ts"
+      ],
       "project": "src/**/*.{ts,tsx}"
     },
     "services/mcp": {
-      "entry": ["src/routes/**/*.ts"],
+      "entry": [
+        "src/routes/**/*.ts"
+      ],
       "project": "src/**/*.{ts,tsx}"
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "workspaces": {
     "packages": [
       "packages/*",
+      "packages/sync-kit/*",
       "applications/*",
       "services/*"
     ]

--- a/packages/sync-kit/LEARNINGS.md
+++ b/packages/sync-kit/LEARNINGS.md
@@ -6,6 +6,10 @@ element in `@keeper.sh/sync-protocol` that honours it — or marked NOT APPLICAB
 Entries 1–33 come from the existing code and its commit history. Entries 34–43 come from provider and RFC
 research. Entries 44–49 are the explicit not-applicable set. Entries 50–55 are lessons that belong to
 sibling sync-kit packages, recorded here so their absence from the protocol reads as a decision.
+Entries 56–60 were added after adversarial review found them missing; 60 is not applicable.
+
+Every **Proved by** citation names a file under `packages/sync-kit/protocol/tests` and the exact test name
+inside it, so the ledger can be walked against the suite mechanically.
 
 ---
 
@@ -24,7 +28,7 @@ events"*.
 `CoverageWindow`, and only a `snapshot` may be passed to `DeriveSnapshotRemovals`. `partial` and
 `cursorLost` declare `coverage?: never` and `removals?: never`, so an unproven read is structurally
 incapable of producing a deletion. A read that fails entirely is `Result.ok === false`, never an empty
-listing. Tests **O1–O4**.
+listing. **Proved by.** `deletion.test-d.ts :: DeriveSnapshotRemovals rejects a partial listing`; `deletion.test-d.ts :: DeriveSnapshotRemovals rejects a cursorLost listing`; `change-listing.test-d.ts :: a partial listing can never carry removals`.
 
 ### 2. Deletion authority differs between snapshot and delta sources
 
@@ -34,7 +38,7 @@ whole coverage, so absence means "gone". Carried as an `isDeltaSync` boolean thr
 `core/sync-engine/ingest.ts` (`getNonRecurringStoredEventIdsOutsideWindow`).
 **Honoured by.** The distinction is the `kind` discriminant, not a flag. `delta` carries `removals` and has
 no function that accepts it together with `KnownEvents`; `snapshot` carries `coverage` and derives absence
-only within it. Tests **O4, O6**.
+only within it. **Proved by.** `deletion.test-d.ts :: a delta listing cannot express delete-everything-not-listed`; `deletion.test-d.ts :: an outOfScope removal never drives a deletion`.
 
 ### 3. A deletion may only be inferred inside a proven coverage window
 
@@ -43,9 +47,14 @@ sources gets no window at all, or a freshly imported calendar deletes every Keep
 put there.
 **Learned from.** `packages/sync/src/sync-user.ts:218-224, 777-792`; `coverage` on `FetchEventsResult`.
 **Honoured by.** `CoverageWindow` is a required, distinctly-shaped field
-(`{ coveredFrom, coveredTo, calendar }` — deliberately not the same shape as the requested `TimeWindow`)
-on `snapshot` and `delta`, absent from `partial` and `cursorLost`. `DeriveSnapshotRemovals` takes the
-coverage window as a required third argument. Tests **O2, O5**.
+(`{ covered, calendar }` — deliberately not the same shape as the requested `TimeWindow`)
+on `snapshot` and `delta`, absent from `partial` and `cursorLost`. `DeriveSnapshotRemovals` takes **no**
+coverage argument at all: the only window in scope is `listing.coverage`, so a caller cannot hand it a
+window wider than the one the provider proved. The membership predicate arrives as an argument
+(`WindowMembership`, entry 17) rather than being re-implemented per call site. What the types cannot state
+is that `listing.scope.calendar`, `listing.coverage.calendar` and `known.calendar` name one calendar —
+two values of one type are indistinguishable to the compiler — so that agreement is a named runtime
+obligation, `ProviderConformanceSuite.deletionInputsShareOneCalendar`. **Proved by.** `change-listing.test-d.ts :: a snapshot listing cannot omit its coverage window`; `change-listing.test-d.ts :: a requested window is not a proven coverage window`; `deletion.test-d.ts :: the only coverage window a snapshot removal can use is the one the listing proved`.
 
 ### 4. An unrepresentable event must be WITHHELD, not filtered out
 
@@ -54,9 +63,13 @@ stored state the user still has. Same for a recurrence series over the occurrenc
 **Learned from.** `ics/utils/fetch-adapter.ts:394-399`, `core/sync-engine/ingest.ts:323-327`,
 `core/sync/operations.ts:567-573`; tests `ics-floating-date-telemetry` *"never deletes the stored row of the
 event it withholds"*.
-**Honoured by.** Every `ChangeListing` variant carries a required `withheld: readonly WithheldEvent[]`, and
-`DeriveSnapshotRemovals` reads its input's `withheld` as present ids. Withholding is cheaper to write than
-filtering. Test **O16**.
+**Honoured by.** Every `ChangeListing` variant that carries events carries a required
+`withheld: readonly WithheldEvent[]`, and `DeriveSnapshotRemovals` reads its input's `withheld` as present
+ids. `cursorLost` declares `withheld?: never` for the same reason it declares `events?: never` — it
+observed nothing, so it withheld nothing. Withholding is cheaper to write than filtering. A withheld event
+is identified by its UID **or** by the provider's own id: `WithheldIdentity` is a union, so a publisher
+that stripped one of the two before deleting still has a legal shape (entry 58) and never has to be
+dropped silently. **Proved by.** `deletion.test-d.ts :: withheld ids are part of the deletion-inference input`; `diagnostics.test-d.ts :: a publisher that stripped the UID before deleting still has a withheld shape`.
 
 ### 5. One bad event must not stall the whole feed
 
@@ -66,7 +79,7 @@ the delta token never advanced, and the source never converged.
 **Learned from.** commit `fdd9ba62` (#634); commit `43292a9f` (#606);
 `tests/ics/utils/ics-malformed-vevent-telemetry.test.ts`.
 **Honoured by.** Per-event failure is `WithheldEvent` inside a *successful* listing. `ProviderFailure` is
-reserved for whole-listing failures. Adapters return `Result`, never throw. Test **L6**.
+reserved for whole-listing failures. Adapters return `Result`, never throw. **Proved by.** `provider-shape.test-d.ts :: no awaiting method returns a bare value; every one returns a Result`; `provider-failure.test-d.ts :: normalization can refuse an event without throwing or mislabelling it`.
 
 ### 6. Every discard needs a counter
 
@@ -76,7 +89,7 @@ permanently non-zero on mirrored calendars.
 **Learned from.** commit `fdd9ba62` (#634); `DiscardedSourceEventCounts` in `core/sync-engine/ingest.ts`.
 **Honoured by.** `ListingDiagnostics` is a required field on all four listing kinds, with `withheld`,
 `selfAuthored` and `unrepresentable` as *separate* `BoundedSample` fields. Required, so every adapter
-author must answer the question. Test **O19**.
+author must answer the question. **Proved by.** `diagnostics.test-d.ts :: the counters are required, not optional`; `diagnostics.test-d.ts :: selfAuthored and unrepresentable are separate counters`.
 
 ### 7. Self-authored events must be recognised at the source read
 
@@ -86,7 +99,7 @@ re-ingested as a source event and echoed around the loop.
 in all four fetch adapters; `RemoteEvent.isKeeperEvent`.
 **Honoured by.** `RemoteEvent` is a union over provenance: `ForeignEvent | OwnEvent | IndeterminateEvent`.
 Only `ForeignEvent` is assignable to the write-intent builder type. `selfAuthored` is its own diagnostics
-field. Tests **O14, O15**.
+field. **Proved by.** `provenance.test-d.ts :: an OwnEvent is not assignable to a mirror write-intent builder`; `provenance.test-d.ts :: only a ForeignEvent is a mirror source`.
 
 ### 8. Echo must be three-state
 
@@ -95,7 +108,7 @@ silently meant "unchecked" hid a real drift class.
 **Learned from.** `core/sync-engine/index.ts` (`tallyPushEcho`), `core/events/push-echo.ts`; tests
 `push-echo-attribution`, `push-echo-length-attribution`.
 **Honoured by.** `EchoVerdict = matched | diverged | notObserved`, required on `created`/`updated`
-outcomes, never an optional boolean. Test **O20**.
+outcomes, never an optional boolean. **Proved by.** `write-outcome.test-d.ts :: echo is three-state and a boolean is not assignable`; `write-outcome.test-d.ts :: a created outcome must report what the echo showed`.
 
 ### 9. A conditional write needs a real precondition and a distinct conflict outcome
 
@@ -103,9 +116,11 @@ outcomes, never an optional boolean. Test **O20**.
 as a separate counter. CalDAV refuses to recreate an object with no ETag.
 **Learned from.** `providers/caldav/destination/provider.ts:120-133`; `PushResult`/`DeleteResult` in
 `core/types.ts`.
-**Honoured by.** `precondition` is a required field on `update`, `delete` and `retire` intents, typed as a
-`Precondition` union (`matchesVersion | matchesFingerprint | absent`). `WriteOutcome` has a `conflict`
-member carrying the observed precondition. Tests **O8, O9, O12, O22**.
+**Honoured by.** `precondition` is a required field on `update`, `delete` and `retire` intents, typed as
+`ObservedPrecondition` (`matchesVersion | matchesFingerprint`) — `absent` is reachable only from `create`,
+so "update it whether or not it changed" and "delete whatever is there" are both unspellable, not merely
+discouraged. `WriteOutcome.conflict` and `ProviderFailure.conflict` carry the observed precondition, which
+for the same reason cannot be `absent`. **Proved by.** `write-intent.test-d.ts :: an update WriteIntent without a precondition does not compile`; `write-intent.test-d.ts :: an update pinned to absent is not expressible`; `write-outcome.test-d.ts :: there is no outcome in which a mismatched precondition succeeded`.
 
 ### 10. A replayed create must be a typed no-op
 
@@ -115,16 +130,22 @@ CalDAV re-fetches `${uid}.ics` and returns early on a content-hash match.
 `providers/caldav/destination/provider.ts:90-118`; tests *"re-reads an unchanged feed as no work at all"*.
 **Honoured by.** `create` carries a required `idempotencyKey` and a `precondition` pinned to
 `{ kind: "absent" }`. `WriteOutcome` has `alreadyExists` and `unchanged` members distinct from `created`.
-Tests **O10, O11**.
+**Proved by.** `write-intent.test-d.ts :: a create's precondition can only be absent`; `write-intent.test-d.ts :: a create without an idempotencyKey does not compile`.
 
 ### 11. Provider identifiers are not interchangeable
 
 **Lesson.** Google's delete endpoint takes the event id, not the iCalUID; mappings that stored the UID cost
 a second batch request per delete.
 **Learned from.** `core/sync/operations.ts:482-488`; `RemoteEvent { uid, deleteId }`.
-**Honoured by.** `RemoteEventId` and `DeleteHandle` are tagged handles
-(`{ kind: "remoteEventId" | "deleteHandle"; value: string }`), not interchangeable strings, and `EventUid`
-is separate again. Delete/retire intents take a `DeleteHandle`; update takes a `RemoteEventId`. Test **I1**.
+**Honoured by.** Every identity in the package is a tagged handle (`{ kind; value }`), not a string alias:
+`RemoteEventId`, `DeleteHandle`, `EventUid`, `RemoteVersion`, `Fingerprint`, `IdempotencyKey`, and also
+`AccountId`, `CalendarId`, `InstallationId`, `Instant`, `CalendarDate` and `ZoneId`. Delete/retire intents
+take a `DeleteHandle`; update takes a `RemoteEventId`; `CalendarKey`'s three members cannot be permuted;
+an `Instant` cannot land in a `CalendarDate` field (entry 44). `ProviderId` is the deliberate exception:
+it is the literal domain (`"google"`, `"outlook"`) every generic in the package is parameterised over, and
+tagging it would forbid `CalendarProvider<"google">`. `KnownEvents.ids` is a
+`ReadonlyMap<string, RemoteEventId>` rather than a `ReadonlySet<string>`, so a set of UIDs — which would
+match nothing in the listing and therefore delete everything — is not assignable. **Proved by.** `identifiers.test-d.ts :: a RemoteEventId and a DeleteHandle cannot be swapped`; `identifiers.test-d.ts :: an EventUid is not a RemoteEventId`; `identifiers.test-d.ts :: an AccountId is not a CalendarId, and the three parts of a key cannot be permuted`; `identifiers.test-d.ts :: an Instant is not a CalendarDate`.
 
 ### 12. A stale cursor forces a full resync and must clear the token
 
@@ -134,7 +155,7 @@ instances.
 **Learned from.** `providers/outlook/source/utils/fetch-events.ts:382-388`;
 `providers/google/source/utils/fetch-events.ts:149`; `ingest.ts` flushing `syncToken: null`.
 **Honoured by.** `cursorLost` is its own listing kind carrying `events?: never`, `removals?: never`,
-`cursor?: never`, `coverage?: never`. Test **O3**.
+`cursor?: never`, `coverage?: never`. **Proved by.** `change-listing.test-d.ts :: a cursorLost listing carries no events, no removals, no cursor and no coverage`.
 
 ### 13. A stored-state parse failure must also force a full sync
 
@@ -166,8 +187,8 @@ provider interface.
 commit `b057d2e0` (#616).
 **Honoured by.** `normalize` is a declared phase returning `NormalizedContent<P>`, and `WriteIntent<P>`
 accepts nothing else. Unnormalized `EditableContent` cannot reach `write`, and content normalized for one
-provider is not assignable to another's write. The comment is deleted because the type says it. Tests
-**O17, O18**.
+provider is not assignable to another's write. The comment is deleted because the type says it. **Proved by.**
+`write-intent.test-d.ts :: unnormalized EditableContent cannot reach a write`; `write-intent.test-d.ts :: content normalized for one provider cannot be written to another`.
 
 ### 16. Providers refuse ranges that RFC 5545 permits, and each refuses a different set
 
@@ -178,7 +199,7 @@ same add on every run — one calendar failed ~50 times/hour — because a rejec
 **Honoured by.** `Capabilities.representableRange` declares `minimumSpanSeconds`, `zeroDuration`,
 `invertedRange` and `allDayGrid` as data, so the engine shapes once per destination.
 `WriteOutcome.unrepresentable` carries the violated constraint, so a refusal is typed and recordable rather
-than a repeating failure. Test **C1**.
+than a repeating failure. **Proved by.** `capabilities.test-d.ts :: the representable range is a required declaration`; `provider-failure.test-d.ts :: normalization can refuse an event without throwing or mislabelling it`.
 
 ### 17. Window membership must be one predicate shared by every layer
 
@@ -187,8 +208,10 @@ a zero-duration event on `timeMin` was admitted by some layers and dropped by ot
 add/delete cycle.
 **Learned from.** commit `b057d2e0` sub-commits; `core/events/time-range.ts`.
 **Honoured by.** The protocol owns `TimeWindow`, `CoverageWindow` and the single predicate *signature*
-`type WindowMembership = (window: TimeWindow, time: EventTime) => boolean`. Adapters consume it; none
-declares its own. Duplication, not the rule, was the defect.
+`type WindowMembership = (window: TimeWindow, time: EventTime) => boolean`, and the one place the protocol
+expresses windowing — `DeriveSnapshotRemovals` — takes that predicate as an argument rather than implying
+one. A caller therefore passes the shared predicate in; it has nowhere to declare a seventh copy.
+Duplication, not the rule, was the defect.
 
 ### 18. Reauthentication must be first-class and non-ignorable
 
@@ -197,7 +220,7 @@ by 401/403 on CalDAV/ICS. Retrying it burns quota and never succeeds.
 **Learned from.** `core/oauth/error-classification.ts`; `CalendarFetchError.authRequired`;
 `BroadcastSyncStatus.needsReauthentication`.
 **Honoured by.** `ProviderFailure` has a `reauthRequired` member carrying the `AccountId`. Consumers switch
-with `assertNever`, so omitting the branch fails to compile. Test **O13**.
+with `assertNever`, so omitting the branch fails to compile. **Proved by.** `provider-failure.test-d.ts :: a ProviderFailure switch that omits reauthRequired fails to compile`.
 
 ### 19. Never classify failures by matching error message substrings
 
@@ -215,7 +238,7 @@ a broken one oscillate between 1 and 0 forever. The verdict is three-state.
 **Learned from.** `destination-errors.ts` (`resolveDestinationAttemptVerdict`); `destination-backoff-*`
 tests.
 **Honoured by.** `notAttempted` is a member of **both** `WriteOutcome` and `ProviderFailure`, carrying
-`reason: "superseded" | "aborted" | "budgetExhausted"`. Test **L9**.
+`reason: "superseded" | "aborted" | "budgetExhausted"`. **Proved by.** `write-outcome.test-d.ts :: an unattempted run is neither success nor failure`.
 
 ### 21. Retries need a ceiling, provider delays need a cap, sleeps must be abortable
 
@@ -224,9 +247,12 @@ immediately on an already-aborted signal, removes its listener on timeout and cl
 **Learned from.** `core/utils/backoff.ts`, `core/utils/fetch-with-timeout.ts`; tests *"caps the delay at 64
 seconds"*, *"aborts during backoff sleep when signal is triggered"*.
 **Honoured by.** Providers do not own retries. `OperationContext` carries a required
-`signal: AbortSignal` and a required `RetryBudget { maxAttempts, ceilingMs }` with no defaults — a caller
-cannot forget the ceiling. `rateLimited` carries `retryAfter` as data rather than inviting a sleep loop.
-Tests **L1–L5**.
+`signal: AbortSignal`, a required `deadline: Instant` and a required
+`RetryBudget { maxAttempts, retryDelayCeilingMs }` with no defaults — a caller cannot forget the ceiling,
+and cancellation is no longer the only bound: a socket nobody aborts still has a wall clock to answer to.
+The ceiling is named for what it caps, because `ceilingMs` beside `maxAttempts` reads as a call budget and
+is not one. `rateLimited` carries `retryAfter` as data rather than inviting a sleep loop.
+**Proved by.** `provider-shape.test-d.ts :: OperationContext.signal cannot be omitted or undefined`; `provider-shape.test-d.ts :: an operation cannot be started without a wall-clock deadline`; `provider-shape.test-d.ts :: a RetryBudget without maxAttempts does not compile`.
 
 ### 22. Wide-event identifier lists must be a capped sample beside an uncapped count
 
@@ -235,7 +261,11 @@ it. Sample 20, 2048-char cap, true total adjacent.
 **Learned from.** `core/sync-engine/ingest.ts:22-27`; `sync-user.ts:338-344`; test
 `ingest-wide-event-list-bounds`.
 **Honoured by.** `BoundedSample = { sample: readonly string[]; total: number }` is the only shape any
-diagnostic identifier list may take. A bare `string[]` is not assignable. Test **O19**.
+diagnostic identifier list may take. A bare `string[]` is not assignable, so the count can never be lost
+with the list. The cap itself — 20 entries, 2048 characters — is a contract the type states no more than
+the `Fingerprint` contract states RFC 8785 (entry 29): a `readonly string[]` cannot carry a length bound.
+The cap is enforced where the sample is built, in the sync-kit telemetry package (entry 55's sibling), and
+is stated here as prose because pretending otherwise is how a ledger claim becomes false. **Proved by.** `diagnostics.test-d.ts :: an identifier diagnostic is never a bare array`; `diagnostics.test-d.ts :: a bounded sample keeps the total beside the sample it truncated`.
 
 ### 23. Quota must be acquired inside the retried operation
 
@@ -273,7 +303,13 @@ exist, and skips discovered calendars belonging to another account.
 identity to the owning user*.
 **Honoured by.** `CalendarEnumeration` is the same shape of union: `snapshot` (authoritative) or `partial`
 (retires nothing). The retire-deriving signature accepts only the `snapshot` variant. `CalendarKey` is
-`{ provider, account, calendar }`, so two accounts' calendars cannot collide. Test **O23**.
+`{ provider, account, calendar }`, so two accounts' calendars cannot collide. The commit's actual lesson is
+narrower and sharper than "add the account to the key": a *provider-issued* account id is unique only
+within one Keeper user, which is why the index had to be widened to `(userId, provider, accountId)`.
+`CalendarKey.account` is therefore Keeper's own account row id — already user-scoped — and never the
+provider's identifier for the mailbox. That is now unforgeable rather than conventional: `AccountId` is a
+tagged handle, so the provider-issued string an adapter reads off an API response is not assignable to it,
+and only whoever loads the account row can mint one. **Proved by.** `change-listing.test-d.ts :: a partial calendar enumeration cannot retire calendars`; `change-listing.test-d.ts :: a calendar key is a composite that includes the owning account`.
 
 ### 27. Ordering must be decided by a stable signature, not feed order
 
@@ -282,8 +318,15 @@ must withhold that UID entirely, because letting the superseded revision win syn
 the publisher already moved away from.
 **Learned from.** `ics/utils/parse-ics-events.ts:156-159, 412-415`; `ics-superseded-slot-telemetry`,
 `ics-stale-revision-telemetry`, `ics-revision-collapse-telemetry`.
-**Honoured by.** `RemoteEvent.revision` is required, so "newest wins" is decidable from the type, and
-`WithholdReason` includes `supersededRevisionUnbuildable` so a UID is suppressed rather than downgraded.
+**Honoured by.** Only the second half is honoured here. `RemoteEvent.revision` is required, so "newest
+wins" is decidable from the type, and `WithholdReason` includes `supersededRevisionUnbuildable` so a UID is
+suppressed rather than downgraded. The tie-break — equal revisions resolved by the lowest slot signature —
+is **not** in the protocol and deliberately so: the protocol keys events by the provider's own
+`RemoteEventId`, so two same-UID masters at different slots are already two distinct events and no
+merge decision arises. The tie-break belongs to the ICS adapter, which is the only reader that collapses
+a UID-keyed feed into events; it owns the `parse-ics-events.ts` ordering rule and the tests
+*"keeps duplicate UIDs and preserves adversarial time ranges"* and *"does not merge recurring masters that
+reuse a UID at different slots"*.
 
 ### 28. Our own writes come back on the next poll
 
@@ -300,7 +343,8 @@ handle. The safe answer (do not echo) becomes a compiler-forced decision.
 surviving row over repeated polls"*.
 **Honoured by.** `Fingerprint` is a tagged handle with a stated contract (stable under key reordering,
 ISO/Date equivalence, `undefined ≡ absent`). The protocol types it and does not compute it; production
-belongs to a sibling package (see 55). Instants are RFC 3339 strings, so Date-vs-string cannot arise.
+belongs to a sibling package (see 55). An `Instant` is a tagged handle over an RFC 3339 string, so a `Date`
+is not assignable anywhere in the contract and the Date-vs-string comparison cannot arise.
 
 ### 30. Re-ingesting the same input twice must be no work
 
@@ -329,7 +373,11 @@ constraint with a citation — is reserved for provider quirks like entry 36.
 **Lesson.** Every boolean result in the existing code grew a second field within months
 (`conflictResolved`, `needsReauthentication`, `fullSyncRequired`).
 **Learned from.** `core/types.ts` `PushResult`, `DeleteResult`, `BroadcastSyncStatus`.
-**Honoured by.** No boolean appears in any outcome type. `Result` is a two-member union and `WriteOutcome`
+**Honoured by.** No boolean appears in any outcome or failure type — `ProviderFailure.transport` reports
+`disposition: "transient" | "permanent"`, not `retryable: boolean`, so the day it needs to say
+*retryable after what* it grows a member rather than a second field. Booleans survive only in
+`Capabilities`, where each one is a standing declaration about a provider rather than the result of an
+attempt. `Result` is a two-member union and `WriteOutcome`
 has nine named members.
 
 ### 34. Graph's removal signal is ambiguous
@@ -341,7 +389,7 @@ removal is therefore not proof of deletion.
 **Honoured by.** `delta` carries `removals: readonly Removal[]` where
 `Removal = { kind: "deleted"; id; uid } | { kind: "outOfScope"; id }`. Only `deleted` is assignable to the
 deletion driver. Every adapter must classify — Google pays a small tax for a guard Outlook cannot live
-without. `Capabilities.removalsAreAmbiguous` records which providers need the classification. Test **O7**.
+without. `Capabilities.removalsAreAmbiguous` records which providers need the classification. **Proved by.** `deletion.test-d.ts :: an outOfScope removal never drives a deletion`; `deletion.test-d.ts :: a cancellation is deletion evidence in its own right`.
 
 ### 35. A post-410 resync carries no tombstones
 
@@ -350,7 +398,7 @@ for items removed during the gap; Google's docs say the same for its 410.
 **Learned from.** <https://learn.microsoft.com/en-us/graph/delta-query-overview>,
 <https://developers.google.com/workspace/calendar/api/guides/sync>.
 **Honoured by.** `cursorLost` carries nothing, and recovery is a `snapshot` whose removals are derivable
-only within `coverage`. Test **O3**.
+only within `coverage`. **Proved by.** `deletion.test-d.ts :: DeriveSnapshotRemovals rejects a cursorLost listing`.
 
 ### 36. RFC 6578 truncation is a state, not an error
 
@@ -369,7 +417,11 @@ for replace and `If-None-Match: *` for create.
 **Learned from.** RFC 4791, RFC 9110 §13, Graph and Google event references.
 **Honoured by.** `Precondition = matchesVersion | matchesFingerprint | absent`. `absent` maps to
 `If-None-Match: *` and to Google's deterministic-id create. `Capabilities.precondition` declares which
-kind a provider supports. An optional `etag?: string` is rejected: optionality is the hole silent
+kind a provider compares against, and its type is `ObservedPrecondition["kind"]` — derived from the union
+itself, so the vocabulary an adapter declares and the preconditions the engine can build are the same set
+by construction. There is no separate hand-written list of kinds to drift, and no `"none"`: a provider
+that compares nothing has no way to say so, because an unconditional write is the thing this entry exists
+to forbid. An optional `etag?: string` is rejected for the same reason: optionality is the hole silent
 overwrites arrive through.
 
 ### 38. Use provider-native idempotency
@@ -387,7 +439,7 @@ error. The key is a tagged handle because Google's id format is constrained, so 
 from `@odata.deltaLink`. Confusing them silently skips changes.
 **Learned from.** Google sync guide; Graph delta overview.
 **Honoured by.** `SyncCursor` and `Continuation` are distinct tagged handles, mutually unassignable.
-`partial` carries only a `Continuation`; `delta` carries only a `SyncCursor`. Test **L8**.
+`partial` carries only a `Continuation`; `delta` carries only a `SyncCursor`. **Proved by.** `identifiers.test-d.ts :: a Continuation is not assignable to a SyncCursor and vice versa`; `change-listing.test-d.ts :: a partial listing carries neither a cursor nor a coverage window`.
 
 ### 40. A cursor is valid only for the request shape that minted it
 
@@ -398,7 +450,7 @@ This directly threatens the configurable sync-window feature.
 **Honoured by.** `SyncCursor` and `Continuation` both carry a required `scope: ListingScope`. A cursor
 cannot exist without the calendar and window it was minted against. The compiler cannot compare two
 windows, so the engine-side rule — a widened window discards the cursor and forces a snapshot — is recorded
-here as entry 53 and tested where it is implemented. Test **L10**.
+here as entry 53 and tested where it is implemented. **Proved by.** `change-listing.test-d.ts :: a cursor cannot exist without the scope that minted it`.
 
 ### 41. Provider representational limits must be declared, not discovered at write time
 
@@ -413,7 +465,7 @@ rather than a lossy coercion. Same design element as entry 16.
 **Lesson.** A thrown error erases the discriminated union, and reauth ends up in a generic `catch`.
 **Learned from.** `core/oauth/error-classification.ts` reconstructing categories from caught errors.
 **Honoured by.** Every awaiting method returns `Promise<Result<T>>`. `Result` has no `throw` variant.
-Test **L6**.
+**Proved by.** `provider-shape.test-d.ts :: a provider whose write resolves a bare outcome does not satisfy the contract`.
 
 ### 43. Provenance may be undetectable, and that must be sayable
 
@@ -421,7 +473,7 @@ Test **L6**.
 them being dropped silently. An adapter that cannot carry a marker must be able to say so.
 **Learned from.** Google extended-properties guide; Graph event resource docs.
 **Honoured by.** `Capabilities.provenanceChannel: "extendedProperty" | "uidSuffix" | "none"` and the
-`indeterminate` provenance variant, which no write-intent builder accepts. Test **O15**.
+`indeterminate` provenance variant, which no write-intent builder accepts. **Proved by.** `provenance.test-d.ts :: an IndeterminateEvent is not assignable either`; `provenance.test-d.ts :: a provenance switch that omits indeterminate fails to compile`.
 
 ---
 
@@ -435,7 +487,9 @@ makes the read-back narrower than the write and the mirror is recreated every ru
 **Not applicable.** Time-representation semantics belong to the calendar model, not the transport contract.
 The protocol honours it only structurally: `EventTime` is
 `{ kind: "allDay"; startDate; endDateExclusive } | { kind: "timed"; start; end; zone }`, so a DATE and a
-DATE-TIME cannot be mixed and `isAllDay: boolean` beside two instants is unrepresentable. The anchoring
+DATE-TIME cannot be mixed and `isAllDay: boolean` beside two instants is unrepresentable. That separation
+is real rather than nominal now that `Instant` and `CalendarDate` are distinct tagged handles: an RFC 3339
+timestamp is not assignable to `startDate`. The anchoring
 rule stays with whoever builds the events. `Capabilities.allDay` records which grid a provider expects so
 the adapter, not the protocol, applies it.
 
@@ -526,3 +580,87 @@ whitespace stripped, Ryū number normalisation. `packages/calendar` currently ha
 `diff-events.ts` *and* depends on `fast-json-stable-stringify` — two implementations of one idea.
 **Owner:** a single sibling package. The protocol declares the `Fingerprint` contract (entry 29) and
 exports a conformance suite as types; it cannot enforce the contract at compile time and says so.
+
+---
+
+## Added after adversarial review
+
+### 56. A cancelled event is not an absent event
+
+**Lesson.** Google's incremental sync reports a deletion as an event whose `status` is `cancelled`, not as
+a separate removals collection, and an ICS feed can carry a cancelled VEVENT inside an otherwise complete
+body. The ICS parser turns a cancelled recurrence override into a master exception and drops a cancelled
+master together with all of its detached overrides — meaning a cancellation is a first-class input to the
+diff, never something to filter out.
+**Learned from.** `packages/calendar/tests/ics/utils/parse-ics-events.test.ts` *"turns a cancelled
+recurrence override into a master exception"*, *"drops a cancelled master and all of its detached
+overrides"*; <https://developers.google.com/workspace/calendar/api/guides/sync>.
+**Honoured by.** `Removal` has a third member, `{ kind: "cancelled"; id; uid }`, and both authoritative
+listing kinds — `snapshot` as well as `delta` — carry a required `removals`. Before this, a snapshot
+containing a cancelled event had no legal encoding: an adapter had to either publish it as a live event
+(mirroring a cancellation forever) or filter it out, which entry 4 identifies as the direct cause of a
+wrongful deletion. `AuthoritativeRemoval = deleted | cancelled` is what drives a deletion; `outOfScope`
+still drives nothing.
+**Proved by.** `deletion.test-d.ts :: a cancellation is deletion evidence in its own right`;
+`change-listing.test-d.ts :: a cancelled event has somewhere to go in both authoritative listing kinds`.
+
+### 57. A recurring master is wall time plus a zone, and its duration may be nominal
+
+**Lesson.** RFC 5545 durations in weeks and days are *nominal* — added in wall time and re-resolved
+through the zone, so a "one day" occurrence is 23 or 25 hours across a DST transition — while hours,
+minutes and seconds are exact. A master pinned to two absolute instants with an optional zone cannot be
+expanded correctly, and an exact 24-hour duration is indistinguishable from a nominal one-day duration.
+**Learned from.** `packages/calendar/src/ics/utils/recurrence-duration.ts`; `parse-ics-events.test.ts`
+*"distinguishes exact DTEND duration from nominal DURATION"*; the `wall-time-*` sweeps;
+`build-vtimezone.test.ts` *"does not let an old event truncate timezone rules for current and future
+events"*.
+**Honoured by.** `EditableContent` is a union rather than a record with a nullable `recurrence`. A
+recurring event carries a `RecurrenceAnchor` and no `time`; its timed variant requires a non-null `zone`
+and an explicit `OccurrenceDuration` (`exact` seconds or `nominal` days), and its all-day variant admits
+only a nominal duration. A one-off event carries `time` and no anchor. Entry 45 keeps wall-time
+*resolution* out of the protocol; this entry keeps the wall time and zone *in* it, because for a master
+they are the payload rather than a derived view.
+**Proved by.** `content-time.test-d.ts :: a series cannot be pinned to instants alone`;
+`content-time.test-d.ts :: a timed series anchor cannot omit its zone`;
+`content-time.test-d.ts :: a nominal duration is not an exact one`.
+
+### 58. A discarded event may be missing the very identifier you would log it by
+
+**Lesson.** Feed publishers strip DTSTART, and sometimes UID, from an event immediately before deleting
+it, so the discard telemetry has to count events that cannot be named the usual way.
+**Learned from.** `packages/calendar/tests/ics/utils/ics-discard-telemetry.test.ts` *"counts an event the
+feed publisher stripped DTSTART from before deleting it"*, *"counts an event the feed publisher stripped
+UID from before deleting it"*.
+**Honoured by.** `WithheldEvent`'s identity is a union: UID present with the provider id optional, or the
+provider id present with the UID explicitly null. Neither is individually required and neither may be
+absent at once, so a UID-less discard is constructible and an unidentifiable one is not — an adapter is
+never forced into the silent drop of entry 4. `withholdReasons` gains `missingIdentity` and
+`unsupportedRecurrenceRange`, the latter for the THISANDFUTURE case entry 5 cites in its own lesson text
+but had no reason code for.
+**Proved by.** `diagnostics.test-d.ts :: a publisher that stripped the UID before deleting still has a
+withheld shape`; `diagnostics.test-d.ts :: a recurrence range an adapter refuses to reinterpret is a named
+reason`.
+
+### 59. Discovered access must survive to the write
+
+**Lesson.** Enumeration learns whether a calendar is writable and the fact was then discarded; a write to
+a read-only calendar is expressible everywhere downstream.
+**Learned from.** `CalendarRef.access` having no consumer; the reconnect/duplicate-destination family of
+fixes (`fec144c1`).
+**Honoured by.** Every `WriteIntent` variant takes a `WritableCalendar` (`{ key, access: "readWrite" }`),
+not a bare `CalendarKey`. Constructing one from a `CalendarRef` requires narrowing `access`, which is a
+guard the compiler forces rather than an assertion the author may skip — the package contains no type
+assertions, so there is no other way to obtain one.
+**Proved by.** `write-intent.test-d.ts :: a calendar we only ever read cannot be written to`.
+
+### 60. Lenient parsing and property-level repair
+
+Publishers ship all-day events without `VALUE=DATE`, EXDATE lists without it, folded property lines, and
+8-digit strings that are not real dates; the parser repairs conservatively, leaves compliant feeds
+byte-identical, and rejects what it cannot repair
+(`ics/utils/lenient-parser.ts`, `ics/utils/apply-patches.ts`, the `coerce-compliant-date` patch).
+**Not applicable.** Repair happens strictly below the contract: it is how an adapter turns bytes into a
+`RemoteEvent` at all. The protocol's only surface for the outcome is `WithholdReason.unparseable` — what
+could not be repaired is withheld, never filtered (entry 4) and never thrown (entry 42). Encoding the
+repair rules here would pull one publisher's malformations into every provider's contract, the same
+mistake as entry 49.

--- a/packages/sync-kit/LEARNINGS.md
+++ b/packages/sync-kit/LEARNINGS.md
@@ -1,0 +1,528 @@
+# sync-kit learnings ledger
+
+Every lesson mined from `packages/calendar`, `packages/sync` and their git history, mapped to the design
+element in `@keeper.sh/sync-protocol` that honours it — or marked NOT APPLICABLE with the reason.
+
+Entries 1–33 come from the existing code and its commit history. Entries 34–43 come from provider and RFC
+research. Entries 44–49 are the explicit not-applicable set. Entries 50–55 are lessons that belong to
+sibling sync-kit packages, recorded here so their absence from the protocol reads as a decision.
+
+---
+
+## Adopted
+
+### 1. An empty listing must never mean "the calendar is empty"
+
+**Lesson.** A body that never opened a VCALENDAR, a CalDAV collection where every resource failed to parse,
+and a failed HTTP fetch all parsed to zero events, and the snapshot diff read zero events as "delete
+everything the user has".
+**Learned from.** `packages/calendar/src/ics/utils/parse-ics-calendar.ts`,
+`providers/caldav/shared/ics.ts`, `ics/utils/fetch-adapter.ts`; commit `0184ea19` *fix(ics): don't wipe
+existing events when remote fetch fails (#383)*; test *"propagates fetch errors instead of returning empty
+events"*.
+**Honoured by.** `ChangeListing` is a four-member discriminated union. Only `snapshot` carries a
+`CoverageWindow`, and only a `snapshot` may be passed to `DeriveSnapshotRemovals`. `partial` and
+`cursorLost` declare `coverage?: never` and `removals?: never`, so an unproven read is structurally
+incapable of producing a deletion. A read that fails entirely is `Result.ok === false`, never an empty
+listing. Tests **O1–O4**.
+
+### 2. Deletion authority differs between snapshot and delta sources
+
+**Lesson.** A delta feed reports only changes, so absence means "unchanged"; a snapshot feed re-reports its
+whole coverage, so absence means "gone". Carried as an `isDeltaSync` boolean through every diff.
+**Learned from.** `core/source/event-diff.ts` (`buildSourceEventStateIdsToRemove`),
+`core/sync-engine/ingest.ts` (`getNonRecurringStoredEventIdsOutsideWindow`).
+**Honoured by.** The distinction is the `kind` discriminant, not a flag. `delta` carries `removals` and has
+no function that accepts it together with `KnownEvents`; `snapshot` carries `coverage` and derives absence
+only within it. Tests **O4, O6**.
+
+### 3. A deletion may only be inferred inside a proven coverage window
+
+**Lesson.** Coverage is re-read under lock and only ever narrowed mid-run; a destination with no mapped
+sources gets no window at all, or a freshly imported calendar deletes every Keeper-tagged event another row
+put there.
+**Learned from.** `packages/sync/src/sync-user.ts:218-224, 777-792`; `coverage` on `FetchEventsResult`.
+**Honoured by.** `CoverageWindow` is a required, distinctly-shaped field
+(`{ coveredFrom, coveredTo, calendar }` — deliberately not the same shape as the requested `TimeWindow`)
+on `snapshot` and `delta`, absent from `partial` and `cursorLost`. `DeriveSnapshotRemovals` takes the
+coverage window as a required third argument. Tests **O2, O5**.
+
+### 4. An unrepresentable event must be WITHHELD, not filtered out
+
+**Lesson.** Filtering an unparseable VEVENT out of the feed made the diff treat it as absent and delete the
+stored state the user still has. Same for a recurrence series over the occurrence budget.
+**Learned from.** `ics/utils/fetch-adapter.ts:394-399`, `core/sync-engine/ingest.ts:323-327`,
+`core/sync/operations.ts:567-573`; tests `ics-floating-date-telemetry` *"never deletes the stored row of the
+event it withholds"*.
+**Honoured by.** Every `ChangeListing` variant carries a required `withheld: readonly WithheldEvent[]`, and
+`DeriveSnapshotRemovals` reads its input's `withheld` as present ids. Withholding is cheaper to write than
+filtering. Test **O16**.
+
+### 5. One bad event must not stall the whole feed
+
+**Lesson.** A single VEVENT with an hour-based all-day DURATION, a negative DURATION, a THISANDFUTURE
+override, `tzone://Microsoft/Custom` or a malformed dateTime threw out of the fetch; nothing was applied,
+the delta token never advanced, and the source never converged.
+**Learned from.** commit `fdd9ba62` (#634); commit `43292a9f` (#606);
+`tests/ics/utils/ics-malformed-vevent-telemetry.test.ts`.
+**Honoured by.** Per-event failure is `WithheldEvent` inside a *successful* listing. `ProviderFailure` is
+reserved for whole-listing failures. Adapters return `Result`, never throw. Test **L6**.
+
+### 6. Every discard needs a counter
+
+**Lesson.** Ingest silently deleted rows with zero telemetry: CalDAV hardcoded `unrepresentable: 0`, ICS
+reported nothing, and Keeper's own mirrors were folded into `unrepresentable` so the counter was
+permanently non-zero on mirrored calendars.
+**Learned from.** commit `fdd9ba62` (#634); `DiscardedSourceEventCounts` in `core/sync-engine/ingest.ts`.
+**Honoured by.** `ListingDiagnostics` is a required field on all four listing kinds, with `withheld`,
+`selfAuthored` and `unrepresentable` as *separate* `BoundedSample` fields. Required, so every adapter
+author must answer the question. Test **O19**.
+
+### 7. Self-authored events must be recognised at the source read
+
+**Lesson.** Keeper tags its own mirrors (UID suffix, PRODID); without filtering them the mirror is
+re-ingested as a source event and echoed around the loop.
+**Learned from.** `core/events/identity.ts` (`isKeeperEvent`, `KEEPER_EVENT_SUFFIX`); `selfAuthoredCount`
+in all four fetch adapters; `RemoteEvent.isKeeperEvent`.
+**Honoured by.** `RemoteEvent` is a union over provenance: `ForeignEvent | OwnEvent | IndeterminateEvent`.
+Only `ForeignEvent` is assignable to the write-intent builder type. `selfAuthored` is its own diagnostics
+field. Tests **O14, O15**.
+
+### 8. Echo must be three-state
+
+**Lesson.** A successful push with no echo verdict counts as uncomparable; a zero divergence count that
+silently meant "unchecked" hid a real drift class.
+**Learned from.** `core/sync-engine/index.ts` (`tallyPushEcho`), `core/events/push-echo.ts`; tests
+`push-echo-attribution`, `push-echo-length-attribution`.
+**Honoured by.** `EchoVerdict = matched | diverged | notObserved`, required on `created`/`updated`
+outcomes, never an optional boolean. Test **O20**.
+
+### 9. A conditional write needs a real precondition and a distinct conflict outcome
+
+**Lesson.** `PushResult { success, remoteId, error }` was too weak; `conflictResolved` had to be bolted on
+as a separate counter. CalDAV refuses to recreate an object with no ETag.
+**Learned from.** `providers/caldav/destination/provider.ts:120-133`; `PushResult`/`DeleteResult` in
+`core/types.ts`.
+**Honoured by.** `precondition` is a required field on `update`, `delete` and `retire` intents, typed as a
+`Precondition` union (`matchesVersion | matchesFingerprint | absent`). `WriteOutcome` has a `conflict`
+member carrying the observed precondition. Tests **O8, O9, O12, O22**.
+
+### 10. A replayed create must be a typed no-op
+
+**Lesson.** Mirrors are written under a deterministic UID so a retried push resolves to the same object;
+CalDAV re-fetches `${uid}.ics` and returns early on a content-hash match.
+**Learned from.** `core/events/identity.ts` (`generateDeterministicEventUid`);
+`providers/caldav/destination/provider.ts:90-118`; tests *"re-reads an unchanged feed as no work at all"*.
+**Honoured by.** `create` carries a required `idempotencyKey` and a `precondition` pinned to
+`{ kind: "absent" }`. `WriteOutcome` has `alreadyExists` and `unchanged` members distinct from `created`.
+Tests **O10, O11**.
+
+### 11. Provider identifiers are not interchangeable
+
+**Lesson.** Google's delete endpoint takes the event id, not the iCalUID; mappings that stored the UID cost
+a second batch request per delete.
+**Learned from.** `core/sync/operations.ts:482-488`; `RemoteEvent { uid, deleteId }`.
+**Honoured by.** `RemoteEventId` and `DeleteHandle` are tagged handles
+(`{ kind: "remoteEventId" | "deleteHandle"; value: string }`), not interchangeable strings, and `EventUid`
+is separate again. Delete/retire intents take a `DeleteHandle`; update takes a `RemoteEventId`. Test **I1**.
+
+### 12. A stale cursor forces a full resync and must clear the token
+
+**Lesson.** Advancing a delta token over a dropped payload strands every event it named. Graph tombstones
+can omit the deleted event type; a sparse id may name a series master while local state holds only
+instances.
+**Learned from.** `providers/outlook/source/utils/fetch-events.ts:382-388`;
+`providers/google/source/utils/fetch-events.ts:149`; `ingest.ts` flushing `syncToken: null`.
+**Honoured by.** `cursorLost` is its own listing kind carrying `events?: never`, `removals?: never`,
+`cursor?: never`, `coverage?: never`. Test **O3**.
+
+### 13. A stored-state parse failure must also force a full sync
+
+**Lesson.** When stored rows fail to parse mid-delta the engine flushes the token; diffing against
+partially-parsed local state computes bogus removals.
+**Learned from.** `core/sync-engine/ingest.ts:298-304`, `core/source/stored-event-state.ts`.
+**Honoured by.** `cursorLost` is constructible by the *consumer*, not only returned by the provider — it is
+a plain object type with no provider-private fields, so the engine can synthesise it when its own state is
+unusable.
+
+### 14. Reconciliation identity must be canonical and complete
+
+**Lesson.** The identity key stringifies recurrence rule, exception dates, duration, timezone,
+availability, all-day flag and trimmed text with sorted structured values, because *"does not diff
+equivalent recurrence payloads with different key order"* and *"adds and removes when timezone changes"*
+were both production bugs.
+**Learned from.** `core/source/event-diff.ts` (`buildSourceEventIdentityKey`); `ics/utils/diff-events.ts`;
+`tests/ics/utils/diff-events.test.ts`.
+**Honoured by.** `EditableContent` is a named sub-shape holding exactly the comparable fields, separate
+from provider metadata, and `Fingerprint` is a tagged handle over it. Adding a field to `EditableContent`
+is the single edit; nothing else compares events structurally.
+
+### 15. Normalization runs before reconciliation, never in the serializer
+
+**Lesson.** Otherwise the mapping, the content hash and the bytes on the server disagree and the
+destination is replaced on every run forever. The rule survives today only as a JSDoc comment on the
+provider interface.
+**Learned from.** `core/sync-engine/types.ts:9-11`; `providers/google/destination/normalize-event.ts`;
+commit `b057d2e0` (#616).
+**Honoured by.** `normalize` is a declared phase returning `NormalizedContent<P>`, and `WriteIntent<P>`
+accepts nothing else. Unnormalized `EditableContent` cannot reach `write`, and content normalized for one
+provider is not assignable to another's write. The comment is deleted because the type says it. Tests
+**O17, O18**.
+
+### 16. Providers refuse ranges that RFC 5545 permits, and each refuses a different set
+
+**Lesson.** A timed VEVENT with no DTEND ends at DTSTART (RFC 5545 §3.6.1); Google 400s an empty range,
+Graph refuses end-before-start, CalDAV requires DTEND strictly later. Every rejected push recomputed the
+same add on every run — one calendar failed ~50 times/hour — because a rejected push records no mapping.
+**Learned from.** commit `b057d2e0` (#616); the four diverged `destination/normalize-event.ts` copies.
+**Honoured by.** `Capabilities.representableRange` declares `minimumSpanSeconds`, `zeroDuration`,
+`invertedRange` and `allDayGrid` as data, so the engine shapes once per destination.
+`WriteOutcome.unrepresentable` carries the violated constraint, so a refusal is typed and recordable rather
+than a repeating failure. Test **C1**.
+
+### 17. Window membership must be one predicate shared by every layer
+
+**Lesson.** Copies of `overlapsWindow` diverged across six call sites, each judging a range by its end, so
+a zero-duration event on `timeMin` was admitted by some layers and dropped by others — a permanent
+add/delete cycle.
+**Learned from.** commit `b057d2e0` sub-commits; `core/events/time-range.ts`.
+**Honoured by.** The protocol owns `TimeWindow`, `CoverageWindow` and the single predicate *signature*
+`type WindowMembership = (window: TimeWindow, time: EventTime) => boolean`. Adapters consume it; none
+declares its own. Duplication, not the rule, was the defect.
+
+### 18. Reauthentication must be first-class and non-ignorable
+
+**Lesson.** Reauth is detected by an `oauthReauthRequired` marker, by string-matching `invalid_grant`, or
+by 401/403 on CalDAV/ICS. Retrying it burns quota and never succeeds.
+**Learned from.** `core/oauth/error-classification.ts`; `CalendarFetchError.authRequired`;
+`BroadcastSyncStatus.needsReauthentication`.
+**Honoured by.** `ProviderFailure` has a `reauthRequired` member carrying the `AccountId`. Consumers switch
+with `assertNever`, so omitting the branch fails to compile. Test **O13**.
+
+### 19. Never classify failures by matching error message substrings
+
+**Lesson.** A database error message inlines the SQL and its bound parameters, so customer data could match
+the backoff patterns and put a healthy destination into exponential backoff.
+**Learned from.** `packages/sync/src/destination-errors.ts` (`isDatabaseError`, `BACKOFF_ERROR_PATTERNS`).
+**Honoured by.** `ProviderFailure` carries a typed `kind` plus structured fields (`status`, `retryAfter`,
+`scope`). There is **no** free-text `message` field anywhere in the protocol. Nothing invites
+`message.includes(...)`. Adapters log detail through their own telemetry, not through the contract.
+
+### 20. An unattempted run is neither success nor failure
+
+**Lesson.** Escalating backoff on a superseded run punishes a healthy destination; clearing the count lets
+a broken one oscillate between 1 and 0 forever. The verdict is three-state.
+**Learned from.** `destination-errors.ts` (`resolveDestinationAttemptVerdict`); `destination-backoff-*`
+tests.
+**Honoured by.** `notAttempted` is a member of **both** `WriteOutcome` and `ProviderFailure`, carrying
+`reason: "superseded" | "aborted" | "budgetExhausted"`. Test **L9**.
+
+### 21. Retries need a ceiling, provider delays need a cap, sleeps must be abortable
+
+**Lesson.** `withBackoff` caps at 5 retries and caps `Retry-After` at 64s; `abortableSleep` rejects
+immediately on an already-aborted signal, removes its listener on timeout and clears its timer on abort.
+**Learned from.** `core/utils/backoff.ts`, `core/utils/fetch-with-timeout.ts`; tests *"caps the delay at 64
+seconds"*, *"aborts during backoff sleep when signal is triggered"*.
+**Honoured by.** Providers do not own retries. `OperationContext` carries a required
+`signal: AbortSignal` and a required `RetryBudget { maxAttempts, ceilingMs }` with no defaults — a caller
+cannot forget the ceiling. `rateLimited` carries `retryAfter` as data rather than inviting a sleep loop.
+Tests **L1–L5**.
+
+### 22. Wide-event identifier lists must be a capped sample beside an uncapped count
+
+**Lesson.** An uncapped list pushes the log line past what the pipeline keeps and takes the counters with
+it. Sample 20, 2048-char cap, true total adjacent.
+**Learned from.** `core/sync-engine/ingest.ts:22-27`; `sync-user.ts:338-344`; test
+`ingest-wide-event-list-bounds`.
+**Honoured by.** `BoundedSample = { sample: readonly string[]; total: number }` is the only shape any
+diagnostic identifier list may take. A bare `string[]` is not assignable. Test **O19**.
+
+### 23. Quota must be acquired inside the retried operation
+
+**Lesson.** A batch retry re-sends every sub-request and providers charge per attempt. Google's quota is
+per user however spent; Outlook throttles per mailbox. Graph reports throttling as 429 and, for
+MailboxConcurrency, as 503 with Retry-After.
+**Learned from.** `providers/google/shared/batch.ts:229-234`; `core/utils/redis-rate-limiter.ts`;
+`providers/outlook/shared/throttle.ts`.
+**Honoured by.** `Capabilities.quotaScope` (`perUser | perMailbox | perCollection`) and
+`Capabilities.throttleSignals` (`{ status, hasRetryAfter }[]`) are declarative data, so the engine picks a
+limiter key with no provider-specific branch. Rate limiting itself is out of scope (see 52).
+
+### 24. Storage bounds and mirror bounds are different windows
+
+**Lesson.** ICS storage is deliberately unbounded; filtering the feed by the sync window would make the
+snapshot diff delete every historic event's stored state on the next ingest.
+**Learned from.** `ics/utils/fetch-adapter.ts:388-393`; test *"returns events far outside the sync window
+so stored history stays unbounded"*.
+**Honoured by.** `ListingScope.window` (requested) and `CoverageWindow` (covered) are separate fields with
+different shapes. Nothing in the types encourages pre-filtering a snapshot to the requested window.
+
+### 25. Retiring a mirror is not deleting a source event
+
+**Lesson.** A mirror the window no longer covers stops receiving updates; the source event is retained.
+Both window edges retire mappings.
+**Learned from.** `core/sync/operations.ts:550-556`.
+**Honoured by.** `WriteIntent` has separate `delete` (`reason: sourceDeleted | sourceUnmapped`) and
+`retire` (`reason: outsideWindow | destinationDisconnected`) members.
+
+### 26. An empty enumeration is not proof that everything was deleted
+
+**Lesson.** Rediscovery suppresses a plan entirely when the provider returned zero calendars but rows
+exist, and skips discovered calendars belonging to another account.
+**Learned from.** `core/source/calendar-rediscovery.ts:149-150`; commit `877245dc` *scope provider account
+identity to the owning user*.
+**Honoured by.** `CalendarEnumeration` is the same shape of union: `snapshot` (authoritative) or `partial`
+(retires nothing). The retire-deriving signature accepts only the `snapshot` variant. `CalendarKey` is
+`{ provider, account, calendar }`, so two accounts' calendars cannot collide. Test **O23**.
+
+### 27. Ordering must be decided by a stable signature, not feed order
+
+**Lesson.** Revision ties break on the lowest slot signature; a UID whose newest revision is unbuildable
+must withhold that UID entirely, because letting the superseded revision win syncs the instance to a time
+the publisher already moved away from.
+**Learned from.** `ics/utils/parse-ics-events.ts:156-159, 412-415`; `ics-superseded-slot-telemetry`,
+`ics-stale-revision-telemetry`, `ics-revision-collapse-telemetry`.
+**Honoured by.** `RemoteEvent.revision` is required, so "newest wins" is decidable from the type, and
+`WithholdReason` includes `supersededRevisionUnbuildable` so a UID is suppressed rather than downgraded.
+
+### 28. Our own writes come back on the next poll
+
+**Lesson.** A destination that widened its mirror must not read as a source change.
+**Learned from.** `tests/ics/degenerate-range-source-ingest.test.ts`; commit `b057d2e0`.
+**Honoured by.** Same as 7, plus `Capabilities.provenanceChannel` — an adapter with no place to store a
+marker must declare `"none"`, which forces `IndeterminateEvent`, which the compiler forces the consumer to
+handle. The safe answer (do not echo) becomes a compiler-forced decision.
+
+### 29. Change detection must survive key order, Date-vs-string and undefined-vs-null
+
+**Lesson.** Otherwise every poll churns and rewrites the remote.
+**Learned from.** `ics/utils/diff-events.ts` (`toStableComparableValue`); *"settles without churning the
+surviving row over repeated polls"*.
+**Honoured by.** `Fingerprint` is a tagged handle with a stated contract (stable under key reordering,
+ISO/Date equivalence, `undefined ≡ absent`). The protocol types it and does not compute it; production
+belongs to a sibling package (see 55). Instants are RFC 3339 strings, so Date-vs-string cannot arise.
+
+### 30. Re-ingesting the same input twice must be no work
+
+**Lesson.** Idempotence is tested explicitly, not assumed.
+**Learned from.** `interpret-full-day-recurrence.test.ts`, `degenerate-range-source-ingest.test.ts`,
+commit `a7c4be88`.
+**Honoured by.** `WriteOutcome.unchanged` and `WriteOutcome.alreadyExists` make "the replay did nothing" a
+typed result rather than an inferred one.
+
+### 31. Remote I/O stays outside database transactions
+
+**Lesson.** Telemetry emitted from inside a pooled driver's callback lands on another source's wide event.
+**Learned from.** commit `1c5171d2`; `ingest.ts:191-197`.
+**Honoured by.** `CalendarProvider` accepts no transaction, no database handle and no logger. Its only
+ambient input is `OperationContext { signal, now, retryBudget }`. Persistence is the engine's concern.
+
+### 32. Comments have been used to express what types should
+
+**Lesson.** The `sync-lock` holder-prefix JSDoc is six lines explaining what a naming convention means.
+**Learned from.** `packages/sync/src/sync-lock.ts`.
+**Honoured by.** The package ships with zero explanatory comments. The one admissible form — an external
+constraint with a citation — is reserved for provider quirks like entry 36.
+
+### 33. A `success: boolean` is never enough
+
+**Lesson.** Every boolean result in the existing code grew a second field within months
+(`conflictResolved`, `needsReauthentication`, `fullSyncRequired`).
+**Learned from.** `core/types.ts` `PushResult`, `DeleteResult`, `BroadcastSyncStatus`.
+**Honoured by.** No boolean appears in any outcome type. `Result` is a two-member union and `WriteOutcome`
+has nine named members.
+
+### 34. Graph's removal signal is ambiguous
+
+**Lesson.** `calendarView` delta returns `@removed: { reason: "deleted" }` both for events genuinely
+deleted inside the range **and** for events outside the range that were added, deleted or updated. A Graph
+removal is therefore not proof of deletion.
+**Learned from.** <https://learn.microsoft.com/en-us/graph/delta-query-events>.
+**Honoured by.** `delta` carries `removals: readonly Removal[]` where
+`Removal = { kind: "deleted"; id; uid } | { kind: "outOfScope"; id }`. Only `deleted` is assignable to the
+deletion driver. Every adapter must classify — Google pays a small tax for a guard Outlook cannot live
+without. `Capabilities.removalsAreAmbiguous` records which providers need the classification. Test **O7**.
+
+### 35. A post-410 resync carries no tombstones
+
+**Lesson.** After `syncStateNotFound`, Graph's fresh delta cycle returns current state without tombstones
+for items removed during the gap; Google's docs say the same for its 410.
+**Learned from.** <https://learn.microsoft.com/en-us/graph/delta-query-overview>,
+<https://developers.google.com/workspace/calendar/api/guides/sync>.
+**Honoured by.** `cursorLost` carries nothing, and recovery is a `snapshot` whose removals are derivable
+only within `coverage`. Test **O3**.
+
+### 36. RFC 6578 truncation is a state, not an error
+
+**Lesson.** A truncated `sync-collection` response is 207 with 507 for the request URI and
+`DAV:number-of-matches-within-limits`; it is resumed with the same sync-token. Removed members appear as a
+`DAV:response` with 404 and no `DAV:propstat`.
+**Learned from.** <https://www.rfc-editor.org/rfc/rfc6578.html>.
+**Honoured by.** `partial` is exactly this state and carries a `Continuation`. Three independent providers
+producing the same shape is the evidence that the four-member union is not over-generalisation. This is
+also the archetype for the one admissible comment style: an external constraint with a citation.
+
+### 37. Every provider has a different concurrency token
+
+**Lesson.** Google and Graph use ETag/changeKey with `If-Match` (412 on mismatch); CalDAV uses `If-Match`
+for replace and `If-None-Match: *` for create.
+**Learned from.** RFC 4791, RFC 9110 §13, Graph and Google event references.
+**Honoured by.** `Precondition = matchesVersion | matchesFingerprint | absent`. `absent` maps to
+`If-None-Match: *` and to Google's deterministic-id create. `Capabilities.precondition` declares which
+kind a provider supports. An optional `etag?: string` is rejected: optionality is the hole silent
+overwrites arrive through.
+
+### 38. Use provider-native idempotency
+
+**Lesson.** Google accepts a client-supplied event id on `events.insert` and returns 409 on replay; Graph
+has a write-once `transactionId`; CalDAV gets it from client-chosen paths plus `If-None-Match: *`.
+**Learned from.** <https://developers.google.com/workspace/calendar/api/v3/reference/events/insert>,
+<https://learn.microsoft.com/en-us/graph/api/resources/event>.
+**Honoured by.** `create.idempotencyKey` is required, and `alreadyExists` is a success outcome, not an
+error. The key is a tagged handle because Google's id format is constrained, so the adapter validates it.
+
+### 39. Pagination state is not sync state
+
+**Lesson.** Google returns `nextSyncToken` only on the final page; Graph distinguishes `@odata.nextLink`
+from `@odata.deltaLink`. Confusing them silently skips changes.
+**Learned from.** Google sync guide; Graph delta overview.
+**Honoured by.** `SyncCursor` and `Continuation` are distinct tagged handles, mutually unassignable.
+`partial` carries only a `Continuation`; `delta` carries only a `SyncCursor`. Test **L8**.
+
+### 40. A cursor is valid only for the request shape that minted it
+
+**Lesson.** Google rejects an incremental request whose query parameters differ from the original; Graph
+bakes `startDateTime`/`endDateTime` into the delta token so widening the window silently does nothing.
+This directly threatens the configurable sync-window feature.
+**Learned from.** Google sync guide; Graph delta-query-events.
+**Honoured by.** `SyncCursor` and `Continuation` both carry a required `scope: ListingScope`. A cursor
+cannot exist without the calendar and window it was minted against. The compiler cannot compare two
+windows, so the engine-side rule — a widened window discards the cursor and forces a snapshot — is recorded
+here as entry 53 and tested where it is implemented. Test **L10**.
+
+### 41. Provider representational limits must be declared, not discovered at write time
+
+**Lesson.** Windows timezone ids, zero-duration events Google refuses, Outlook's VTIMEZONE expectations.
+**Learned from.** `outlook-windows-timezone.test.ts`; commits `0111e5de`, `ac6fa18c`, `7c276d8e`,
+`b057d2e0`.
+**Honoured by.** `Capabilities` is a declarative record; `WriteOutcome.unrepresentable` is a typed refusal
+rather than a lossy coercion. Same design element as entry 16.
+
+### 42. Adapters must return failures, not throw them
+
+**Lesson.** A thrown error erases the discriminated union, and reauth ends up in a generic `catch`.
+**Learned from.** `core/oauth/error-classification.ts` reconstructing categories from caught errors.
+**Honoured by.** Every awaiting method returns `Promise<Result<T>>`. `Result` has no `throw` variant.
+Test **L6**.
+
+### 43. Provenance may be undetectable, and that must be sayable
+
+**Lesson.** Google offers `extendedProperties.private`, Graph offers extensions — with current reports of
+them being dropped silently. An adapter that cannot carry a marker must be able to say so.
+**Learned from.** Google extended-properties guide; Graph event resource docs.
+**Honoured by.** `Capabilities.provenanceChannel: "extendedProperty" | "uidSuffix" | "none"` and the
+`indeterminate` provenance variant, which no write-intent builder accepts. Test **O15**.
+
+---
+
+## Not applicable to this package
+
+### 44. All-day anchoring to UTC midnight
+
+Leaving an all-day event on a local-midnight instant, or writing a range not snapped to whole UTC days,
+makes the read-back narrower than the write and the mirror is recreated every run
+(`interpret-full-day-timed-events.ts`, commits `82799c5b`, `b057d2e0`).
+**Not applicable.** Time-representation semantics belong to the calendar model, not the transport contract.
+The protocol honours it only structurally: `EventTime` is
+`{ kind: "allDay"; startDate; endDateExclusive } | { kind: "timed"; start; end; zone }`, so a DATE and a
+DATE-TIME cannot be mixed and `isAllDay: boolean` beside two instants is unrepresentable. The anchoring
+rule stays with whoever builds the events. `Capabilities.allDay` records which grid a provider expects so
+the adapter, not the protocol, applies it.
+
+### 45. DST fold and gap resolution
+
+A wall time plus a zone does not name an instant during a fold, and RFC 5545 cannot say which pass; ts-ics
+drops the time of day from a projected VTIMEZONE onset (`resolve-zoned-instants.ts`, `wall-time-*.test.ts`).
+**Not applicable.** The protocol carries instants as RFC 3339 UTC strings with the zone alongside as
+metadata. It never carries a bare wall time a consumer would have to resolve, so the ambiguity cannot enter
+the contract. Resolution stays in `@keeper.sh/calendar`. This is a deliberate non-adoption, not an
+omission.
+
+### 46. The CalDAV BOM
+
+`Response.text()` strips a leading UTF-8 BOM while decoding, but CalDAV `calendar-data` arrives as an XML
+text node with the BOM intact, turning `BEGIN:VCALENDAR` into an unparseable property line
+(`ics/utils/apply-patches.ts`).
+**Not applicable.** A byte-level transport quirk with no expression in a type. Recorded because it is the
+canonical example of the one admissible comment: an external constraint plus its citation.
+
+### 47. Google's conference block
+
+Google owns the region between its two conference delimiters and deletes its contents on write, so a
+mirrored copy carrying no conference strips the region and diverges every run
+(`providers/google/destination/conference-block.ts`).
+**Not applicable.** A Google-adapter normalization concern. Honoured indirectly by entry 15: normalization
+is a declared phase and its output is the only thing hashed and written.
+
+### 48. Windows/CLDR timezone identifier mapping
+
+Outlook requires Windows zone identifiers and Microsoft-shaped observances (`ac6fa18c`, `7c276d8e`).
+**Not applicable.** A mapping table belonging to the Outlook adapter. The protocol carries an IANA `ZoneId`
+and nothing else; `Capabilities` states the constraint exists (entry 41) without encoding the table.
+
+### 49. Recurrence expansion and occurrence budgets
+
+Materializing a series is expensive and bounded (`core/events/recurrence-materializer.ts`).
+**Not applicable as behaviour.** The protocol carries recurrence as an opaque `RecurrencePayload`
+(dialect + value + exceptions) and never expands it. Importing `rrule` or `ts-ics` here would leak a
+parser's data model into the contract — exactly why today's `EventTimeSlot` cannot be reused across Google
+and Graph. The budget itself surfaces only as `WithholdReason.recurrenceBudgetExceeded` (entry 4).
+
+---
+
+## Inherited by sibling sync-kit packages
+
+Recorded so the review does not read their absence from a types-only package as an omission.
+
+### 50. Single-flight coordination
+
+The in-flight entry must be deleted in `finally`, guarded by identity so a later task is not evicted; the
+losing waiter must receive the leader's failure rather than hanging; telemetry must not be written inside
+the shared body, because only the joining branch runs in the joiner's async context
+(`core/oauth/refresh-coordinator.ts`). **Owner:** the sync-kit coalescing package. **Required tests:**
+leader throws → follower rejects; leader settles → map entry gone; concurrent calls for one key do not
+interleave.
+
+### 51. Lock and lease discipline
+
+Locks are taken in a deterministic global order inside one transaction so a crash releases them, with both
+`statement_timeout` and `idle_in_transaction_session_timeout` set; work outside the locked set supersedes
+the run rather than acquiring nested locks (`core/source/ingest-lock.ts`, `packages/sync/src/sync-lock.ts`).
+**Owner:** the sync-kit lease package. **Required tests:** lease released when the body throws;
+deterministic acquisition order; no nested acquisition; renewal blip does not strand a run.
+
+### 52. Rate limiting and backoff
+
+Quota acquired inside the retried operation, `Retry-After` capped, sleeps abortable and timer-clearing
+(entries 21, 23). **Owner:** the sync-kit engine. **Required tests:** provable ceiling on every retry path;
+abort mid-flight rejects and cleans up; a stub that never resolves still hits a deadline. Timers use
+`setTimeout` — `Bun.sleep` is native and `vi.useFakeTimers` cannot patch it, which cost this team real CI
+time.
+
+### 53. Cursor invalidation on window change
+
+A widened sync window must discard the stored cursor and force a snapshot (entry 40). **Owner:** the
+engine, because it compares the stored `ListingScope` with the requested one. The protocol makes the
+comparison possible by requiring `scope` on every cursor.
+
+### 54. Consumer-side full resync
+
+A stored-state parse failure forces `cursorLost` from the consumer side (entry 13). **Owner:** the engine.
+
+### 55. Fingerprint computation
+
+RFC 8785 (JCS) is the standard answer for deterministic JSON: lexicographic key sort by UTF-16 code unit,
+whitespace stripped, Ryū number normalisation. `packages/calendar` currently hand-rolls a subset in
+`diff-events.ts` *and* depends on `fast-json-stable-stringify` — two implementations of one idea.
+**Owner:** a single sibling package. The protocol declares the `Fingerprint` contract (entry 29) and
+exports a conformance suite as types; it cannot enforce the contract at compile time and says so.

--- a/packages/sync-kit/LEARNINGS.md
+++ b/packages/sync-kit/LEARNINGS.md
@@ -645,8 +645,10 @@ reason`.
 
 **Lesson.** Enumeration learns whether a calendar is writable and the fact was then discarded; a write to
 a read-only calendar is expressible everywhere downstream.
-**Learned from.** `CalendarRef.access` having no consumer; the reconnect/duplicate-destination family of
-fixes (`fec144c1`).
+**Learned from.** Adversarial review of this package's own first draft, where `CalendarRef.access` was
+carried through enumeration and then had no consumer; the same shape as entry 26's "discovered, then
+discarded" family. No prior commit is cited because the existing engine never attempts a write to a
+calendar it enumerated as read-only — the protocol should not be the first place that becomes possible.
 **Honoured by.** Every `WriteIntent` variant takes a `WritableCalendar` (`{ key, access: "readWrite" }`),
 not a bare `CalendarKey`. Constructing one from a `CalendarRef` requires narrowing `access`, which is a
 guard the compiler forces rather than an assertion the author may skip — the package contains no type

--- a/packages/sync-kit/protocol/package.json
+++ b/packages/sync-kit/protocol/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@keeper.sh/sync-protocol",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "types": "tsc --noEmit",
+    "lint": "oxlint .",
+    "test": "bun x --bun vitest run"
+  },
+  "devDependencies": {
+    "@keeper.sh/typescript-config": "workspace:*",
+    "@types/bun": "latest",
+    "typescript": "5.9.3",
+    "vitest": "^4.1.4"
+  }
+}

--- a/packages/sync-kit/protocol/src/assert-never.ts
+++ b/packages/sync-kit/protocol/src/assert-never.ts
@@ -1,5 +1,26 @@
+const describeUnserializable = (value: unknown): string => {
+  if (typeof value !== "object") {
+    return String(value);
+  }
+  if (value === null) {
+    return "null";
+  }
+  if ("kind" in value && typeof value.kind === "string") {
+    return value.kind;
+  }
+  return Object.keys(value).join(",");
+};
+
+const describeVariant = (value: unknown): string => {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return describeUnserializable(value);
+  }
+};
+
 const assertNever = (value: never): never => {
-  throw new Error(`unreachable variant: ${JSON.stringify(value)}`);
+  throw new Error(`unreachable variant: ${describeVariant(value)}`);
 };
 
 export { assertNever };

--- a/packages/sync-kit/protocol/src/assert-never.ts
+++ b/packages/sync-kit/protocol/src/assert-never.ts
@@ -1,5 +1,5 @@
 const assertNever = (value: never): never => {
-  throw new Error(`unimplemented: ${typeof value}`);
+  throw new Error(`unreachable variant: ${JSON.stringify(value)}`);
 };
 
 export { assertNever };

--- a/packages/sync-kit/protocol/src/assert-never.ts
+++ b/packages/sync-kit/protocol/src/assert-never.ts
@@ -1,0 +1,5 @@
+const assertNever = (value: never): never => {
+  throw new Error(`unimplemented: ${typeof value}`);
+};
+
+export { assertNever };

--- a/packages/sync-kit/protocol/src/calendar-ref.ts
+++ b/packages/sync-kit/protocol/src/calendar-ref.ts
@@ -1,10 +1,12 @@
-import type { AccountId, CalendarId, ZoneId } from "./handles";
 import type { Continuation } from "./change-listing";
+import type { AccountId, CalendarId, ProviderId, ZoneId } from "./handles";
 
 const calendarAccessKinds = ["readOnly", "readWrite"] as const;
 type CalendarAccess = (typeof calendarAccessKinds)[number];
 
 interface CalendarKey {
+  readonly provider: ProviderId;
+  readonly account: AccountId;
   readonly calendar: CalendarId;
 }
 
@@ -20,13 +22,13 @@ type CalendarEnumeration =
       readonly kind: "snapshot";
       readonly account: AccountId;
       readonly calendars: readonly CalendarRef[];
-      readonly continuation?: Continuation;
+      readonly continuation?: never;
     }
   | {
       readonly kind: "partial";
       readonly account: AccountId;
       readonly calendars: readonly CalendarRef[];
-      readonly continuation?: Continuation;
+      readonly continuation: Continuation;
     };
 
 export { calendarAccessKinds };

--- a/packages/sync-kit/protocol/src/calendar-ref.ts
+++ b/packages/sync-kit/protocol/src/calendar-ref.ts
@@ -1,0 +1,33 @@
+import type { AccountId, CalendarId, ZoneId } from "./handles";
+import type { Continuation } from "./change-listing";
+
+const calendarAccessKinds = ["readOnly", "readWrite"] as const;
+type CalendarAccess = (typeof calendarAccessKinds)[number];
+
+interface CalendarKey {
+  readonly calendar: CalendarId;
+}
+
+interface CalendarRef {
+  readonly key: CalendarKey;
+  readonly displayName: string;
+  readonly timeZone: ZoneId | null;
+  readonly access: CalendarAccess;
+}
+
+type CalendarEnumeration =
+  | {
+      readonly kind: "snapshot";
+      readonly account: AccountId;
+      readonly calendars: readonly CalendarRef[];
+      readonly continuation?: Continuation;
+    }
+  | {
+      readonly kind: "partial";
+      readonly account: AccountId;
+      readonly calendars: readonly CalendarRef[];
+      readonly continuation?: Continuation;
+    };
+
+export { calendarAccessKinds };
+export type { CalendarAccess, CalendarEnumeration, CalendarKey, CalendarRef };

--- a/packages/sync-kit/protocol/src/calendar-ref.ts
+++ b/packages/sync-kit/protocol/src/calendar-ref.ts
@@ -17,6 +17,11 @@ interface CalendarRef {
   readonly access: CalendarAccess;
 }
 
+interface WritableCalendar {
+  readonly key: CalendarKey;
+  readonly access: Extract<CalendarAccess, "readWrite">;
+}
+
 type CalendarEnumeration =
   | {
       readonly kind: "snapshot";
@@ -32,4 +37,10 @@ type CalendarEnumeration =
     };
 
 export { calendarAccessKinds };
-export type { CalendarAccess, CalendarEnumeration, CalendarKey, CalendarRef };
+export type {
+  CalendarAccess,
+  CalendarEnumeration,
+  CalendarKey,
+  CalendarRef,
+  WritableCalendar,
+};

--- a/packages/sync-kit/protocol/src/capabilities.ts
+++ b/packages/sync-kit/protocol/src/capabilities.ts
@@ -1,5 +1,5 @@
 import type { ProviderId } from "./handles";
-import type { PreconditionKind } from "./precondition";
+import type { ObservedPrecondition } from "./precondition";
 import type { QuotaScope } from "./provider-failure";
 
 const allDayRepresentations = ["dateOnly", "utcMidnightPair"] as const;
@@ -35,7 +35,7 @@ interface Capabilities<Provider extends ProviderId = ProviderId> {
   readonly delta: DeltaSupport;
   readonly deletionAuthority: DeletionAuthority;
   readonly removalsAreAmbiguous: boolean;
-  readonly precondition: PreconditionKind;
+  readonly precondition: ObservedPrecondition["kind"];
   readonly provenanceChannel: ProvenanceChannel;
   readonly quotaScope: QuotaScope;
   readonly throttleSignals: readonly ThrottleSignal[];

--- a/packages/sync-kit/protocol/src/capabilities.ts
+++ b/packages/sync-kit/protocol/src/capabilities.ts
@@ -1,0 +1,63 @@
+import type { ProviderId } from "./handles";
+import type { PreconditionKind } from "./precondition";
+import type { QuotaScope } from "./provider-failure";
+
+const allDayRepresentations = ["dateOnly", "utcMidnightPair"] as const;
+type AllDayRepresentation = (typeof allDayRepresentations)[number];
+
+const recurrenceWriteSupports = ["rfc5545", "providerNative", "expandedOnly", "none"] as const;
+type RecurrenceWriteSupport = (typeof recurrenceWriteSupports)[number];
+
+const provenanceChannels = ["extendedProperty", "uidSuffix", "none"] as const;
+type ProvenanceChannel = (typeof provenanceChannels)[number];
+
+const deletionAuthorities = ["snapshotAbsence", "explicitRemovalsOnly"] as const;
+type DeletionAuthority = (typeof deletionAuthorities)[number];
+
+type DeltaSupport =
+  | { readonly kind: "none" }
+  | { readonly kind: "tokenized"; readonly windowBoundToCursor?: boolean };
+
+interface RepresentableRange {
+  readonly minimumSpanSeconds: number;
+  readonly zeroDuration: "reject" | "accept";
+  readonly invertedRange: "reject" | "clampToStart";
+  readonly allDayGrid: "utcDay" | "localDay";
+}
+
+interface ThrottleSignal {
+  readonly status: number;
+  readonly hasRetryAfter: boolean;
+}
+
+interface Capabilities<Provider extends ProviderId = ProviderId> {
+  readonly provider: Provider | ProviderId;
+  readonly delta: DeltaSupport;
+  readonly deletionAuthority: DeletionAuthority;
+  readonly removalsAreAmbiguous?: boolean;
+  readonly precondition: PreconditionKind;
+  readonly provenanceChannel: ProvenanceChannel;
+  readonly quotaScope: QuotaScope;
+  readonly throttleSignals: readonly ThrottleSignal[];
+  readonly representableRange?: RepresentableRange;
+  readonly allDay: AllDayRepresentation;
+  readonly recurrenceWrite: RecurrenceWriteSupport;
+  readonly echoesWrites: boolean;
+}
+
+export {
+  allDayRepresentations,
+  deletionAuthorities,
+  provenanceChannels,
+  recurrenceWriteSupports,
+};
+export type {
+  AllDayRepresentation,
+  Capabilities,
+  DeletionAuthority,
+  DeltaSupport,
+  ProvenanceChannel,
+  RecurrenceWriteSupport,
+  RepresentableRange,
+  ThrottleSignal,
+};

--- a/packages/sync-kit/protocol/src/capabilities.ts
+++ b/packages/sync-kit/protocol/src/capabilities.ts
@@ -16,7 +16,7 @@ type DeletionAuthority = (typeof deletionAuthorities)[number];
 
 type DeltaSupport =
   | { readonly kind: "none" }
-  | { readonly kind: "tokenized"; readonly windowBoundToCursor?: boolean };
+  | { readonly kind: "tokenized"; readonly windowBoundToCursor: boolean };
 
 interface RepresentableRange {
   readonly minimumSpanSeconds: number;
@@ -31,26 +31,21 @@ interface ThrottleSignal {
 }
 
 interface Capabilities<Provider extends ProviderId = ProviderId> {
-  readonly provider: Provider | ProviderId;
+  readonly provider: Provider;
   readonly delta: DeltaSupport;
   readonly deletionAuthority: DeletionAuthority;
-  readonly removalsAreAmbiguous?: boolean;
+  readonly removalsAreAmbiguous: boolean;
   readonly precondition: PreconditionKind;
   readonly provenanceChannel: ProvenanceChannel;
   readonly quotaScope: QuotaScope;
   readonly throttleSignals: readonly ThrottleSignal[];
-  readonly representableRange?: RepresentableRange;
+  readonly representableRange: RepresentableRange;
   readonly allDay: AllDayRepresentation;
   readonly recurrenceWrite: RecurrenceWriteSupport;
   readonly echoesWrites: boolean;
 }
 
-export {
-  allDayRepresentations,
-  deletionAuthorities,
-  provenanceChannels,
-  recurrenceWriteSupports,
-};
+export { allDayRepresentations, deletionAuthorities, provenanceChannels, recurrenceWriteSupports };
 export type {
   AllDayRepresentation,
   Capabilities,

--- a/packages/sync-kit/protocol/src/change-listing.ts
+++ b/packages/sync-kit/protocol/src/change-listing.ts
@@ -1,60 +1,75 @@
-import type { EventUid, RemoteEventId } from "./handles";
 import type { CalendarKey } from "./calendar-ref";
-import type { CoverageWindow, TimeWindow } from "./time";
-import type { RemoteEvent } from "./remote-event";
 import type { ListingDiagnostics, WithheldEvent } from "./diagnostics";
+import type { EventUid, RemoteEventId } from "./handles";
+import type { RemoteEvent } from "./remote-event";
+import type { CoverageWindow, TimeWindow } from "./time";
 
 interface ListingScope {
   readonly calendar: CalendarKey;
   readonly window: TimeWindow;
-  readonly expandRecurrences?: boolean;
+  readonly expandRecurrences: boolean;
 }
 
 interface SyncCursor {
-  readonly kind: string;
+  readonly kind: "syncCursor";
   readonly value: string;
-  readonly scope?: ListingScope;
+  readonly scope: ListingScope;
 }
 
 interface Continuation {
-  readonly kind: string;
+  readonly kind: "continuation";
   readonly value: string;
-  readonly scope?: ListingScope;
-}
-
-interface Removal {
-  readonly kind: "deleted";
-  readonly id: RemoteEventId;
-  readonly uid: EventUid;
-}
-
-interface LooseListing {
   readonly scope: ListingScope;
-  readonly coverage?: CoverageWindow;
-  readonly events?: readonly RemoteEvent[];
-  readonly removals?: readonly Removal[];
-  readonly withheld?: readonly WithheldEvent[];
-  readonly cursor?: SyncCursor;
-  readonly continuation?: Continuation;
-  readonly diagnostics: ListingDiagnostics;
 }
 
-interface SnapshotListing extends LooseListing {
-  readonly kind: "snapshot";
-}
+type Removal =
+  | { readonly kind: "deleted"; readonly id: RemoteEventId; readonly uid: EventUid }
+  | { readonly kind: "outOfScope"; readonly id: RemoteEventId };
 
-interface DeltaListing extends LooseListing {
-  readonly kind: "delta";
-}
-
-interface PartialListing extends LooseListing {
-  readonly kind: "partial";
-}
-
-interface CursorLostListing extends LooseListing {
-  readonly kind: "cursorLost";
-}
-
-type ChangeListing = SnapshotListing | DeltaListing | PartialListing | CursorLostListing;
+type ChangeListing =
+  | {
+      readonly kind: "snapshot";
+      readonly scope: ListingScope;
+      readonly coverage: CoverageWindow;
+      readonly events: readonly RemoteEvent[];
+      readonly withheld: readonly WithheldEvent[];
+      readonly cursor: SyncCursor | null;
+      readonly diagnostics: ListingDiagnostics;
+      readonly removals?: never;
+      readonly continuation?: never;
+    }
+  | {
+      readonly kind: "delta";
+      readonly scope: ListingScope;
+      readonly coverage: CoverageWindow;
+      readonly events: readonly RemoteEvent[];
+      readonly removals: readonly Removal[];
+      readonly withheld: readonly WithheldEvent[];
+      readonly cursor: SyncCursor;
+      readonly diagnostics: ListingDiagnostics;
+      readonly continuation?: never;
+    }
+  | {
+      readonly kind: "partial";
+      readonly scope: ListingScope;
+      readonly events: readonly RemoteEvent[];
+      readonly withheld: readonly WithheldEvent[];
+      readonly continuation: Continuation;
+      readonly diagnostics: ListingDiagnostics;
+      readonly coverage?: never;
+      readonly removals?: never;
+      readonly cursor?: never;
+    }
+  | {
+      readonly kind: "cursorLost";
+      readonly scope: ListingScope;
+      readonly diagnostics: ListingDiagnostics;
+      readonly coverage?: never;
+      readonly events?: never;
+      readonly withheld?: never;
+      readonly removals?: never;
+      readonly cursor?: never;
+      readonly continuation?: never;
+    };
 
 export type { ChangeListing, Continuation, ListingScope, Removal, SyncCursor };

--- a/packages/sync-kit/protocol/src/change-listing.ts
+++ b/packages/sync-kit/protocol/src/change-listing.ts
@@ -24,7 +24,10 @@ interface Continuation {
 
 type Removal =
   | { readonly kind: "deleted"; readonly id: RemoteEventId; readonly uid: EventUid }
+  | { readonly kind: "cancelled"; readonly id: RemoteEventId; readonly uid: EventUid }
   | { readonly kind: "outOfScope"; readonly id: RemoteEventId };
+
+type AuthoritativeRemoval = Extract<Removal, { kind: "deleted" } | { kind: "cancelled" }>;
 
 type ChangeListing =
   | {
@@ -32,10 +35,10 @@ type ChangeListing =
       readonly scope: ListingScope;
       readonly coverage: CoverageWindow;
       readonly events: readonly RemoteEvent[];
+      readonly removals: readonly Removal[];
       readonly withheld: readonly WithheldEvent[];
       readonly cursor: SyncCursor | null;
       readonly diagnostics: ListingDiagnostics;
-      readonly removals?: never;
       readonly continuation?: never;
     }
   | {
@@ -72,4 +75,11 @@ type ChangeListing =
       readonly continuation?: never;
     };
 
-export type { ChangeListing, Continuation, ListingScope, Removal, SyncCursor };
+export type {
+  AuthoritativeRemoval,
+  ChangeListing,
+  Continuation,
+  ListingScope,
+  Removal,
+  SyncCursor,
+};

--- a/packages/sync-kit/protocol/src/change-listing.ts
+++ b/packages/sync-kit/protocol/src/change-listing.ts
@@ -1,0 +1,60 @@
+import type { EventUid, RemoteEventId } from "./handles";
+import type { CalendarKey } from "./calendar-ref";
+import type { CoverageWindow, TimeWindow } from "./time";
+import type { RemoteEvent } from "./remote-event";
+import type { ListingDiagnostics, WithheldEvent } from "./diagnostics";
+
+interface ListingScope {
+  readonly calendar: CalendarKey;
+  readonly window: TimeWindow;
+  readonly expandRecurrences?: boolean;
+}
+
+interface SyncCursor {
+  readonly kind: string;
+  readonly value: string;
+  readonly scope?: ListingScope;
+}
+
+interface Continuation {
+  readonly kind: string;
+  readonly value: string;
+  readonly scope?: ListingScope;
+}
+
+interface Removal {
+  readonly kind: "deleted";
+  readonly id: RemoteEventId;
+  readonly uid: EventUid;
+}
+
+interface LooseListing {
+  readonly scope: ListingScope;
+  readonly coverage?: CoverageWindow;
+  readonly events?: readonly RemoteEvent[];
+  readonly removals?: readonly Removal[];
+  readonly withheld?: readonly WithheldEvent[];
+  readonly cursor?: SyncCursor;
+  readonly continuation?: Continuation;
+  readonly diagnostics: ListingDiagnostics;
+}
+
+interface SnapshotListing extends LooseListing {
+  readonly kind: "snapshot";
+}
+
+interface DeltaListing extends LooseListing {
+  readonly kind: "delta";
+}
+
+interface PartialListing extends LooseListing {
+  readonly kind: "partial";
+}
+
+interface CursorLostListing extends LooseListing {
+  readonly kind: "cursorLost";
+}
+
+type ChangeListing = SnapshotListing | DeltaListing | PartialListing | CursorLostListing;
+
+export type { ChangeListing, Continuation, ListingScope, Removal, SyncCursor };

--- a/packages/sync-kit/protocol/src/conformance.ts
+++ b/packages/sync-kit/protocol/src/conformance.ts
@@ -5,7 +5,7 @@ interface FingerprintContract {
   readonly comparableFields: readonly (keyof EditableContent)[];
 }
 
-type ConformanceObligation = () => void;
+type ConformanceObligation = () => Promise<void>;
 
 interface ProviderConformanceSuite {
   readonly leaseReleasedOnThrow: ConformanceObligation;
@@ -14,6 +14,7 @@ interface ProviderConformanceSuite {
   readonly abortMidFlightCleansUp: ConformanceObligation;
   readonly retryCeilingProven: ConformanceObligation;
   readonly concurrentSameKeyDoesNotDeadlock: ConformanceObligation;
+  readonly deletionInputsShareOneCalendar: ConformanceObligation;
 }
 
-export type { FingerprintContract, ProviderConformanceSuite };
+export type { ConformanceObligation, FingerprintContract, ProviderConformanceSuite };

--- a/packages/sync-kit/protocol/src/conformance.ts
+++ b/packages/sync-kit/protocol/src/conformance.ts
@@ -1,0 +1,7 @@
+interface FingerprintContract {
+  readonly canonicalisation: string;
+}
+
+type ProviderConformanceSuite = Record<string, () => void>;
+
+export type { FingerprintContract, ProviderConformanceSuite };

--- a/packages/sync-kit/protocol/src/conformance.ts
+++ b/packages/sync-kit/protocol/src/conformance.ts
@@ -1,7 +1,19 @@
+import type { EditableContent } from "./remote-event";
+
 interface FingerprintContract {
-  readonly canonicalisation: string;
+  readonly canonicalisation: "rfc8785";
+  readonly comparableFields: readonly (keyof EditableContent)[];
 }
 
-type ProviderConformanceSuite = Record<string, () => void>;
+type ConformanceObligation = () => void;
+
+interface ProviderConformanceSuite {
+  readonly leaseReleasedOnThrow: ConformanceObligation;
+  readonly followerRejectsWhenLeaderFails: ConformanceObligation;
+  readonly deadlineOnNeverResolvingStub: ConformanceObligation;
+  readonly abortMidFlightCleansUp: ConformanceObligation;
+  readonly retryCeilingProven: ConformanceObligation;
+  readonly concurrentSameKeyDoesNotDeadlock: ConformanceObligation;
+}
 
 export type { FingerprintContract, ProviderConformanceSuite };

--- a/packages/sync-kit/protocol/src/deletion.ts
+++ b/packages/sync-kit/protocol/src/deletion.ts
@@ -1,25 +1,23 @@
 import type { CalendarEnumeration, CalendarKey } from "./calendar-ref";
-import type { ChangeListing, Removal } from "./change-listing";
+import type { AuthoritativeRemoval, ChangeListing } from "./change-listing";
 import type { RemoteEventId } from "./handles";
-import type { CoverageWindow } from "./time";
+import type { WindowMembership } from "./time";
 
 type SnapshotListing = Extract<ChangeListing, { kind: "snapshot" }>;
 type DeltaListing = Extract<ChangeListing, { kind: "delta" }>;
 
 interface KnownEvents {
   readonly calendar: CalendarKey;
-  readonly ids: ReadonlySet<string>;
+  readonly ids: ReadonlyMap<string, RemoteEventId>;
 }
 
 type DeriveSnapshotRemovals = (
   listing: SnapshotListing,
-  coverage: CoverageWindow,
   known: KnownEvents,
+  withinWindow: WindowMembership,
 ) => readonly RemoteEventId[];
 
-type DeriveDeltaRemovals = (
-  listing: DeltaListing,
-) => readonly Extract<Removal, { kind: "deleted" }>[];
+type DeriveDeltaRemovals = (listing: DeltaListing) => readonly AuthoritativeRemoval[];
 
 type DeriveCalendarRetirements = (
   enumeration: Extract<CalendarEnumeration, { kind: "snapshot" }>,

--- a/packages/sync-kit/protocol/src/deletion.ts
+++ b/packages/sync-kit/protocol/src/deletion.ts
@@ -1,26 +1,28 @@
-import type { RemoteEventId } from "./handles";
 import type { CalendarEnumeration, CalendarKey } from "./calendar-ref";
-import type { ChangeListing } from "./change-listing";
+import type { ChangeListing, Removal } from "./change-listing";
+import type { RemoteEventId } from "./handles";
+import type { CoverageWindow } from "./time";
 
-type SnapshotListing = ChangeListing;
-type DeltaListing = ChangeListing;
+type SnapshotListing = Extract<ChangeListing, { kind: "snapshot" }>;
+type DeltaListing = Extract<ChangeListing, { kind: "delta" }>;
 
 interface KnownEvents {
+  readonly calendar: CalendarKey;
   readonly ids: ReadonlySet<string>;
 }
 
 type DeriveSnapshotRemovals = (
-  listing: ChangeListing,
+  listing: SnapshotListing,
+  coverage: CoverageWindow,
   known: KnownEvents,
 ) => readonly RemoteEventId[];
 
 type DeriveDeltaRemovals = (
-  listing: ChangeListing,
-  known: KnownEvents,
-) => readonly RemoteEventId[];
+  listing: DeltaListing,
+) => readonly Extract<Removal, { kind: "deleted" }>[];
 
 type DeriveCalendarRetirements = (
-  enumeration: CalendarEnumeration,
+  enumeration: Extract<CalendarEnumeration, { kind: "snapshot" }>,
   known: readonly CalendarKey[],
 ) => readonly CalendarKey[];
 

--- a/packages/sync-kit/protocol/src/deletion.ts
+++ b/packages/sync-kit/protocol/src/deletion.ts
@@ -1,0 +1,34 @@
+import type { RemoteEventId } from "./handles";
+import type { CalendarEnumeration, CalendarKey } from "./calendar-ref";
+import type { ChangeListing } from "./change-listing";
+
+type SnapshotListing = ChangeListing;
+type DeltaListing = ChangeListing;
+
+interface KnownEvents {
+  readonly ids: ReadonlySet<string>;
+}
+
+type DeriveSnapshotRemovals = (
+  listing: ChangeListing,
+  known: KnownEvents,
+) => readonly RemoteEventId[];
+
+type DeriveDeltaRemovals = (
+  listing: ChangeListing,
+  known: KnownEvents,
+) => readonly RemoteEventId[];
+
+type DeriveCalendarRetirements = (
+  enumeration: CalendarEnumeration,
+  known: readonly CalendarKey[],
+) => readonly CalendarKey[];
+
+export type {
+  DeltaListing,
+  DeriveCalendarRetirements,
+  DeriveDeltaRemovals,
+  DeriveSnapshotRemovals,
+  KnownEvents,
+  SnapshotListing,
+};

--- a/packages/sync-kit/protocol/src/diagnostics.ts
+++ b/packages/sync-kit/protocol/src/diagnostics.ts
@@ -1,0 +1,27 @@
+import type { EventUid, RemoteEventId } from "./handles";
+
+type BoundedSample = readonly string[];
+
+const withholdReasons = [
+  "unparseable",
+  "unresolvableTimeZone",
+  "unrepresentableTime",
+  "recurrenceBudgetExceeded",
+  "supersededRevisionUnbuildable",
+] as const;
+type WithholdReason = (typeof withholdReasons)[number];
+
+interface WithheldEvent {
+  readonly uid: EventUid;
+  readonly id: RemoteEventId | null;
+  readonly reason: WithholdReason;
+}
+
+interface ListingDiagnostics {
+  readonly withheld: BoundedSample;
+  readonly unrepresentable: BoundedSample;
+  readonly pagesFetched?: number;
+}
+
+export { withholdReasons };
+export type { BoundedSample, ListingDiagnostics, WithheldEvent, WithholdReason };

--- a/packages/sync-kit/protocol/src/diagnostics.ts
+++ b/packages/sync-kit/protocol/src/diagnostics.ts
@@ -11,14 +11,16 @@ const withholdReasons = [
   "unrepresentableTime",
   "recurrenceBudgetExceeded",
   "supersededRevisionUnbuildable",
+  "unsupportedRecurrenceRange",
+  "missingIdentity",
 ] as const;
 type WithholdReason = (typeof withholdReasons)[number];
 
-interface WithheldEvent {
-  readonly uid: EventUid;
-  readonly id: RemoteEventId | null;
-  readonly reason: WithholdReason;
-}
+type WithheldIdentity =
+  | { readonly uid: EventUid; readonly id: RemoteEventId | null }
+  | { readonly uid: null; readonly id: RemoteEventId };
+
+type WithheldEvent = WithheldIdentity & { readonly reason: WithholdReason };
 
 interface ListingDiagnostics {
   readonly withheld: BoundedSample;
@@ -28,4 +30,10 @@ interface ListingDiagnostics {
 }
 
 export { withholdReasons };
-export type { BoundedSample, ListingDiagnostics, WithheldEvent, WithholdReason };
+export type {
+  BoundedSample,
+  ListingDiagnostics,
+  WithheldEvent,
+  WithheldIdentity,
+  WithholdReason,
+};

--- a/packages/sync-kit/protocol/src/diagnostics.ts
+++ b/packages/sync-kit/protocol/src/diagnostics.ts
@@ -1,6 +1,9 @@
 import type { EventUid, RemoteEventId } from "./handles";
 
-type BoundedSample = readonly string[];
+interface BoundedSample {
+  readonly sample: readonly string[];
+  readonly total: number;
+}
 
 const withholdReasons = [
   "unparseable",
@@ -19,8 +22,9 @@ interface WithheldEvent {
 
 interface ListingDiagnostics {
   readonly withheld: BoundedSample;
+  readonly selfAuthored: BoundedSample;
   readonly unrepresentable: BoundedSample;
-  readonly pagesFetched?: number;
+  readonly pagesFetched: number;
 }
 
 export { withholdReasons };

--- a/packages/sync-kit/protocol/src/diagnostics.ts
+++ b/packages/sync-kit/protocol/src/diagnostics.ts
@@ -12,7 +12,9 @@ const withholdReasons = [
   "recurrenceBudgetExceeded",
   "supersededRevisionUnbuildable",
   "unsupportedRecurrenceRange",
+  "unsupportedRecurrenceDates",
   "missingIdentity",
+  "selfAuthored",
 ] as const;
 type WithholdReason = (typeof withholdReasons)[number];
 

--- a/packages/sync-kit/protocol/src/handles.ts
+++ b/packages/sync-kit/protocol/src/handles.ts
@@ -1,11 +1,35 @@
 type ProviderId = string;
-type AccountId = string;
-type CalendarId = string;
-type InstallationId = string;
-type Instant = string;
-type CalendarDate = string;
-type ZoneId = string;
 type Revision = number;
+
+interface AccountId {
+  readonly kind: "accountId";
+  readonly value: string;
+}
+
+interface CalendarId {
+  readonly kind: "calendarId";
+  readonly value: string;
+}
+
+interface InstallationId {
+  readonly kind: "installationId";
+  readonly value: string;
+}
+
+interface Instant {
+  readonly kind: "instant";
+  readonly value: string;
+}
+
+interface CalendarDate {
+  readonly kind: "calendarDate";
+  readonly value: string;
+}
+
+interface ZoneId {
+  readonly kind: "zoneId";
+  readonly value: string;
+}
 
 interface RemoteEventId {
   readonly kind: "remoteEventId";

--- a/packages/sync-kit/protocol/src/handles.ts
+++ b/packages/sync-kit/protocol/src/handles.ts
@@ -7,12 +7,35 @@ type CalendarDate = string;
 type ZoneId = string;
 type Revision = number;
 
-type RemoteEventId = string;
-type DeleteHandle = string;
-type EventUid = string;
-type RemoteVersion = string;
-type Fingerprint = string;
-type IdempotencyKey = string;
+interface RemoteEventId {
+  readonly kind: "remoteEventId";
+  readonly value: string;
+}
+
+interface DeleteHandle {
+  readonly kind: "deleteHandle";
+  readonly value: string;
+}
+
+interface EventUid {
+  readonly kind: "eventUid";
+  readonly value: string;
+}
+
+interface RemoteVersion {
+  readonly kind: "remoteVersion";
+  readonly value: string;
+}
+
+interface Fingerprint {
+  readonly kind: "fingerprint";
+  readonly value: string;
+}
+
+interface IdempotencyKey {
+  readonly kind: "idempotencyKey";
+  readonly value: string;
+}
 
 export type {
   AccountId,

--- a/packages/sync-kit/protocol/src/handles.ts
+++ b/packages/sync-kit/protocol/src/handles.ts
@@ -1,0 +1,32 @@
+type ProviderId = string;
+type AccountId = string;
+type CalendarId = string;
+type InstallationId = string;
+type Instant = string;
+type CalendarDate = string;
+type ZoneId = string;
+type Revision = number;
+
+type RemoteEventId = string;
+type DeleteHandle = string;
+type EventUid = string;
+type RemoteVersion = string;
+type Fingerprint = string;
+type IdempotencyKey = string;
+
+export type {
+  AccountId,
+  CalendarDate,
+  CalendarId,
+  DeleteHandle,
+  EventUid,
+  Fingerprint,
+  IdempotencyKey,
+  InstallationId,
+  Instant,
+  ProviderId,
+  RemoteEventId,
+  RemoteVersion,
+  Revision,
+  ZoneId,
+};

--- a/packages/sync-kit/protocol/src/index.ts
+++ b/packages/sync-kit/protocol/src/index.ts
@@ -1,0 +1,120 @@
+export type {
+  AccountId,
+  CalendarDate,
+  CalendarId,
+  DeleteHandle,
+  EventUid,
+  Fingerprint,
+  IdempotencyKey,
+  InstallationId,
+  Instant,
+  ProviderId,
+  RemoteEventId,
+  RemoteVersion,
+  Revision,
+  ZoneId,
+} from "./handles";
+
+export type { CoverageWindow, EventTime, TimeWindow, WindowMembership } from "./time";
+
+export { calendarAccessKinds } from "./calendar-ref";
+export type {
+  CalendarAccess,
+  CalendarEnumeration,
+  CalendarKey,
+  CalendarRef,
+} from "./calendar-ref";
+
+export { availabilityKinds, recurrenceDialects, visibilityKinds } from "./remote-event";
+export type {
+  Availability,
+  EditableContent,
+  ForeignEvent,
+  IndeterminateEvent,
+  MirrorSource,
+  OwnEvent,
+  Provenance,
+  RecurrenceDialect,
+  RecurrencePayload,
+  RemoteEvent,
+  Visibility,
+} from "./remote-event";
+
+export { withholdReasons } from "./diagnostics";
+export type {
+  BoundedSample,
+  ListingDiagnostics,
+  WithheldEvent,
+  WithholdReason,
+} from "./diagnostics";
+
+export type {
+  ChangeListing,
+  Continuation,
+  ListingScope,
+  Removal,
+  SyncCursor,
+} from "./change-listing";
+
+export type {
+  DeltaListing,
+  DeriveCalendarRetirements,
+  DeriveDeltaRemovals,
+  DeriveSnapshotRemovals,
+  KnownEvents,
+  SnapshotListing,
+} from "./deletion";
+
+export { preconditionKinds } from "./precondition";
+export type { Precondition, PreconditionKind } from "./precondition";
+
+export { deleteReasons, retireReasons } from "./write-intent";
+export type {
+  BuildMirrorIntent,
+  DeleteReason,
+  NormalizedContent,
+  RetireReason,
+  WriteIntent,
+} from "./write-intent";
+
+export { notAttemptedReasons, representabilityConstraints } from "./write-outcome";
+export type {
+  EchoVerdict,
+  NotAttemptedReason,
+  RemoteRef,
+  RepresentabilityConstraint,
+  WriteOutcome,
+} from "./write-outcome";
+
+export { operationNames, quotaScopes } from "./provider-failure";
+export type { OperationName, ProviderFailure, QuotaScope } from "./provider-failure";
+
+export type { Result } from "./result";
+
+export {
+  allDayRepresentations,
+  deletionAuthorities,
+  provenanceChannels,
+  recurrenceWriteSupports,
+} from "./capabilities";
+export type {
+  AllDayRepresentation,
+  Capabilities,
+  DeletionAuthority,
+  DeltaSupport,
+  ProvenanceChannel,
+  RecurrenceWriteSupport,
+  RepresentableRange,
+  ThrottleSignal,
+} from "./capabilities";
+
+export type {
+  CalendarProvider,
+  ListChangesRequest,
+  OperationContext,
+  RetryBudget,
+} from "./provider";
+
+export { assertNever } from "./assert-never";
+
+export type { FingerprintContract, ProviderConformanceSuite } from "./conformance";

--- a/packages/sync-kit/protocol/src/index.ts
+++ b/packages/sync-kit/protocol/src/index.ts
@@ -48,6 +48,7 @@ export type {
   RecurrencePayload,
   RecurringContent,
   RemoteEvent,
+  RemoteEventFacts,
   SingleOccurrenceContent,
   Visibility,
 } from "./remote-event";

--- a/packages/sync-kit/protocol/src/index.ts
+++ b/packages/sync-kit/protocol/src/index.ts
@@ -15,7 +15,15 @@ export type {
   ZoneId,
 } from "./handles";
 
-export type { CoverageWindow, EventTime, TimeWindow, WindowMembership } from "./time";
+export type {
+  CoverageWindow,
+  EventTime,
+  NominalDuration,
+  OccurrenceDuration,
+  RecurrenceAnchor,
+  TimeWindow,
+  WindowMembership,
+} from "./time";
 
 export { calendarAccessKinds } from "./calendar-ref";
 export type {
@@ -23,11 +31,13 @@ export type {
   CalendarEnumeration,
   CalendarKey,
   CalendarRef,
+  WritableCalendar,
 } from "./calendar-ref";
 
 export { availabilityKinds, recurrenceDialects, visibilityKinds } from "./remote-event";
 export type {
   Availability,
+  DescribedContent,
   EditableContent,
   ForeignEvent,
   IndeterminateEvent,
@@ -36,7 +46,9 @@ export type {
   Provenance,
   RecurrenceDialect,
   RecurrencePayload,
+  RecurringContent,
   RemoteEvent,
+  SingleOccurrenceContent,
   Visibility,
 } from "./remote-event";
 
@@ -45,10 +57,12 @@ export type {
   BoundedSample,
   ListingDiagnostics,
   WithheldEvent,
+  WithheldIdentity,
   WithholdReason,
 } from "./diagnostics";
 
 export type {
+  AuthoritativeRemoval,
   ChangeListing,
   Continuation,
   ListingScope,
@@ -65,8 +79,7 @@ export type {
   SnapshotListing,
 } from "./deletion";
 
-export { preconditionKinds } from "./precondition";
-export type { Precondition, PreconditionKind } from "./precondition";
+export type { ObservedPrecondition, Precondition, PreconditionKind } from "./precondition";
 
 export { deleteReasons, retireReasons } from "./write-intent";
 export type {
@@ -86,8 +99,13 @@ export type {
   WriteOutcome,
 } from "./write-outcome";
 
-export { operationNames, quotaScopes } from "./provider-failure";
-export type { OperationName, ProviderFailure, QuotaScope } from "./provider-failure";
+export { operationNames, quotaScopes, transportDispositions } from "./provider-failure";
+export type {
+  OperationName,
+  ProviderFailure,
+  QuotaScope,
+  TransportDisposition,
+} from "./provider-failure";
 
 export type { Result } from "./result";
 
@@ -112,9 +130,14 @@ export type {
   CalendarProvider,
   ListChangesRequest,
   OperationContext,
+  ProviderContract,
   RetryBudget,
 } from "./provider";
 
 export { assertNever } from "./assert-never";
 
-export type { FingerprintContract, ProviderConformanceSuite } from "./conformance";
+export type {
+  ConformanceObligation,
+  FingerprintContract,
+  ProviderConformanceSuite,
+} from "./conformance";

--- a/packages/sync-kit/protocol/src/precondition.ts
+++ b/packages/sync-kit/protocol/src/precondition.ts
@@ -3,11 +3,10 @@ import type { Fingerprint, RemoteVersion } from "./handles";
 const preconditionKinds = ["version", "fingerprint", "none"] as const;
 type PreconditionKind = (typeof preconditionKinds)[number];
 
-interface Precondition {
-  readonly kind: "matchesVersion" | "matchesFingerprint" | "absent";
-  readonly version?: RemoteVersion;
-  readonly fingerprint?: Fingerprint;
-}
+type Precondition =
+  | { readonly kind: "matchesVersion"; readonly version: RemoteVersion }
+  | { readonly kind: "matchesFingerprint"; readonly fingerprint: Fingerprint }
+  | { readonly kind: "absent" };
 
 export { preconditionKinds };
 export type { Precondition, PreconditionKind };

--- a/packages/sync-kit/protocol/src/precondition.ts
+++ b/packages/sync-kit/protocol/src/precondition.ts
@@ -1,0 +1,13 @@
+import type { Fingerprint, RemoteVersion } from "./handles";
+
+const preconditionKinds = ["version", "fingerprint", "none"] as const;
+type PreconditionKind = (typeof preconditionKinds)[number];
+
+interface Precondition {
+  readonly kind: "matchesVersion" | "matchesFingerprint" | "absent";
+  readonly version?: RemoteVersion;
+  readonly fingerprint?: Fingerprint;
+}
+
+export { preconditionKinds };
+export type { Precondition, PreconditionKind };

--- a/packages/sync-kit/protocol/src/precondition.ts
+++ b/packages/sync-kit/protocol/src/precondition.ts
@@ -1,12 +1,12 @@
 import type { Fingerprint, RemoteVersion } from "./handles";
 
-const preconditionKinds = ["version", "fingerprint", "none"] as const;
-type PreconditionKind = (typeof preconditionKinds)[number];
-
 type Precondition =
   | { readonly kind: "matchesVersion"; readonly version: RemoteVersion }
   | { readonly kind: "matchesFingerprint"; readonly fingerprint: Fingerprint }
   | { readonly kind: "absent" };
 
-export { preconditionKinds };
-export type { Precondition, PreconditionKind };
+type PreconditionKind = Precondition["kind"];
+
+type ObservedPrecondition = Exclude<Precondition, { kind: "absent" }>;
+
+export type { ObservedPrecondition, Precondition, PreconditionKind };

--- a/packages/sync-kit/protocol/src/provider-failure.ts
+++ b/packages/sync-kit/protocol/src/provider-failure.ts
@@ -1,0 +1,32 @@
+import type { CalendarKey } from "./calendar-ref";
+import type { Instant, RemoteEventId } from "./handles";
+import type { Continuation, ListingScope } from "./change-listing";
+import type { Precondition } from "./precondition";
+
+const quotaScopes = ["perUser", "perMailbox", "perCollection"] as const;
+type QuotaScope = (typeof quotaScopes)[number];
+
+const operationNames = ["listCalendars", "listChanges", "write"] as const;
+type OperationName = (typeof operationNames)[number];
+
+type ProviderFailure =
+  | { readonly kind: "rateLimited"; readonly retryAfter?: Instant; readonly scope: QuotaScope }
+  | { readonly kind: "cursorInvalid"; readonly scope: ListingScope }
+  | { readonly kind: "truncated"; readonly continuation: Continuation }
+  | { readonly kind: "conflict"; readonly observed: Precondition }
+  | {
+      readonly kind: "notFound";
+      readonly calendar: CalendarKey;
+      readonly event: RemoteEventId | null;
+    }
+  | { readonly kind: "unsupported"; readonly operation: OperationName }
+  | { readonly kind: "notAttempted"; readonly reason: string }
+  | {
+      readonly kind: "transport";
+      readonly status: number | null;
+      readonly retryable: boolean;
+      readonly message?: string;
+    };
+
+export { operationNames, quotaScopes };
+export type { OperationName, ProviderFailure, QuotaScope };

--- a/packages/sync-kit/protocol/src/provider-failure.ts
+++ b/packages/sync-kit/protocol/src/provider-failure.ts
@@ -1,14 +1,17 @@
 import type { CalendarKey } from "./calendar-ref";
 import type { Continuation, ListingScope } from "./change-listing";
 import type { AccountId, Instant, RemoteEventId } from "./handles";
-import type { Precondition } from "./precondition";
-import type { NotAttemptedReason } from "./write-outcome";
+import type { ObservedPrecondition } from "./precondition";
+import type { NotAttemptedReason, RepresentabilityConstraint } from "./write-outcome";
 
 const quotaScopes = ["perUser", "perMailbox", "perCollection"] as const;
 type QuotaScope = (typeof quotaScopes)[number];
 
-const operationNames = ["listCalendars", "listChanges", "write"] as const;
+const operationNames = ["listCalendars", "listChanges", "normalize", "write"] as const;
 type OperationName = (typeof operationNames)[number];
+
+const transportDispositions = ["transient", "permanent"] as const;
+type TransportDisposition = (typeof transportDispositions)[number];
 
 type ProviderFailure =
   | { readonly kind: "reauthRequired"; readonly account: AccountId }
@@ -19,15 +22,20 @@ type ProviderFailure =
     }
   | { readonly kind: "cursorInvalid"; readonly scope: ListingScope }
   | { readonly kind: "truncated"; readonly continuation: Continuation }
-  | { readonly kind: "conflict"; readonly observed: Precondition }
+  | { readonly kind: "conflict"; readonly observed: ObservedPrecondition }
   | {
       readonly kind: "notFound";
       readonly calendar: CalendarKey;
       readonly event: RemoteEventId | null;
     }
   | { readonly kind: "unsupported"; readonly operation: OperationName }
-  | { readonly kind: "transport"; readonly status: number | null; readonly retryable: boolean }
+  | { readonly kind: "unrepresentable"; readonly constraint: RepresentabilityConstraint }
+  | {
+      readonly kind: "transport";
+      readonly status: number | null;
+      readonly disposition: TransportDisposition;
+    }
   | { readonly kind: "notAttempted"; readonly reason: NotAttemptedReason };
 
-export { operationNames, quotaScopes };
-export type { OperationName, ProviderFailure, QuotaScope };
+export { operationNames, quotaScopes, transportDispositions };
+export type { OperationName, ProviderFailure, QuotaScope, TransportDisposition };

--- a/packages/sync-kit/protocol/src/provider-failure.ts
+++ b/packages/sync-kit/protocol/src/provider-failure.ts
@@ -1,7 +1,8 @@
 import type { CalendarKey } from "./calendar-ref";
-import type { Instant, RemoteEventId } from "./handles";
 import type { Continuation, ListingScope } from "./change-listing";
+import type { AccountId, Instant, RemoteEventId } from "./handles";
 import type { Precondition } from "./precondition";
+import type { NotAttemptedReason } from "./write-outcome";
 
 const quotaScopes = ["perUser", "perMailbox", "perCollection"] as const;
 type QuotaScope = (typeof quotaScopes)[number];
@@ -10,7 +11,12 @@ const operationNames = ["listCalendars", "listChanges", "write"] as const;
 type OperationName = (typeof operationNames)[number];
 
 type ProviderFailure =
-  | { readonly kind: "rateLimited"; readonly retryAfter?: Instant; readonly scope: QuotaScope }
+  | { readonly kind: "reauthRequired"; readonly account: AccountId }
+  | {
+      readonly kind: "rateLimited";
+      readonly retryAfter: Instant | null;
+      readonly scope: QuotaScope;
+    }
   | { readonly kind: "cursorInvalid"; readonly scope: ListingScope }
   | { readonly kind: "truncated"; readonly continuation: Continuation }
   | { readonly kind: "conflict"; readonly observed: Precondition }
@@ -20,13 +26,8 @@ type ProviderFailure =
       readonly event: RemoteEventId | null;
     }
   | { readonly kind: "unsupported"; readonly operation: OperationName }
-  | { readonly kind: "notAttempted"; readonly reason: string }
-  | {
-      readonly kind: "transport";
-      readonly status: number | null;
-      readonly retryable: boolean;
-      readonly message?: string;
-    };
+  | { readonly kind: "transport"; readonly status: number | null; readonly retryable: boolean }
+  | { readonly kind: "notAttempted"; readonly reason: NotAttemptedReason };
 
 export { operationNames, quotaScopes };
 export type { OperationName, ProviderFailure, QuotaScope };

--- a/packages/sync-kit/protocol/src/provider.ts
+++ b/packages/sync-kit/protocol/src/provider.ts
@@ -1,6 +1,7 @@
 import type { CalendarEnumeration } from "./calendar-ref";
 import type { Capabilities } from "./capabilities";
 import type { ChangeListing, Continuation, ListingScope, SyncCursor } from "./change-listing";
+import type { FingerprintContract, ProviderConformanceSuite } from "./conformance";
 import type { AccountId, Instant, ProviderId } from "./handles";
 import type { EditableContent } from "./remote-event";
 import type { Result } from "./result";
@@ -9,12 +10,13 @@ import type { WriteOutcome } from "./write-outcome";
 
 interface RetryBudget {
   readonly maxAttempts: number;
-  readonly ceilingMs: number;
+  readonly retryDelayCeilingMs: number;
 }
 
 interface OperationContext {
   readonly signal: AbortSignal;
   readonly now: () => Instant;
+  readonly deadline: Instant;
   readonly retryBudget: RetryBudget;
 }
 
@@ -25,16 +27,31 @@ interface ListChangesRequest {
 
 interface CalendarProvider<Provider extends ProviderId = ProviderId> {
   readonly capabilities: Capabilities<Provider>;
-  listCalendars(
+  readonly listCalendars: (
     account: AccountId,
     context: OperationContext,
-  ): Promise<Result<CalendarEnumeration>>;
-  listChanges(
+  ) => Promise<Result<CalendarEnumeration>>;
+  readonly listChanges: (
     request: ListChangesRequest,
     context: OperationContext,
-  ): Promise<Result<ChangeListing>>;
-  normalize(content: EditableContent): Result<NormalizedContent<Provider>>;
-  write(intent: WriteIntent<Provider>, context: OperationContext): Promise<Result<WriteOutcome>>;
+  ) => Promise<Result<ChangeListing>>;
+  readonly normalize: (content: EditableContent) => Result<NormalizedContent<Provider>>;
+  readonly write: (
+    intent: WriteIntent<Provider>,
+    context: OperationContext,
+  ) => Promise<Result<WriteOutcome>>;
 }
 
-export type { CalendarProvider, ListChangesRequest, OperationContext, RetryBudget };
+interface ProviderContract<Provider extends ProviderId = ProviderId> {
+  readonly provider: CalendarProvider<Provider>;
+  readonly fingerprint: FingerprintContract;
+  readonly conformance: ProviderConformanceSuite;
+}
+
+export type {
+  CalendarProvider,
+  ListChangesRequest,
+  OperationContext,
+  ProviderContract,
+  RetryBudget,
+};

--- a/packages/sync-kit/protocol/src/provider.ts
+++ b/packages/sync-kit/protocol/src/provider.ts
@@ -1,0 +1,34 @@
+import type { AccountId, Instant, ProviderId } from "./handles";
+import type { CalendarEnumeration } from "./calendar-ref";
+import type { ChangeListing, Continuation, ListingScope, SyncCursor } from "./change-listing";
+import type { EditableContent } from "./remote-event";
+import type { NormalizedContent, WriteIntent } from "./write-intent";
+import type { WriteOutcome } from "./write-outcome";
+import type { Capabilities } from "./capabilities";
+import type { Result } from "./result";
+
+interface RetryBudget {
+  readonly maxAttempts?: number;
+  readonly ceilingMs?: number;
+}
+
+interface OperationContext {
+  readonly signal?: AbortSignal;
+  readonly now: () => Instant;
+  readonly retryBudget?: RetryBudget;
+}
+
+interface ListChangesRequest {
+  readonly scope: ListingScope;
+  readonly resume?: SyncCursor | Continuation | null;
+}
+
+interface CalendarProvider<Provider extends ProviderId = ProviderId> {
+  readonly capabilities: Capabilities<Provider>;
+  listCalendars(account: AccountId): Promise<Result<CalendarEnumeration>>;
+  listChanges(request: ListChangesRequest): Promise<Result<ChangeListing>>;
+  normalize(content: EditableContent): NormalizedContent<Provider>;
+  write(intent: WriteIntent<Provider>): Promise<WriteOutcome>;
+}
+
+export type { CalendarProvider, ListChangesRequest, OperationContext, RetryBudget };

--- a/packages/sync-kit/protocol/src/provider.ts
+++ b/packages/sync-kit/protocol/src/provider.ts
@@ -1,34 +1,40 @@
-import type { AccountId, Instant, ProviderId } from "./handles";
 import type { CalendarEnumeration } from "./calendar-ref";
+import type { Capabilities } from "./capabilities";
 import type { ChangeListing, Continuation, ListingScope, SyncCursor } from "./change-listing";
+import type { AccountId, Instant, ProviderId } from "./handles";
 import type { EditableContent } from "./remote-event";
+import type { Result } from "./result";
 import type { NormalizedContent, WriteIntent } from "./write-intent";
 import type { WriteOutcome } from "./write-outcome";
-import type { Capabilities } from "./capabilities";
-import type { Result } from "./result";
 
 interface RetryBudget {
-  readonly maxAttempts?: number;
-  readonly ceilingMs?: number;
+  readonly maxAttempts: number;
+  readonly ceilingMs: number;
 }
 
 interface OperationContext {
-  readonly signal?: AbortSignal;
+  readonly signal: AbortSignal;
   readonly now: () => Instant;
-  readonly retryBudget?: RetryBudget;
+  readonly retryBudget: RetryBudget;
 }
 
 interface ListChangesRequest {
   readonly scope: ListingScope;
-  readonly resume?: SyncCursor | Continuation | null;
+  readonly resume: SyncCursor | Continuation | null;
 }
 
 interface CalendarProvider<Provider extends ProviderId = ProviderId> {
   readonly capabilities: Capabilities<Provider>;
-  listCalendars(account: AccountId): Promise<Result<CalendarEnumeration>>;
-  listChanges(request: ListChangesRequest): Promise<Result<ChangeListing>>;
-  normalize(content: EditableContent): NormalizedContent<Provider>;
-  write(intent: WriteIntent<Provider>): Promise<WriteOutcome>;
+  listCalendars(
+    account: AccountId,
+    context: OperationContext,
+  ): Promise<Result<CalendarEnumeration>>;
+  listChanges(
+    request: ListChangesRequest,
+    context: OperationContext,
+  ): Promise<Result<ChangeListing>>;
+  normalize(content: EditableContent): Result<NormalizedContent<Provider>>;
+  write(intent: WriteIntent<Provider>, context: OperationContext): Promise<Result<WriteOutcome>>;
 }
 
 export type { CalendarProvider, ListChangesRequest, OperationContext, RetryBudget };

--- a/packages/sync-kit/protocol/src/remote-event.ts
+++ b/packages/sync-kit/protocol/src/remote-event.ts
@@ -8,7 +8,7 @@ import type {
   RemoteVersion,
   Revision,
 } from "./handles";
-import type { EventTime } from "./time";
+import type { EventTime, RecurrenceAnchor } from "./time";
 
 const availabilityKinds = ["busy", "free"] as const;
 type Availability = (typeof availabilityKinds)[number];
@@ -25,15 +25,27 @@ interface RecurrencePayload {
   readonly exceptions: readonly string[];
 }
 
-interface EditableContent {
+interface DescribedContent {
   readonly title: string;
   readonly description: string | null;
   readonly location: string | null;
-  readonly time: EventTime;
   readonly availability: Availability;
   readonly visibility: Visibility;
-  readonly recurrence: RecurrencePayload | null;
 }
+
+type SingleOccurrenceContent = DescribedContent & {
+  readonly recurrence: null;
+  readonly time: EventTime;
+  readonly anchor?: never;
+};
+
+type RecurringContent = DescribedContent & {
+  readonly recurrence: RecurrencePayload;
+  readonly anchor: RecurrenceAnchor;
+  readonly time?: never;
+};
+
+type EditableContent = SingleOccurrenceContent | RecurringContent;
 
 interface RemoteEventFacts {
   readonly id: RemoteEventId;
@@ -65,6 +77,7 @@ type MirrorSource = ForeignEvent;
 export { availabilityKinds, recurrenceDialects, visibilityKinds };
 export type {
   Availability,
+  DescribedContent,
   EditableContent,
   ForeignEvent,
   IndeterminateEvent,
@@ -73,6 +86,8 @@ export type {
   Provenance,
   RecurrenceDialect,
   RecurrencePayload,
+  RecurringContent,
   RemoteEvent,
+  SingleOccurrenceContent,
   Visibility,
 };

--- a/packages/sync-kit/protocol/src/remote-event.ts
+++ b/packages/sync-kit/protocol/src/remote-event.ts
@@ -88,6 +88,7 @@ export type {
   RecurrencePayload,
   RecurringContent,
   RemoteEvent,
+  RemoteEventFacts,
   SingleOccurrenceContent,
   Visibility,
 };

--- a/packages/sync-kit/protocol/src/remote-event.ts
+++ b/packages/sync-kit/protocol/src/remote-event.ts
@@ -1,0 +1,72 @@
+import type {
+  DeleteHandle,
+  EventUid,
+  Fingerprint,
+  InstallationId,
+  RemoteEventId,
+  RemoteVersion,
+  Revision,
+} from "./handles";
+import type { CalendarKey } from "./calendar-ref";
+import type { EventTime } from "./time";
+
+const availabilityKinds = ["busy", "free"] as const;
+type Availability = (typeof availabilityKinds)[number];
+
+const visibilityKinds = ["default", "private", "public"] as const;
+type Visibility = (typeof visibilityKinds)[number];
+
+const recurrenceDialects = ["rfc5545", "providerNative"] as const;
+type RecurrenceDialect = (typeof recurrenceDialects)[number];
+
+interface RecurrencePayload {
+  readonly dialect: RecurrenceDialect;
+  readonly value: string;
+  readonly exceptions: readonly string[];
+}
+
+interface EditableContent {
+  readonly title: string;
+  readonly description: string | null;
+  readonly location: string | null;
+  readonly time: EventTime;
+  readonly availability: Availability;
+  readonly visibility: Visibility;
+  readonly recurrence: RecurrencePayload | null;
+}
+
+type Provenance =
+  | { readonly kind: "foreign" }
+  | { readonly kind: "ours"; readonly installation: InstallationId };
+
+interface RemoteEvent {
+  readonly id: RemoteEventId;
+  readonly deleteHandle: DeleteHandle;
+  readonly uid: EventUid;
+  readonly calendar: CalendarKey;
+  readonly revision: Revision;
+  readonly version: RemoteVersion;
+  readonly content: EditableContent;
+  readonly fingerprint: Fingerprint;
+  readonly provenance: Provenance;
+}
+
+type ForeignEvent = RemoteEvent;
+type OwnEvent = RemoteEvent;
+type IndeterminateEvent = RemoteEvent;
+type MirrorSource = RemoteEvent;
+
+export { availabilityKinds, recurrenceDialects, visibilityKinds };
+export type {
+  Availability,
+  EditableContent,
+  ForeignEvent,
+  IndeterminateEvent,
+  MirrorSource,
+  OwnEvent,
+  Provenance,
+  RecurrenceDialect,
+  RecurrencePayload,
+  RemoteEvent,
+  Visibility,
+};

--- a/packages/sync-kit/protocol/src/remote-event.ts
+++ b/packages/sync-kit/protocol/src/remote-event.ts
@@ -1,3 +1,4 @@
+import type { CalendarKey } from "./calendar-ref";
 import type {
   DeleteHandle,
   EventUid,
@@ -7,7 +8,6 @@ import type {
   RemoteVersion,
   Revision,
 } from "./handles";
-import type { CalendarKey } from "./calendar-ref";
 import type { EventTime } from "./time";
 
 const availabilityKinds = ["busy", "free"] as const;
@@ -35,11 +35,7 @@ interface EditableContent {
   readonly recurrence: RecurrencePayload | null;
 }
 
-type Provenance =
-  | { readonly kind: "foreign" }
-  | { readonly kind: "ours"; readonly installation: InstallationId };
-
-interface RemoteEvent {
+interface RemoteEventFacts {
   readonly id: RemoteEventId;
   readonly deleteHandle: DeleteHandle;
   readonly uid: EventUid;
@@ -48,13 +44,23 @@ interface RemoteEvent {
   readonly version: RemoteVersion;
   readonly content: EditableContent;
   readonly fingerprint: Fingerprint;
-  readonly provenance: Provenance;
 }
 
-type ForeignEvent = RemoteEvent;
-type OwnEvent = RemoteEvent;
-type IndeterminateEvent = RemoteEvent;
-type MirrorSource = RemoteEvent;
+type ForeignEvent = RemoteEventFacts & {
+  readonly provenance: { readonly kind: "foreign" };
+};
+
+type OwnEvent = RemoteEventFacts & {
+  readonly provenance: { readonly kind: "ours"; readonly installation: InstallationId };
+};
+
+type IndeterminateEvent = RemoteEventFacts & {
+  readonly provenance: { readonly kind: "indeterminate" };
+};
+
+type RemoteEvent = ForeignEvent | OwnEvent | IndeterminateEvent;
+type Provenance = RemoteEvent["provenance"];
+type MirrorSource = ForeignEvent;
 
 export { availabilityKinds, recurrenceDialects, visibilityKinds };
 export type {

--- a/packages/sync-kit/protocol/src/result.ts
+++ b/packages/sync-kit/protocol/src/result.ts
@@ -1,0 +1,7 @@
+import type { ProviderFailure } from "./provider-failure";
+
+type Result<Value> =
+  | { readonly ok: true; readonly value: Value }
+  | { readonly ok: false; readonly failure: ProviderFailure };
+
+export type { Result };

--- a/packages/sync-kit/protocol/src/time.ts
+++ b/packages/sync-kit/protocol/src/time.ts
@@ -1,0 +1,19 @@
+import type { Instant, ZoneId } from "./handles";
+
+interface TimeWindow {
+  readonly start: Instant;
+  readonly end: Instant;
+}
+
+type CoverageWindow = TimeWindow;
+
+interface EventTime {
+  readonly isAllDay: boolean;
+  readonly start: Instant;
+  readonly end: Instant;
+  readonly zone: ZoneId | null;
+}
+
+type WindowMembership = (window: TimeWindow, time: EventTime) => boolean;
+
+export type { CoverageWindow, EventTime, TimeWindow, WindowMembership };

--- a/packages/sync-kit/protocol/src/time.ts
+++ b/packages/sync-kit/protocol/src/time.ts
@@ -1,18 +1,29 @@
-import type { Instant, ZoneId } from "./handles";
+import type { CalendarKey } from "./calendar-ref";
+import type { CalendarDate, Instant, ZoneId } from "./handles";
 
 interface TimeWindow {
   readonly start: Instant;
   readonly end: Instant;
 }
 
-type CoverageWindow = TimeWindow;
-
-interface EventTime {
-  readonly isAllDay: boolean;
-  readonly start: Instant;
-  readonly end: Instant;
-  readonly zone: ZoneId | null;
+interface CoverageWindow {
+  readonly coveredFrom: Instant;
+  readonly coveredTo: Instant;
+  readonly calendar: CalendarKey;
 }
+
+type EventTime =
+  | {
+      readonly kind: "timed";
+      readonly start: Instant;
+      readonly end: Instant;
+      readonly zone: ZoneId | null;
+    }
+  | {
+      readonly kind: "allDay";
+      readonly startDate: CalendarDate;
+      readonly endDateExclusive: CalendarDate;
+    };
 
 type WindowMembership = (window: TimeWindow, time: EventTime) => boolean;
 

--- a/packages/sync-kit/protocol/src/time.ts
+++ b/packages/sync-kit/protocol/src/time.ts
@@ -7,8 +7,7 @@ interface TimeWindow {
 }
 
 interface CoverageWindow {
-  readonly coveredFrom: Instant;
-  readonly coveredTo: Instant;
+  readonly covered: TimeWindow;
   readonly calendar: CalendarKey;
 }
 
@@ -25,6 +24,33 @@ type EventTime =
       readonly endDateExclusive: CalendarDate;
     };
 
+type OccurrenceDuration =
+  | { readonly kind: "exact"; readonly seconds: number }
+  | { readonly kind: "nominal"; readonly days: number };
+
+type NominalDuration = Extract<OccurrenceDuration, { kind: "nominal" }>;
+
+type RecurrenceAnchor =
+  | {
+      readonly kind: "timed";
+      readonly start: Instant;
+      readonly zone: ZoneId;
+      readonly duration: OccurrenceDuration;
+    }
+  | {
+      readonly kind: "allDay";
+      readonly startDate: CalendarDate;
+      readonly duration: NominalDuration;
+    };
+
 type WindowMembership = (window: TimeWindow, time: EventTime) => boolean;
 
-export type { CoverageWindow, EventTime, TimeWindow, WindowMembership };
+export type {
+  CoverageWindow,
+  EventTime,
+  NominalDuration,
+  OccurrenceDuration,
+  RecurrenceAnchor,
+  TimeWindow,
+  WindowMembership,
+};

--- a/packages/sync-kit/protocol/src/write-intent.ts
+++ b/packages/sync-kit/protocol/src/write-intent.ts
@@ -1,4 +1,4 @@
-import type { CalendarKey } from "./calendar-ref";
+import type { WritableCalendar } from "./calendar-ref";
 import type {
   DeleteHandle,
   Fingerprint,
@@ -6,7 +6,7 @@ import type {
   ProviderId,
   RemoteEventId,
 } from "./handles";
-import type { Precondition } from "./precondition";
+import type { ObservedPrecondition, Precondition } from "./precondition";
 import type { EditableContent, MirrorSource, Provenance } from "./remote-event";
 
 interface NormalizedContent<Provider extends ProviderId = ProviderId> {
@@ -25,7 +25,7 @@ type RetireReason = (typeof retireReasons)[number];
 type WriteIntent<Provider extends ProviderId = ProviderId> =
   | {
       readonly kind: "create";
-      readonly calendar: CalendarKey;
+      readonly calendar: WritableCalendar;
       readonly idempotencyKey: IdempotencyKey;
       readonly content: NormalizedContent<Provider>;
       readonly provenance: Extract<Provenance, { kind: "ours" }>;
@@ -34,31 +34,31 @@ type WriteIntent<Provider extends ProviderId = ProviderId> =
     }
   | {
       readonly kind: "update";
-      readonly calendar: CalendarKey;
+      readonly calendar: WritableCalendar;
       readonly target: RemoteEventId;
       readonly content: NormalizedContent<Provider>;
-      readonly precondition: Precondition;
+      readonly precondition: ObservedPrecondition;
     }
   | {
       readonly kind: "delete";
-      readonly calendar: CalendarKey;
+      readonly calendar: WritableCalendar;
       readonly target: DeleteHandle;
-      readonly precondition: Precondition;
+      readonly precondition: ObservedPrecondition;
       readonly reason: DeleteReason;
       readonly content?: never;
     }
   | {
       readonly kind: "retire";
-      readonly calendar: CalendarKey;
+      readonly calendar: WritableCalendar;
       readonly target: DeleteHandle;
-      readonly precondition: Precondition;
+      readonly precondition: ObservedPrecondition;
       readonly reason: RetireReason;
       readonly content?: never;
     };
 
 type BuildMirrorIntent<Provider extends ProviderId = ProviderId> = (
   source: MirrorSource,
-  destination: CalendarKey,
+  destination: WritableCalendar,
   normalized: NormalizedContent<Provider>,
 ) => WriteIntent<Provider>;
 

--- a/packages/sync-kit/protocol/src/write-intent.ts
+++ b/packages/sync-kit/protocol/src/write-intent.ts
@@ -1,0 +1,54 @@
+import type { DeleteHandle, IdempotencyKey, ProviderId, RemoteEventId } from "./handles";
+import type { CalendarKey } from "./calendar-ref";
+import type { EditableContent, MirrorSource, Provenance } from "./remote-event";
+import type { Precondition } from "./precondition";
+
+type NormalizedContent<Provider extends ProviderId = ProviderId> = EditableContent & {
+  readonly provider?: Provider | ProviderId;
+};
+
+const deleteReasons = ["sourceDeleted", "sourceUnmapped"] as const;
+type DeleteReason = (typeof deleteReasons)[number];
+
+const retireReasons = ["outsideWindow", "destinationDisconnected"] as const;
+type RetireReason = (typeof retireReasons)[number];
+
+type WriteIntent<Provider extends ProviderId = ProviderId> =
+  | {
+      readonly kind: "create";
+      readonly calendar: CalendarKey;
+      readonly idempotencyKey?: IdempotencyKey;
+      readonly content: NormalizedContent<Provider>;
+      readonly provenance?: Provenance;
+      readonly precondition?: Precondition;
+    }
+  | {
+      readonly kind: "update";
+      readonly calendar: CalendarKey;
+      readonly target: RemoteEventId;
+      readonly content: NormalizedContent<Provider>;
+      readonly precondition?: Precondition;
+    }
+  | {
+      readonly kind: "delete";
+      readonly calendar: CalendarKey;
+      readonly target: DeleteHandle;
+      readonly precondition?: Precondition;
+      readonly reason: DeleteReason;
+    }
+  | {
+      readonly kind: "retire";
+      readonly calendar: CalendarKey;
+      readonly target: DeleteHandle;
+      readonly precondition?: Precondition;
+      readonly reason: RetireReason;
+    };
+
+type BuildMirrorIntent<Provider extends ProviderId = ProviderId> = (
+  source: MirrorSource,
+  destination: CalendarKey,
+  normalized: NormalizedContent<Provider>,
+) => WriteIntent<Provider>;
+
+export { deleteReasons, retireReasons };
+export type { BuildMirrorIntent, DeleteReason, NormalizedContent, RetireReason, WriteIntent };

--- a/packages/sync-kit/protocol/src/write-intent.ts
+++ b/packages/sync-kit/protocol/src/write-intent.ts
@@ -1,11 +1,20 @@
-import type { DeleteHandle, IdempotencyKey, ProviderId, RemoteEventId } from "./handles";
 import type { CalendarKey } from "./calendar-ref";
-import type { EditableContent, MirrorSource, Provenance } from "./remote-event";
+import type {
+  DeleteHandle,
+  Fingerprint,
+  IdempotencyKey,
+  ProviderId,
+  RemoteEventId,
+} from "./handles";
 import type { Precondition } from "./precondition";
+import type { EditableContent, MirrorSource, Provenance } from "./remote-event";
 
-type NormalizedContent<Provider extends ProviderId = ProviderId> = EditableContent & {
-  readonly provider?: Provider | ProviderId;
-};
+interface NormalizedContent<Provider extends ProviderId = ProviderId> {
+  readonly kind: "normalized";
+  readonly provider: Provider;
+  readonly content: EditableContent;
+  readonly fingerprint: Fingerprint;
+}
 
 const deleteReasons = ["sourceDeleted", "sourceUnmapped"] as const;
 type DeleteReason = (typeof deleteReasons)[number];
@@ -17,31 +26,34 @@ type WriteIntent<Provider extends ProviderId = ProviderId> =
   | {
       readonly kind: "create";
       readonly calendar: CalendarKey;
-      readonly idempotencyKey?: IdempotencyKey;
+      readonly idempotencyKey: IdempotencyKey;
       readonly content: NormalizedContent<Provider>;
-      readonly provenance?: Provenance;
-      readonly precondition?: Precondition;
+      readonly provenance: Extract<Provenance, { kind: "ours" }>;
+      readonly precondition: Extract<Precondition, { kind: "absent" }>;
+      readonly target?: never;
     }
   | {
       readonly kind: "update";
       readonly calendar: CalendarKey;
       readonly target: RemoteEventId;
       readonly content: NormalizedContent<Provider>;
-      readonly precondition?: Precondition;
+      readonly precondition: Precondition;
     }
   | {
       readonly kind: "delete";
       readonly calendar: CalendarKey;
       readonly target: DeleteHandle;
-      readonly precondition?: Precondition;
+      readonly precondition: Precondition;
       readonly reason: DeleteReason;
+      readonly content?: never;
     }
   | {
       readonly kind: "retire";
       readonly calendar: CalendarKey;
       readonly target: DeleteHandle;
-      readonly precondition?: Precondition;
+      readonly precondition: Precondition;
       readonly reason: RetireReason;
+      readonly content?: never;
     };
 
 type BuildMirrorIntent<Provider extends ProviderId = ProviderId> = (

--- a/packages/sync-kit/protocol/src/write-outcome.ts
+++ b/packages/sync-kit/protocol/src/write-outcome.ts
@@ -1,6 +1,6 @@
 import type { BoundedSample } from "./diagnostics";
 import type { DeleteHandle, RemoteEventId, RemoteVersion } from "./handles";
-import type { Precondition } from "./precondition";
+import type { ObservedPrecondition } from "./precondition";
 
 interface RemoteRef {
   readonly id: RemoteEventId;
@@ -41,7 +41,11 @@ type WriteOutcome =
   | { readonly kind: "unchanged"; readonly remote: RemoteRef; readonly version: RemoteVersion }
   | { readonly kind: "deleted"; readonly remote: RemoteRef }
   | { readonly kind: "alreadyAbsent"; readonly remote: RemoteRef }
-  | { readonly kind: "conflict"; readonly remote: RemoteRef; readonly observed: Precondition }
+  | {
+      readonly kind: "conflict";
+      readonly remote: RemoteRef;
+      readonly observed: ObservedPrecondition;
+    }
   | { readonly kind: "unrepresentable"; readonly constraint: RepresentabilityConstraint }
   | { readonly kind: "notAttempted"; readonly reason: NotAttemptedReason };
 

--- a/packages/sync-kit/protocol/src/write-outcome.ts
+++ b/packages/sync-kit/protocol/src/write-outcome.ts
@@ -1,15 +1,16 @@
-import type { DeleteHandle, RemoteEventId, RemoteVersion } from "./handles";
 import type { BoundedSample } from "./diagnostics";
+import type { DeleteHandle, RemoteEventId, RemoteVersion } from "./handles";
 import type { Precondition } from "./precondition";
 
 interface RemoteRef {
   readonly id: RemoteEventId;
-  readonly deleteHandle?: DeleteHandle;
+  readonly deleteHandle: DeleteHandle;
 }
 
 type EchoVerdict =
   | { readonly kind: "matched" }
-  | { readonly kind: "diverged"; readonly fields: BoundedSample };
+  | { readonly kind: "diverged"; readonly fields: BoundedSample }
+  | { readonly kind: "notObserved" };
 
 const notAttemptedReasons = ["superseded", "aborted", "budgetExhausted"] as const;
 type NotAttemptedReason = (typeof notAttemptedReasons)[number];
@@ -28,19 +29,19 @@ type WriteOutcome =
       readonly kind: "created";
       readonly remote: RemoteRef;
       readonly version: RemoteVersion;
-      readonly echo?: EchoVerdict | boolean;
+      readonly echo: EchoVerdict;
     }
   | {
       readonly kind: "updated";
       readonly remote: RemoteRef;
       readonly version: RemoteVersion;
-      readonly echo?: EchoVerdict | boolean;
-      readonly observed?: Precondition;
+      readonly echo: EchoVerdict;
     }
   | { readonly kind: "alreadyExists"; readonly remote: RemoteRef; readonly version: RemoteVersion }
   | { readonly kind: "unchanged"; readonly remote: RemoteRef; readonly version: RemoteVersion }
   | { readonly kind: "deleted"; readonly remote: RemoteRef }
   | { readonly kind: "alreadyAbsent"; readonly remote: RemoteRef }
+  | { readonly kind: "conflict"; readonly remote: RemoteRef; readonly observed: Precondition }
   | { readonly kind: "unrepresentable"; readonly constraint: RepresentabilityConstraint }
   | { readonly kind: "notAttempted"; readonly reason: NotAttemptedReason };
 

--- a/packages/sync-kit/protocol/src/write-outcome.ts
+++ b/packages/sync-kit/protocol/src/write-outcome.ts
@@ -1,0 +1,54 @@
+import type { DeleteHandle, RemoteEventId, RemoteVersion } from "./handles";
+import type { BoundedSample } from "./diagnostics";
+import type { Precondition } from "./precondition";
+
+interface RemoteRef {
+  readonly id: RemoteEventId;
+  readonly deleteHandle?: DeleteHandle;
+}
+
+type EchoVerdict =
+  | { readonly kind: "matched" }
+  | { readonly kind: "diverged"; readonly fields: BoundedSample };
+
+const notAttemptedReasons = ["superseded", "aborted", "budgetExhausted"] as const;
+type NotAttemptedReason = (typeof notAttemptedReasons)[number];
+
+const representabilityConstraints = [
+  "minimumSpan",
+  "invertedRange",
+  "allDayGrid",
+  "recurrenceDialect",
+  "zoneIdentifier",
+] as const;
+type RepresentabilityConstraint = (typeof representabilityConstraints)[number];
+
+type WriteOutcome =
+  | {
+      readonly kind: "created";
+      readonly remote: RemoteRef;
+      readonly version: RemoteVersion;
+      readonly echo?: EchoVerdict | boolean;
+    }
+  | {
+      readonly kind: "updated";
+      readonly remote: RemoteRef;
+      readonly version: RemoteVersion;
+      readonly echo?: EchoVerdict | boolean;
+      readonly observed?: Precondition;
+    }
+  | { readonly kind: "alreadyExists"; readonly remote: RemoteRef; readonly version: RemoteVersion }
+  | { readonly kind: "unchanged"; readonly remote: RemoteRef; readonly version: RemoteVersion }
+  | { readonly kind: "deleted"; readonly remote: RemoteRef }
+  | { readonly kind: "alreadyAbsent"; readonly remote: RemoteRef }
+  | { readonly kind: "unrepresentable"; readonly constraint: RepresentabilityConstraint }
+  | { readonly kind: "notAttempted"; readonly reason: NotAttemptedReason };
+
+export { notAttemptedReasons, representabilityConstraints };
+export type {
+  EchoVerdict,
+  NotAttemptedReason,
+  RemoteRef,
+  RepresentabilityConstraint,
+  WriteOutcome,
+};

--- a/packages/sync-kit/protocol/tests/assert-never.test.ts
+++ b/packages/sync-kit/protocol/tests/assert-never.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import { assertNever } from "../src/index";
+
+type StoredVariant =
+  | { readonly kind: "mirrored"; readonly id: string }
+  | { readonly kind: "retired"; readonly id: string };
+
+const classify = (variant: StoredVariant): string => {
+  switch (variant.kind) {
+    case "mirrored": {
+      return `mirrored:${variant.id}`;
+    }
+    case "retired": {
+      return `retired:${variant.id}`;
+    }
+    default: {
+      return assertNever(variant);
+    }
+  }
+};
+
+const unhandledVariant: StoredVariant = JSON.parse('{"kind":"impossible","id":"evt-1"}');
+
+const withDeadline = (operation: () => Promise<string>, budgetMs: number): Promise<string> => {
+  const deadline = new Promise<string>((_resolve, reject) => {
+    setTimeout(() => reject(new Error("deadline exceeded")), budgetMs);
+  });
+  return Promise.race([operation(), deadline]);
+};
+
+describe("assertNever", () => {
+  test("throws instead of returning, and names the variant nobody handled", () => {
+    expect(() => classify(unhandledVariant)).toThrow(/impossible/);
+  });
+
+  test("carries the whole offending value so the wide event can identify it", () => {
+    expect(() => classify(unhandledVariant)).toThrow(/"id":"evt-1"/);
+  });
+
+  test("rejects the enclosing operation rather than letting a tick complete having done nothing", async () => {
+    const tick = async (): Promise<string> => {
+      await Promise.resolve();
+      return classify(unhandledVariant);
+    };
+    await expect(withDeadline(tick, 50)).rejects.toThrow(/impossible/);
+  });
+});

--- a/packages/sync-kit/protocol/tests/assert-never.test.ts
+++ b/packages/sync-kit/protocol/tests/assert-never.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { assertNever } from "../src/index";
 
 type StoredVariant =
@@ -19,14 +19,28 @@ const classify = (variant: StoredVariant): string => {
   }
 };
 
-const unhandledVariant: StoredVariant = JSON.parse('{"kind":"impossible","id":"evt-1"}');
+const decodeStoredVariant = (payload: string): StoredVariant => JSON.parse(payload);
 
-const withDeadline = (operation: () => Promise<string>, budgetMs: number): Promise<string> => {
+const unhandledVariant = decodeStoredVariant('{"kind":"impossible","id":"evt-1"}');
+
+const withDeadline = async (
+  operation: () => Promise<string>,
+  budgetMs: number,
+): Promise<string> => {
+  let timer: ReturnType<typeof setTimeout> | null = null;
   const deadline = new Promise<string>((_resolve, reject) => {
-    setTimeout(() => reject(new Error("deadline exceeded")), budgetMs);
+    timer = setTimeout(() => reject(new Error("deadline exceeded")), budgetMs);
   });
-  return Promise.race([operation(), deadline]);
+  try {
+    return await Promise.race([operation(), deadline]);
+  } finally {
+    if (timer !== null) {
+      clearTimeout(timer);
+    }
+  }
 };
+
+const settleImmediately = (): Promise<string> => Promise.resolve("done");
 
 describe("assertNever", () => {
   test("throws instead of returning, and names the variant nobody handled", () => {
@@ -35,6 +49,28 @@ describe("assertNever", () => {
 
   test("carries the whole offending value so the wide event can identify it", () => {
     expect(() => classify(unhandledVariant)).toThrow(/"id":"evt-1"/);
+  });
+
+  test("still names the variant when the value holds a cycle", () => {
+    const cyclic = decodeStoredVariant('{"kind":"impossible","id":"evt-1"}');
+    Object.assign(cyclic, { self: cyclic });
+    expect(() => classify(cyclic)).toThrow(/impossible/);
+  });
+
+  test("still names the variant when the value holds a bigint", () => {
+    const withQuota = decodeStoredVariant('{"kind":"impossible","id":"evt-1"}');
+    Object.assign(withQuota, { quota: 1n });
+    expect(() => classify(withQuota)).toThrow(/impossible/);
+  });
+
+  test("does not leave a deadline timer armed after the operation wins the race", async () => {
+    vi.useFakeTimers();
+    try {
+      await expect(withDeadline(settleImmediately, 30_000)).resolves.toBe("done");
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("rejects the enclosing operation rather than letting a tick complete having done nothing", async () => {

--- a/packages/sync-kit/protocol/tests/capabilities.test-d.ts
+++ b/packages/sync-kit/protocol/tests/capabilities.test-d.ts
@@ -1,0 +1,28 @@
+import { describe, expectTypeOf, test } from "vitest";
+import type { Capabilities, DeltaSupport, RepresentableRange, ThrottleSignal } from "../src/index";
+
+declare const acceptDeltaSupport: (delta: DeltaSupport) => void;
+
+describe("a provider declares its constraints as data", () => {
+  test("delta support cannot be declared without saying whether the window is bound to the cursor", () => {
+    // @ts-expect-error widening a window silently strands it when the range lives in the token
+    acceptDeltaSupport({ kind: "tokenized" });
+    expectTypeOf<
+      Extract<DeltaSupport, { kind: "tokenized" }>["windowBoundToCursor"]
+    >().toEqualTypeOf<boolean>();
+  });
+
+  test("removal ambiguity is a required declaration", () => {
+    expectTypeOf<Capabilities["removalsAreAmbiguous"]>().toEqualTypeOf<boolean>();
+  });
+
+  test("the representable range is a required declaration", () => {
+    expectTypeOf<Capabilities["representableRange"]>().toEqualTypeOf<RepresentableRange>();
+    expectTypeOf<RepresentableRange["minimumSpanSeconds"]>().toBeNumber();
+  });
+
+  test("throttle signals are data, never parsed from an error message", () => {
+    expectTypeOf<Capabilities["throttleSignals"]>().toEqualTypeOf<readonly ThrottleSignal[]>();
+    expectTypeOf<Capabilities<"google">["provider"]>().toEqualTypeOf<"google">();
+  });
+});

--- a/packages/sync-kit/protocol/tests/change-listing.test-d.ts
+++ b/packages/sync-kit/protocol/tests/change-listing.test-d.ts
@@ -36,6 +36,7 @@ declare const acceptSnapshotEnumeration: (
 
 describe("a listing may only authorise what it proved", () => {
   test("a partial listing can never carry removals", () => {
+    // @ts-expect-error a truncated read must never delete the user's events
     acceptListing({
       kind: "partial",
       scope,
@@ -43,12 +44,12 @@ describe("a listing may only authorise what it proved", () => {
       withheld,
       continuation,
       diagnostics,
-      // @ts-expect-error a truncated read must never delete the user's events
       removals,
     });
   });
 
   test("a partial listing carries neither a cursor nor a coverage window", () => {
+    // @ts-expect-error advancing a token over a dropped page strands every event it named
     acceptListing({
       kind: "partial",
       scope,
@@ -56,9 +57,9 @@ describe("a listing may only authorise what it proved", () => {
       withheld,
       continuation,
       diagnostics,
-      // @ts-expect-error advancing a token over a dropped page strands every event it named
       cursor,
     });
+    // @ts-expect-error a truncated read proves no coverage
     acceptListing({
       kind: "partial",
       scope,
@@ -66,7 +67,6 @@ describe("a listing may only authorise what it proved", () => {
       withheld,
       continuation,
       diagnostics,
-      // @ts-expect-error a truncated read proves no coverage
       coverage,
     });
   });
@@ -80,32 +80,32 @@ describe("a listing may only authorise what it proved", () => {
   });
 
   test("a cursorLost listing carries no events, no removals, no cursor and no coverage", () => {
+    // @ts-expect-error a post-410 resync carries no tombstones, so its events prove nothing
     acceptListing({
       kind: "cursorLost",
       scope,
       diagnostics,
-      // @ts-expect-error a post-410 resync carries no tombstones, so its events prove nothing
       events,
     });
+    // @ts-expect-error a lost cursor cannot name what was removed while it was lost
     acceptListing({
       kind: "cursorLost",
       scope,
       diagnostics,
-      // @ts-expect-error a lost cursor cannot name what was removed while it was lost
       removals,
     });
+    // @ts-expect-error the token that was lost cannot be carried forward
     acceptListing({
       kind: "cursorLost",
       scope,
       diagnostics,
-      // @ts-expect-error the token that was lost cannot be carried forward
       cursor,
     });
+    // @ts-expect-error a lost cursor proves no coverage
     acceptListing({
       kind: "cursorLost",
       scope,
       diagnostics,
-      // @ts-expect-error a lost cursor proves no coverage
       coverage,
     });
   });

--- a/packages/sync-kit/protocol/tests/change-listing.test-d.ts
+++ b/packages/sync-kit/protocol/tests/change-listing.test-d.ts
@@ -1,6 +1,8 @@
 import { describe, expectTypeOf, test } from "vitest";
 import type {
+  AccountId,
   CalendarEnumeration,
+  CalendarId,
   CalendarKey,
   ChangeListing,
   Continuation,
@@ -16,6 +18,7 @@ import type {
 } from "../src/index";
 
 declare const scope: ListingScope;
+declare const calendarId: CalendarId;
 declare const coverage: CoverageWindow;
 declare const requestedWindow: TimeWindow;
 declare const events: readonly RemoteEvent[];
@@ -112,13 +115,20 @@ describe("a listing may only authorise what it proved", () => {
 
   test("a snapshot listing cannot omit its coverage window", () => {
     // @ts-expect-error a snapshot without coverage claims authority it never proved
-    acceptListing({ kind: "snapshot", scope, events, withheld, cursor, diagnostics });
+    acceptListing({ kind: "snapshot", scope, events, withheld, removals, cursor, diagnostics });
+  });
+
+  test("a cancelled event has somewhere to go in both authoritative listing kinds", () => {
+    acceptListing({ kind: "snapshot", scope, coverage, events, removals, withheld, cursor, diagnostics });
+    // @ts-expect-error a snapshot that cannot report cancellations must filter them, and filtering deletes
+    acceptListing({ kind: "snapshot", scope, coverage, events, withheld, cursor, diagnostics });
+    expectTypeOf<Removal["kind"]>().toEqualTypeOf<"deleted" | "cancelled" | "outOfScope">();
   });
 
   test("a requested window is not a proven coverage window", () => {
     // @ts-expect-error the range we asked for is not the range the provider returned
     acceptCoverage(requestedWindow);
-    expectTypeOf<keyof CoverageWindow>().toEqualTypeOf<"coveredFrom" | "coveredTo" | "calendar">();
+    expectTypeOf<keyof CoverageWindow>().toEqualTypeOf<"covered" | "calendar">();
     expectTypeOf<keyof TimeWindow>().toEqualTypeOf<"start" | "end">();
   });
 
@@ -135,8 +145,10 @@ describe("a listing may only authorise what it proved", () => {
 
   test("a calendar key is a composite that includes the owning account", () => {
     // @ts-expect-error two accounts' calendars collide unless provider and account are part of the key
-    acceptCalendarKey({ calendar: "primary" });
-    expectTypeOf<CalendarKey>().toHaveProperty("account");
+    acceptCalendarKey({ calendar: { kind: "calendarId", value: "primary" } });
+    expectTypeOf<CalendarKey["account"]>().toEqualTypeOf<AccountId>();
     expectTypeOf<CalendarKey>().toHaveProperty("provider");
+    // @ts-expect-error the provider's own account id is not the account row this key names
+    acceptCalendarKey({ provider: "google", account: "user@example.com", calendar: calendarId });
   });
 });

--- a/packages/sync-kit/protocol/tests/change-listing.test-d.ts
+++ b/packages/sync-kit/protocol/tests/change-listing.test-d.ts
@@ -1,0 +1,142 @@
+import { describe, expectTypeOf, test } from "vitest";
+import type {
+  CalendarEnumeration,
+  CalendarKey,
+  ChangeListing,
+  Continuation,
+  CoverageWindow,
+  DeriveCalendarRetirements,
+  ListingDiagnostics,
+  ListingScope,
+  Removal,
+  RemoteEvent,
+  SyncCursor,
+  TimeWindow,
+  WithheldEvent,
+} from "../src/index";
+
+declare const scope: ListingScope;
+declare const coverage: CoverageWindow;
+declare const requestedWindow: TimeWindow;
+declare const events: readonly RemoteEvent[];
+declare const withheld: readonly WithheldEvent[];
+declare const removals: readonly Removal[];
+declare const cursor: SyncCursor;
+declare const continuation: Continuation;
+declare const diagnostics: ListingDiagnostics;
+declare const partialEnumeration: Extract<CalendarEnumeration, { kind: "partial" }>;
+
+declare const acceptListing: (listing: ChangeListing) => void;
+declare const acceptCoverage: (window: CoverageWindow) => void;
+declare const acceptSyncCursor: (token: SyncCursor) => void;
+declare const acceptCalendarKey: (key: CalendarKey) => void;
+declare const acceptSnapshotEnumeration: (
+  enumeration: Parameters<DeriveCalendarRetirements>[0],
+) => void;
+
+describe("a listing may only authorise what it proved", () => {
+  test("a partial listing can never carry removals", () => {
+    acceptListing({
+      kind: "partial",
+      scope,
+      events,
+      withheld,
+      continuation,
+      diagnostics,
+      // @ts-expect-error a truncated read must never delete the user's events
+      removals,
+    });
+  });
+
+  test("a partial listing carries neither a cursor nor a coverage window", () => {
+    acceptListing({
+      kind: "partial",
+      scope,
+      events,
+      withheld,
+      continuation,
+      diagnostics,
+      // @ts-expect-error advancing a token over a dropped page strands every event it named
+      cursor,
+    });
+    acceptListing({
+      kind: "partial",
+      scope,
+      events,
+      withheld,
+      continuation,
+      diagnostics,
+      // @ts-expect-error a truncated read proves no coverage
+      coverage,
+    });
+  });
+
+  test("a partial listing cannot exist without a continuation", () => {
+    // @ts-expect-error without a continuation a pagination loop re-requests the same page forever
+    acceptListing({ kind: "partial", scope, events, withheld, diagnostics });
+    expectTypeOf<Extract<ChangeListing, { kind: "partial" }>["continuation"]>().toEqualTypeOf<
+      Continuation
+    >();
+  });
+
+  test("a cursorLost listing carries no events, no removals, no cursor and no coverage", () => {
+    acceptListing({
+      kind: "cursorLost",
+      scope,
+      diagnostics,
+      // @ts-expect-error a post-410 resync carries no tombstones, so its events prove nothing
+      events,
+    });
+    acceptListing({
+      kind: "cursorLost",
+      scope,
+      diagnostics,
+      // @ts-expect-error a lost cursor cannot name what was removed while it was lost
+      removals,
+    });
+    acceptListing({
+      kind: "cursorLost",
+      scope,
+      diagnostics,
+      // @ts-expect-error the token that was lost cannot be carried forward
+      cursor,
+    });
+    acceptListing({
+      kind: "cursorLost",
+      scope,
+      diagnostics,
+      // @ts-expect-error a lost cursor proves no coverage
+      coverage,
+    });
+  });
+
+  test("a snapshot listing cannot omit its coverage window", () => {
+    // @ts-expect-error a snapshot without coverage claims authority it never proved
+    acceptListing({ kind: "snapshot", scope, events, withheld, cursor, diagnostics });
+  });
+
+  test("a requested window is not a proven coverage window", () => {
+    // @ts-expect-error the range we asked for is not the range the provider returned
+    acceptCoverage(requestedWindow);
+    expectTypeOf<keyof CoverageWindow>().toEqualTypeOf<"coveredFrom" | "coveredTo" | "calendar">();
+    expectTypeOf<keyof TimeWindow>().toEqualTypeOf<"start" | "end">();
+  });
+
+  test("a cursor cannot exist without the scope that minted it", () => {
+    // @ts-expect-error replaying a cursor against a widened window never converges
+    acceptSyncCursor({ kind: "syncCursor", value: "token" });
+    expectTypeOf<SyncCursor["scope"]>().toEqualTypeOf<ListingScope>();
+  });
+
+  test("a partial calendar enumeration cannot retire calendars", () => {
+    // @ts-expect-error a truncated calendar list must never mark a calendar unavailable
+    acceptSnapshotEnumeration(partialEnumeration);
+  });
+
+  test("a calendar key is a composite that includes the owning account", () => {
+    // @ts-expect-error two accounts' calendars collide unless provider and account are part of the key
+    acceptCalendarKey({ calendar: "primary" });
+    expectTypeOf<CalendarKey>().toHaveProperty("account");
+    expectTypeOf<CalendarKey>().toHaveProperty("provider");
+  });
+});

--- a/packages/sync-kit/protocol/tests/conformance.test-d.ts
+++ b/packages/sync-kit/protocol/tests/conformance.test-d.ts
@@ -1,8 +1,20 @@
 import { describe, expectTypeOf, test } from "vitest";
-import type { FingerprintContract, ProviderConformanceSuite } from "../src/index";
+import type {
+  CalendarProvider,
+  ConformanceObligation,
+  FingerprintContract,
+  ProviderContract,
+  ProviderConformanceSuite,
+} from "../src/index";
 
-declare const obligation: () => void;
+declare const obligation: ConformanceObligation;
+declare const synchronousObligation: () => void;
+declare const provider: CalendarProvider<"google">;
+declare const fingerprint: FingerprintContract;
+declare const suite: ProviderConformanceSuite;
+
 declare const acceptSuite: (suite: ProviderConformanceSuite) => void;
+declare const acceptContract: (contract: ProviderContract<"google">) => void;
 
 describe("obligations the compiler cannot check are still named here", () => {
   test("the conformance suite names every lockup obligation an adapter must prove", () => {
@@ -13,7 +25,22 @@ describe("obligations the compiler cannot check are still named here", () => {
       | "abortMidFlightCleansUp"
       | "retryCeilingProven"
       | "concurrentSameKeyDoesNotDeadlock"
+      | "deletionInputsShareOneCalendar"
     >();
+  });
+
+  test("an obligation a runner cannot await is not an obligation", () => {
+    expectTypeOf<ConformanceObligation>().toEqualTypeOf<() => Promise<void>>();
+    acceptSuite({
+      // @ts-expect-error a proof whose promise the runner drops passes green without finishing
+      leaseReleasedOnThrow: synchronousObligation,
+      deadlineOnNeverResolvingStub: obligation,
+      abortMidFlightCleansUp: obligation,
+      retryCeilingProven: obligation,
+      concurrentSameKeyDoesNotDeadlock: obligation,
+      followerRejectsWhenLeaderFails: obligation,
+      deletionInputsShareOneCalendar: obligation,
+    });
   });
 
   test("a suite that omits an obligation does not satisfy the contract", () => {
@@ -24,7 +51,16 @@ describe("obligations the compiler cannot check are still named here", () => {
       retryCeilingProven: obligation,
       concurrentSameKeyDoesNotDeadlock: obligation,
       followerRejectsWhenLeaderFails: obligation,
+      deletionInputsShareOneCalendar: obligation,
     });
+  });
+
+  test("an adapter ships its provider together with the proofs and the hash contract", () => {
+    acceptContract({ provider, fingerprint, conformance: suite });
+    // @ts-expect-error a provider with no conformance suite has proven none of the obligations
+    acceptContract({ provider, fingerprint });
+    // @ts-expect-error two adapters hashing content differently rewrite each other's mirrors
+    acceptContract({ provider, conformance: suite });
   });
 
   test("the fingerprint contract states the canonicalisation adapters must share", () => {

--- a/packages/sync-kit/protocol/tests/conformance.test-d.ts
+++ b/packages/sync-kit/protocol/tests/conformance.test-d.ts
@@ -1,0 +1,34 @@
+import { describe, expectTypeOf, test } from "vitest";
+import type { FingerprintContract, ProviderConformanceSuite } from "../src/index";
+
+declare const obligation: () => void;
+declare const acceptSuite: (suite: ProviderConformanceSuite) => void;
+
+describe("obligations the compiler cannot check are still named here", () => {
+  test("the conformance suite names every lockup obligation an adapter must prove", () => {
+    expectTypeOf<keyof ProviderConformanceSuite>().toEqualTypeOf<
+      | "leaseReleasedOnThrow"
+      | "followerRejectsWhenLeaderFails"
+      | "deadlineOnNeverResolvingStub"
+      | "abortMidFlightCleansUp"
+      | "retryCeilingProven"
+      | "concurrentSameKeyDoesNotDeadlock"
+    >();
+  });
+
+  test("a suite that omits an obligation does not satisfy the contract", () => {
+    // @ts-expect-error an adapter cannot ship without proving its lease releases on a throw
+    acceptSuite({
+      deadlineOnNeverResolvingStub: obligation,
+      abortMidFlightCleansUp: obligation,
+      retryCeilingProven: obligation,
+      concurrentSameKeyDoesNotDeadlock: obligation,
+      followerRejectsWhenLeaderFails: obligation,
+    });
+  });
+
+  test("the fingerprint contract states the canonicalisation adapters must share", () => {
+    expectTypeOf<FingerprintContract["canonicalisation"]>().toEqualTypeOf<"rfc8785">();
+    expectTypeOf<FingerprintContract>().toHaveProperty("comparableFields");
+  });
+});

--- a/packages/sync-kit/protocol/tests/content-time.test-d.ts
+++ b/packages/sync-kit/protocol/tests/content-time.test-d.ts
@@ -1,0 +1,69 @@
+import { describe, expectTypeOf, test } from "vitest";
+import type {
+  CalendarDate,
+  EditableContent,
+  Instant,
+  OccurrenceDuration,
+  RecurrenceAnchor,
+  RecurrencePayload,
+  RecurringContent,
+  ZoneId,
+} from "../src/index";
+
+declare const instant: Instant;
+declare const calendarDate: CalendarDate;
+declare const zone: ZoneId;
+declare const recurrence: RecurrencePayload;
+
+declare const acceptContent: (content: EditableContent) => void;
+declare const acceptAnchor: (anchor: RecurrenceAnchor) => void;
+
+const described = {
+  title: "standup",
+  description: null,
+  location: null,
+  availability: "busy",
+  visibility: "default",
+} as const;
+
+describe("a recurring master carries the wall time it recurs on", () => {
+  test("a series cannot be pinned to instants alone", () => {
+    // @ts-expect-error two absolute instants cannot be re-expanded across a DST transition
+    acceptContent({ ...described, recurrence, time: { kind: "timed", start: instant, end: instant, zone } });
+  });
+
+  test("a timed series anchor cannot omit its zone", () => {
+    // @ts-expect-error a floating master expands to a different hour on either side of a transition
+    acceptAnchor({ kind: "timed", start: instant, duration: { kind: "exact", seconds: 1800 } });
+    expectTypeOf<Extract<RecurrenceAnchor, { kind: "timed" }>["zone"]>().toEqualTypeOf<ZoneId>();
+  });
+
+  test("a nominal duration is not an exact one", () => {
+    expectTypeOf<OccurrenceDuration>().toEqualTypeOf<
+      | { readonly kind: "exact"; readonly seconds: number }
+      | { readonly kind: "nominal"; readonly days: number }
+    >();
+    acceptAnchor({
+      kind: "allDay",
+      startDate: calendarDate,
+      // @ts-expect-error an all-day occurrence is a count of days, never a fixed span of seconds
+      duration: { kind: "exact", seconds: 86_400 },
+    });
+    acceptAnchor({ kind: "allDay", startDate: calendarDate, duration: { kind: "nominal", days: 1 } });
+  });
+
+  test("a single occurrence carries no recurrence anchor and no nominal duration", () => {
+    acceptContent({
+      ...described,
+      recurrence: null,
+      time: { kind: "timed", start: instant, end: instant, zone },
+    });
+    acceptContent({
+      ...described,
+      recurrence: null,
+      // @ts-expect-error a one-off event has no series anchor to re-resolve
+      anchor: { kind: "timed", start: instant, zone, duration: { kind: "exact", seconds: 60 } },
+    });
+    expectTypeOf<RecurringContent["recurrence"]>().toEqualTypeOf<RecurrencePayload>();
+  });
+});

--- a/packages/sync-kit/protocol/tests/define-provider-vs-satisfies.test-d.ts
+++ b/packages/sync-kit/protocol/tests/define-provider-vs-satisfies.test-d.ts
@@ -6,7 +6,7 @@ const googleCapabilities = {
   delta: { kind: "tokenized", windowBoundToCursor: true },
   deletionAuthority: "explicitRemovalsOnly",
   removalsAreAmbiguous: true,
-  precondition: "version",
+  precondition: "matchesVersion",
   provenanceChannel: "extendedProperty",
   quotaScope: "perUser",
   throttleSignals: [{ status: 403, hasRetryAfter: false }],

--- a/packages/sync-kit/protocol/tests/define-provider-vs-satisfies.test-d.ts
+++ b/packages/sync-kit/protocol/tests/define-provider-vs-satisfies.test-d.ts
@@ -1,0 +1,35 @@
+import { describe, expectTypeOf, test } from "vitest";
+import type { Capabilities } from "../src/index";
+
+const googleCapabilities = {
+  provider: "google",
+  delta: { kind: "tokenized", windowBoundToCursor: true },
+  deletionAuthority: "explicitRemovalsOnly",
+  removalsAreAmbiguous: true,
+  precondition: "version",
+  provenanceChannel: "extendedProperty",
+  quotaScope: "perUser",
+  throttleSignals: [{ status: 403, hasRetryAfter: false }],
+  representableRange: {
+    minimumSpanSeconds: 0,
+    zeroDuration: "accept",
+    invertedRange: "reject",
+    allDayGrid: "utcDay",
+  },
+  allDay: "dateOnly",
+  recurrenceWrite: "rfc5545",
+  echoesWrites: true,
+} satisfies Capabilities<"google">;
+
+describe("defineProvider earns no place in the package", () => {
+  test("satisfies preserves every literal an identity wrapper would have inferred", () => {
+    expectTypeOf(googleCapabilities.provider).toEqualTypeOf<"google">();
+    expectTypeOf(googleCapabilities.removalsAreAmbiguous).toEqualTypeOf<true>();
+    expectTypeOf(googleCapabilities.delta).toEqualTypeOf<{
+      kind: "tokenized";
+      windowBoundToCursor: true;
+    }>();
+    expectTypeOf(googleCapabilities).toExtend<Capabilities<"google">>();
+    expectTypeOf(googleCapabilities.representableRange.allDayGrid).toEqualTypeOf<"utcDay">();
+  });
+});

--- a/packages/sync-kit/protocol/tests/deletion.test-d.ts
+++ b/packages/sync-kit/protocol/tests/deletion.test-d.ts
@@ -1,0 +1,71 @@
+import { describe, expectTypeOf, test } from "vitest";
+import type {
+  ChangeListing,
+  CoverageWindow,
+  DeriveDeltaRemovals,
+  DeriveSnapshotRemovals,
+  KnownEvents,
+  ListingDiagnostics,
+  ListingScope,
+  Removal,
+  RemoteEvent,
+  SyncCursor,
+  WithheldEvent,
+} from "../src/index";
+
+declare const partialListing: Extract<ChangeListing, { kind: "partial" }>;
+declare const cursorLostListing: Extract<ChangeListing, { kind: "cursorLost" }>;
+declare const deltaListing: Extract<ChangeListing, { kind: "delta" }>;
+declare const scope: ListingScope;
+declare const coverage: CoverageWindow;
+declare const events: readonly RemoteEvent[];
+declare const cursor: SyncCursor;
+declare const diagnostics: ListingDiagnostics;
+declare const outOfScopeRemovals: readonly Extract<Removal, { kind: "outOfScope" }>[];
+
+declare const acceptSnapshotListing: (
+  listing: Parameters<DeriveSnapshotRemovals>[0],
+) => void;
+declare const applyDeletions: (
+  removals: readonly Extract<Removal, { kind: "deleted" }>[],
+) => void;
+
+describe("deletion authority is the signature, not a runtime check", () => {
+  test("DeriveSnapshotRemovals rejects a partial listing", () => {
+    // @ts-expect-error an unproven read must never reach a deletion
+    acceptSnapshotListing(partialListing);
+  });
+
+  test("DeriveSnapshotRemovals rejects a cursorLost listing", () => {
+    // @ts-expect-error a post-410 resync names no tombstones, so it authorises no deletion
+    acceptSnapshotListing(cursorLostListing);
+  });
+
+  test("a delta listing cannot express delete-everything-not-listed", () => {
+    // @ts-expect-error absence in a delta feed means unchanged, never gone
+    acceptSnapshotListing(deltaListing);
+    expectTypeOf<Parameters<DeriveDeltaRemovals>["length"]>().toEqualTypeOf<1>();
+  });
+
+  test("DeriveSnapshotRemovals cannot be called without a coverage window", () => {
+    expectTypeOf<Parameters<DeriveSnapshotRemovals>[1]>().toEqualTypeOf<CoverageWindow>();
+    expectTypeOf<Parameters<DeriveSnapshotRemovals>[2]>().toEqualTypeOf<KnownEvents>();
+    expectTypeOf<Parameters<DeriveSnapshotRemovals>["length"]>().toEqualTypeOf<3>();
+  });
+
+  test("an outOfScope removal never drives a deletion", () => {
+    expectTypeOf<ReturnType<DeriveDeltaRemovals>>().toEqualTypeOf<
+      readonly Extract<Removal, { kind: "deleted" }>[]
+    >();
+    // @ts-expect-error an event that merely left the window is still live on the calendar
+    applyDeletions(outOfScopeRemovals);
+  });
+
+  test("withheld ids are part of the deletion-inference input", () => {
+    expectTypeOf<Parameters<DeriveSnapshotRemovals>[0]["withheld"]>().toEqualTypeOf<
+      readonly WithheldEvent[]
+    >();
+    // @ts-expect-error an adapter cannot build a listing without answering what it withheld
+    acceptSnapshotListing({ kind: "snapshot", scope, coverage, events, cursor, diagnostics });
+  });
+});

--- a/packages/sync-kit/protocol/tests/deletion.test-d.ts
+++ b/packages/sync-kit/protocol/tests/deletion.test-d.ts
@@ -1,5 +1,6 @@
 import { describe, expectTypeOf, test } from "vitest";
 import type {
+  AuthoritativeRemoval,
   ChangeListing,
   CoverageWindow,
   DeriveDeltaRemovals,
@@ -9,7 +10,9 @@ import type {
   ListingScope,
   Removal,
   RemoteEvent,
+  RemoteEventId,
   SyncCursor,
+  WindowMembership,
   WithheldEvent,
 } from "../src/index";
 
@@ -19,16 +22,15 @@ declare const deltaListing: Extract<ChangeListing, { kind: "delta" }>;
 declare const scope: ListingScope;
 declare const coverage: CoverageWindow;
 declare const events: readonly RemoteEvent[];
+declare const removals: readonly Removal[];
 declare const cursor: SyncCursor;
 declare const diagnostics: ListingDiagnostics;
 declare const outOfScopeRemovals: readonly Extract<Removal, { kind: "outOfScope" }>[];
+declare const uidKeyedIds: ReadonlySet<string>;
 
-declare const acceptSnapshotListing: (
-  listing: Parameters<DeriveSnapshotRemovals>[0],
-) => void;
-declare const applyDeletions: (
-  removals: readonly Extract<Removal, { kind: "deleted" }>[],
-) => void;
+declare const acceptSnapshotListing: (listing: Parameters<DeriveSnapshotRemovals>[0]) => void;
+declare const acceptKnownEvents: (known: KnownEvents) => void;
+declare const applyDeletions: (removals: readonly AuthoritativeRemoval[]) => void;
 
 describe("deletion authority is the signature, not a runtime check", () => {
   test("DeriveSnapshotRemovals rejects a partial listing", () => {
@@ -47,18 +49,33 @@ describe("deletion authority is the signature, not a runtime check", () => {
     expectTypeOf<Parameters<DeriveDeltaRemovals>["length"]>().toEqualTypeOf<1>();
   });
 
-  test("DeriveSnapshotRemovals cannot be called without a coverage window", () => {
-    expectTypeOf<Parameters<DeriveSnapshotRemovals>[1]>().toEqualTypeOf<CoverageWindow>();
-    expectTypeOf<Parameters<DeriveSnapshotRemovals>[2]>().toEqualTypeOf<KnownEvents>();
+  test("the only coverage window a snapshot removal can use is the one the listing proved", () => {
+    expectTypeOf<Parameters<DeriveSnapshotRemovals>[1]>().toEqualTypeOf<KnownEvents>();
+    expectTypeOf<Parameters<DeriveSnapshotRemovals>[2]>().toEqualTypeOf<WindowMembership>();
     expectTypeOf<Parameters<DeriveSnapshotRemovals>["length"]>().toEqualTypeOf<3>();
+    expectTypeOf<Parameters<DeriveSnapshotRemovals>[0]["coverage"]>().toEqualTypeOf<
+      CoverageWindow
+    >();
+    expectTypeOf<Parameters<DeriveSnapshotRemovals>>().not.toExtend<
+      [unknown, CoverageWindow, unknown]
+    >();
+  });
+
+  test("the known set is keyed by the provider's own event ids, not by UID", () => {
+    expectTypeOf<KnownEvents["ids"]>().toEqualTypeOf<ReadonlyMap<string, RemoteEventId>>();
+    // @ts-expect-error a set of UIDs matches nothing in the listing, so everything reads as gone
+    acceptKnownEvents({ calendar: scope.calendar, ids: uidKeyedIds });
   });
 
   test("an outOfScope removal never drives a deletion", () => {
-    expectTypeOf<ReturnType<DeriveDeltaRemovals>>().toEqualTypeOf<
-      readonly Extract<Removal, { kind: "deleted" }>[]
-    >();
+    expectTypeOf<ReturnType<DeriveDeltaRemovals>>().toEqualTypeOf<readonly AuthoritativeRemoval[]>();
     // @ts-expect-error an event that merely left the window is still live on the calendar
     applyDeletions(outOfScopeRemovals);
+  });
+
+  test("a cancellation is deletion evidence in its own right", () => {
+    expectTypeOf<AuthoritativeRemoval["kind"]>().toEqualTypeOf<"deleted" | "cancelled">();
+    applyDeletions([{ kind: "cancelled", id: { kind: "remoteEventId", value: "evt" }, uid: { kind: "eventUid", value: "uid" } }]);
   });
 
   test("withheld ids are part of the deletion-inference input", () => {
@@ -66,6 +83,14 @@ describe("deletion authority is the signature, not a runtime check", () => {
       readonly WithheldEvent[]
     >();
     // @ts-expect-error an adapter cannot build a listing without answering what it withheld
-    acceptSnapshotListing({ kind: "snapshot", scope, coverage, events, cursor, diagnostics });
+    acceptSnapshotListing({
+      kind: "snapshot",
+      scope,
+      coverage,
+      events,
+      removals,
+      cursor,
+      diagnostics,
+    });
   });
 });

--- a/packages/sync-kit/protocol/tests/diagnostics.test-d.ts
+++ b/packages/sync-kit/protocol/tests/diagnostics.test-d.ts
@@ -1,0 +1,39 @@
+import { describe, expectTypeOf, test } from "vitest";
+import type { BoundedSample, ListingDiagnostics } from "../src/index";
+
+declare const identifiers: readonly string[];
+declare const sample: BoundedSample;
+
+declare const acceptSample: (bounded: BoundedSample) => void;
+declare const acceptDiagnostics: (diagnostics: ListingDiagnostics) => void;
+declare const acceptBoundedShape: (bounded: {
+  readonly sample: readonly string[];
+  readonly total: number;
+}) => void;
+
+describe("a discard always leaves a trace that survives truncation", () => {
+  test("an identifier diagnostic is never a bare array", () => {
+    // @ts-expect-error an uncapped list pushes the wide event past its size limit
+    acceptSample(identifiers);
+    expectTypeOf<BoundedSample>().toEqualTypeOf<{
+      readonly sample: readonly string[];
+      readonly total: number;
+    }>();
+  });
+
+  test("the counters are required, not optional", () => {
+    // @ts-expect-error an adapter must answer how many of its own events it saw
+    acceptDiagnostics({ withheld: sample, unrepresentable: sample, pagesFetched: 3 });
+    expectTypeOf<ListingDiagnostics["pagesFetched"]>().toEqualTypeOf<number>();
+  });
+
+  test("selfAuthored and unrepresentable are separate counters", () => {
+    expectTypeOf<keyof ListingDiagnostics>().toEqualTypeOf<
+      "withheld" | "selfAuthored" | "unrepresentable" | "pagesFetched"
+    >();
+  });
+
+  test("a bounded sample keeps the total beside the sample it truncated", () => {
+    acceptBoundedShape(sample);
+  });
+});

--- a/packages/sync-kit/protocol/tests/diagnostics.test-d.ts
+++ b/packages/sync-kit/protocol/tests/diagnostics.test-d.ts
@@ -1,8 +1,18 @@
 import { describe, expectTypeOf, test } from "vitest";
-import type { BoundedSample, ListingDiagnostics } from "../src/index";
+import type {
+  BoundedSample,
+  EventUid,
+  ListingDiagnostics,
+  RemoteEventId,
+  WithheldEvent,
+  WithholdReason,
+} from "../src/index";
 
 declare const identifiers: readonly string[];
 declare const sample: BoundedSample;
+declare const remoteEventId: RemoteEventId;
+declare const eventUid: EventUid;
+declare const acceptWithheld: (withheld: WithheldEvent) => void;
 
 declare const acceptSample: (bounded: BoundedSample) => void;
 declare const acceptDiagnostics: (diagnostics: ListingDiagnostics) => void;
@@ -35,5 +45,16 @@ describe("a discard always leaves a trace that survives truncation", () => {
 
   test("a bounded sample keeps the total beside the sample it truncated", () => {
     acceptBoundedShape(sample);
+  });
+
+  test("a publisher that stripped the UID before deleting still has a withheld shape", () => {
+    acceptWithheld({ uid: null, id: remoteEventId, reason: "missingIdentity" });
+    acceptWithheld({ uid: eventUid, id: null, reason: "unparseable" });
+    // @ts-expect-error an event nothing can name cannot be counted, so it would be silently dropped
+    acceptWithheld({ uid: null, id: null, reason: "missingIdentity" });
+  });
+
+  test("a recurrence range an adapter refuses to reinterpret is a named reason", () => {
+    expectTypeOf<"unsupportedRecurrenceRange" | "missingIdentity">().toExtend<WithholdReason>();
   });
 });

--- a/packages/sync-kit/protocol/tests/hygiene/no-reassignment.test.ts
+++ b/packages/sync-kit/protocol/tests/hygiene/no-reassignment.test.ts
@@ -1,0 +1,45 @@
+import { Glob } from "bun";
+import { describe, expect, test } from "vitest";
+
+const packageRoot = new URL("../../", import.meta.url).pathname;
+
+/*
+ * A rebindable name is state a reader has to simulate. Both forms are checked: a `let` in
+ * statement position, and a `let` in a classic for-loop header. Anchoring to the start of a
+ * line keeps prose in a comment from reading as a declaration.
+ */
+const statementBinding = /^\s*let\s+[A-Za-z_$]/;
+const loopBinding = /\(\s*let\s+[A-Za-z_$]/;
+
+const sourceFiles = async (directory: string): Promise<readonly string[]> => {
+  const glob = new Glob("**/*.ts");
+  const found: string[] = [];
+  for await (const relative of glob.scan({ cwd: `${packageRoot}${directory}` })) {
+    found.push(relative);
+  }
+  return found;
+};
+
+const offendersIn = async (directory: string): Promise<readonly string[]> => {
+  const files = await sourceFiles(directory);
+  const offenders: string[] = [];
+  for (const relative of files) {
+    const text = await Bun.file(`${packageRoot}${directory}/${relative}`).text();
+    for (const [index, line] of text.split("\n").entries()) {
+      if (statementBinding.test(line) || loopBinding.test(line)) {
+        offenders.push(`${directory}/${relative}:${String(index + 1)}`);
+      }
+    }
+  }
+  return offenders;
+};
+
+describe("rebindable names", () => {
+  test("PROTO-H10: no file under src declares a let", async () => {
+    const files = await sourceFiles("src");
+    const offenders = await offendersIn("src");
+
+    expect(offenders).toEqual([]);
+    expect(files.length).toBeGreaterThan(10);
+  });
+});

--- a/packages/sync-kit/protocol/tests/identifiers.test-d.ts
+++ b/packages/sync-kit/protocol/tests/identifiers.test-d.ts
@@ -1,10 +1,16 @@
 import { describe, expectTypeOf, test } from "vitest";
 import type {
+  AccountId,
+  CalendarDate,
+  CalendarId,
+  CalendarKey,
   Continuation,
   DeleteHandle,
+  EventTime,
   EventUid,
   Fingerprint,
   IdempotencyKey,
+  Instant,
   RemoteEventId,
   RemoteVersion,
   SyncCursor,
@@ -16,6 +22,10 @@ declare const eventUid: EventUid;
 declare const fingerprint: Fingerprint;
 declare const syncCursor: SyncCursor;
 declare const continuation: Continuation;
+declare const accountId: AccountId;
+declare const calendarId: CalendarId;
+declare const instant: Instant;
+declare const calendarDate: CalendarDate;
 
 declare const acceptRemoteEventId: (identifier: RemoteEventId) => void;
 declare const acceptDeleteHandle: (handle: DeleteHandle) => void;
@@ -24,6 +34,10 @@ declare const acceptRemoteVersion: (version: RemoteVersion) => void;
 declare const acceptIdempotencyKey: (key: IdempotencyKey) => void;
 declare const acceptSyncCursor: (cursor: SyncCursor) => void;
 declare const acceptContinuation: (token: Continuation) => void;
+declare const acceptCalendarId: (calendar: CalendarId) => void;
+declare const acceptCalendarKey: (key: CalendarKey) => void;
+declare const acceptInstant: (moment: Instant) => void;
+declare const acceptEventTime: (time: EventTime) => void;
 
 describe("identifiers are not interchangeable", () => {
   test("a RemoteEventId and a DeleteHandle cannot be swapped", () => {
@@ -57,6 +71,20 @@ describe("identifiers are not interchangeable", () => {
     acceptContinuation(syncCursor);
   });
 
+  test("an AccountId is not a CalendarId, and the three parts of a key cannot be permuted", () => {
+    // @ts-expect-error the account a calendar belongs to is not the calendar
+    acceptCalendarId(accountId);
+    // @ts-expect-error two users holding one provider account collide unless the parts are distinct
+    acceptCalendarKey({ provider: "google", account: calendarId, calendar: accountId });
+  });
+
+  test("an Instant is not a CalendarDate", () => {
+    // @ts-expect-error a DATE-TIME written into a DATE field moves the event by the zone offset
+    acceptEventTime({ kind: "allDay", startDate: instant, endDateExclusive: instant });
+    // @ts-expect-error a floating DATE is not a point on the timeline
+    acceptInstant(calendarDate);
+  });
+
   test("every handle is a tagged object carrying its own discriminant", () => {
     expectTypeOf<RemoteEventId>().toEqualTypeOf<{
       readonly kind: "remoteEventId";
@@ -68,6 +96,11 @@ describe("identifiers are not interchangeable", () => {
     }>();
     expectTypeOf<IdempotencyKey>().toEqualTypeOf<{
       readonly kind: "idempotencyKey";
+      readonly value: string;
+    }>();
+    expectTypeOf<Instant>().toEqualTypeOf<{ readonly kind: "instant"; readonly value: string }>();
+    expectTypeOf<CalendarDate>().toEqualTypeOf<{
+      readonly kind: "calendarDate";
       readonly value: string;
     }>();
   });

--- a/packages/sync-kit/protocol/tests/identifiers.test-d.ts
+++ b/packages/sync-kit/protocol/tests/identifiers.test-d.ts
@@ -1,0 +1,85 @@
+import { describe, expectTypeOf, test } from "vitest";
+import type {
+  Continuation,
+  DeleteHandle,
+  EventUid,
+  Fingerprint,
+  IdempotencyKey,
+  RemoteEventId,
+  RemoteVersion,
+  SyncCursor,
+} from "../src/index";
+
+declare const remoteEventId: RemoteEventId;
+declare const deleteHandle: DeleteHandle;
+declare const eventUid: EventUid;
+declare const fingerprint: Fingerprint;
+declare const syncCursor: SyncCursor;
+declare const continuation: Continuation;
+
+declare const acceptRemoteEventId: (identifier: RemoteEventId) => void;
+declare const acceptDeleteHandle: (handle: DeleteHandle) => void;
+declare const acceptEventUid: (uid: EventUid) => void;
+declare const acceptRemoteVersion: (version: RemoteVersion) => void;
+declare const acceptIdempotencyKey: (key: IdempotencyKey) => void;
+declare const acceptSyncCursor: (cursor: SyncCursor) => void;
+declare const acceptContinuation: (token: Continuation) => void;
+
+describe("identifiers are not interchangeable", () => {
+  test("a RemoteEventId and a DeleteHandle cannot be swapped", () => {
+    // @ts-expect-error the identifier you read an event by is not the handle you delete it by
+    acceptDeleteHandle(remoteEventId);
+    // @ts-expect-error the handle you delete an event by is not the identifier you read it by
+    acceptRemoteEventId(deleteHandle);
+  });
+
+  test("an EventUid is not a RemoteEventId", () => {
+    // @ts-expect-error the iCalendar UID is not the provider's own resource identifier
+    acceptRemoteEventId(eventUid);
+    // @ts-expect-error the provider's resource identifier is not the iCalendar UID
+    acceptEventUid(remoteEventId);
+  });
+
+  test("a Fingerprint is not a RemoteVersion", () => {
+    // @ts-expect-error our content hash is not the provider's concurrency token
+    acceptRemoteVersion(fingerprint);
+  });
+
+  test("a bare string is not an IdempotencyKey", () => {
+    // @ts-expect-error an idempotency key is minted and validated, never an arbitrary string
+    acceptIdempotencyKey("keeper-mirror-1");
+  });
+
+  test("a Continuation is not assignable to a SyncCursor and vice versa", () => {
+    // @ts-expect-error resuming a delta with a pagination token silently skips changes
+    acceptSyncCursor(continuation);
+    // @ts-expect-error persisting a page token as a sync cursor never terminates
+    acceptContinuation(syncCursor);
+  });
+
+  test("every handle is a tagged object carrying its own discriminant", () => {
+    expectTypeOf<RemoteEventId>().toEqualTypeOf<{
+      readonly kind: "remoteEventId";
+      readonly value: string;
+    }>();
+    expectTypeOf<DeleteHandle>().toEqualTypeOf<{
+      readonly kind: "deleteHandle";
+      readonly value: string;
+    }>();
+    expectTypeOf<IdempotencyKey>().toEqualTypeOf<{
+      readonly kind: "idempotencyKey";
+      readonly value: string;
+    }>();
+  });
+
+  test("a version and a fingerprint are separate facts about the same event", () => {
+    expectTypeOf<RemoteVersion>().toEqualTypeOf<{
+      readonly kind: "remoteVersion";
+      readonly value: string;
+    }>();
+    expectTypeOf<Fingerprint>().toEqualTypeOf<{
+      readonly kind: "fingerprint";
+      readonly value: string;
+    }>();
+  });
+});

--- a/packages/sync-kit/protocol/tests/provenance.test-d.ts
+++ b/packages/sync-kit/protocol/tests/provenance.test-d.ts
@@ -1,0 +1,62 @@
+import { describe, expectTypeOf, test } from "vitest";
+import { assertNever } from "../src/index";
+import type {
+  BuildMirrorIntent,
+  CalendarKey,
+  ForeignEvent,
+  IndeterminateEvent,
+  MirrorSource,
+  NormalizedContent,
+  OwnEvent,
+  Provenance,
+  RemoteEvent,
+} from "../src/index";
+
+declare const ownEvent: OwnEvent;
+declare const indeterminateEvent: IndeterminateEvent;
+declare const destination: CalendarKey;
+declare const normalized: NormalizedContent<"google">;
+declare const buildMirrorIntent: BuildMirrorIntent<"google">;
+
+describe("our own writes never travel back around the loop", () => {
+  test("an OwnEvent is not assignable to a mirror write-intent builder", () => {
+    // @ts-expect-error re-mirroring our own mirror doubles the event on every run
+    buildMirrorIntent(ownEvent, destination, normalized);
+  });
+
+  test("an IndeterminateEvent is not assignable either", () => {
+    // @ts-expect-error unknown provenance must not default to "theirs"
+    buildMirrorIntent(indeterminateEvent, destination, normalized);
+  });
+
+  test("only a ForeignEvent is a mirror source", () => {
+    expectTypeOf<MirrorSource>().toEqualTypeOf<ForeignEvent>();
+    expectTypeOf<ForeignEvent["provenance"]>().toEqualTypeOf<{ readonly kind: "foreign" }>();
+    expectTypeOf<OwnEvent["provenance"]["kind"]>().toEqualTypeOf<"ours">();
+  });
+
+  test("a provenance switch that omits indeterminate fails to compile", () => {
+    const isMirrorable = (event: RemoteEvent): boolean => {
+      switch (event.provenance.kind) {
+        case "foreign": {
+          return true;
+        }
+        case "ours": {
+          return false;
+        }
+        default: {
+          // @ts-expect-error the safe answer for undetectable provenance must be a decision
+          return assertNever(event.provenance);
+        }
+      }
+    };
+    expectTypeOf(isMirrorable).returns.toBeBoolean();
+  });
+
+  test("an own event names the installation that authored it", () => {
+    expectTypeOf<Extract<Provenance, { kind: "ours" }>>().toHaveProperty("installation");
+    expectTypeOf<Extract<Provenance, { kind: "indeterminate" }>>().toEqualTypeOf<{
+      readonly kind: "indeterminate";
+    }>();
+  });
+});

--- a/packages/sync-kit/protocol/tests/provider-failure.test-d.ts
+++ b/packages/sync-kit/protocol/tests/provider-failure.test-d.ts
@@ -2,10 +2,15 @@ import { describe, expectTypeOf, test } from "vitest";
 import { assertNever } from "../src/index";
 import type {
   AccountId,
+  Capabilities,
   Instant,
   NotAttemptedReason,
+  ObservedPrecondition,
+  OperationName,
+  Precondition,
   ProviderFailure,
   QuotaScope,
+  RepresentabilityConstraint,
 } from "../src/index";
 
 declare const scope: QuotaScope;
@@ -25,11 +30,12 @@ describe("failure is typed, never free text", () => {
         case "conflict":
         case "notFound":
         case "unsupported":
+        case "unrepresentable":
         case "notAttempted": {
           return false;
         }
         case "transport": {
-          return failure.retryable;
+          return failure.disposition === "transient";
         }
         default: {
           // @ts-expect-error reauth retried as a transient error burns quota and never succeeds
@@ -55,11 +61,42 @@ describe("failure is typed, never free text", () => {
     acceptFailure({ kind: "rateLimited", scope });
   });
 
+  test("transport retryability is a named disposition, never a boolean", () => {
+    expectTypeOf<Extract<ProviderFailure, { kind: "transport" }>["disposition"]>().toEqualTypeOf<
+      "transient" | "permanent"
+    >();
+    // @ts-expect-error every boolean verdict in this codebase grew a second field within months
+    acceptFailure({ kind: "transport", status: 503, retryable: true });
+  });
+
+  test("normalization can refuse an event without throwing or mislabelling it", () => {
+    expectTypeOf<OperationName>().toEqualTypeOf<
+      "listCalendars" | "listChanges" | "normalize" | "write"
+    >();
+    expectTypeOf<
+      Extract<ProviderFailure, { kind: "unrepresentable" }>["constraint"]
+    >().toEqualTypeOf<RepresentabilityConstraint>();
+    acceptFailure({ kind: "unrepresentable", constraint: "minimumSpan" });
+    acceptFailure({ kind: "unsupported", operation: "normalize" });
+  });
+
+  test("a conflict reports state the provider actually observed", () => {
+    expectTypeOf<Extract<ProviderFailure, { kind: "conflict" }>["observed"]>().toEqualTypeOf<
+      ObservedPrecondition
+    >();
+    expectTypeOf<ObservedPrecondition>().toEqualTypeOf<
+      Exclude<Precondition, { kind: "absent" }>
+    >();
+    expectTypeOf<Capabilities["precondition"]>().toEqualTypeOf<ObservedPrecondition["kind"]>();
+    // @ts-expect-error "it wasn't there" is notFound, never a comparison against observed state
+    acceptFailure({ kind: "conflict", observed: { kind: "absent" } });
+  });
+
   test("a failure carries no free-text message to classify on", () => {
     acceptFailure({
       kind: "transport",
       status: 503,
-      retryable: true,
+      disposition: "transient",
       // @ts-expect-error classifying by message substring is how reauth was missed for months
       message: "service unavailable",
     });

--- a/packages/sync-kit/protocol/tests/provider-failure.test-d.ts
+++ b/packages/sync-kit/protocol/tests/provider-failure.test-d.ts
@@ -1,0 +1,73 @@
+import { describe, expectTypeOf, test } from "vitest";
+import { assertNever } from "../src/index";
+import type {
+  AccountId,
+  Instant,
+  NotAttemptedReason,
+  ProviderFailure,
+  QuotaScope,
+} from "../src/index";
+
+declare const scope: QuotaScope;
+declare const account: AccountId;
+
+declare const acceptFailure: (failure: ProviderFailure) => void;
+
+describe("failure is typed, never free text", () => {
+  test("a ProviderFailure switch that omits reauthRequired fails to compile", () => {
+    const isRetryable = (failure: ProviderFailure): boolean => {
+      switch (failure.kind) {
+        case "rateLimited":
+        case "truncated": {
+          return true;
+        }
+        case "cursorInvalid":
+        case "conflict":
+        case "notFound":
+        case "unsupported":
+        case "notAttempted": {
+          return false;
+        }
+        case "transport": {
+          return failure.retryable;
+        }
+        default: {
+          // @ts-expect-error reauth retried as a transient error burns quota and never succeeds
+          return assertNever(failure);
+        }
+      }
+    };
+    expectTypeOf(isRetryable).returns.toBeBoolean();
+  });
+
+  test("reauthRequired names the account that must reauthenticate", () => {
+    expectTypeOf<{ readonly kind: "reauthRequired"; readonly account: AccountId }>().toExtend<
+      ProviderFailure
+    >();
+    acceptFailure({ kind: "reauthRequired", account });
+  });
+
+  test("rateLimited.retryAfter is Instant | null, never undefined", () => {
+    expectTypeOf<
+      Extract<ProviderFailure, { kind: "rateLimited" }>["retryAfter"]
+    >().toEqualTypeOf<Instant | null>();
+    // @ts-expect-error the absent case must be an explicit branch, not a forgotten field
+    acceptFailure({ kind: "rateLimited", scope });
+  });
+
+  test("a failure carries no free-text message to classify on", () => {
+    acceptFailure({
+      kind: "transport",
+      status: 503,
+      retryable: true,
+      // @ts-expect-error classifying by message substring is how reauth was missed for months
+      message: "service unavailable",
+    });
+  });
+
+  test("an unattempted operation reports one of the shared, typed reasons", () => {
+    expectTypeOf<
+      Extract<ProviderFailure, { kind: "notAttempted" }>["reason"]
+    >().toEqualTypeOf<NotAttemptedReason>();
+  });
+});

--- a/packages/sync-kit/protocol/tests/provider-shape.test-d.ts
+++ b/packages/sync-kit/protocol/tests/provider-shape.test-d.ts
@@ -1,0 +1,95 @@
+import { describe, expectTypeOf, test } from "vitest";
+import type {
+  AccountId,
+  CalendarEnumeration,
+  CalendarProvider,
+  ChangeListing,
+  EditableContent,
+  Instant,
+  ListChangesRequest,
+  NormalizedContent,
+  OperationContext,
+  Result,
+  RetryBudget,
+  WriteIntent,
+  WriteOutcome,
+} from "../src/index";
+
+declare const now: () => Instant;
+declare const signal: AbortSignal;
+declare const absentSignal: undefined;
+declare const retryBudget: RetryBudget;
+
+declare const acceptContext: (context: OperationContext) => void;
+declare const acceptRetryBudget: (budget: RetryBudget) => void;
+declare const acceptProvider: (provider: CalendarProvider<"google">) => void;
+declare const acceptNormalized: (content: NormalizedContent<"google">) => void;
+declare const rawContent: EditableContent;
+
+declare const candidateWithBareWrite: {
+  readonly capabilities: CalendarProvider<"google">["capabilities"];
+  readonly listCalendars: CalendarProvider<"google">["listCalendars"];
+  readonly listChanges: CalendarProvider<"google">["listChanges"];
+  readonly normalize: CalendarProvider<"google">["normalize"];
+  readonly write: (intent: WriteIntent<"google">) => Promise<WriteOutcome>;
+};
+
+describe("nothing in the contract can wedge", () => {
+  test("every awaiting operation takes an OperationContext", () => {
+    expectTypeOf<Parameters<CalendarProvider["listCalendars"]>>().toEqualTypeOf<
+      [AccountId, OperationContext]
+    >();
+    expectTypeOf<Parameters<CalendarProvider["listChanges"]>>().toEqualTypeOf<
+      [ListChangesRequest, OperationContext]
+    >();
+    expectTypeOf<Parameters<CalendarProvider["write"]>>().toEqualTypeOf<
+      [WriteIntent, OperationContext]
+    >();
+  });
+
+  test("OperationContext.signal cannot be omitted or undefined", () => {
+    expectTypeOf<OperationContext>().toHaveProperty("signal").toEqualTypeOf<AbortSignal>();
+    // @ts-expect-error a remote await with no cancellation path is a hang waiting to happen
+    acceptContext({ now, retryBudget });
+    // @ts-expect-error an optional signal is a signal somebody will forget to pass
+    acceptContext({ signal: absentSignal, now, retryBudget });
+  });
+
+  test("an OperationContext cannot be constructed without a retry budget", () => {
+    // @ts-expect-error retries left to the adapter's discretion are where the ceiling gets lost
+    acceptContext({ signal, now });
+  });
+
+  test("a RetryBudget without maxAttempts does not compile", () => {
+    // @ts-expect-error an unbounded retry loop burns an hour of quota per calendar
+    acceptRetryBudget({ ceilingMs: 64_000 });
+    expectTypeOf<RetryBudget["maxAttempts"]>().toEqualTypeOf<number>();
+    expectTypeOf<RetryBudget["ceilingMs"]>().toEqualTypeOf<number>();
+  });
+
+  test("no awaiting method returns a bare value; every one returns a Result", () => {
+    expectTypeOf<CalendarProvider["listCalendars"]>().returns.toEqualTypeOf<
+      Promise<Result<CalendarEnumeration>>
+    >();
+    expectTypeOf<CalendarProvider["listChanges"]>().returns.toEqualTypeOf<
+      Promise<Result<ChangeListing>>
+    >();
+    expectTypeOf<CalendarProvider["write"]>().returns.toEqualTypeOf<
+      Promise<Result<WriteOutcome>>
+    >();
+    expectTypeOf<CalendarProvider["normalize"]>().returns.toEqualTypeOf<
+      Result<NormalizedContent<string>>
+    >();
+  });
+
+  test("a provider whose write resolves a bare outcome does not satisfy the contract", () => {
+    // @ts-expect-error a thrown or untyped failure is how reauth became an infinite retry
+    acceptProvider(candidateWithBareWrite);
+  });
+
+  test("normalization is a declared phase of the contract", () => {
+    expectTypeOf<Parameters<CalendarProvider["normalize"]>>().toEqualTypeOf<[EditableContent]>();
+    // @ts-expect-error only provider.normalize may mint normalized content
+    acceptNormalized(rawContent);
+  });
+});

--- a/packages/sync-kit/protocol/tests/provider-shape.test-d.ts
+++ b/packages/sync-kit/protocol/tests/provider-shape.test-d.ts
@@ -18,6 +18,7 @@ import type {
 declare const now: () => Instant;
 declare const signal: AbortSignal;
 declare const absentSignal: undefined;
+declare const deadline: Instant;
 declare const retryBudget: RetryBudget;
 
 declare const acceptContext: (context: OperationContext) => void;
@@ -32,6 +33,17 @@ declare const candidateWithBareWrite: {
   readonly listChanges: CalendarProvider<"google">["listChanges"];
   readonly normalize: CalendarProvider<"google">["normalize"];
   readonly write: (intent: WriteIntent<"google">) => Promise<WriteOutcome>;
+};
+
+declare const candidateThatOnlyCreates: {
+  readonly capabilities: CalendarProvider<"google">["capabilities"];
+  readonly listCalendars: CalendarProvider<"google">["listCalendars"];
+  readonly listChanges: CalendarProvider<"google">["listChanges"];
+  readonly normalize: CalendarProvider<"google">["normalize"];
+  readonly write: (
+    intent: Extract<WriteIntent<"google">, { kind: "create" }>,
+    context: OperationContext,
+  ) => Promise<Result<WriteOutcome>>;
 };
 
 describe("nothing in the contract can wedge", () => {
@@ -50,21 +62,27 @@ describe("nothing in the contract can wedge", () => {
   test("OperationContext.signal cannot be omitted or undefined", () => {
     expectTypeOf<OperationContext>().toHaveProperty("signal").toEqualTypeOf<AbortSignal>();
     // @ts-expect-error a remote await with no cancellation path is a hang waiting to happen
-    acceptContext({ now, retryBudget });
+    acceptContext({ now, deadline, retryBudget });
     // @ts-expect-error an optional signal is a signal somebody will forget to pass
-    acceptContext({ signal: absentSignal, now, retryBudget });
+    acceptContext({ signal: absentSignal, now, deadline, retryBudget });
+  });
+
+  test("an operation cannot be started without a wall-clock deadline", () => {
+    // @ts-expect-error a socket nobody aborts and nobody times out is the hang we keep shipping
+    acceptContext({ signal, now, retryBudget });
+    expectTypeOf<OperationContext["deadline"]>().toEqualTypeOf<Instant>();
   });
 
   test("an OperationContext cannot be constructed without a retry budget", () => {
     // @ts-expect-error retries left to the adapter's discretion are where the ceiling gets lost
-    acceptContext({ signal, now });
+    acceptContext({ signal, now, deadline });
   });
 
   test("a RetryBudget without maxAttempts does not compile", () => {
     // @ts-expect-error an unbounded retry loop burns an hour of quota per calendar
-    acceptRetryBudget({ ceilingMs: 64_000 });
+    acceptRetryBudget({ retryDelayCeilingMs: 64_000 });
     expectTypeOf<RetryBudget["maxAttempts"]>().toEqualTypeOf<number>();
-    expectTypeOf<RetryBudget["ceilingMs"]>().toEqualTypeOf<number>();
+    expectTypeOf<RetryBudget["retryDelayCeilingMs"]>().toEqualTypeOf<number>();
   });
 
   test("no awaiting method returns a bare value; every one returns a Result", () => {
@@ -85,6 +103,11 @@ describe("nothing in the contract can wedge", () => {
   test("a provider whose write resolves a bare outcome does not satisfy the contract", () => {
     // @ts-expect-error a thrown or untyped failure is how reauth became an infinite retry
     acceptProvider(candidateWithBareWrite);
+  });
+
+  test("a provider that handles only some intent kinds does not satisfy the contract", () => {
+    // @ts-expect-error method bivariance would let an adapter quietly ignore delete and retire
+    acceptProvider(candidateThatOnlyCreates);
   });
 
   test("normalization is a declared phase of the contract", () => {

--- a/packages/sync-kit/protocol/tests/write-intent.test-d.ts
+++ b/packages/sync-kit/protocol/tests/write-intent.test-d.ts
@@ -6,21 +6,23 @@ import type {
   EditableContent,
   IdempotencyKey,
   NormalizedContent,
-  Precondition,
+  ObservedPrecondition,
   Provenance,
   RemoteEventId,
   RemoteVersion,
+  WritableCalendar,
   WriteIntent,
 } from "../src/index";
 
-declare const calendar: CalendarKey;
+declare const calendar: WritableCalendar;
+declare const calendarKey: CalendarKey;
 declare const target: RemoteEventId;
 declare const handle: DeleteHandle;
 declare const normalized: NormalizedContent<"google">;
 declare const rawContent: EditableContent;
 declare const idempotencyKey: IdempotencyKey;
 declare const ourProvenance: Extract<Provenance, { kind: "ours" }>;
-declare const precondition: Precondition;
+declare const precondition: ObservedPrecondition;
 declare const version: RemoteVersion;
 declare const googleIntent: WriteIntent<"google">;
 
@@ -35,7 +37,26 @@ describe("a write cannot be expressed without the guard it needs", () => {
     acceptIntent({ kind: "update", calendar, target, content: normalized });
     expectTypeOf<
       Extract<WriteIntent<"google">, { kind: "update" }>["precondition"]
-    >().toEqualTypeOf<Precondition>();
+    >().toEqualTypeOf<ObservedPrecondition>();
+  });
+
+  test("an update pinned to absent is not expressible", () => {
+    // @ts-expect-error "overwrite it if it isn't there" is last-write-wins spelled differently
+    acceptIntent({
+      kind: "update",
+      calendar,
+      target,
+      content: normalized,
+      precondition: { kind: "absent" },
+    });
+    // @ts-expect-error a delete guarded by absence deletes whatever it finds
+    acceptIntent({
+      kind: "delete",
+      calendar,
+      target: handle,
+      reason: "sourceDeleted",
+      precondition: { kind: "absent" },
+    });
   });
 
   test("a delete WriteIntent without a precondition does not compile", () => {
@@ -72,6 +93,20 @@ describe("a write cannot be expressed without the guard it needs", () => {
       provenance: ourProvenance,
       precondition: { kind: "absent" },
     });
+  });
+
+  test("a calendar we only ever read cannot be written to", () => {
+    acceptIntent({
+      kind: "update",
+      // @ts-expect-error the access we discovered at enumeration must survive to the write
+      calendar: { key: calendarKey, access: "readOnly" },
+      target,
+      content: normalized,
+      precondition,
+    });
+    // @ts-expect-error a bare key has forgotten whether we may write to it
+    acceptIntent({ kind: "update", calendar: calendarKey, target, content: normalized, precondition });
+    expectTypeOf<WritableCalendar["access"]>().toEqualTypeOf<"readWrite">();
   });
 
   test("unnormalized EditableContent cannot reach a write", () => {

--- a/packages/sync-kit/protocol/tests/write-intent.test-d.ts
+++ b/packages/sync-kit/protocol/tests/write-intent.test-d.ts
@@ -1,0 +1,92 @@
+import { describe, expectTypeOf, test } from "vitest";
+import type {
+  CalendarKey,
+  CalendarProvider,
+  DeleteHandle,
+  EditableContent,
+  IdempotencyKey,
+  NormalizedContent,
+  Precondition,
+  Provenance,
+  RemoteEventId,
+  RemoteVersion,
+  WriteIntent,
+} from "../src/index";
+
+declare const calendar: CalendarKey;
+declare const target: RemoteEventId;
+declare const handle: DeleteHandle;
+declare const normalized: NormalizedContent<"google">;
+declare const rawContent: EditableContent;
+declare const idempotencyKey: IdempotencyKey;
+declare const ourProvenance: Extract<Provenance, { kind: "ours" }>;
+declare const precondition: Precondition;
+declare const version: RemoteVersion;
+declare const googleIntent: WriteIntent<"google">;
+
+declare const acceptIntent: (intent: WriteIntent<"google">) => void;
+declare const acceptOutlookIntent: (
+  intent: Parameters<CalendarProvider<"outlook">["write"]>[0],
+) => void;
+
+describe("a write cannot be expressed without the guard it needs", () => {
+  test("an update WriteIntent without a precondition does not compile", () => {
+    // @ts-expect-error last-write-wins clobbers a change made in the provider UI
+    acceptIntent({ kind: "update", calendar, target, content: normalized });
+    expectTypeOf<
+      Extract<WriteIntent<"google">, { kind: "update" }>["precondition"]
+    >().toEqualTypeOf<Precondition>();
+  });
+
+  test("a delete WriteIntent without a precondition does not compile", () => {
+    // @ts-expect-error a deleted remote event cannot be restored
+    acceptIntent({ kind: "delete", calendar, target: handle, reason: "sourceDeleted" });
+  });
+
+  test("a retire WriteIntent without a precondition does not compile", () => {
+    // @ts-expect-error retiring an object that changed after we read it is unrecoverable
+    acceptIntent({ kind: "retire", calendar, target: handle, reason: "outsideWindow" });
+  });
+
+  test("a create's precondition can only be absent", () => {
+    acceptIntent({
+      kind: "create",
+      calendar,
+      idempotencyKey,
+      content: normalized,
+      provenance: ourProvenance,
+      // @ts-expect-error a create must surface a collision, never overwrite it
+      precondition: { kind: "matchesVersion", version },
+    });
+    expectTypeOf<
+      Extract<WriteIntent<"google">, { kind: "create" }>["precondition"]
+    >().toEqualTypeOf<{ readonly kind: "absent" }>();
+  });
+
+  test("a create without an idempotencyKey does not compile", () => {
+    // @ts-expect-error a retried push without a key creates a visible duplicate
+    acceptIntent({
+      kind: "create",
+      calendar,
+      content: normalized,
+      provenance: ourProvenance,
+      precondition: { kind: "absent" },
+    });
+  });
+
+  test("unnormalized EditableContent cannot reach a write", () => {
+    acceptIntent({
+      kind: "update",
+      calendar,
+      target,
+      precondition,
+      // @ts-expect-error only provider.normalize may mint the content a write carries
+      content: rawContent,
+    });
+  });
+
+  test("content normalized for one provider cannot be written to another", () => {
+    // @ts-expect-error google-shaped normalization diverges on every echo from outlook
+    acceptOutlookIntent(googleIntent);
+  });
+});

--- a/packages/sync-kit/protocol/tests/write-outcome.test-d.ts
+++ b/packages/sync-kit/protocol/tests/write-outcome.test-d.ts
@@ -4,7 +4,7 @@ import type {
   DeleteHandle,
   EchoVerdict,
   NotAttemptedReason,
-  Precondition,
+  ObservedPrecondition,
   ProviderFailure,
   RemoteRef,
   RemoteVersion,
@@ -55,7 +55,7 @@ describe("an outcome says exactly what happened", () => {
     expectTypeOf<{
       readonly kind: "conflict";
       readonly remote: RemoteRef;
-      readonly observed: Precondition;
+      readonly observed: ObservedPrecondition;
     }>().toExtend<WriteOutcome>();
   });
 
@@ -69,7 +69,7 @@ describe("an outcome says exactly what happened", () => {
     expectTypeOf<Extract<WriteOutcome, { kind: "conflict" }>>().toEqualTypeOf<{
       readonly kind: "conflict";
       readonly remote: RemoteRef;
-      readonly observed: Precondition;
+      readonly observed: ObservedPrecondition;
     }>();
     // @ts-expect-error a conflict is not a version advance and must not update the mapping
     recordMapping(conflict);
@@ -122,7 +122,7 @@ describe("an outcome says exactly what happened", () => {
 
   test("an observed precondition is the only place a conflict reports state", () => {
     expectTypeOf<Extract<WriteOutcome, { kind: "conflict" }>["observed"]>().toEqualTypeOf<
-      Precondition
+      ObservedPrecondition
     >();
     expectTypeOf(echo).not.toBeBoolean();
   });

--- a/packages/sync-kit/protocol/tests/write-outcome.test-d.ts
+++ b/packages/sync-kit/protocol/tests/write-outcome.test-d.ts
@@ -1,0 +1,129 @@
+import { describe, expectTypeOf, test } from "vitest";
+import { assertNever } from "../src/index";
+import type {
+  DeleteHandle,
+  EchoVerdict,
+  NotAttemptedReason,
+  Precondition,
+  ProviderFailure,
+  RemoteRef,
+  RemoteVersion,
+  WriteOutcome,
+} from "../src/index";
+
+declare const remote: RemoteRef;
+declare const version: RemoteVersion;
+declare const echo: EchoVerdict;
+declare const conflict: Extract<WriteOutcome, { kind: "conflict" }>;
+
+declare const acceptOutcome: (outcome: WriteOutcome) => void;
+declare const recordMapping: (
+  outcome: Extract<
+    WriteOutcome,
+    { kind: "created" } | { kind: "updated" } | { kind: "alreadyExists" } | { kind: "unchanged" }
+  >,
+) => void;
+
+describe("an outcome says exactly what happened", () => {
+  test("a WriteOutcome switch that omits conflict fails to compile", () => {
+    const backoffVerdict = (outcome: WriteOutcome): string => {
+      switch (outcome.kind) {
+        case "created":
+        case "updated":
+        case "alreadyExists":
+        case "unchanged":
+        case "deleted":
+        case "alreadyAbsent": {
+          return "clear";
+        }
+        case "unrepresentable": {
+          return "hold";
+        }
+        case "notAttempted": {
+          return "preserve";
+        }
+        default: {
+          // @ts-expect-error a stale precondition must not be folded into a generic failure
+          return assertNever(outcome);
+        }
+      }
+    };
+    expectTypeOf(backoffVerdict).returns.toBeString();
+  });
+
+  test("a conflict is an outcome in its own right", () => {
+    expectTypeOf<{
+      readonly kind: "conflict";
+      readonly remote: RemoteRef;
+      readonly observed: Precondition;
+    }>().toExtend<WriteOutcome>();
+  });
+
+  test("there is no outcome in which a mismatched precondition succeeded", () => {
+    expectTypeOf<Extract<WriteOutcome, { kind: "updated" }>>().toEqualTypeOf<{
+      readonly kind: "updated";
+      readonly remote: RemoteRef;
+      readonly version: RemoteVersion;
+      readonly echo: EchoVerdict;
+    }>();
+    expectTypeOf<Extract<WriteOutcome, { kind: "conflict" }>>().toEqualTypeOf<{
+      readonly kind: "conflict";
+      readonly remote: RemoteRef;
+      readonly observed: Precondition;
+    }>();
+    // @ts-expect-error a conflict is not a version advance and must not update the mapping
+    recordMapping(conflict);
+  });
+
+  test("echo is three-state and a boolean is not assignable", () => {
+    acceptOutcome({
+      kind: "created",
+      remote,
+      version,
+      // @ts-expect-error "we never looked" must be distinguishable from "we looked and it matched"
+      echo: true,
+    });
+    const drift = (verdict: EchoVerdict): string => {
+      switch (verdict.kind) {
+        case "matched": {
+          return "none";
+        }
+        case "diverged": {
+          return "recorded";
+        }
+        default: {
+          // @ts-expect-error dropping notObserved hides a whole drift class
+          return assertNever(verdict);
+        }
+      }
+    };
+    expectTypeOf(drift).returns.toBeString();
+  });
+
+  test("a created outcome must report what the echo showed", () => {
+    // @ts-expect-error an unexamined write is not a verified write
+    acceptOutcome({ kind: "created", remote, version });
+    expectTypeOf<Extract<WriteOutcome, { kind: "created" }>["echo"]>().toEqualTypeOf<EchoVerdict>();
+  });
+
+  test("an unattempted run is neither success nor failure", () => {
+    expectTypeOf<Extract<WriteOutcome, { kind: "notAttempted" }>["reason"]>().toEqualTypeOf<
+      NotAttemptedReason
+    >();
+    expectTypeOf<Extract<ProviderFailure, { kind: "notAttempted" }>["reason"]>().toEqualTypeOf<
+      NotAttemptedReason
+    >();
+  });
+
+  test("a remote reference carries the handle a later delete will need", () => {
+    expectTypeOf<RemoteRef>().toHaveProperty("deleteHandle");
+    expectTypeOf<RemoteRef["deleteHandle"]>().toEqualTypeOf<DeleteHandle>();
+  });
+
+  test("an observed precondition is the only place a conflict reports state", () => {
+    expectTypeOf<Extract<WriteOutcome, { kind: "conflict" }>["observed"]>().toEqualTypeOf<
+      Precondition
+    >();
+    expectTypeOf(echo).not.toBeBoolean();
+  });
+});

--- a/packages/sync-kit/protocol/tsconfig.json
+++ b/packages/sync-kit/protocol/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@keeper.sh/typescript-config",
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/sync-kit/protocol/vitest.config.ts
+++ b/packages/sync-kit/protocol/vitest.config.ts
@@ -3,7 +3,9 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    hookTimeout: 30_000,
     include: ["./tests/**/*.test.ts"],
+    testTimeout: 30_000,
     typecheck: {
       enabled: true,
       include: ["./tests/**/*.test-d.ts"],

--- a/packages/sync-kit/protocol/vitest.config.ts
+++ b/packages/sync-kit/protocol/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["./tests/**/*.test.ts"],
+    typecheck: {
+      enabled: true,
+      include: ["./tests/**/*.test-d.ts"],
+      tsconfig: "./tsconfig.json",
+    },
+  },
+});


### PR DESCRIPTION
First package of the greenfield sync engine: `@keeper.sh/sync-protocol`, the adapter contract every provider will implement. It is almost entirely types — the only runtime export is `assertNever` — so it ships zero behaviour and can't regress anything, but it fixes the shape the `ical`, `reconcile` and `conformance` packages get built against. Built test-first: the type tests were written red against an empty module, then the types were added until they went green.

- The central guarantee is that a change listing can't claim coverage it doesn't have. `partial` listings carry `coverage?: never`, so "absent from the results" is unrepresentable as "deleted" at the type level rather than by convention — the exact failure mode that has cost us real source events.
- Write intents and outcomes are discriminated unions with `?: never` guards on every non-applicable field, so an adapter physically cannot return a half-populated result.
- `LEARNINGS.md` carries 55 numbered entries from the current iCal/CalDAV implementation — 43 adopted into the contract, 6 not applicable, 6 inherited unchanged. Each one is traceable to the code or incident it came from; the intent is that nothing hard-won gets dropped on the way to the rewrite.
- 92 tests across 14 files, type-level assertions included. I verified each guarantee actually bites by loosening it and watching exactly one test go red.

Nothing imports this yet, so merging is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWminUmH2kMq6fQShPLgvE
