### PR TITLE
feat(sync-kit): the executable conformance specification

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -240,6 +240,18 @@
         "vitest": "^4.1.4",
       },
     },
+    "packages/sync-kit/conformance": {
+      "name": "@keeper.sh/sync-conformance",
+      "dependencies": {
+        "@keeper.sh/sync-protocol": "workspace:*",
+      },
+      "devDependencies": {
+        "@keeper.sh/typescript-config": "workspace:*",
+        "@types/bun": "latest",
+        "typescript": "5.9.3",
+        "vitest": "^4.1.4",
+      },
+    },
     "packages/sync-kit/ical": {
       "name": "@keeper.sh/sync-ical",
       "dependencies": {
@@ -631,6 +643,8 @@
     "@keeper.sh/queue": ["@keeper.sh/queue@workspace:packages/queue"],
 
     "@keeper.sh/sync": ["@keeper.sh/sync@workspace:packages/sync"],
+
+    "@keeper.sh/sync-conformance": ["@keeper.sh/sync-conformance@workspace:packages/sync-kit/conformance"],
 
     "@keeper.sh/sync-ical": ["@keeper.sh/sync-ical@workspace:packages/sync-kit/ical"],
 

--- a/packages/sync-kit/LEARNINGS.md
+++ b/packages/sync-kit/LEARNINGS.md
@@ -3296,12 +3296,14 @@ page, expire a cursor, force a precondition conflict and stall a request forever
 Numbering is prefixed `CONF-` so it appends to the protocol (1–60), sync-ical (`ICAL-I1`–`ICAL-I71`) and
 sync-reconcile (`RECON-I1`–`RECON-I85`) ledgers above without renumbering anyone. `CONF-I1`–`CONF-I60` are
 adopted. `CONF-I61`–`CONF-I68` are not applicable and say why. `CONF-I69`–`CONF-I78` are the dependency and
-process decisions. The module map, the public API and the `CONF-O` (overwrite) / `CONF-L` (lockup) test
-indexes are the closing sections.
+process decisions. `CONF-I79`–`CONF-I82` were added by review. The module map, the public API and the
+`CONF-O` (overwrite) / `CONF-L` (lockup) test indexes are the closing sections.
 
-This document is written **before** the implementation. Citations are therefore **Planned case.** lines
-naming the case id and the test file it will live in. When the suite lands, each becomes a **Proved by.**
-line and the same mechanical walk `RECON-I84` added for sync-reconcile is added for this section.
+The suite has landed. Every citation is a **Proved by.** line naming the case id and the test file whose
+titles carry it, and `conformance/tests/hygiene/ledger-citations.test.ts` walks this section against
+`src/case-id.ts` and against the test titles themselves — the same mechanical walk `RECON-I84` added for
+sync-reconcile. `CONF-I79`–`CONF-I82` were added by the adversarial review of the first implementation
+pass and are collected in the closing **Added after review** section.
 
 A note on what "honoured" means here, because this package is unusual. sync-protocol honours a lesson by
 making the wrong thing unsayable in the type system; sync-reconcile honours it by computing the right
@@ -3329,7 +3331,7 @@ truncation with a 207 whose request-URI response carries 507 plus `DAV:number-of
 unchanged. The type system already forbids `removals` and `coverage` on `partial` (protocol entry 1), so
 the runtime case exists to prove the **adapter** reaches that kind rather than manufacturing a `snapshot`
 from a short read.
-**Planned case.** `CONF-O1` in `conformance/tests/deletion-safety.test.ts`.
+**Proved by.** `CONF-O1` in `conformance/tests/deletion-safety.test.ts`.
 
 ### CONF-I2. An empty listing must never mean "the calendar is empty"
 
@@ -3341,7 +3343,7 @@ authoritatively has zero events" and deleted every `event_state` row for the cal
 `Result.ok === false` with a typed `ProviderFailure`. A separate case seeds a genuinely empty calendar and
 asserts the two outputs are **distinguishable** — a suite that only checked "does not throw" would pass
 both.
-**Planned case.** `CONF-O2` in `conformance/tests/deletion-safety.test.ts`.
+**Proved by.** `CONF-O2` in `conformance/tests/deletion-safety.test.ts`.
 
 ### CONF-I3. Deletion authority is a discriminant, not a flag, and differs per adapter
 
@@ -3354,7 +3356,7 @@ its coverage, so absence means gone. The old code threaded `isDeltaSync?: boolea
 `explicitRemovalsOnly` gets "an event absent from a listing is never removed, and a named removal is". Both
 halves are generated; neither adapter runs the other's. The report records which branch was taken so the
 adapter's own test file asserts on it.
-**Planned case.** `CONF-O3` in `conformance/tests/deletion-safety.test.ts`.
+**Proved by.** `CONF-O3` in `conformance/tests/deletion-safety.test.ts`.
 
 ### CONF-I4. Deletion may only be inferred inside a coverage window the listing itself proved
 
@@ -3368,7 +3370,7 @@ tests *"does not reconcile a mapping inside the requested window but outside sou
 asserts the returned `listing.coverage.covered` is the narrower one and that no removal is derivable for
 identities in the requested-but-uncovered band. It also asserts `coverage.calendar` equals `scope.calendar`
 — a coverage window proved for a different calendar is a foreign-calendar overwrite (RECON-I27).
-**Planned case.** `CONF-O4` in `conformance/tests/deletion-safety.test.ts`.
+**Proved by.** `CONF-O4` in `conformance/tests/deletion-safety.test.ts`.
 
 ### CONF-I5. A withheld event is present, not absent
 
@@ -3382,7 +3384,7 @@ lines 226–232, 323–336; tests *"withholds unsupported events, counts them, a
 `listing.withheld` with a `WithholdReason`, and asserts no removal is derivable for its identity. The
 assertion runs on **both** sides: the withheld identity must also not appear as a deletable mirror
 (CONF-I41).
-**Planned case.** `CONF-O5` in `conformance/tests/deletion-safety.test.ts`.
+**Proved by.** `CONF-O5` in `conformance/tests/deletion-safety.test.ts`.
 
 ### CONF-I6. One bad event must not stall the whole feed, and a real deletion in the same payload still applies
 
@@ -3395,7 +3397,7 @@ malformed VEVENT"`, *"converges over repeated polls of the same malformed feed"*
 **Honoured by.** A three-part case: a listing carrying one unusable item still returns `ok` with the other
 items; a genuine removal delivered in the same listing is still expressed; and polling the same input twice
 produces byte-identical output including diagnostics.
-**Planned case.** `CONF-O6` in `conformance/tests/isolation.test.ts`.
+**Proved by.** `CONF-O6` in `conformance/tests/isolation.test.ts`.
 
 ### CONF-I7. An unbuildable newest revision must withhold its whole identity, not fall back to the older one
 
@@ -3407,7 +3409,7 @@ away from"`.
 **Honoured by.** An overwrite case that seeds two revisions of one identity where the newer is
 unrepresentable, and asserts the older revision's time is **not** written — the adapter must withhold the
 identity, not downgrade it.
-**Planned case.** `CONF-O7` in `conformance/tests/writes.test.ts`.
+**Proved by.** `CONF-O7` in `conformance/tests/writes.test.ts`.
 
 ### CONF-I8. Revision order is a total order derived from content, never feed order
 
@@ -3418,7 +3420,7 @@ stored row on every poll.
 *"settles without churning the surviving row over repeated polls"*.
 **Honoured by.** The order-permutation case: the same colliding pair is fed in both orders and the two
 listings must be deeply equal after canonicalisation, then polled twice for zero further writes.
-**Planned case.** `CONF-O8` in `conformance/tests/convergence.test.ts`.
+**Proved by.** `CONF-O8` in `conformance/tests/convergence.test.ts`.
 
 ### CONF-I9. Re-ingesting identical input must be no work at all, not an idempotent write
 
@@ -3426,10 +3428,13 @@ listings must be deeply equal after canonicalisation, then polled twice for zero
 invalidation for other clients.
 **Learned from.** `degenerate-range-source-ingest.test.ts :: "re-reads an unchanged feed as no work at
 all"`; `ingest.test.ts :: "does not flush when there are no changes"`; the twelve `*convergence*` suites.
-**Honoured by.** Convergence is asserted as a **count of write operations**, not state equality: every
-generated case ends with a second run whose write count must be zero. The reference provider is exercised
-by a full fixed point — list, plan, apply, list, plan — and the second plan must be empty.
-**Planned case.** `CONF-O9` in `conformance/tests/convergence.test.ts`.
+**Honoured by.** Convergence is asserted as a **count of write operations**, not state equality.
+`CONF-O9` polls an unchanged calendar twice and asserts the provider's write log did not grow; `CONF-O28`
+writes a degenerate range, lets the provider widen it, and asserts the replay is not a fresh write; the
+reference provider is exercised by a full fixed point — list, apply, list, list — and the write log after
+convergence must equal the write log after the apply. "No work" means **no write**, never no read: see
+`CONF-I82`.
+**Proved by.** `CONF-O9` in `conformance/tests/convergence.test.ts`.
 
 ### CONF-I10. An expired cursor discards the whole pagination, clears the token, and carries no tombstones
 
@@ -3443,7 +3448,7 @@ Graph's 410 `syncStateNotFound`; RFC 6578 §3.2 `DAV:valid-sync-token`.
 is `cursorLost`; no events and no removals leak out (the type forbids the fields, the case proves the
 adapter does not instead return an empty `delta`); the cursor is cleared rather than retained; and the
 resync that follows is what deletes.
-**Planned case.** `CONF-O10` in `conformance/tests/cursor.test.ts`.
+**Proved by.** `CONF-O10` in `conformance/tests/cursor.test.ts`.
 
 ### CONF-I11. A cursor is valid only for the request shape that minted it
 
@@ -3456,7 +3461,7 @@ events in the newly added range.
 window B ⊃ A with the same cursor, and assert the adapter answers `cursorLost` (or a `cursorInvalid`
 failure) rather than a delta that silently omits the new range. The protocol already carries `scope` on
 `SyncCursor`, so the adapter has the information; the case proves it uses it.
-**Planned case.** `CONF-O11` in `conformance/tests/cursor.test.ts`.
+**Proved by.** `CONF-O11` in `conformance/tests/cursor.test.ts`.
 
 ### CONF-I12. Corrupt known state forces a resync and never becomes a tombstone by omission
 
@@ -3467,7 +3472,7 @@ stored row requires full-sync recovery"*, *"keeps an unparseable stored row belo
 over-budget series"*.
 **Honoured by.** A case that seeds the provider-under-test with a corrupt known row through the
 `ProviderUnderTest.seed` seam, asserts a resync is demanded, and asserts zero removals are emitted.
-**Planned case.** `CONF-O12` in `conformance/tests/deletion-safety.test.ts`.
+**Proved by.** `CONF-O12` in `conformance/tests/deletion-safety.test.ts`.
 
 ### CONF-I13. An ambiguous removal is not a deletion
 
@@ -3476,10 +3481,11 @@ while local state holds only expanded instances — advancing the token would st
 code declares the whole delta unusable and demands a full sync rather than guessing.
 **Learned from.** `providers/outlook/source/utils/fetch-events.ts` (the `@removed && !event.type` branch,
 the seriesMaster-in-delta branch).
-**Honoured by.** Gated on `supports.removalsAreAmbiguous`. An ambiguous removal must produce either
-`cursorLost` or a listing whose removals exclude it; never an `AuthoritativeRemoval`. The negative control
-is a mutant that maps the ambiguous tombstone to `kind: "deleted"`.
-**Planned case.** `CONF-O13` in `conformance/tests/deletion-safety.test.ts`.
+**Honoured by.** Gated on `supports.removalsAreAmbiguous`. `ProviderSeed.unattributableRemovals` is the
+seam: the case seeds a tombstone the adapter cannot attribute to an identity and asserts it produces either
+`cursorLost` or a removal the suite cannot name — never an `AuthoritativeRemoval`, and never a blank uid.
+The negative control is a mutant that blanks the uid of a removal it does report.
+**Proved by.** `CONF-O13` in `conformance/tests/deletion-safety.test.ts`.
 
 ### CONF-I14. A replayed create is a no-op; a create conflict without a usable precondition is a refusal
 
@@ -3494,7 +3500,7 @@ return `alreadyExists` or `unchanged` with the same `RemoteRef`, and the store m
 object. A conflicting create whose remote copy differs must return `conflict` carrying the observed
 precondition — never a `deleted` followed by a `created`, which the suite detects by counting the
 provider's write log.
-**Planned case.** `CONF-O14` and `CONF-O15` in `conformance/tests/writes.test.ts`.
+**Proved by.** `CONF-O14` and `CONF-O15` in `conformance/tests/writes.test.ts`.
 
 ### CONF-I15. Provenance is per-provider and may be undetectable, and that must be sayable
 
@@ -3507,7 +3513,7 @@ rewrites `iCalUId`; CalDAV by the `.ics` filename. Outlook's reader checks both.
 with our `InstallationId` — never by inspecting provider internals. For `none`, the alternative case
 asserts the round-tripped event is `IndeterminateEvent` and that no deletion of an indeterminate event is
 derivable.
-**Planned case.** `CONF-O16` in `conformance/tests/provenance.test.ts`.
+**Proved by.** `CONF-O16` in `conformance/tests/provenance.test.ts`.
 
 ### CONF-I16. A foreign event must survive every reconciliation the suite can generate
 
@@ -3516,10 +3522,13 @@ window. Without the window check, a freshly imported calendar deletes Keeper-tag
 legitimately placed there.
 **Learned from.** `core/sync/operations.ts` lines 590–613; tests *"does not remove unmapped non-keeper
 future events"*, *"does not remove an unmapped non-keeper event after it becomes historical"*.
-**Honoured by.** Every write-family case seeds one `ForeignEvent` in the destination calendar as a
-**canary**, and the shared teardown asserts it is byte-identical afterwards. It is also asserted in its own
-case, so a teardown regression cannot silently disarm it.
-**Planned case.** `CONF-O17` in `conformance/tests/provenance.test.ts`.
+**Honoured by.** `CONF-O17` seeds a `ForeignEvent` canary, writes beside it, lists, and asserts the canary
+is byte-identical afterwards; the negative control bumps the canary's revision on **any** successful create
+or update, so every write path in the reference is covered by that one mutant. The originally planned
+*shared teardown* over every write-family case was **not** built: `create` runs per case (`CONF-I57`) and a
+shared hook cannot know each case's seed, so the mutant — which disturbs the canary from inside the
+provider — is what makes the guarantee general rather than local to `CONF-O17`.
+**Proved by.** `CONF-O17` in `conformance/tests/provenance.test.ts`.
 
 ### CONF-I17. Echo verification is three-state, and "no echo" is not "matched"
 
@@ -3533,7 +3542,7 @@ echo module — never field values.
 matched. A separate ungated assertion scans every `BoundedSample` the adapter emits for the seeded event's
 title, description and location strings, and fails if any appears — diagnostics carry identifiers, never
 content.
-**Planned case.** `CONF-O18` in `conformance/tests/writes.test.ts`; the content-leak scan is `CONF-O19` in
+**Proved by.** `CONF-O18` in `conformance/tests/writes.test.ts`; the content-leak scan is `CONF-O19` in
 `conformance/tests/diagnostics.test.ts`.
 
 ### CONF-I18. Echo must tolerate the provider's own lossless rewrites, or the mirror churns forever
@@ -3549,7 +3558,7 @@ ETag when the stored bytes differ from the submitted bytes.
 precision, normalises CRLF and trims trailing whitespace — so any adapter that trusts its own submitted
 representation instead of the provider's returned `RemoteVersion`/`Fingerprint` fails the convergence case
 rather than passing it by luck.
-**Planned case.** `CONF-O20` in `conformance/tests/convergence.test.ts`.
+**Proved by.** `CONF-O20` in `conformance/tests/convergence.test.ts`.
 
 ### CONF-I19. Identity is canonical and excludes mutable content
 
@@ -3563,7 +3572,7 @@ order"*, *"handles null/undefined timezone by treating them as equivalent"*.
 the same event twice with permuted key order and equivalent absent-value spellings, and asserts one
 identity and zero writes. A dedicated case covers astral-plane and combining-mark keys, because the sorting
 rule is the footgun.
-**Planned case.** `CONF-O21` in `conformance/tests/convergence.test.ts`.
+**Proved by.** `CONF-O21` in `conformance/tests/convergence.test.ts`.
 
 ### CONF-I20. A repeated identity in one listing is one entry, last observation wins
 
@@ -3576,7 +3585,7 @@ learn.microsoft.com/graph/delta-query-overview §Replays.
 **Honoured by.** A case that makes the provider emit one identity N times in a single listing and asserts
 the reconciled result has exactly one entry equal to the last observation, and that feeding the repeats in
 reverse order yields the same winner (CONF-I8).
-**Planned case.** `CONF-O22` in `conformance/tests/convergence.test.ts`.
+**Proved by.** `CONF-O22` in `conformance/tests/convergence.test.ts`.
 
 ### CONF-I21. Every retry path has a provable ceiling and a capped provider-supplied delay
 
@@ -3585,11 +3594,15 @@ sleep that removes its listener on the timeout path and clears the timer on the 
 an explicit unreachable throw so the loop cannot fall out silently.
 **Learned from.** `core/utils/backoff.ts`; `backoff.test.ts :: "caps a provider-supplied delay at the
 maximum backoff"`, *"throws after exhausting all retries"*.
-**Honoured by.** `OperationContext.retryBudget` is handed to the adapter by the suite, and the lockup case
-drives a transport that always answers `rateLimited` with a `retryAfter` far past the budget ceiling. The
-case asserts a bounded transport call count and that total advanced fake time stays under
-`maxAttempts * retryDelayCeilingMs`.
-**Planned case.** `CONF-L1` in `conformance/tests/lockups.test.ts`.
+**Honoured by.** `OperationContext.retryBudget` is handed to the adapter by the suite, and the generated
+case drives a transport that answers `rateLimited` forever with a `retryAfter` in 2099. It asserts the
+transport was reached exactly `maxAttempts` times and that the injected clock advanced by no more than
+`maxAttempts * retryDelayCeilingMs`, then calls the adapter's own `retryCeilingProven` obligation. The
+abortable sleep is `TestClock.sleep`, which registers its abort listener against its own `AbortController`
+and tears it down on **both** paths, so a caller reusing one signal across a retry loop accumulates no
+listeners — asserted directly with `getEventListeners`. The backoff sleeps on a signal composed from the
+provider's lifetime and the caller's, so an abort cancels the pending delay instead of leaving it armed.
+**Proved by.** `CONF-L1` in `conformance/tests/lockups.test.ts`.
 
 ### CONF-I22. Every await on an outside resource carries a deadline, and a timeout is not a caller abort
 
@@ -3597,12 +3610,14 @@ case asserts a bounded transport call count and that total advanced fake time st
 separate `isTimeout()` so a caller-initiated abort is not misreported as a provider timeout.
 **Learned from.** `core/utils/fetch-with-timeout.ts` (`RequestTimeoutError`, `isTimeoutError`);
 `fetch-with-timeout.test.ts`.
-**Honoured by.** The `stallingOn(predicate)` fixture returns `new Promise(() => {})` — a permanently
-pending promise, never a long timer, so the case proves the deadline comes from outside the awaited work.
-Two separate cases: a deadline elapsed on the fake clock must settle as a `transport`/`notAttempted`
-failure; an externally aborted signal mid-flight must settle as `notAttempted` with reason `aborted`, which
-the suite asserts is a **different** value from the deadline case.
-**Planned case.** `CONF-L2` and `CONF-L3` in `conformance/tests/lockups.test.ts`.
+**Honoured by.** Both the `stallingOn(predicate)` fixture and `TransportStub.stall()` answer with a
+permanently pending promise, never a long timer, so the deadline must come from outside the awaited work.
+`CONF-L2` stalls the transport, gives the call a **positive** budget, and asserts both that the transport
+was reached and that the answer is `budgetExhausted`; `CONF-L3` stalls the transport, lets the call reach
+it, then aborts mid-flight and asserts `aborted` — a different value from the deadline case. A caller that
+walks away from a flight abandons its coalescing key, so the caller after it starts a fresh flight rather
+than joining a leader nobody is waiting for.
+**Proved by.** `CONF-L2` and `CONF-L3` in `conformance/tests/lockups.test.ts`.
 
 ### CONF-I23. A single-flight leader's failure reaches every follower, and the slot is freed on the throwing path
 
@@ -3617,7 +3632,7 @@ rejected starts a fresh attempt rather than inheriting the dead one (the gap the
 cover); and a second generation started after the first settled is not evicted by the first's `finally`.
 Gated on the adapter declaring any coalescing at all, which the suite detects by observing fewer transport
 calls than concurrent invocations.
-**Planned case.** `CONF-L4` in `conformance/tests/lockups.test.ts`.
+**Proved by.** `CONF-L4` in `conformance/tests/lockups.test.ts`.
 
 ### CONF-I24. Telemetry emitted inside a coalesced body lands on a foreign caller's context
 
@@ -3629,7 +3644,7 @@ whichever context created the promise, so telemetry emitted there is attributed 
 `ListingDiagnostics` to the call that returned them, and the concurrency case asserts that two coalesced
 callers each receive their own diagnostics object with their own `pagesFetched`, rather than one object
 shared by reference.
-**Planned case.** `CONF-L5` in `conformance/tests/lockups.test.ts`.
+**Proved by.** `CONF-L5` in `conformance/tests/lockups.test.ts`.
 
 ### CONF-I25. Multi-key acquisition must be in a canonical order
 
@@ -3640,7 +3655,7 @@ running work"`.
 **Honoured by.** A case that issues two concurrent `listChanges` calls over overlapping calendar sets in
 opposite orders and asserts both settle before the fake clock passes the deadline. Gated on the adapter
 enumerating more than one calendar.
-**Planned case.** `CONF-L6` in `conformance/tests/lockups.test.ts`.
+**Proved by.** `CONF-L6` in `conformance/tests/lockups.test.ts`.
 
 ### CONF-I26. A lease releases on the throwing path and leaves no timer behind
 
@@ -3652,8 +3667,14 @@ script, so an abandoned handle cannot leave a timer running.
 and once with one that rejects, then asserts the operation can be invoked again and succeed — a lease held
 past a throw shows up as the second call hanging, which the deadline turns into a failure rather than a CI
 hang. After each case the suite advances the fake clock past every declared budget and asserts no timer
-callback fires.
-**Planned case.** `CONF-L7` and `CONF-L8` in `conformance/tests/lockups.test.ts`.
+callback fires. The coalescing slot is released on **both** settlement paths, so a rejecting body cannot
+poison its key for the process lifetime, and the seven `ProviderConformanceSuite` obligations are not
+decoration: each is invoked by the case that owns it — `retryCeilingProven` by `CONF-L1`,
+`deadlineOnNeverResolvingStub` by `CONF-L2`, `abortMidFlightCleansUp` by `CONF-L3`,
+`followerRejectsWhenLeaderFails` by `CONF-L4`, `concurrentSameKeyDoesNotDeadlock` by `CONF-L6`,
+`leaseReleasedOnThrow` by `CONF-L7` and `deletionInputsShareOneCalendar` by `CONF-O4` — and each has a
+body that reads a different piece of the adapter's own state.
+**Proved by.** `CONF-L7` and `CONF-L8` in `conformance/tests/lockups.test.ts`.
 
 ### CONF-I27. A cancelled waiter must not strand its successors, and every poll has a ceiling
 
@@ -3663,7 +3684,7 @@ callback fires.
 **Honoured by.** A case that starts three concurrent same-key operations, aborts the second mid-flight, and
 asserts the first and third both settle. The aborted one must reject; the others must not inherit its abort
 reason.
-**Planned case.** `CONF-L9` in `conformance/tests/lockups.test.ts`.
+**Proved by.** `CONF-L9` in `conformance/tests/lockups.test.ts`.
 
 ### CONF-I28. An aborted queued task is rejected, not dropped, and its slot is not lost
 
@@ -3675,7 +3696,7 @@ without starting it"`.
 **Honoured by.** A case that queues N operations against an adapter whose declared concurrency is less than
 N, makes one throw and aborts another, and asserts the remaining N−2 all complete. A permanently leaked
 permit shows up as the tail never settling, which the deadline converts into a failure.
-**Planned case.** `CONF-L10` in `conformance/tests/lockups.test.ts`.
+**Proved by.** `CONF-L10` in `conformance/tests/lockups.test.ts`.
 
 ### CONF-I29. Fan-out returns a result for every task, and never exceeds the declared concurrency
 
@@ -3685,7 +3706,7 @@ rejection cannot abort the pool or leave holes in the results.
 **Honoured by.** A case in which task k rejects and task j stalls forever: the suite asserts N results are
 returned (not N−1), that the stalled one is a deadline failure rather than a missing entry, and that
 `transport.inFlightPeak()` never exceeded the concurrency the adapter declared.
-**Planned case.** `CONF-L11` in `conformance/tests/lockups.test.ts`.
+**Proved by.** `CONF-L11` in `conformance/tests/lockups.test.ts`.
 
 ### CONF-I30. Failures are classified by discriminant, never by matching message text
 
@@ -3697,7 +3718,7 @@ match a backoff pattern and put a healthy calendar into permanent backoff.
 structural: the suite seeds an event whose title and description contain `"rate limit exceeded"`,
 `"410 Gone"`, `"Precondition Failed"` and a NUL byte, and asserts every failure classification and every
 identity key is unchanged from the benign run.
-**Planned case.** `CONF-O23` in `conformance/tests/hostile-content.test.ts`.
+**Proved by.** `CONF-O23` in `conformance/tests/hostile-content.test.ts`.
 
 ### CONF-I31. An unattempted run is a third state, neither success nor failure
 
@@ -3707,7 +3728,7 @@ operations — escalating punishes a healthy destination, clearing lets a broken
 **Honoured by.** A case that aborts before the first transport call and asserts the outcome is
 `notAttempted`, plus an assertion that the suite's own report counts it in neither the passed nor the
 failed tally — the third state must survive the harness, not just the adapter.
-**Planned case.** `CONF-L12` in `conformance/tests/lockups.test.ts`.
+**Proved by.** `CONF-L12` in `conformance/tests/lockups.test.ts`.
 
 ### CONF-I32. A superseded run never advances the cursor
 
@@ -3719,7 +3740,7 @@ sync token on the superseded path"`.
 **Honoured by.** A case that aborts the operation after the first page and before the last, and asserts the
 adapter returns no `SyncCursor` — with that test name reused verbatim, because the name is the invariant.
 Cursor non-advancement is asserted on three separate paths: truncated read, aborted run, transport failure.
-**Planned case.** `CONF-O24` in `conformance/tests/cursor.test.ts`.
+**Proved by.** `CONF-O24` in `conformance/tests/cursor.test.ts`.
 
 ### CONF-I33. A replace whose create fails after the delete succeeded must leave a recoverable state
 
@@ -3728,13 +3749,13 @@ fails, and keeps the stale mapping when a recreation fails after a successful de
 delete and create does not orphan a real event.
 **Learned from.** commit `1c5171d2`; `index.test.ts :: "keeps the stale mapping when recreation fails after
 a successful delete"`, *"does not checkpoint the stale mapping when recreation aborts after deletion"*.
-**Honoured by.** The `conflictingOn(predicate)` fixture is pointed at the create half of a replace. The
-case asserts the outcome of the half that already succeeded survives the half that did not — the object it
-created is still on the calendar and its entry is still in the write log — so the caller retains enough to
-recreate on the next run. A refused create is a `WriteOutcome` of kind `conflict` carrying the `RemoteRef`
-of the copy that blocked it (CONF-I14), not a `ProviderFailure`; only a write whose target could not be
-named at all fails outright.
-**Planned case.** `CONF-O25` in `conformance/tests/writes.test.ts`.
+**Honoured by.** The case performs a real replace: it deletes the original, then issues the create half
+against an identity another copy already blocks, so the second half fails the way `CONF-I14` says it must —
+a `conflict` carrying the blocking `RemoteRef`. It then asserts the deleted target is still named in the
+write log, that the blocking copy came through the failed half unchanged, and that recreating the original
+on the next run succeeds. `assertNoUnplannedRecreation` takes the removals the case *planned*, so a
+deliberate delete-then-create is expressible while an unplanned one is still a violation.
+**Proved by.** `CONF-O25` in `conformance/tests/writes.test.ts`.
 
 ### CONF-I34. Storage bounds and mirror bounds are different windows
 
@@ -3743,10 +3764,15 @@ delete every historic stored row on the next ingest; the sync window bounds only
 **Learned from.** `ics/utils/fetch-adapter.ts` (*"The whole feed is kept on purpose…"*);
 `fetch-adapter.test.ts :: "returns events far outside the sync window so stored history stays unbounded"`;
 `ingest.test.ts :: "keeps stored history a snapshot source still reports outside the sync window"`.
-**Honoured by.** A case gated on `supports.deletionAuthority === "snapshotAbsence"` in which the provider
-reports an event outside the requested window: the suite asserts it is returned, that no removal is
-derivable for it, and that two polls do not oscillate between add and retire.
-**Planned case.** `CONF-O26` in `conformance/tests/window.test.ts`.
+**Honoured by.** A case gated on `supports.deletionAuthority` in which the source still holds an event
+outside the requested window. The adapter must either report it or leave it outside the coverage it proved
+— Google's `timeMin`/`timeMax` and Graph's `calendarView` filter, so demanding it be *returned* would fail
+an honest adapter — and in both branches no removal may be derivable for it. That second half is only
+meaningful because the removal basis carries each known identity's **time**: `derivableRemovals` calls the
+injected `withinWindow` per identity, so an identity outside the proven coverage can never be called
+absent. The negative control drops the out-of-window event **and** claims coverage 90 days past what it
+read, which is the only shape that turns window filtering into a deletion.
+**Proved by.** `CONF-O26` in `conformance/tests/window.test.ts`.
 
 ### CONF-I35. Window membership is one predicate, used at every stage, swept at every boundary
 
@@ -3757,10 +3783,13 @@ derivable for it, and that two polls do not oscillate between add and retire.
 agreement between adapter filter and delta pruner"`.
 **Honoured by.** `runConformance` takes `withinWindow: WindowMembership` as an **argument** and uses that
 one function for every window judgement it makes, so an adapter cannot be checked against a predicate that
-differs from the one the reconciler will use. A boundary sweep case covers exactly-on-lower-edge,
-exactly-on-upper-edge, zero-duration and inverted, and asserts the same verdict at listing time and at
-removal time, then convergence after two polls.
-**Planned case.** `CONF-O27` in `conformance/tests/window.test.ts`.
+differs from the one the reconciler will use. The boundary set is generated from the requested window
+rather than hand-picked — on the lower edge, before it, on the upper edge, past it, and zero-duration — and
+each member is judged twice: at listing time (a member the predicate admits must be in the listing) and at
+removal time (a member the predicate excludes from the proven coverage must not be derivable as a removal).
+The case then polls a second time and asserts the two polls agree, and finishes on an inverted window that
+may admit nothing.
+**Proved by.** `CONF-O27` in `conformance/tests/window.test.ts`.
 
 ### CONF-I36. Degenerate ranges are real events; widening at the destination must not read as drift
 
@@ -3770,11 +3799,14 @@ The source row must not then read as changed.
 **Learned from.** `core/events/time-range.ts` (`POINT_IN_TIME_DURATION_MS`); commit `b057d2e0` (#616);
 `degenerate-range-source-ingest.test.ts :: "does not treat a stored source row as changed after a
 destination widened its mirror"`.
-**Honoured by.** Gated on `supports.representableRange.zeroDuration` and `.invertedRange`. `accept` gets
-the mirror-and-echo case: write a zero-duration event, have the fixture echo back the widened copy, assert
-the next run performs zero writes. `reject` gets the alternative case: the write must return
-`unrepresentable` with constraint `minimumSpan`, and must not silently widen.
-**Planned case.** `CONF-O28` in `conformance/tests/window.test.ts`.
+**Honoured by.** Gated on `supports.representableRange.zeroDuration`. The reference declares
+`minimumSpanSeconds: 900` and widens what it stores, exactly as a destination would. `accept` gets the
+mirror-and-echo case: the seeded zero-duration event must still be listed as the source holds it, the
+written copy must come back at or above the declared minimum span, and replaying the same create must
+answer `alreadyExists`/`unchanged` with the stored revision unmoved — the destination's widening must not
+read as drift. `reject` gets the alternative: the write must fail `unrepresentable` with constraint
+`minimumSpan`, and must not silently widen.
+**Proved by.** `CONF-O28` in `conformance/tests/window.test.ts`.
 
 ### CONF-I37. A capability declaration that is never checked against behaviour is worthless
 
@@ -3782,14 +3814,15 @@ the next run performs zero writes. `reject` gets the alternative case: the write
 time, and `supportedAvailabilities` exists so a coercion is expected rather than read as drift.
 **Learned from.** `providers/outlook/destination/provider.ts`; `operations.test.ts :: "does not churn when
 a provider coerces unsupported OOO availability to busy"`.
-**Honoured by.** `supports` drives selection in **both** directions. For every capability whose value is a
-refusal (`zeroDuration: "reject"`, `recurrenceWrite: "none"`, `delta: { kind: "none" }`,
-`echoesWrites: false`), the suite generates a case asserting the adapter **actually refuses** the input it
-declared unsupported, with a typed `unsupported`/`unrepresentable` result. No capability value removes a
-case; each selects a different one. The ungated set — deletion safety, precondition, provenance, deadline,
-retry ceiling — is a named `as const` list, and the report exposes it so an adapter's own test file can
-assert none of them was skipped.
-**Planned case.** `CONF-O29` in `conformance/tests/capabilities.test.ts`.
+**Honoured by.** `supports` drives selection in **both** directions and no capability value removes a
+case — `delta: { kind: "none" }` takes the `noDelta` branch, under which no cursor may be minted and the
+cursor cases assert exactly that instead of returning early. Every declared capability is read by a case:
+`allDay` and `representableRange.allDayGrid` by `CONF-O45`, `.minimumSpanSeconds` and `.zeroDuration` by
+`CONF-O28`, `.invertedRange` by `CONF-O29`, `throttleSignals` by `CONF-O46`, `quotaScope` by `CONF-L1`, and
+the rest by the gates. The ungated set is derived from the gate table and surfaced on the report, and a
+test drives selection with an adapter that refuses everything it can and asserts every declared case id is
+still generated.
+**Proved by.** `CONF-O29` in `conformance/tests/capabilities.test.ts`.
 
 ### CONF-I38. Every drop is counted, self-authored separately, and the counts are stable across polls
 
@@ -3805,7 +3838,7 @@ without churn"`.
 Three generated cases: a clean listing reports all-zero totals; a listing with one self-authored and one
 unrepresentable event increments exactly one counter each; and the same input polled twice produces
 identical diagnostics, including sample order.
-**Planned case.** `CONF-O30` in `conformance/tests/diagnostics.test.ts`.
+**Proved by.** `CONF-O30` in `conformance/tests/diagnostics.test.ts`.
 
 ### CONF-I39. Identifier lists are a bounded sample beside an exact uncapped total
 
@@ -3817,7 +3850,7 @@ with it, losing the alarm entirely. Capped by both entry count and total bytes.
 asserts `BoundedSample.sample` is bounded in both entry count and total UTF-16 length while
 `BoundedSample.total` is exact. A companion assertion checks every diagnostic value is a loggable scalar —
 never an object, never `undefined`.
-**Planned case.** `CONF-O31` in `conformance/tests/diagnostics.test.ts`.
+**Proved by.** `CONF-O31` in `conformance/tests/diagnostics.test.ts`.
 
 ### CONF-I40. A discarded event may be missing the identifier you would log it by
 
@@ -3827,7 +3860,7 @@ before deleting it"`.
 **Honoured by.** `WithheldIdentity` already requires at least one of `uid` and `id`. The fixture corpus
 includes an identity-less discard, and the case asserts it is still reported with reason `missingIdentity`
 rather than dropped silently.
-**Planned case.** `CONF-O32` in `conformance/tests/diagnostics.test.ts`.
+**Proved by.** `CONF-O32` in `conformance/tests/diagnostics.test.ts`.
 
 ### CONF-I41. A withheld identity must not cost the user its existing mirror
 
@@ -3842,7 +3875,7 @@ requested window"*.
 identity was withheld this run must still exist afterwards, and must still be retired when it leaves the
 window. It is called out separately because a listing-only assertion would have missed the production
 incident.
-**Planned case.** `CONF-O33` in `conformance/tests/deletion-safety.test.ts`.
+**Proved by.** `CONF-O33` in `conformance/tests/deletion-safety.test.ts`.
 
 ### CONF-I42. A cancelled event is not an absent event
 
@@ -3850,11 +3883,13 @@ incident.
 overrides; Google carries `cancelledEventIds` separately from `changedEventIds`.
 **Learned from.** `ics/utils/parse-ics-events.ts`; `parse-ics-events.test.ts :: "drops a cancelled master
 and all of its detached overrides"`; `providers/google/source/utils/fetch-events.ts`.
-**Honoured by.** `Removal` already distinguishes `deleted`, `cancelled` and `outOfScope`. The case
-exercises all three states a delta can express — named-and-changed, named-and-cancelled, unnamed — and
-asserts an unnamed identity is never removed while a cancelled one always is, and that `outOfScope` never
-drives a deletion.
-**Planned case.** `CONF-O34` in `conformance/tests/deletion-safety.test.ts`.
+**Honoured by.** `Removal` already distinguishes `deleted`, `cancelled` and `outOfScope`, and
+`ProviderSeed` carries `cancelled` and `unattributableRemovals` so all three states can be produced. The
+case seeds one identity the source keeps, one it reports as cancelled and one tombstone that names no
+identity, then asserts the cancellation is removed **as a cancellation**, the kept identity is not removed,
+the unnamed tombstone appears only as `outOfScope`, and that no `outOfScope` marker drives a derivable
+removal. The negative control reports the cancellation as a plain deletion.
+**Proved by.** `CONF-O34` in `conformance/tests/deletion-safety.test.ts`.
 
 ### CONF-I43. An unsupported construct is withheld and counted, never approximated
 
@@ -3866,7 +3901,7 @@ its meaning"`.
 cannot meet, the suite feeds an input violating it and asserts the result is `unrepresentable` with that
 exact constraint — never a "best effort" representation. The negative control is a mutant adapter that
 clamps instead of refusing.
-**Planned case.** `CONF-O35` in `conformance/tests/capabilities.test.ts`.
+**Proved by.** `CONF-O35` in `conformance/tests/capabilities.test.ts`.
 
 ### CONF-I44. An occurrence changing identity is a reassignment, not delete plus add
 
@@ -3874,10 +3909,12 @@ clamps instead of refusing.
 reassignment must first prove the mirror is still ours.
 **Learned from.** `core/sync/operations.ts` (`OccurrenceReassignment`); `operations.test.ts :: "recreates a
 mapped event when the same event ID moves"`.
-**Honoured by.** A case that moves one occurrence of a series and asserts exactly one write, carrying an
-`ObservedPrecondition`, against a target whose provenance is `ours` — the write log must not contain an
-unconditional delete followed by a create.
-**Planned case.** `CONF-O36` in `conformance/tests/writes.test.ts`.
+**Honoured by.** A case that writes a recurring series, lists it back and asserts the target it is about
+to reassign is `ours` (or `indeterminate`, where the adapter declares no provenance channel), then moves the
+series' anchor with a single conditional update. It asserts exactly one update, no delete, a precondition on
+every write, and that the fingerprint changed — the anchor is part of identity, so a series moved to a new
+`DTSTART` must not hash the same as the one it left (RFC 5545 §3.8.5.3).
+**Proved by.** `CONF-O36` in `conformance/tests/writes.test.ts`.
 
 ### CONF-I45. A quiet calendar still advances its cursor
 
@@ -3890,7 +3927,7 @@ when delta sync yields no event changes"`.
 listing carries a `SyncCursor` different from the one supplied, while the write count is zero. "No work"
 must not mean "no cursor write" — this is the exact counterweight to CONF-I9, and the pair is generated
 together so neither can be satisfied by breaking the other.
-**Planned case.** `CONF-O37` in `conformance/tests/cursor.test.ts`.
+**Proved by.** `CONF-O37` in `conformance/tests/cursor.test.ts`.
 
 ### CONF-I46. A delta item is a patch, not a snapshot
 
@@ -3901,7 +3938,7 @@ that the same entity can appear multiple times in one session, and that no order
 field: the adapter must either fill the omitted fields from its own read or report the item as withheld —
 it must never emit a `RemoteEvent` whose omitted fields are blanked, which the case detects by comparing
 against the pre-delta content.
-**Planned case.** `CONF-O38` in `conformance/tests/cursor.test.ts`.
+**Proved by.** `CONF-O38` in `conformance/tests/cursor.test.ts`.
 
 ### CONF-I47. Servers rewrite what you submit, so the written representation is not authoritative
 
@@ -3909,10 +3946,13 @@ against the pre-delta content.
 bytes, so the client must re-read rather than assume its local copy is authoritative. Google normalises
 bodies likewise.
 **Learned from.** RFC 4791 §5.3.4; the push-echo suites.
-**Honoured by.** Every write outcome carries a `RemoteVersion`; the suite asserts a write that returns no
-fresh version forces a re-read before the next write of the same target, by making the reference provider
-reject a second write whose precondition was derived from the submission rather than from a read.
-**Planned case.** `CONF-O39` in `conformance/tests/writes.test.ts`.
+**Honoured by.** Every write outcome carries a `RemoteVersion`, and the reference deliberately rewrites
+what it stores, so the submitted representation is never the stored one. `CONF-O39` proves the consequence
+the caller must live with: a second write whose precondition was **not** taken from the provider's latest
+answer — the version the previous write returned — is refused as a typed `conflict`, which is what forces
+the re-read. The case is filed here rather than under `CONF-I14` because the lesson is about the
+authority of the returned version, not about create idempotency.
+**Proved by.** `CONF-O39` in `conformance/tests/writes.test.ts`.
 
 ### CONF-I48. There is no universal create-idempotency primitive, so it is declared vocabulary
 
@@ -3925,7 +3965,7 @@ modifications for insert"*) and the `events.import` reference.
 which mechanism the case exercises, and there is **no** value that removes the replayed-create case: an
 adapter that cannot express a conditional insert must instead prove that the caller-supplied
 `IdempotencyKey` deduplicates.
-**Planned case.** shared with CONF-I14, which owns the replayed-create case in
+**Proved by.** shared with CONF-I14, which owns the replayed-create case in
 `conformance/tests/writes.test.ts`; this entry adds no case of its own.
 
 ### CONF-I49. A cursor is opaque, and a cursor the adapter cannot read is `cursorLost`, never an empty delta
@@ -3937,7 +3977,7 @@ answer: it reads as "nothing changed" and, to a snapshot-shaped consumer, as "ev
 **Honoured by.** The harness never parses `SyncCursor.value`. A case hands the adapter a cursor whose bytes
 have been mutated and asserts `cursorLost` or a `cursorInvalid` failure — never a throw, and never an empty
 `delta`. The suite asserts nothing about the cursor's format.
-**Planned case.** `CONF-O40` in `conformance/tests/cursor.test.ts`.
+**Proved by.** `CONF-O40` in `conformance/tests/cursor.test.ts`.
 
 ### CONF-I50. Truncation and coverage are different claims, even where the RFC lets one token carry both
 
@@ -3950,7 +3990,7 @@ source event when a fetch silently returns a subset"`.
 `Continuation` and structurally no `cursor` and no `coverage`. The case asserts a CalDAV-shaped adapter
 surfaces the per-page token as a `Continuation` and never as a `SyncCursor` — resumability is preserved,
 coverage is not claimed.
-**Planned case.** `CONF-O41` in `conformance/tests/deletion-safety.test.ts`.
+**Proved by.** `CONF-O41` in `conformance/tests/deletion-safety.test.ts`.
 
 ### CONF-I51. Timing fixtures are built on `setTimeout` and a fake clock, never `Bun.sleep`, never real time
 
@@ -3962,10 +4002,12 @@ bogus *"vi.hoisted is not a function"* errors.
 **Honoured by.** The package's `TestClock` is built on `setTimeout` only, the stall fixture is
 `new Promise(() => {})` rather than a long timer, and every advance uses `vi.advanceTimersByTimeAsync` —
 the synchronous variant does not flush microtasks between callbacks and deadlocks against awaited promises.
-A hygiene test greps `src/` and `tests/` for `Bun.sleep` and fails on any hit, mirroring
-`ical/tests/hygiene/no-bun-sleep.test.ts`. The vitest config keeps a real per-test timeout as a backstop so
-a genuine wedge fails fast instead of hanging CI.
-**Planned case.** `conformance/tests/hygiene/no-bun-sleep.test.ts`.
+The hygiene test greps `src/` and `tests/` for the unfakeable primitive **and** drives a real sleep under
+fake timers, asserting the timer is armed, that advancing fake time resolves it, and that the injected
+clock moved by exactly the interval slept. The generated `CONF-L` cases run on **real** timers, because an
+adapter's own suite will; their budgets are milliseconds, not seconds. The vitest config keeps a real
+per-test timeout as a backstop so a genuine wedge fails fast instead of hanging CI.
+**Proved by.** `conformance/tests/hygiene/no-bun-sleep.test.ts`.
 
 ### CONF-I52. `AbortSignal.timeout` is not patched by fake timers, so deadlines come from the injected clock
 
@@ -3975,7 +4017,7 @@ is upstream in sinon fake-timers and the issue is still open.
 **Honoured by.** `OperationContext.deadline` is an `Instant` and `OperationContext.now` is a function, both
 supplied by the suite; the suite constructs its own `AbortController` and fires it from a `setTimeout`.
 Neither the suite nor the reference provider calls `AbortSignal.timeout`, and a hygiene test asserts that.
-**Planned case.** `conformance/tests/hygiene/no-unpatchable-timers.test.ts`.
+**Proved by.** `conformance/tests/hygiene/no-unpatchable-timers.test.ts`.
 
 ### CONF-I53. A wall-clock assertion measures the CI agent, not the algorithm
 
@@ -3985,7 +4027,7 @@ timing attribution by injecting a clock rather than measuring.
 **Honoured by.** The deadline obligation is phrased as *"rejected with a deadline failure after the deadline
 elapsed on the fake clock"*, never *"completed within N real milliseconds"*. No case in this package reads
 `performance.now()` or `Date.now()`; a hygiene test enforces it.
-**Planned case.** `conformance/tests/hygiene/no-wall-clock.test.ts`.
+**Proved by.** `conformance/tests/hygiene/no-wall-clock.test.ts`.
 
 ### CONF-I54. Dependencies arrive as arguments, and the suite must detect an adapter that ignores them
 
@@ -3994,22 +4036,28 @@ the lockup tests possible with stubs. An adapter that imports its own clock or `
 and abort obligations pass **vacuously**, which is worse than not running them.
 **Learned from.** `core/oauth/refresh-coordinator.ts`, `core/sync-engine/generation.ts`,
 `packages/sync/src/sync-lock.ts`, `core/source/ingest-lock.ts`.
-**Honoured by.** `create(environment)` receives the clock, the hash function, the installation id and the
-transport stub. A dedicated **injection** case runs before every lockup case and asserts
-`environment.transport.callCount() > 0` and that `environment.clock.now` was called; an adapter that
-reached past its arguments fails that case explicitly instead of quietly passing the whole family.
-**Planned case.** `CONF-L13` in `conformance/tests/injection.test.ts`.
+**Honoured by.** `create(environment)` receives the clock, the concurrency ceiling, the hash function, the
+installation id and the transport stub, and `runConformance` takes the `describe`/`it` runner as an
+argument rather than importing one. A dedicated **injection** case asserts the transport call count and the
+clock read count both rose across one listing; an adapter that reached past its arguments fails that case
+explicitly instead of quietly passing the whole lockup family vacuously. It is a case in the same generated
+set rather than a hook that runs before each lockup case, so it is visible in the report and in the ledger
+walk like every other guarantee.
+**Proved by.** `CONF-L13` in `conformance/tests/injection.test.ts`.
 
 ### CONF-I55. The reference implementation must be adversarial about its own success
 
 **Lesson.** The repo's convergence tests re-run the whole pipeline and assert a fixed point, and several are
 named for it.
 **Learned from.** the twelve `*convergence*` suites; `vfy-shaping-fixed-point.test.ts`.
-**Honoured by.** The reference provider is exercised by a fixed-point case — list, plan, apply, list, plan,
-assert the second plan is empty — and is run through the full suite **bare and under each single fixture
-decorator**, so the fixtures are proven not to break correct behaviour. Separately, every case ships a
-negative control: a mutated reference provider that must fail exactly that case.
-**Planned case.** `conformance/tests/reference/fixed-point.test.ts`,
+**Honoured by.** The reference provider is exercised by a fixed-point case — list, apply, list, list,
+assert the write log did not grow — and is run through the full suite **bare**, with a companion test
+asserting the unmutated reference fails nothing at all. Each fixture is then asserted for the outcome it
+exists to produce: `truncatingAfter(1)` must answer `partial`, `expiringCursorAfter(1)` must answer
+`cursorLost` on the poll after the first, `conflictingOn(create)` must answer `conflict`, and
+`stallingOn(write)` must settle at its deadline rather than never. Separately, every case ships a negative
+control: a mutated reference provider that must fail exactly that case and no other.
+**Proved by.** `conformance/tests/reference/fixed-point.test.ts`,
 `conformance/tests/reference/negative-controls.test.ts`.
 
 ### CONF-I56. A failed run must not leak state into the run that follows it
@@ -4021,7 +4069,7 @@ runs that follow it"`; `ingest.test.ts :: "checkpoints a successful chunk before
 **Honoured by.** A case that fails mid-run against a provider instance and then runs again against the same
 instance, asserting the second run converges and reports fresh per-run diagnostics rather than accumulated
 ones.
-**Planned case.** `CONF-O42` in `conformance/tests/diagnostics.test.ts`.
+**Proved by.** `CONF-O42` in `conformance/tests/diagnostics.test.ts`.
 
 ### CONF-I57. A conformance suite with a shared provider acquires order dependence
 
@@ -4030,7 +4078,7 @@ ones.
 **Honoured by.** `create` is invoked **per case**, never per suite, and `ProviderUnderTest.dispose` runs in
 `afterEach`. Case order is derived from the `as const` case-id list, so it is stable and inspectable, but no
 case may depend on it.
-**Planned case.** `conformance/tests/harness/per-case-isolation.test.ts`.
+**Proved by.** `conformance/tests/harness/per-case-isolation.test.ts`.
 
 ### CONF-I58. Provider differences belong in declared data, not in three copies of the same describe block
 
@@ -4040,7 +4088,7 @@ provider — parity written three times instead of once.
 **Honoured by.** This is the whole package: one `runConformance` call per adapter, one case list, capability
 values selecting branches. The existing three-block test is the prototype, and retiring it is the
 acceptance criterion for the package.
-**Planned case.** n/a — this is the package's premise, not a case.
+**Proved by.** n/a — this is the package's premise, not a case.
 
 ### CONF-I59. The invariant is the test name
 
@@ -4052,7 +4100,7 @@ blocks).
 **Honoured by.** Every generated case's title is the invariant, prefixed with its `CONF-O`/`CONF-L` id and
 cross-referenced to its ledger entry in `src/case-id.ts`, so the ledger can be walked against the suite by
 grep — the mechanical walk `RECON-I84` added for sync-reconcile.
-**Planned case.** `conformance/tests/hygiene/ledger-citations.test.ts`.
+**Proved by.** `conformance/tests/hygiene/ledger-citations.test.ts`.
 
 ### CONF-I60. A non-IANA zone identifier must never reach a canonical event
 
@@ -4064,7 +4112,7 @@ never leak out as `startTimeZone`.
 **Honoured by.** Zone **resolution** belongs to sync-ical (ICAL-I17), but one negative assertion is cheap
 and it caught a real production bug: every `ZoneId` an adapter returns on a `RemoteEvent` must be accepted
 by `Intl.DateTimeFormat` as an IANA identifier, or the write must fail with constraint `zoneIdentifier`.
-**Planned case.** `CONF-O43` in `conformance/tests/capabilities.test.ts`.
+**Proved by.** `CONF-O43` in `conformance/tests/capabilities.test.ts`.
 
 ---
 
@@ -4080,9 +4128,10 @@ from `@keeper.sh/sync-ical`, never recompute them here.
 ### CONF-I62. All-day events as a pair of UTC midnights on the UTC day grid
 
 Interpreted all-day events are anchored to the UTC midnight of their local calendar day, and re-anchoring
-must move the whole recurrence identity set together. **Not applicable.** This is entry 44 / `ICAL-I26` /
-`ICAL-I27`. Conformance needs only `supports.allDay` (`dateOnly` vs `utcMidnightPair`) to decide which shape
-to feed an adapter, plus one assertion that an adapter never silently converts between them.
+must move the whole recurrence identity set together. **Not applicable** as arithmetic — that is entry 44 /
+`ICAL-I26` / `ICAL-I27`. The one transferable half **is** adopted, as `CONF-I80`: `supports.allDay` decides
+which shape the suite feeds the adapter, and `CONF-O45` asserts the adapter never silently converts between
+them.
 
 ### CONF-I63. VTIMEZONE synthesis
 
@@ -4134,12 +4183,14 @@ under a hundred lines each and is code we must own, because it is the thing bein
 
 ### CONF-I70. `@fast-check/vitest` is the one proposed dev dependency
 
-Adopted for exactly three invariants: canonicalisation (permuted key order and equivalent absent-value
+Proposed for exactly three invariants: canonicalisation (permuted key order and equivalent absent-value
 spellings produce identical canonical bytes), convergence (`apply(apply(x)) === apply(x)`), and a
 model-based command sequence over create/update/delete/list asserting no lost update. Official vitest 4.x
-support starts at `0.2.3`. Confined to invariants: property tests give worse failure messages and
-non-obvious shrink output, and **the named example cases are the specification** (`CONF-I59`). The suite
-must not become property-based.
+support starts at `0.2.3`. **Not taken in this pass**: the package ships zero dev dependencies beyond
+vitest and the shared config, and each of the three invariants is currently asserted by a named case
+(`CONF-O21`, `CONF-O9`, `CONF-O44`) whose failure message says what broke. Confined to invariants if it
+is ever taken: property tests give worse failure messages and non-obvious shrink output, and **the named
+example cases are the specification** (`CONF-I59`). The suite must not become property-based.
 
 ### CONF-I71. Rejected: `ical.js`, `ts-ics`, `rrule`, `tsdav`
 
@@ -4170,9 +4221,13 @@ for free. We own the reporting; that is a few dozen lines.
 
 ### CONF-I75. `Bun.CryptoHasher` is used, but injected
 
-Native, synchronous, no import ceremony — but it arrives as `environment.hash: (input: string) => string`
-per the no-module-level-dependencies rule, so the suite can substitute a collision-forcing hasher and prove
-the conflict path actually fires rather than being unreachable.
+Native, synchronous, no import ceremony — and it is what `runConformance` injects by default, as
+`environment.hash: (input: string) => string`, per the no-module-level-dependencies rule.
+`RunConformanceOptions.hash` overrides it so a suite can substitute a collision-forcing hasher and prove the
+conflict path actually fires rather than being unreachable. A hasher that collides on equal-length inputs is
+not a seam by accident: fingerprints feed `matchesFingerprint` preconditions, so a collision would make a
+stale precondition compare equal. The package's own harness therefore hashes with `Bun.CryptoHasher` too and
+keeps the colliding one as an explicit, named seam.
 
 ### CONF-I76. vitest stays; `bun test` is not adopted
 
@@ -4186,8 +4241,11 @@ Bun's coverage and vitest 4 API parity are complete across every package at once
 The brief's flat capability record is the one thing worth challenging, and this is the resolution: no
 capability value deletes a case. Create idempotency has no `none` branch; `deletionAuthority` has two
 branches and both are generated; `provenanceChannel: "none"` gets the indeterminate-provenance case rather
-than no case. The ungated list — deletion safety, precondition, provenance, deadline, retry ceiling — is
-exported as an `as const` array and surfaced on the report, so an adapter cannot quietly declare its way out.
+than no case; `delta: { kind: "none" }` gets the `noDelta` branch. `CaseGate` has exactly two shapes,
+`ungated` and `branch` — the `skip` shape was **deleted**, so a future gate cannot quietly drop a case, and
+`ConformanceReport` no longer carries a `skipped` list nobody could fill or a `notAttempted` list nothing
+could populate. The gate table is one `as const` record, so the gated ids and the branch selection cannot
+drift apart, and the ungated list is derived from it and surfaced on the report.
 
 ### CONF-I78. Every case ships a negative control
 
@@ -4195,6 +4253,64 @@ A conformance case nobody has watched fail is an assertion, not a test. Each `CO
 matching mutant of the reference provider in `conformance/tests/reference/negative-controls.test.ts`, and
 the control asserts the mutant fails **that** case — a mutant that fails three cases is over-broad, and a
 mutant that fails none is a hole in the suite.
+
+---
+
+## Added after review
+
+### CONF-I79. Two writers holding one precondition must not both win
+
+**Lesson.** The mirror now writes back to real calendars, and two ticks can overlap: a scheduled sync and a
+push-triggered one both read the same version and both write. If the provider decides against the version it
+read and commits after the other has already committed, the second write silently reverts the first — an
+overwrite nobody can see in the write log, because both entries say `updated`.
+**Learned from.** the adversarial review of this package's first implementation pass, which found the brief's
+explicit obligation *"two concurrent writers cannot clobber each other without one seeing a conflict"*
+unexercised: `CONF-O39` covered only the sequential replay, and the only `concurrently` helper fanned out
+`listChanges`, never `write`.
+**Honoured by.** `CONF-O44` issues two updates carrying the same `matchesVersion` precondition without
+awaiting the first, and insists exactly one answers `updated` while the other is a typed conflict that did
+not overwrite, with the calendar left holding exactly one applied write. The negative control is a reference
+that yields between deciding a write and committing it, which is precisely the read-modify-write window a
+provider with an await in the middle would open.
+**Proved by.** `CONF-O44` in `conformance/tests/writes.test.ts`.
+
+### CONF-I80. An all-day event must never be silently converted between representations
+
+**Lesson.** `dateOnly` and `utcMidnightPair` are both legitimate; converting between them without being asked
+moves every all-day event by up to a day, in whichever direction the destination's grid disagrees.
+**Learned from.** `ICAL-I26`/`ICAL-I27` and entry 44 (`interpret-full-day-timed-events`, `build-zoned-date`),
+read against `supports.allDay`, which was declared by every adapter and consulted by nothing.
+**Honoured by.** `CONF-O45` writes an all-day event in the representation the adapter declared, lists it back,
+and asserts the returned `EventTime.kind` is the one submitted and that a `utcDay` grid really lands on UTC
+midnights. The negative control converts `allDay` to a midnight pair on the way out.
+**Proved by.** `CONF-O45` in `conformance/tests/capabilities.test.ts`.
+
+### CONF-I81. A declared throttle signal is a promise about classification
+
+**Lesson.** Backoff decisions are made from a status, and a status the adapter did not declare must not be
+backed off as a throttle — that is how a permanent failure becomes an infinite polite retry, and how a real
+throttle becomes a hard failure.
+**Learned from.** `CONF-I30` (classify by discriminant, never by message text) read against
+`supports.throttleSignals`, which was declared and consulted by nothing.
+**Honoured by.** `TransportBehaviour` carries a `status` shape, and `CONF-O46` drives every signal the adapter
+declared, asserting each is classified `rateLimited` and that `retryAfter` is present exactly when the
+declaration promised it, then drives an undeclared status and asserts it is **not** classified as a throttle.
+The negative control ignores the declaration.
+**Proved by.** `CONF-O46` in `conformance/tests/capabilities.test.ts`.
+
+### CONF-I82. "No work" means no write, never no read
+
+**Lesson.** An unchanged feed must still be re-read and re-validated: the ICS adapter reparses byte-identical
+snapshot content on purpose, because that is how a stored row that fails validation is recovered. An adapter
+that short-circuits on an unchanged ETag satisfies the convergence lesson and defeats the recovery one.
+**Learned from.** `fetch-adapter.test.ts :: "reparses unchanged snapshot content so stored-state validation
+can recover"` (`ICAL-I38`), read against `CONF-I9` and `CONF-I12`, which were in tension and said so nowhere.
+**Honoured by.** `CONF-I9`'s convergence claim is now phrased as a count of **writes**, and `CONF-O12` polls
+a feed byte-identical to the previous poll while a known row is corrupt, asserting the second poll still
+demands a resync rather than short-circuiting past the row it has to recover.
+**Proved by.** the corrupt-known-row case in `conformance/tests/deletion-safety.test.ts`, which this entry
+shares with `CONF-I12`; it adds no case of its own.
 
 ---
 
@@ -4210,6 +4326,11 @@ src/clock.ts                     TestClock — setTimeout only, injected, never 
 src/canonical.ts                 RFC 8785 key ordering; the one deep-comparison encoder
 src/registry/case.ts             ConformanceCase: id, title, ledger, gate, run
 src/registry/gates.ts            capability -> branch selection; never case removal
+src/single-flight.ts             the coalescing slot: released on every settlement, abandonable
+src/deadline.ts                  raceDeadline — the one place an await is given a ceiling
+src/transport.ts                 the injected transport stub and its typed failures
+src/environment.ts               createConformanceEnvironment: clock, concurrency, hash, transport
+src/limits.ts                    the suite's declared ceilings, handed to the adapter where they bind
 src/registry/suite.ts            assembles the ordered case list from the case families
 src/cases/deletion-safety.ts     truncation, cursorLost, coverage, withheld, cancelled, empty-vs-failed
 src/cases/cursor.ts              advancement, clearing, opacity, scope binding, supersession, patches
@@ -4222,6 +4343,8 @@ src/cases/convergence.ts         second-poll no-op, order permutation, dedupe, c
 src/cases/hostile-content.ts     failure classification is immune to event content
 src/cases/lockups.ts             deadline, abort, ceiling, lease, single-flight, fan-out, concurrency
 src/cases/injection.ts           the anti-vacuity case: the injected seams were actually used
+src/cases/isolation.ts           one bad item does not stall the feed
+src/cases/intents.ts             the write intents the cases submit
 src/assertions/no-removal.ts     assertNoRemovalDerivable — the one deletion-safety predicate
 src/assertions/listing.ts        listing kind, coverage and cursor assertions
 src/assertions/outcome.ts        write-outcome assertions
@@ -4244,14 +4367,21 @@ src/run-conformance.ts           runConformance: gate, register, report
 
 ```ts
 const runConformance: <Provider extends ProviderId>(
+  runner: SuiteRunner,
   options: RunConformanceOptions<Provider>,
 ) => ConformanceReport
+
+interface SuiteRunner {
+  readonly describe: (name: string, body: () => void) => void
+  readonly it: (name: string, body: () => Promise<void>) => void
+}
 
 interface RunConformanceOptions<Provider extends ProviderId> {
   readonly name: string
   readonly supports: Capabilities<Provider>
   readonly create: CreateProvider<Provider>
   readonly withinWindow: WindowMembership
+  readonly hash?: (input: string) => string
 }
 
 type CreateProvider<Provider extends ProviderId> = (
@@ -4267,6 +4397,7 @@ interface ProviderUnderTest<Provider extends ProviderId> {
 
 interface ConformanceEnvironment {
   readonly clock: TestClock
+  readonly concurrency: number
   readonly hash: (input: string) => string
   readonly installation: InstallationId
   readonly transport: TransportStub
@@ -4293,12 +4424,25 @@ interface ProviderInspection {
 interface ConformanceReport {
   readonly name: string
   readonly selected: readonly SelectedCase[]
-  readonly skipped: readonly SkippedCase[]
   readonly ungated: readonly ConformanceCaseId[]
+}
+
+interface ProviderSeed {
+  readonly events: readonly RemoteEvent[]
+  readonly corruptKnownRows: readonly string[]
+  readonly cancelled: readonly EventUid[]
+  readonly unattributableRemovals: readonly RemoteEventId[]
 }
 ```
 
+`runConformance` takes the runner as its first argument — `runConformance({ describe, it }, options)` — so
+the one dependency this package would otherwise import into the module that uses it arrives as an argument
+like every other (`CONF-I54`). `RunConformanceOptions.hash` is optional and defaults to `Bun.CryptoHasher`
+(`CONF-I75`); `ConformanceEnvironment.concurrency` is the ceiling `CONF-L11` holds the adapter to, so the
+number is declared to the adapter rather than kept private to the suite.
+
 ## Test index
 
-`CONF-O1`–`CONF-O43` are the overwrite family; `CONF-L1`–`CONF-L13` are the lockup family. Each id appears
-verbatim in its generated case title and in `src/case-id.ts` beside the ledger entry it enforces.
+`CONF-O1`–`CONF-O46` are the overwrite family; `CONF-L1`–`CONF-L13` are the lockup family. Each id appears
+verbatim in its generated case title and in `src/case-id.ts` beside the ledger entry it enforces, and
+`tests/hygiene/ledger-citations.test.ts` fails if the three ever disagree.

--- a/packages/sync-kit/LEARNINGS.md
+++ b/packages/sync-kit/LEARNINGS.md
@@ -3281,3 +3281,1020 @@ listed a narrower or wider window than it mirrors can still retire what it no lo
 **Proved by.**
 `tests/deletion/two-windows.test.ts :: RECON-O7: an event inside proven coverage but outside the mirror window retires the mirror`;
 `tests/coverage/proven-coverage.test.ts :: RECON-O4: the same absence is reported as unresolved rather than silently dropped`.
+
+---
+
+# sync-conformance learnings ledger
+
+`@keeper.sh/sync-conformance` at `packages/sync-kit/conformance`: the executable specification every
+adapter runs against itself. One entry point, `runConformance({ name, supports, create, withinWindow })`,
+which generates the case set from the adapter's declared `Capabilities`, registers it with `describe`/`it`
+and returns a report naming every case it selected, every case it took the alternative branch of, and every
+case it skipped. It ships an in-memory reference provider that passes, plus four fixtures that truncate a
+page, expire a cursor, force a precondition conflict and stall a request forever.
+
+Numbering is prefixed `CONF-` so it appends to the protocol (1–60), sync-ical (`ICAL-I1`–`ICAL-I71`) and
+sync-reconcile (`RECON-I1`–`RECON-I85`) ledgers above without renumbering anyone. `CONF-I1`–`CONF-I60` are
+adopted. `CONF-I61`–`CONF-I68` are not applicable and say why. `CONF-I69`–`CONF-I78` are the dependency and
+process decisions. The module map, the public API and the `CONF-O` (overwrite) / `CONF-L` (lockup) test
+indexes are the closing sections.
+
+This document is written **before** the implementation. Citations are therefore **Planned case.** lines
+naming the case id and the test file it will live in. When the suite lands, each becomes a **Proved by.**
+line and the same mechanical walk `RECON-I84` added for sync-reconcile is added for this section.
+
+A note on what "honoured" means here, because this package is unusual. sync-protocol honours a lesson by
+making the wrong thing unsayable in the type system; sync-reconcile honours it by computing the right
+answer. sync-conformance honours it by **generating a case that fails when an adapter gets it wrong**, and
+by shipping a **negative control** — a deliberately mutated provider that must fail exactly that case and no
+other. A conformance case with no negative control is an assertion nobody has ever seen fail, which is the
+same failure class as a capability flag nobody checks (CONF-I37).
+
+---
+
+## Adopted
+
+### CONF-I1. A truncated read is indistinguishable from a deletion, so it must be a different listing kind
+
+**Lesson.** `ingestSource` given a fetch that silently returned 1 of 3 stored events emitted 2 deletes, and
+those deletes reached real calendars. The repo keeps this as a characterization test, not a bug report,
+because it is the executable reason `CalDAVClient.fetchCalendarObjects` throws on a short multiget.
+**Learned from.** `packages/calendar/tests/core/sync-engine/ingest-truncation.test.ts ::
+"deletes every stored source event when a fetch silently returns a subset"`;
+`providers/caldav/shared/client.ts` (`CalDAVIncompleteMultiGetError`); RFC 6578 §3.6, which signals
+truncation with a 207 whose request-URI response carries 507 plus `DAV:number-of-matches-within-limits`.
+**Honoured by.** The flagship fixture `truncatingAfter(n)`, and the flagship case family
+`deletion-safety`. For every adapter the suite asserts: a truncated page yields `kind: "partial"` or
+`Result.ok === false`, never `snapshot`; `assertNoRemovalDerivable` passes on the result; and the cursor is
+unchanged. The type system already forbids `removals` and `coverage` on `partial` (protocol entry 1), so
+the runtime case exists to prove the **adapter** reaches that kind rather than manufacturing a `snapshot`
+from a short read.
+**Planned case.** `CONF-O1` in `conformance/tests/deletion-safety.test.ts`.
+
+### CONF-I2. An empty listing must never mean "the calendar is empty"
+
+**Lesson.** A failed HTTP fetch was swallowed and returned as empty, which ingest read as "the source
+authoritatively has zero events" and deleted every `event_state` row for the calendar on the next tick.
+**Learned from.** commit `0184ea19` *fix(ics): don't wipe existing events when remote fetch fails (#383)*;
+`ics/utils/fetch-adapter.ts`; test *"propagates fetch errors instead of returning empty events"*.
+**Honoured by.** An ungated case that drives the adapter with a transport that fails, and asserts
+`Result.ok === false` with a typed `ProviderFailure`. A separate case seeds a genuinely empty calendar and
+asserts the two outputs are **distinguishable** — a suite that only checked "does not throw" would pass
+both.
+**Planned case.** `CONF-O2` in `conformance/tests/deletion-safety.test.ts`.
+
+### CONF-I3. Deletion authority is a discriminant, not a flag, and differs per adapter
+
+**Lesson.** A delta source reports only changes, so absence means unchanged; a snapshot source re-reports
+its coverage, so absence means gone. The old code threaded `isDeltaSync?: boolean` through four call sites.
+**Learned from.** `core/source/event-diff.ts` (`buildSourceEventStateIdsToRemove`);
+`core/sync-engine/ingest.ts` (`getNonRecurringStoredEventIdsOutsideWindow`).
+**Honoured by.** `supports.deletionAuthority` selects a case set rather than removing one.
+`snapshotAbsence` gets "an event absent from a snapshot inside proven coverage is removed";
+`explicitRemovalsOnly` gets "an event absent from a listing is never removed, and a named removal is". Both
+halves are generated; neither adapter runs the other's. The report records which branch was taken so the
+adapter's own test file asserts on it.
+**Planned case.** `CONF-O3` in `conformance/tests/deletion-safety.test.ts`.
+
+### CONF-I4. Deletion may only be inferred inside a coverage window the listing itself proved
+
+**Lesson.** Reconciliation carries `authoritativeWindow`, `authoritativeSourceWindows` and
+`requestedWindow` as three separate values with different powers; a destination whose sources are
+unverified is limited to explicit requested-window cleanup.
+**Learned from.** `core/sync/operations.ts` (`ReconciliationScope`, `isInsideSourceAuthoritativeWindow`);
+tests *"does not reconcile a mapping inside the requested window but outside source coverage"*,
+*"limits unverified reconciliation to explicit requested-window cleanup"*.
+**Honoured by.** The suite requests a window strictly wider than the reference provider will cover, and
+asserts the returned `listing.coverage.covered` is the narrower one and that no removal is derivable for
+identities in the requested-but-uncovered band. It also asserts `coverage.calendar` equals `scope.calendar`
+— a coverage window proved for a different calendar is a foreign-calendar overwrite (RECON-I27).
+**Planned case.** `CONF-O4` in `conformance/tests/deletion-safety.test.ts`.
+
+### CONF-I5. A withheld event is present, not absent
+
+**Lesson.** Filtering an unrepresentable event out of the listing makes the diff see it as absent and
+delete the stored row the user still has. The ICS adapter deliberately keeps unsupported UIDs **in**
+`events` and reports them separately.
+**Learned from.** `ics/utils/fetch-adapter.ts` (`unsupportedEventUids`); `core/sync-engine/ingest.ts`
+lines 226–232, 323–336; tests *"withholds unsupported events, counts them, and keeps their stored state"*,
+*"never deletes the stored row of the event it withholds"*.
+**Honoured by.** An ungated case that seeds an event the adapter cannot represent, asserts it appears in
+`listing.withheld` with a `WithholdReason`, and asserts no removal is derivable for its identity. The
+assertion runs on **both** sides: the withheld identity must also not appear as a deletable mirror
+(CONF-I41).
+**Planned case.** `CONF-O5` in `conformance/tests/deletion-safety.test.ts`.
+
+### CONF-I6. One bad event must not stall the whole feed, and a real deletion in the same payload still applies
+
+**Lesson.** A single VEVENT with an hour-based all-day DURATION, a negative DURATION, a THISANDFUTURE
+override or an uninterpretable TZID used to throw out of the whole fetch — nothing applied, the token never
+advanced, the calendar never converged.
+**Learned from.** commits `fdd9ba62` (#634) and `43292a9f` (#606);
+`ics-malformed-vevent-telemetry.test.ts :: "applies a real deletion that arrives in the same feed as a
+malformed VEVENT"`, *"converges over repeated polls of the same malformed feed"*.
+**Honoured by.** A three-part case: a listing carrying one unusable item still returns `ok` with the other
+items; a genuine removal delivered in the same listing is still expressed; and polling the same input twice
+produces byte-identical output including diagnostics.
+**Planned case.** `CONF-O6` in `conformance/tests/isolation.test.ts`.
+
+### CONF-I7. An unbuildable newest revision must withhold its whole identity, not fall back to the older one
+
+**Lesson.** Letting the superseded revision win syncs the instance at a stale time — a silent wrong write,
+not a missing one.
+**Learned from.** `ics/utils/parse-ics-events.ts` lines 413–444; commit `8106280b`;
+`ics-stale-revision-telemetry.test.ts :: "never reverts a stored event to the time the publisher moved it
+away from"`.
+**Honoured by.** An overwrite case that seeds two revisions of one identity where the newer is
+unrepresentable, and asserts the older revision's time is **not** written — the adapter must withhold the
+identity, not downgrade it.
+**Planned case.** `CONF-O7` in `conformance/tests/writes.test.ts`.
+
+### CONF-I8. Revision order is a total order derived from content, never feed order
+
+**Lesson.** Producing a different winner when the same pair is listed in the opposite order churns the
+stored row on every poll.
+**Learned from.** `ics/utils/parse-ics-events.ts` (`compareEventRevisions`);
+`ics-superseded-slot-telemetry.test.ts :: "drops the same copy whichever order the feed lists the pair in"`,
+*"settles without churning the surviving row over repeated polls"*.
+**Honoured by.** The order-permutation case: the same colliding pair is fed in both orders and the two
+listings must be deeply equal after canonicalisation, then polled twice for zero further writes.
+**Planned case.** `CONF-O8` in `conformance/tests/convergence.test.ts`.
+
+### CONF-I9. Re-ingesting identical input must be no work at all, not an idempotent write
+
+**Lesson.** Any residual churn multiplies into destination writes, quota, audit-log entries and etag
+invalidation for other clients.
+**Learned from.** `degenerate-range-source-ingest.test.ts :: "re-reads an unchanged feed as no work at
+all"`; `ingest.test.ts :: "does not flush when there are no changes"`; the twelve `*convergence*` suites.
+**Honoured by.** Convergence is asserted as a **count of write operations**, not state equality: every
+generated case ends with a second run whose write count must be zero. The reference provider is exercised
+by a full fixed point — list, plan, apply, list, plan — and the second plan must be empty.
+**Planned case.** `CONF-O9` in `conformance/tests/convergence.test.ts`.
+
+### CONF-I10. An expired cursor discards the whole pagination, clears the token, and carries no tombstones
+
+**Lesson.** A 410 mid-pagination must discard every accumulated page rather than commit a partial result,
+and the sync token only advances when the whole pagination completes.
+**Learned from.** `providers/google/source/utils/fetch-events.ts` (`fullSyncRequired` returned from inside
+the page loop); the Outlook equivalent; `core/sync-engine/ingest.ts`
+(`fullSyncRequired => flush({inserts:[],deletes:[],syncToken:null})`); Google's documented 410 GONE;
+Graph's 410 `syncStateNotFound`; RFC 6578 §3.2 `DAV:valid-sync-token`.
+**Honoured by.** The `expiringCursorAfter(n)` fixture, and a case asserting all four of: the listing kind
+is `cursorLost`; no events and no removals leak out (the type forbids the fields, the case proves the
+adapter does not instead return an empty `delta`); the cursor is cleared rather than retained; and the
+resync that follows is what deletes.
+**Planned case.** `CONF-O10` in `conformance/tests/cursor.test.ts`.
+
+### CONF-I11. A cursor is valid only for the request shape that minted it
+
+**Lesson.** Sync tokens were stored with an encoded sync-window version; widening the required window
+discards the token and forces a backfill, because a token minted under a narrower window will never report
+events in the newly added range.
+**Learned from.** `core/oauth/sync-token.ts` (`resolveSyncTokenForWindow`, `requiresBackfill`);
+`tests/core/oauth/sync-token.test.ts`.
+**Honoured by.** Gated on `supports.delta.windowBoundToCursor`. Mint a cursor under window A, request
+window B ⊃ A with the same cursor, and assert the adapter answers `cursorLost` (or a `cursorInvalid`
+failure) rather than a delta that silently omits the new range. The protocol already carries `scope` on
+`SyncCursor`, so the adapter has the information; the case proves it uses it.
+**Planned case.** `CONF-O11` in `conformance/tests/cursor.test.ts`.
+
+### CONF-I12. Corrupt known state forces a resync and never becomes a tombstone by omission
+
+**Lesson.** A stored row that fails validation is removed only if the fetch still reports its identity; on
+a delta sync any validation failure resets the token instead of diffing against a partial picture.
+**Learned from.** `core/sync-engine/ingest.ts` lines 285–304; tests *"resets delta sync when a corrupt
+stored row requires full-sync recovery"*, *"keeps an unparseable stored row belonging to a withheld
+over-budget series"*.
+**Honoured by.** A case that seeds the provider-under-test with a corrupt known row through the
+`ProviderUnderTest.seed` seam, asserts a resync is demanded, and asserts zero removals are emitted.
+**Planned case.** `CONF-O12` in `conformance/tests/deletion-safety.test.ts`.
+
+### CONF-I13. An ambiguous removal is not a deletion
+
+**Lesson.** Graph's `@removed` tombstone may omit the event type, and a sparse id may name a series master
+while local state holds only expanded instances — advancing the token would strand every occurrence. The
+code declares the whole delta unusable and demands a full sync rather than guessing.
+**Learned from.** `providers/outlook/source/utils/fetch-events.ts` (the `@removed && !event.type` branch,
+the seriesMaster-in-delta branch).
+**Honoured by.** Gated on `supports.removalsAreAmbiguous`. An ambiguous removal must produce either
+`cursorLost` or a listing whose removals exclude it; never an `AuthoritativeRemoval`. The negative control
+is a mutant that maps the ambiguous tombstone to `kind: "deleted"`.
+**Planned case.** `CONF-O13` in `conformance/tests/deletion-safety.test.ts`.
+
+### CONF-I14. A replayed create is a no-op; a create conflict without a usable precondition is a refusal
+
+**Lesson.** `recoverCreateConflict` returns early when the remote copy already matches, and otherwise
+requires an ETag, throwing *"already exists but has no ETag for a safe recreation"* rather than
+delete-then-create blind.
+**Learned from.** `providers/caldav/destination/provider.ts`; `caldav/shared/client.ts`
+(412 → `CalDAVCreateConflictError`); RFC 4791 §4.1 (`CALDAV:no-uid-conflict`) and §5.3.2
+(`If-None-Match: *`).
+**Honoured by.** Two ungated cases. Replaying an identical `create` with the same `IdempotencyKey` must
+return `alreadyExists` or `unchanged` with the same `RemoteRef`, and the store must hold exactly one
+object. A conflicting create whose remote copy differs must return `conflict` carrying the observed
+precondition — never a `deleted` followed by a `created`, which the suite detects by counting the
+provider's write log.
+**Planned case.** `CONF-O14` and `CONF-O15` in `conformance/tests/writes.test.ts`.
+
+### CONF-I15. Provenance is per-provider and may be undetectable, and that must be sayable
+
+**Lesson.** Google and ICS detect our own events by a UID suffix; Outlook by a category, because Graph
+rewrites `iCalUId`; CalDAV by the `.ics` filename. Outlook's reader checks both.
+**Learned from.** `core/events/identity.ts` (`isKeeperEvent`);
+`providers/outlook/source/utils/fetch-events.ts` lines 565–573; `providers/caldav/destination/provider.ts`.
+**Honoured by.** `supports.provenanceChannel` selects the carrier, and the case is proved by **round trip**
+— write through the adapter, list back through the same adapter, assert the returned event is `OwnEvent`
+with our `InstallationId` — never by inspecting provider internals. For `none`, the alternative case
+asserts the round-tripped event is `IndeterminateEvent` and that no deletion of an indeterminate event is
+derivable.
+**Planned case.** `CONF-O16` in `conformance/tests/provenance.test.ts`.
+
+### CONF-I16. A foreign event must survive every reconciliation the suite can generate
+
+**Lesson.** Orphan cleanup skips `!remoteEvent.isKeeperEvent` and skips anything outside the authoritative
+window. Without the window check, a freshly imported calendar deletes Keeper-tagged events another row
+legitimately placed there.
+**Learned from.** `core/sync/operations.ts` lines 590–613; tests *"does not remove unmapped non-keeper
+future events"*, *"does not remove an unmapped non-keeper event after it becomes historical"*.
+**Honoured by.** Every write-family case seeds one `ForeignEvent` in the destination calendar as a
+**canary**, and the shared teardown asserts it is byte-identical afterwards. It is also asserted in its own
+case, so a teardown regression cannot silently disarm it.
+**Planned case.** `CONF-O17` in `conformance/tests/provenance.test.ts`.
+
+### CONF-I17. Echo verification is three-state, and "no echo" is not "matched"
+
+**Lesson.** A CalDAV PUT answers 201/204 with no body, so there is nothing to compare; the code declares
+`{ comparable: false }` rather than reporting zero divergence. Only booleans and lengths ever leave the
+echo module — never field values.
+**Learned from.** `providers/caldav/destination/provider.ts` (`CALDAV_PUSH_ECHO`);
+`core/events/push-echo.ts` header comment; `core/sync-engine/index.ts` (`tallyPushEcho`).
+**Honoured by.** Gated on `supports.echoesWrites`. An adapter that cannot echo must return
+`echo: { kind: "notObserved" }`, and the suite asserts the report counts it as **not observed**, not as
+matched. A separate ungated assertion scans every `BoundedSample` the adapter emits for the seeded event's
+title, description and location strings, and fails if any appears — diagnostics carry identifiers, never
+content.
+**Planned case.** `CONF-O18` in `conformance/tests/writes.test.ts`; the content-leak scan is `CONF-O19` in
+`conformance/tests/diagnostics.test.ts`.
+
+### CONF-I18. Echo must tolerate the provider's own lossless rewrites, or the mirror churns forever
+
+**Lesson.** Timestamps compared at whole-second granularity, text CRLF-normalised and trimmed,
+availability defaulting to busy, and an unsupported OOO availability coerced to busy must not read as
+drift.
+**Learned from.** `core/events/push-echo.ts` (`isSameSerializedSecond`); `core/events/content-hash.ts`;
+tests *"does not churn when a destination serializes timestamps to whole seconds"*, *"does not churn when a
+provider coerces unsupported OOO availability to busy"*; RFC 4791 §5.3.4, which forbids returning a strong
+ETag when the stored bytes differ from the submitted bytes.
+**Honoured by.** The **reference provider deliberately rewrites what it stores** — it truncates sub-second
+precision, normalises CRLF and trims trailing whitespace — so any adapter that trusts its own submitted
+representation instead of the provider's returned `RemoteVersion`/`Fingerprint` fails the convergence case
+rather than passing it by luck.
+**Planned case.** `CONF-O20` in `conformance/tests/convergence.test.ts`.
+
+### CONF-I19. Identity is canonical and excludes mutable content
+
+**Lesson.** Key order, `undefined` vs `null`, and array order must not produce a false change; occurrence
+identity is distinct from resource identity.
+**Learned from.** `core/source/event-diff.ts` (`canonicalizeStructuredIdentityValue`,
+`buildSourceEventIdentityKey`); tests *"does not diff equivalent recurrence payloads with different key
+order"*, *"handles null/undefined timezone by treating them as equivalent"*.
+**Honoured by.** The suite's own canonical encoder follows RFC 8785 key ordering (UTF-16 code-unit order,
+**not** `localeCompare`) and is used for every deep comparison the suite makes. A generated case presents
+the same event twice with permuted key order and equivalent absent-value spellings, and asserts one
+identity and zero writes. A dedicated case covers astral-plane and combining-mark keys, because the sorting
+rule is the footgun.
+**Planned case.** `CONF-O21` in `conformance/tests/convergence.test.ts`.
+
+### CONF-I20. A repeated identity in one listing is one entry, last observation wins
+
+**Lesson.** One provider batch reporting the same occurrence several times produced duplicate inserts;
+Google's delta applies only the final version when an occurrence changes repeatedly in one delta. Graph
+documents replays explicitly and guarantees no ordering.
+**Learned from.** `core/source/event-diff.ts` (`deduplicateIncomingEvents`); `ingest.test.ts :: "applies
+only the final version when a provider occurrence changes repeatedly in one delta"`;
+learn.microsoft.com/graph/delta-query-overview §Replays.
+**Honoured by.** A case that makes the provider emit one identity N times in a single listing and asserts
+the reconciled result has exactly one entry equal to the last observation, and that feeding the repeats in
+reverse order yields the same winner (CONF-I8).
+**Planned case.** `CONF-O22` in `conformance/tests/convergence.test.ts`.
+
+### CONF-I21. Every retry path has a provable ceiling and a capped provider-supplied delay
+
+**Lesson.** `withBackoff` bounds attempts, caps `Retry-After` at 64s, uses an abortable `setTimeout`-based
+sleep that removes its listener on the timeout path and clears the timer on the abort path, and ends with
+an explicit unreachable throw so the loop cannot fall out silently.
+**Learned from.** `core/utils/backoff.ts`; `backoff.test.ts :: "caps a provider-supplied delay at the
+maximum backoff"`, *"throws after exhausting all retries"*.
+**Honoured by.** `OperationContext.retryBudget` is handed to the adapter by the suite, and the lockup case
+drives a transport that always answers `rateLimited` with a `retryAfter` far past the budget ceiling. The
+case asserts a bounded transport call count and that total advanced fake time stays under
+`maxAttempts * retryDelayCeilingMs`.
+**Planned case.** `CONF-L1` in `conformance/tests/lockups.test.ts`.
+
+### CONF-I22. Every await on an outside resource carries a deadline, and a timeout is not a caller abort
+
+**Lesson.** `mergeAbortSignals` removes every listener on the first abort, and `buildTimeoutSignal` keeps a
+separate `isTimeout()` so a caller-initiated abort is not misreported as a provider timeout.
+**Learned from.** `core/utils/fetch-with-timeout.ts` (`RequestTimeoutError`, `isTimeoutError`);
+`fetch-with-timeout.test.ts`.
+**Honoured by.** The `stallingOn(predicate)` fixture returns `new Promise(() => {})` — a permanently
+pending promise, never a long timer, so the case proves the deadline comes from outside the awaited work.
+Two separate cases: a deadline elapsed on the fake clock must settle as a `transport`/`notAttempted`
+failure; an externally aborted signal mid-flight must settle as `notAttempted` with reason `aborted`, which
+the suite asserts is a **different** value from the deadline case.
+**Planned case.** `CONF-L2` and `CONF-L3` in `conformance/tests/lockups.test.ts`.
+
+### CONF-I23. A single-flight leader's failure reaches every follower, and the slot is freed on the throwing path
+
+**Lesson.** The refresh coordinator deletes its in-flight entry in a `finally` guarded by an identity check
+so a later generation is not evicted, and the distributed release is best-effort with a TTL fallback so a
+release failure cannot wedge the next caller.
+**Learned from.** `core/oauth/refresh-coordinator.ts`; `refresh-coordinator.test.ts :: "coalesces
+concurrent refreshes for the same credential"`, *"releases the lock after failures"*.
+**Honoured by.** Four assertions, not two: the leader's rejection reaches every follower registered before
+it settled; the coalescing slot is freed on the rejecting path; a follower registering **after** the leader
+rejected starts a fresh attempt rather than inheriting the dead one (the gap the existing repo tests do not
+cover); and a second generation started after the first settled is not evicted by the first's `finally`.
+Gated on the adapter declaring any coalescing at all, which the suite detects by observing fewer transport
+calls than concurrent invocations.
+**Planned case.** `CONF-L4` in `conformance/tests/lockups.test.ts`.
+
+### CONF-I24. Telemetry emitted inside a coalesced body lands on a foreign caller's context
+
+**Lesson.** Only the joining branch runs in the joining caller's async context; a shared body runs in
+whichever context created the promise, so telemetry emitted there is attributed to the wrong wide event.
+**Learned from.** `core/oauth/refresh-coordinator.ts` (the comment above
+`widelog.set("token.refresh_coalesced")`); `core/sync-engine/ingest.ts` lines 191–205 (`measureDiff`).
+**Honoured by.** A constraint on the harness rather than a generated case: `runConformance` attributes
+`ListingDiagnostics` to the call that returned them, and the concurrency case asserts that two coalesced
+callers each receive their own diagnostics object with their own `pagesFetched`, rather than one object
+shared by reference.
+**Planned case.** `CONF-L5` in `conformance/tests/lockups.test.ts`.
+
+### CONF-I25. Multi-key acquisition must be in a canonical order
+
+**Lesson.** `withSourceIngestLocks` dedupes and sorts calendar ids before taking each advisory lock,
+because two runs touching the same pair in opposite orders deadlock.
+**Learned from.** `core/source/ingest-lock.ts`; `ingest-lock.test.ts :: "acquires every source lock before
+running work"`.
+**Honoured by.** A case that issues two concurrent `listChanges` calls over overlapping calendar sets in
+opposite orders and asserts both settle before the fake clock passes the deadline. Gated on the adapter
+enumerating more than one calendar.
+**Planned case.** `CONF-L6` in `conformance/tests/lockups.test.ts`.
+
+### CONF-I26. A lease releases on the throwing path and leaves no timer behind
+
+**Lesson.** The sync lock's renewal records an error and clears it on the next success; loss is detected by
+reading a different holder, not by the renewal flag; release always clears the interval before the release
+script, so an abandoned handle cannot leave a timer running.
+**Learned from.** `packages/sync/src/sync-lock.ts` (`createLockHandle`).
+**Honoured by.** The suite invokes every adapter operation once with a transport that throws synchronously
+and once with one that rejects, then asserts the operation can be invoked again and succeed — a lease held
+past a throw shows up as the second call hanging, which the deadline turns into a failure rather than a CI
+hang. After each case the suite advances the fake clock past every declared budget and asserts no timer
+callback fires.
+**Planned case.** `CONF-L7` and `CONF-L8` in `conformance/tests/lockups.test.ts`.
+
+### CONF-I27. A cancelled waiter must not strand its successors, and every poll has a ceiling
+
+**Lesson.** The sync lock's poll loop has an explicit timeout, returns `{acquired:false}` on abort, and its
+`finally` cancels the waiter on every non-acquiring exit, atomically promoting the previous live waiter.
+**Learned from.** `packages/sync/src/sync-lock.ts` (`CANCEL_WAITER_SCRIPT`).
+**Honoured by.** A case that starts three concurrent same-key operations, aborts the second mid-flight, and
+asserts the first and third both settle. The aborted one must reject; the others must not inherit its abort
+reason.
+**Planned case.** `CONF-L9` in `conformance/tests/lockups.test.ts`.
+
+### CONF-I28. An aborted queued task is rejected, not dropped, and its slot is not lost
+
+**Lesson.** The rate limiter splices the cancelled task out, rejects it with a named error and re-runs the
+queue so the concurrency slot is not lost; `executeTask` decrements in a `finally` so a throwing task
+cannot leak a permit permanently.
+**Learned from.** `core/utils/rate-limiter.ts`; `rate-limiter.test.ts :: "rejects an aborted queued task
+without starting it"`.
+**Honoured by.** A case that queues N operations against an adapter whose declared concurrency is less than
+N, makes one throw and aborts another, and asserts the remaining N−2 all complete. A permanently leaked
+permit shows up as the tail never settling, which the deadline converts into a failure.
+**Planned case.** `CONF-L10` in `conformance/tests/lockups.test.ts`.
+
+### CONF-I29. Fan-out returns a result for every task, and never exceeds the declared concurrency
+
+**Lesson.** `allSettledWithConcurrency` builds a bounded worker pool that catches per task, so one
+rejection cannot abort the pool or leave holes in the results.
+**Learned from.** `core/utils/concurrency.ts`.
+**Honoured by.** A case in which task k rejects and task j stalls forever: the suite asserts N results are
+returned (not N−1), that the stalled one is a deadline failure rather than a missing entry, and that
+`transport.inFlightPeak()` never exceeded the concurrency the adapter declared.
+**Planned case.** `CONF-L11` in `conformance/tests/lockups.test.ts`.
+
+### CONF-I30. Failures are classified by discriminant, never by matching message text
+
+**Lesson.** A database error's message inlines the SQL and its bound parameters, so **customer data** can
+match a backoff pattern and put a healthy calendar into permanent backoff.
+**Learned from.** `packages/sync/src/destination-errors.ts` (`BACKOFF_ERROR_PATTERNS` and its
+`isDatabaseError` early return).
+**Honoured by.** `ProviderFailure` is already a discriminated union, so the case is hostile rather than
+structural: the suite seeds an event whose title and description contain `"rate limit exceeded"`,
+`"410 Gone"`, `"Precondition Failed"` and a NUL byte, and asserts every failure classification and every
+identity key is unchanged from the benign run.
+**Planned case.** `CONF-O23` in `conformance/tests/hostile-content.test.ts`.
+
+### CONF-I31. An unattempted run is a third state, neither success nor failure
+
+**Lesson.** `resolveDestinationAttemptVerdict` returns "inconclusive" when superseded with zero attempted
+operations — escalating punishes a healthy destination, clearing lets a broken one oscillate forever.
+**Learned from.** `packages/sync/src/destination-errors.ts`.
+**Honoured by.** A case that aborts before the first transport call and asserts the outcome is
+`notAttempted`, plus an assertion that the suite's own report counts it in neither the passed nor the
+failed tally — the third state must survive the harness, not just the adapter.
+**Planned case.** `CONF-L12` in `conformance/tests/lockups.test.ts`.
+
+### CONF-I32. A superseded run never advances the cursor
+
+**Lesson.** ingest fetches, checks `isCurrent()`, then opens the transaction; on supersession it returns
+empty with `flushed: false` and no sync token. Writing a cursor on the superseded path advances the sync
+frontier past changes that were never applied — silent, unrecoverable data loss.
+**Learned from.** `core/sync-engine/ingest.ts` lines 260–266; `ingest-superseded.test.ts :: "never writes a
+sync token on the superseded path"`.
+**Honoured by.** A case that aborts the operation after the first page and before the last, and asserts the
+adapter returns no `SyncCursor` — with that test name reused verbatim, because the name is the invariant.
+Cursor non-advancement is asserted on three separate paths: truncated read, aborted run, transport failure.
+**Planned case.** `CONF-O24` in `conformance/tests/cursor.test.ts`.
+
+### CONF-I33. A replace whose create fails after the delete succeeded must leave a recoverable state
+
+**Lesson.** The engine checkpoints removals before adds, checkpoints a successful chunk before a later one
+fails, and keeps the stale mapping when a recreation fails after a successful delete, so a crash between
+delete and create does not orphan a real event.
+**Learned from.** commit `1c5171d2`; `index.test.ts :: "keeps the stale mapping when recreation fails after
+a successful delete"`, *"does not checkpoint the stale mapping when recreation aborts after deletion"*.
+**Honoured by.** The `conflictingOn(predicate)` fixture is pointed at the create half of a replace. The
+case asserts the delete outcome is reported separately from the create failure — the adapter must not
+report a replace atomically when it was not — so the caller retains enough to recreate on the next run.
+**Planned case.** `CONF-O25` in `conformance/tests/writes.test.ts`.
+
+### CONF-I34. Storage bounds and mirror bounds are different windows
+
+**Lesson.** ICS retains the whole feed unbounded, because filtering by window would make the snapshot diff
+delete every historic stored row on the next ingest; the sync window bounds only what is mirrored.
+**Learned from.** `ics/utils/fetch-adapter.ts` (*"The whole feed is kept on purpose…"*);
+`fetch-adapter.test.ts :: "returns events far outside the sync window so stored history stays unbounded"`;
+`ingest.test.ts :: "keeps stored history a snapshot source still reports outside the sync window"`.
+**Honoured by.** A case gated on `supports.deletionAuthority === "snapshotAbsence"` in which the provider
+reports an event outside the requested window: the suite asserts it is returned, that no removal is
+derivable for it, and that two polls do not oscillate between add and retire.
+**Planned case.** `CONF-O26` in `conformance/tests/window.test.ts`.
+
+### CONF-I35. Window membership is one predicate, used at every stage, swept at every boundary
+
+**Lesson.** An event that survives one stage and is dropped by the next oscillates forever.
+`overlapsTimeWindow` is a single predicate with a documented special case: a degenerate range is judged by
+`start >= windowStart && start < windowEnd`.
+**Learned from.** `core/events/time-range.ts`; `ingest-window-boundary.test.ts :: "window boundary
+agreement between adapter filter and delta pruner"`.
+**Honoured by.** `runConformance` takes `withinWindow: WindowMembership` as an **argument** and uses that
+one function for every window judgement it makes, so an adapter cannot be checked against a predicate that
+differs from the one the reconciler will use. A boundary sweep case covers exactly-on-lower-edge,
+exactly-on-upper-edge, zero-duration and inverted, and asserts the same verdict at listing time and at
+removal time, then convergence after two polls.
+**Planned case.** `CONF-O27` in `conformance/tests/window.test.ts`.
+
+### CONF-I36. Degenerate ranges are real events; widening at the destination must not read as drift
+
+**Lesson.** Zero-duration and inverted ranges are legitimate and must be preserved, but must be widened at
+the destination because RFC 5545 §3.6.1 requires DTEND > DTSTART and Google rejects a non-positive span.
+The source row must not then read as changed.
+**Learned from.** `core/events/time-range.ts` (`POINT_IN_TIME_DURATION_MS`); commit `b057d2e0` (#616);
+`degenerate-range-source-ingest.test.ts :: "does not treat a stored source row as changed after a
+destination widened its mirror"`.
+**Honoured by.** Gated on `supports.representableRange.zeroDuration` and `.invertedRange`. `accept` gets
+the mirror-and-echo case: write a zero-duration event, have the fixture echo back the widened copy, assert
+the next run performs zero writes. `reject` gets the alternative case: the write must return
+`unrepresentable` with constraint `minimumSpan`, and must not silently widen.
+**Planned case.** `CONF-O28` in `conformance/tests/window.test.ts`.
+
+### CONF-I37. A capability declaration that is never checked against behaviour is worthless
+
+**Lesson.** Provider representational limits must be declared up front rather than discovered at write
+time, and `supportedAvailabilities` exists so a coercion is expected rather than read as drift.
+**Learned from.** `providers/outlook/destination/provider.ts`; `operations.test.ts :: "does not churn when
+a provider coerces unsupported OOO availability to busy"`.
+**Honoured by.** `supports` drives selection in **both** directions. For every capability whose value is a
+refusal (`zeroDuration: "reject"`, `recurrenceWrite: "none"`, `delta: { kind: "none" }`,
+`echoesWrites: false`), the suite generates a case asserting the adapter **actually refuses** the input it
+declared unsupported, with a typed `unsupported`/`unrepresentable` result. No capability value removes a
+case; each selects a different one. The ungated set — deletion safety, precondition, provenance, deadline,
+retry ceiling — is a named `as const` list, and the report exposes it so an adapter's own test file can
+assert none of them was skipped.
+**Planned case.** `CONF-O29` in `conformance/tests/capabilities.test.ts`.
+
+### CONF-I38. Every drop is counted, self-authored separately, and the counts are stable across polls
+
+**Lesson.** Folding Keeper's own mirrors into `unrepresentable` made that counter permanently non-zero on
+every mirrored calendar, destroying its value as an alarm. Counters must be per-run, not accumulating, and
+must not churn between identical polls.
+**Learned from.** commit `fdd9ba62` (#634); `core/sync-engine/ingest.ts` (`DiscardedSourceEventCounts`:
+*"These counts are the only trace that removal leaves"*);
+`ics-discard-telemetry.test.ts :: "reports a clean feed as having discarded nothing"`;
+`ics-revision-collapse-telemetry.test.ts :: "keeps reporting the dropped occurrence on every later run
+without churn"`.
+**Honoured by.** `ListingDiagnostics` already separates `withheld`, `selfAuthored` and `unrepresentable`.
+Three generated cases: a clean listing reports all-zero totals; a listing with one self-authored and one
+unrepresentable event increments exactly one counter each; and the same input polled twice produces
+identical diagnostics, including sample order.
+**Planned case.** `CONF-O30` in `conformance/tests/diagnostics.test.ts`.
+
+### CONF-I39. Identifier lists are a bounded sample beside an exact uncapped total
+
+**Lesson.** An uncapped list pushed the wide event past what the log pipeline retains and took the counters
+with it, losing the alarm entirely. Capped by both entry count and total bytes.
+**Learned from.** `core/sync-engine/ingest.ts` (`WIDE_EVENT_LIST_LIMIT`, `WIDE_EVENT_LIST_MAX_LENGTH`);
+`ingest-wide-event-list-bounds.test.ts`.
+**Honoured by.** A case that seeds thousands of withheld events and one pathologically long identifier, and
+asserts `BoundedSample.sample` is bounded in both entry count and total UTF-16 length while
+`BoundedSample.total` is exact. A companion assertion checks every diagnostic value is a loggable scalar —
+never an object, never `undefined`.
+**Planned case.** `CONF-O31` in `conformance/tests/diagnostics.test.ts`.
+
+### CONF-I40. A discarded event may be missing the identifier you would log it by
+
+**Lesson.** Publishers strip DTSTART, or strip UID, before deleting.
+**Learned from.** `ics-discard-telemetry.test.ts :: "counts an event the feed publisher stripped UID from
+before deleting it"`.
+**Honoured by.** `WithheldIdentity` already requires at least one of `uid` and `id`. The fixture corpus
+includes an identity-less discard, and the case asserts it is still reported with reason `missingIdentity`
+rather than dropped silently.
+**Planned case.** `CONF-O32` in `conformance/tests/diagnostics.test.ts`.
+
+### CONF-I41. A withheld identity must not cost the user its existing mirror
+
+**Lesson.** An over-budget series was dropped from inserts but had to be kept from removals, and its
+mirrors kept too, or a widened sync range mass-deletes the user's events and pushes the calendar into
+permanent backoff.
+**Learned from.** `core/sync-engine/ingest.ts` lines 247–257; `core/sync/operations.ts`
+(`withheldSourceEventStateIds`); `operations.test.ts :: "keeps the mirrors of a series withheld for
+exceeding the occurrence budget"`, *"still retires a withheld series' mapping once it falls outside the
+requested window"*.
+**Honoured by.** The withheld case is asserted on the **destination** side as well: a mirror whose source
+identity was withheld this run must still exist afterwards, and must still be retired when it leaves the
+window. It is called out separately because a listing-only assertion would have missed the production
+incident.
+**Planned case.** `CONF-O33` in `conformance/tests/deletion-safety.test.ts`.
+
+### CONF-I42. A cancelled event is not an absent event
+
+**Lesson.** `STATUS:CANCELLED` is an input, never a filter; a cancelled master cancels its detached
+overrides; Google carries `cancelledEventIds` separately from `changedEventIds`.
+**Learned from.** `ics/utils/parse-ics-events.ts`; `parse-ics-events.test.ts :: "drops a cancelled master
+and all of its detached overrides"`; `providers/google/source/utils/fetch-events.ts`.
+**Honoured by.** `Removal` already distinguishes `deleted`, `cancelled` and `outOfScope`. The case
+exercises all three states a delta can express — named-and-changed, named-and-cancelled, unnamed — and
+asserts an unnamed identity is never removed while a cancelled one always is, and that `outOfScope` never
+drives a deletion.
+**Planned case.** `CONF-O34` in `conformance/tests/deletion-safety.test.ts`.
+
+### CONF-I43. An unsupported construct is withheld and counted, never approximated
+
+**Lesson.** Silently treating THISANDFUTURE as a plain override changes the meaning of every subsequent
+occurrence.
+**Learned from.** `parse-ics-events.test.ts :: "reports THISANDFUTURE as unsupported instead of changing
+its meaning"`.
+**Honoured by.** The generic form: for every `RepresentabilityConstraint` the adapter's capabilities say it
+cannot meet, the suite feeds an input violating it and asserts the result is `unrepresentable` with that
+exact constraint — never a "best effort" representation. The negative control is a mutant adapter that
+clamps instead of refusing.
+**Planned case.** `CONF-O35` in `conformance/tests/capabilities.test.ts`.
+
+### CONF-I44. An occurrence changing identity is a reassignment, not delete plus add
+
+**Lesson.** Treating it as delete+add makes the destination flicker and can orphan the real event; the
+reassignment must first prove the mirror is still ours.
+**Learned from.** `core/sync/operations.ts` (`OccurrenceReassignment`); `operations.test.ts :: "recreates a
+mapped event when the same event ID moves"`.
+**Honoured by.** A case that moves one occurrence of a series and asserts exactly one write, carrying an
+`ObservedPrecondition`, against a target whose provenance is `ours` — the write log must not contain an
+unconditional delete followed by a create.
+**Planned case.** `CONF-O36` in `conformance/tests/writes.test.ts`.
+
+### CONF-I45. A quiet calendar still advances its cursor
+
+**Lesson.** With zero inserts and zero deletes, ingest still flushes when there is a new sync token, a
+changed snapshot or new coverage — otherwise the cursor never advances and every poll refetches from the
+same point forever.
+**Learned from.** `core/sync-engine/ingest.ts` lines 344–366; `ingest.test.ts :: "flushes sync token even
+when delta sync yields no event changes"`.
+**Honoured by.** A case that polls an unchanged calendar under a delta cursor and asserts the returned
+listing carries a `SyncCursor` different from the one supplied, while the write count is zero. "No work"
+must not mean "no cursor write" — this is the exact counterweight to CONF-I9, and the pair is generated
+together so neither can be satisfied by breaking the other.
+**Planned case.** `CONF-O37` in `conformance/tests/cursor.test.ts`.
+
+### CONF-I46. A delta item is a patch, not a snapshot
+
+**Lesson.** Graph documents that updated instances carry the id plus *at least* the changed properties,
+that the same entity can appear multiple times in one session, and that no ordering may be assumed.
+**Learned from.** learn.microsoft.com/graph/delta-query-overview §Resource representation, §Replays.
+**Honoured by.** A case in which the provider emits a delta item carrying only the id and one changed
+field: the adapter must either fill the omitted fields from its own read or report the item as withheld —
+it must never emit a `RemoteEvent` whose omitted fields are blanked, which the case detects by comparing
+against the pre-delta content.
+**Planned case.** `CONF-O38` in `conformance/tests/cursor.test.ts`.
+
+### CONF-I47. Servers rewrite what you submit, so the written representation is not authoritative
+
+**Lesson.** RFC 4791 §5.3.4 forbids returning a strong ETag when the stored bytes differ from the submitted
+bytes, so the client must re-read rather than assume its local copy is authoritative. Google normalises
+bodies likewise.
+**Learned from.** RFC 4791 §5.3.4; the push-echo suites.
+**Honoured by.** Every write outcome carries a `RemoteVersion`; the suite asserts a write that returns no
+fresh version forces a re-read before the next write of the same target, by making the reference provider
+reject a second write whose precondition was derived from the submission rather than from a read.
+**Planned case.** `CONF-O39` in `conformance/tests/writes.test.ts`.
+
+### CONF-I48. There is no universal create-idempotency primitive, so it is declared vocabulary
+
+**Lesson.** CalDAV mandates UID uniqueness within a collection and offers `If-None-Match: *`; Google has no
+conditional insert at all and must go through `events.import` with an `iCalUID`.
+**Learned from.** RFC 4791 §4.1 and §5.3.2; Google's version-resources guide (*"no support for conditional
+modifications for insert"*) and the `events.import` reference.
+**Honoured by.** `WriteIntent.create` requires both an `IdempotencyKey` and `precondition: { kind:
+"absent" }`, so the guarantee is in the type regardless of vocabulary. `supports.precondition` selects
+which mechanism the case exercises, and there is **no** value that removes the replayed-create case: an
+adapter that cannot express a conditional insert must instead prove that the caller-supplied
+`IdempotencyKey` deduplicates.
+**Planned case.** `CONF-O14` in `conformance/tests/writes.test.ts`.
+
+### CONF-I49. A cursor is opaque, and a cursor the adapter cannot read is `cursorLost`, never an empty delta
+
+**Lesson.** Graph encodes `$select` and other query parameters inside the deltaLink, so reconstructing a
+request from a token's parts changes its meaning. An empty delta on a bad cursor is the worst possible
+answer: it reads as "nothing changed" and, to a snapshot-shaped consumer, as "everything was deleted".
+**Learned from.** learn.microsoft.com/graph/delta-query-overview §State tokens; RFC 6578 §3.2.
+**Honoured by.** The harness never parses `SyncCursor.value`. A case hands the adapter a cursor whose bytes
+have been mutated and asserts `cursorLost` or a `cursorInvalid` failure — never a throw, and never an empty
+`delta`. The suite asserts nothing about the cursor's format.
+**Planned case.** `CONF-O40` in `conformance/tests/cursor.test.ts`.
+
+### CONF-I50. Truncation and coverage are different claims, even where the RFC lets one token carry both
+
+**Lesson.** RFC 6578 §3.6 says the `DAV:sync-token` returned with a truncated result *"MUST represent the
+correct state for the partial set of changes returned"* — so a compliant CalDAV server hands back a
+resumable token on a short page. That token is safe to page with and catastrophic to treat as coverage.
+**Learned from.** RFC 6578 §3.6/§3.7 read against `ingest-truncation.test.ts :: "deletes every stored
+source event when a fetch silently returns a subset"`.
+**Honoured by.** The protocol splits the two: a truncated read is `kind: "partial"` carrying a
+`Continuation` and structurally no `cursor` and no `coverage`. The case asserts a CalDAV-shaped adapter
+surfaces the per-page token as a `Continuation` and never as a `SyncCursor` — resumability is preserved,
+coverage is not claimed.
+**Planned case.** `CONF-O41` in `conformance/tests/deletion-safety.test.ts`.
+
+### CONF-I51. Timing fixtures are built on `setTimeout` and a fake clock, never `Bun.sleep`, never real time
+
+**Lesson.** `Bun.sleep` is a native primitive `vi.useFakeTimers` cannot patch, so any test built on it burns
+real wall time in CI. The repo has paid for this twice. `bun test` is also the wrong runner and produces
+bogus *"vi.hoisted is not a function"* errors.
+**Learned from.** commits `34dc5079` (#806) and `e39851df` (#808); `core/utils/backoff.ts`;
+`packages/sync/src/sync-lock.ts`.
+**Honoured by.** The package's `TestClock` is built on `setTimeout` only, the stall fixture is
+`new Promise(() => {})` rather than a long timer, and every advance uses `vi.advanceTimersByTimeAsync` —
+the synchronous variant does not flush microtasks between callbacks and deadlocks against awaited promises.
+A hygiene test greps `src/` and `tests/` for `Bun.sleep` and fails on any hit, mirroring
+`ical/tests/hygiene/no-bun-sleep.test.ts`. The vitest config keeps a real per-test timeout as a backstop so
+a genuine wedge fails fast instead of hanging CI.
+**Planned case.** `conformance/tests/hygiene/no-bun-sleep.test.ts`.
+
+### CONF-I52. `AbortSignal.timeout` is not patched by fake timers, so deadlines come from the injected clock
+
+**Lesson.** vitest's fake timers do not mock `AbortSignal.timeout` or `node:timers/promises`; the root cause
+is upstream in sinon fake-timers and the issue is still open.
+**Learned from.** github.com/vitest-dev/vitest/issues/3088.
+**Honoured by.** `OperationContext.deadline` is an `Instant` and `OperationContext.now` is a function, both
+supplied by the suite; the suite constructs its own `AbortController` and fires it from a `setTimeout`.
+Neither the suite nor the reference provider calls `AbortSignal.timeout`, and a hygiene test asserts that.
+**Planned case.** `conformance/tests/hygiene/no-unpatchable-timers.test.ts`.
+
+### CONF-I53. A wall-clock assertion measures the CI agent, not the algorithm
+
+**Lesson.** The repo learned to assert on structure — call counts, ordering, emitted fields — and to test
+timing attribution by injecting a clock rather than measuring.
+**Learned from.** `phase-timing-clock.test.ts`; ledger `RECON-I83`.
+**Honoured by.** The deadline obligation is phrased as *"rejected with a deadline failure after the deadline
+elapsed on the fake clock"*, never *"completed within N real milliseconds"*. No case in this package reads
+`performance.now()` or `Date.now()`; a hygiene test enforces it.
+**Planned case.** `conformance/tests/hygiene/no-wall-clock.test.ts`.
+
+### CONF-I54. Dependencies arrive as arguments, and the suite must detect an adapter that ignores them
+
+**Lesson.** Every coordinator in the codebase takes its store as a parameter, which is precisely what makes
+the lockup tests possible with stubs. An adapter that imports its own clock or `fetch` makes the deadline
+and abort obligations pass **vacuously**, which is worse than not running them.
+**Learned from.** `core/oauth/refresh-coordinator.ts`, `core/sync-engine/generation.ts`,
+`packages/sync/src/sync-lock.ts`, `core/source/ingest-lock.ts`.
+**Honoured by.** `create(environment)` receives the clock, the hash function, the installation id and the
+transport stub. A dedicated **injection** case runs before every lockup case and asserts
+`environment.transport.callCount() > 0` and that `environment.clock.now` was called; an adapter that
+reached past its arguments fails that case explicitly instead of quietly passing the whole family.
+**Planned case.** `CONF-L13` in `conformance/tests/injection.test.ts`.
+
+### CONF-I55. The reference implementation must be adversarial about its own success
+
+**Lesson.** The repo's convergence tests re-run the whole pipeline and assert a fixed point, and several are
+named for it.
+**Learned from.** the twelve `*convergence*` suites; `vfy-shaping-fixed-point.test.ts`.
+**Honoured by.** The reference provider is exercised by a fixed-point case — list, plan, apply, list, plan,
+assert the second plan is empty — and is run through the full suite **bare and under each single fixture
+decorator**, so the fixtures are proven not to break correct behaviour. Separately, every case ships a
+negative control: a mutated reference provider that must fail exactly that case.
+**Planned case.** `conformance/tests/reference/fixed-point.test.ts`,
+`conformance/tests/reference/negative-controls.test.ts`.
+
+### CONF-I56. A failed run must not leak state into the run that follows it
+
+**Lesson.** No phase time carried forward, no counters accumulated, no partially flushed checkpoint left
+ambiguous.
+**Learned from.** `phase-timing-failures.test.ts :: "keeps a failed run from leaking phase time into the
+runs that follow it"`; `ingest.test.ts :: "checkpoints a successful chunk before a later chunk fails"`.
+**Honoured by.** A case that fails mid-run against a provider instance and then runs again against the same
+instance, asserting the second run converges and reports fresh per-run diagnostics rather than accumulated
+ones.
+**Planned case.** `CONF-O42` in `conformance/tests/diagnostics.test.ts`.
+
+### CONF-I57. A conformance suite with a shared provider acquires order dependence
+
+**Lesson.** Order dependence in a suite whose job is proving convergence is self-defeating.
+**Learned from.** the repo's per-test factory pattern; the brief's `create` factory.
+**Honoured by.** `create` is invoked **per case**, never per suite, and `ProviderUnderTest.dispose` runs in
+`afterEach`. Case order is derived from the `as const` case-id list, so it is stable and inspectable, but no
+case may depend on it.
+**Planned case.** `conformance/tests/harness/per-case-isolation.test.ts`.
+
+### CONF-I58. Provider differences belong in declared data, not in three copies of the same describe block
+
+**Lesson.** `calendar-rediscovery-adapters.test.ts` is three near-identical describe blocks, one per
+provider — parity written three times instead of once.
+**Learned from.** `packages/calendar/tests/core/source/calendar-rediscovery-adapters.test.ts`.
+**Honoured by.** This is the whole package: one `runConformance` call per adapter, one case list, capability
+values selecting branches. The existing three-block test is the prototype, and retiring it is the
+acceptance criterion for the package.
+**Planned case.** n/a — this is the package's premise, not a case.
+
+### CONF-I59. The invariant is the test name
+
+**Lesson.** Nearly every hard-won invariant in the old code survives as prose above a boolean flag
+(`isDeltaSync`, `unchanged`, `fullSyncRequired`, `comparable`), which is exactly why the same bug classes
+recurred.
+**Learned from.** `core/sync-engine/ingest.ts` (`FetchEventsResult`: nine optional flags and four comment
+blocks).
+**Honoured by.** Every generated case's title is the invariant, prefixed with its `CONF-O`/`CONF-L` id and
+cross-referenced to its ledger entry in `src/case-id.ts`, so the ledger can be walked against the suite by
+grep — the mechanical walk `RECON-I84` added for sync-reconcile.
+**Planned case.** `conformance/tests/hygiene/ledger-citations.test.ts`.
+
+### CONF-I60. A non-IANA zone identifier must never reach a canonical event
+
+**Lesson.** Windows/CLDR identifiers must be mapped from the full CLDR table and `tzone://Microsoft/Custom`
+TZIDs resolved from their declared VTIMEZONE offsets or refused — never guessed — and a Windows id must
+never leak out as `startTimeZone`.
+**Learned from.** commits `ac6fa18c` (#244) and `7c276d8e` (#242);
+`outlook-windows-timezone.test.ts :: "does not return Windows timezone ID as startTimeZone"`.
+**Honoured by.** Zone **resolution** belongs to sync-ical (ICAL-I17), but one negative assertion is cheap
+and it caught a real production bug: every `ZoneId` an adapter returns on a `RemoteEvent` must be accepted
+by `Intl.DateTimeFormat` as an IANA identifier, or the write must fail with constraint `zoneIdentifier`.
+**Planned case.** `CONF-O43` in `conformance/tests/capabilities.test.ts`.
+
+---
+
+## Not applicable
+
+### CONF-I61. RFC 5545 nominal versus exact DURATION
+
+Weeks and days are applied in wall time (a DST day is 23 or 25 hours); hours, minutes and seconds are
+absolute. **Not applicable.** This is `ICAL-I23` and `RECON-I57`. sync-conformance computes no durations. It
+applies only indirectly: a fixture that needs a DST-crossing recurring event must take its expected values
+from `@keeper.sh/sync-ical`, never recompute them here.
+
+### CONF-I62. All-day events as a pair of UTC midnights on the UTC day grid
+
+Interpreted all-day events are anchored to the UTC midnight of their local calendar day, and re-anchoring
+must move the whole recurrence identity set together. **Not applicable.** This is entry 44 / `ICAL-I26` /
+`ICAL-I27`. Conformance needs only `supports.allDay` (`dateOnly` vs `utcMidnightPair`) to decide which shape
+to feed an adapter, plus one assertion that an adapter never silently converts between them.
+
+### CONF-I63. VTIMEZONE synthesis
+
+Validate-then-emit, no perpetual annual rule for zones whose transitions move, southern-hemisphere direction
+preserved, whole-minute offsets, an old event must not truncate the rules current events need.
+**Not applicable.** `ICAL-I30`/`I31`/`I22`. Recorded so its absence is a decision, not an oversight.
+
+### CONF-I64. Wall-time resolution: normal, gap, fold
+
+A gap time shifts forward by the transition, a fold takes the earlier instant, and the second pass of a
+fall-back hour must be written in UTC. **Not applicable.** `ICAL-I20`/`I32`. Conformance fixtures use UTC
+instants only, so no case here depends on a fold or gap decision. **Fixtures must not sit on a DST
+boundary** — that is a rule on the fixture corpus, and it is why this entry exists rather than being absent.
+
+### CONF-I65. Property-level lenient parsing
+
+Bare 8-digit dates are rewritten to declare `VALUE=DATE` only when they are real calendar dates, only for
+date-typed properties, only when no parameters are declared, and mixed lists are rejected wholesale.
+**Not applicable.** `ICAL-I16`. The transferable rule is that any fixture that emits a malformed feed must
+be byte-exact, so a repair regression is visible rather than absorbed.
+
+### CONF-I66. TZID applies to every value on a property
+
+A mixed multi-value EXDATE must be split across two property lines; `X-WR-TIMEZONE` never overrides an
+explicit TZID. **Not applicable.** `ICAL-I28`/`I29`. Relevant here only as a source of realistic fixture
+content.
+
+### CONF-I67. Recurrence expansion budgets
+
+The occurrence-budget arithmetic belongs elsewhere. **Not applicable** as arithmetic; its *consequence* — a
+withheld series must not lose its mirror — is adopted as `CONF-I41`.
+
+### CONF-I68. Exhaustive wall-time sweeps
+
+Every transition since 1925 across every zone. **Not applicable** as subject matter; sync-conformance
+asserts on instants, never on wall times. The **methodology** is adopted: prefer a generated sweep to a
+handful of hand-picked examples, which is what the window-boundary sweep (`CONF-I35`) and the
+property-based invariants (`CONF-I70`) do.
+
+---
+
+## Dependencies and process
+
+### CONF-I69. Zero runtime dependencies
+
+`package.json` declares one dependency, `@keeper.sh/sync-protocol` (workspace, source-consumed), and nothing
+else. Everything this package needs — a canonical encoder, a clock, a hash seam, an in-memory store — is
+under a hundred lines each and is code we must own, because it is the thing being tested.
+
+### CONF-I70. `@fast-check/vitest` is the one proposed dev dependency
+
+Adopted for exactly three invariants: canonicalisation (permuted key order and equivalent absent-value
+spellings produce identical canonical bytes), convergence (`apply(apply(x)) === apply(x)`), and a
+model-based command sequence over create/update/delete/list asserting no lost update. Official vitest 4.x
+support starts at `0.2.3`. Confined to invariants: property tests give worse failure messages and
+non-obvious shrink output, and **the named example cases are the specification** (`CONF-I59`). The suite
+must not become property-based.
+
+### CONF-I71. Rejected: `ical.js`, `ts-ics`, `rrule`, `tsdav`
+
+They belong to `@keeper.sh/sync-ical` and `@keeper.sh/calendar`. Pulling any of them in would drag timezone
+resolution into the conformance layer and re-litigate settled ICS learnings in a package that has no
+business owning them.
+
+### CONF-I72. Rejected: `temporal-polyfill` / `@js-temporal/polyfill`
+
+Temporal is Stage 4 and ships natively in current Firefox, Chrome and Node, but Safari is still flagged and
+the polyfills cost 35–50KB. Decisively: this package needs instants only, and the protocol already models
+them as `Instant`. A second time model in a package that does no wall-time arithmetic buys nothing. Revisit
+only if `@keeper.sh/sync-ical` migrates first.
+
+### CONF-I73. Rejected: `fast-json-stable-stringify` and any canonicalisation package
+
+We canonicalise only our own protocol objects, which are I-JSON by construction: no bigints, no `NaN`, no
+unpaired surrogates, integers only. The hard eighty percent of RFC 8785 is ECMAScript number serialisation
+we do not need. Roughly forty lines, owned here, with an explicit test for the sorting rule — UTF-16
+code-unit order, **not** `localeCompare` — including astral-plane and combining-mark keys.
+
+### CONF-I74. Rejected: an off-the-shelf conformance framework
+
+The MCP and Connect conformance suites are process-level harnesses driving out-of-process implementations
+over a wire protocol. Our adapters are in-process TypeScript functions, so an exported `runConformance` that
+calls `describe`/`it` is simpler and gives adapters native vitest reporting, watch mode and turbo caching
+for free. We own the reporting; that is a few dozen lines.
+
+### CONF-I75. `Bun.CryptoHasher` is used, but injected
+
+Native, synchronous, no import ceremony — but it arrives as `environment.hash: (input: string) => string`
+per the no-module-level-dependencies rule, so the suite can substitute a collision-forcing hasher and prove
+the conflict path actually fires rather than being unreachable.
+
+### CONF-I76. vitest stays; `bun test` is not adopted
+
+Bun 1.3 has landed `vi.useFakeTimers` compatibility, which makes the switch newly tempting. The repo is on
+vitest 4.1.4 with turbo caching per package, and a runner split would fragment fixtures. Revisit only if
+Bun's coverage and vitest 4 API parity are complete across every package at once. The package script stays
+`bun x --bun vitest run`.
+
+### CONF-I77. `supports` selects a branch; it never removes a guarantee
+
+The brief's flat capability record is the one thing worth challenging, and this is the resolution: no
+capability value deletes a case. Create idempotency has no `none` branch; `deletionAuthority` has two
+branches and both are generated; `provenanceChannel: "none"` gets the indeterminate-provenance case rather
+than no case. The ungated list — deletion safety, precondition, provenance, deadline, retry ceiling — is
+exported as an `as const` array and surfaced on the report, so an adapter cannot quietly declare its way out.
+
+### CONF-I78. Every case ships a negative control
+
+A conformance case nobody has watched fail is an assertion, not a test. Each `CONF-O`/`CONF-L` id has a
+matching mutant of the reference provider in `conformance/tests/reference/negative-controls.test.ts`, and
+the control asserts the mutant fails **that** case — a mutant that fails three cases is over-broad, and a
+mutant that fails none is a hole in the suite.
+
+---
+
+## Module map
+
+```
+src/index.ts                     the public surface and nothing else
+src/violation.ts                 ConformanceViolation — the suite's own typed failure
+src/case-id.ts                   conformanceCaseIds as const, ConformanceCaseId, ledger cross-reference
+src/options.ts                   RunConformanceOptions, ConformanceEnvironment, ProviderUnderTest
+src/report.ts                    ConformanceReport, SelectedCase, SkippedCase, ungatedCaseIds
+src/clock.ts                     TestClock — setTimeout only, injected, never Bun.sleep
+src/canonical.ts                 RFC 8785 key ordering; the one deep-comparison encoder
+src/registry/case.ts             ConformanceCase: id, title, ledger, gate, run
+src/registry/gates.ts            capability -> branch selection; never case removal
+src/registry/suite.ts            assembles the ordered case list from the case families
+src/cases/deletion-safety.ts     truncation, cursorLost, coverage, withheld, cancelled, empty-vs-failed
+src/cases/cursor.ts              advancement, clearing, opacity, scope binding, supersession, patches
+src/cases/writes.ts              precondition required, conflict, replayed create, replace, reassignment
+src/cases/provenance.ts          own-event round trip, foreign canary, indeterminate
+src/cases/window.ts              boundary sweep, degenerate ranges, storage versus mirror bounds
+src/cases/capabilities.ts        declared refusals actually refuse; zone identifier
+src/cases/diagnostics.ts         bounded samples, zeros, idempotence, no content leakage
+src/cases/convergence.ts         second-poll no-op, order permutation, dedupe, canonicalisation
+src/cases/hostile-content.ts     failure classification is immune to event content
+src/cases/lockups.ts             deadline, abort, ceiling, lease, single-flight, fan-out, concurrency
+src/cases/injection.ts           the anti-vacuity case: the injected seams were actually used
+src/assertions/no-removal.ts     assertNoRemovalDerivable — the one deletion-safety predicate
+src/assertions/listing.ts        listing kind, coverage and cursor assertions
+src/assertions/outcome.ts        write-outcome assertions
+src/reference/capabilities.ts    the reference provider's declared Capabilities
+src/reference/store.ts           in-memory calendars, versions, tombstones, write log
+src/reference/cursor.ts          opaque cursor mint and verify, scope-bound, generation log
+src/reference/normalize.ts       representability refusals and the deliberate provider-side rewrite
+src/reference/fingerprint.ts     canonical encoding fed to the injected hash
+src/reference/provider.ts        createReferenceProvider(environment) -> ProviderUnderTest
+src/fixtures/decorate.ts         ProviderDecorator and composition
+src/fixtures/truncate-page.ts    truncatingAfter(n)
+src/fixtures/expire-cursor.ts    expiringCursorAfter(n)
+src/fixtures/conflict.ts         conflictingOn(predicate)
+src/fixtures/stall.ts            stallingOn(predicate) — new Promise(() => {})
+src/fixtures/index.ts            the fixture surface
+src/run-conformance.ts           runConformance: gate, register, report
+```
+
+## Public API
+
+```ts
+const runConformance: <Provider extends ProviderId>(
+  options: RunConformanceOptions<Provider>,
+) => ConformanceReport
+
+interface RunConformanceOptions<Provider extends ProviderId> {
+  readonly name: string
+  readonly supports: Capabilities<Provider>
+  readonly create: CreateProvider<Provider>
+  readonly withinWindow: WindowMembership
+}
+
+type CreateProvider<Provider extends ProviderId> = (
+  environment: ConformanceEnvironment,
+) => Promise<ProviderUnderTest<Provider>>
+
+interface ProviderUnderTest<Provider extends ProviderId> {
+  readonly contract: ProviderContract<Provider>
+  readonly seed: (seed: ProviderSeed) => Promise<void>
+  readonly inspect: () => Promise<ProviderInspection>
+  readonly dispose: () => Promise<void>
+}
+
+interface ConformanceEnvironment {
+  readonly clock: TestClock
+  readonly hash: (input: string) => string
+  readonly installation: InstallationId
+  readonly transport: TransportStub
+}
+
+interface TestClock {
+  readonly now: () => Instant
+  readonly sleep: (milliseconds: number, signal: AbortSignal) => Promise<void>
+  readonly advance: (milliseconds: number) => Promise<void>
+}
+
+interface TransportStub {
+  readonly callCount: () => number
+  readonly inFlightPeak: () => number
+  readonly stall: () => void
+  readonly resume: () => void
+}
+
+interface ProviderInspection {
+  readonly objects: readonly RemoteEvent[]
+  readonly writeLog: readonly WriteLogEntry[]
+}
+
+interface ConformanceReport {
+  readonly name: string
+  readonly selected: readonly SelectedCase[]
+  readonly skipped: readonly SkippedCase[]
+  readonly ungated: readonly ConformanceCaseId[]
+}
+```
+
+## Test index
+
+`CONF-O1`–`CONF-O43` are the overwrite family; `CONF-L1`–`CONF-L13` are the lockup family. Each id appears
+verbatim in its generated case title and in `src/case-id.ts` beside the ledger entry it enforces.

--- a/packages/sync-kit/LEARNINGS.md
+++ b/packages/sync-kit/LEARNINGS.md
@@ -3729,8 +3729,11 @@ delete and create does not orphan a real event.
 **Learned from.** commit `1c5171d2`; `index.test.ts :: "keeps the stale mapping when recreation fails after
 a successful delete"`, *"does not checkpoint the stale mapping when recreation aborts after deletion"*.
 **Honoured by.** The `conflictingOn(predicate)` fixture is pointed at the create half of a replace. The
-case asserts the delete outcome is reported separately from the create failure — the adapter must not
-report a replace atomically when it was not — so the caller retains enough to recreate on the next run.
+case asserts the outcome of the half that already succeeded survives the half that did not — the object it
+created is still on the calendar and its entry is still in the write log — so the caller retains enough to
+recreate on the next run. A refused create is a `WriteOutcome` of kind `conflict` carrying the `RemoteRef`
+of the copy that blocked it (CONF-I14), not a `ProviderFailure`; only a write whose target could not be
+named at all fails outright.
 **Planned case.** `CONF-O25` in `conformance/tests/writes.test.ts`.
 
 ### CONF-I34. Storage bounds and mirror bounds are different windows
@@ -3922,7 +3925,8 @@ modifications for insert"*) and the `events.import` reference.
 which mechanism the case exercises, and there is **no** value that removes the replayed-create case: an
 adapter that cannot express a conditional insert must instead prove that the caller-supplied
 `IdempotencyKey` deduplicates.
-**Planned case.** `CONF-O14` in `conformance/tests/writes.test.ts`.
+**Planned case.** shared with CONF-I14, which owns the replayed-create case in
+`conformance/tests/writes.test.ts`; this entry adds no case of its own.
 
 ### CONF-I49. A cursor is opaque, and a cursor the adapter cannot read is `cursorLost`, never an empty delta
 

--- a/packages/sync-kit/conformance/package.json
+++ b/packages/sync-kit/conformance/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@keeper.sh/sync-conformance",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "types": "tsc --noEmit",
+    "lint": "oxlint .",
+    "test": "TZ=UTC bun x --bun vitest run"
+  },
+  "dependencies": {
+    "@keeper.sh/sync-protocol": "workspace:*"
+  },
+  "devDependencies": {
+    "@keeper.sh/typescript-config": "workspace:*",
+    "@types/bun": "latest",
+    "typescript": "5.9.3",
+    "vitest": "^4.1.4"
+  }
+}

--- a/packages/sync-kit/conformance/src/assertions/listing.ts
+++ b/packages/sync-kit/conformance/src/assertions/listing.ts
@@ -1,29 +1,87 @@
-import type { ChangeListing, ListingScope, Result } from "@keeper.sh/sync-protocol";
+import type { ChangeListing, ListingScope, RemoteEvent, Result } from "@keeper.sh/sync-protocol";
+import type { CanonicalValue } from "../canonical";
+import { canonicalise } from "../canonical";
+import { violated } from "../violation";
 
 const assertNotSnapshotUnderTruncation = (result: Result<ChangeListing>): void => {
-  throw new Error(`unimplemented: assertNotSnapshotUnderTruncation(${result.ok})`);
+  if (!result.ok) {
+    return;
+  }
+  if (result.value.kind === "snapshot" || result.value.kind === "delta") {
+    throw violated(
+      "CONF-O1",
+      `a truncated read answered "${result.value.kind}", which claims coverage it never proved`,
+    );
+  }
 };
 
 const assertCoverageProven = (listing: ChangeListing, scope: ListingScope): void => {
-  throw new Error(`unimplemented: assertCoverageProven(${listing.kind}, ${scope.calendar.provider})`);
+  if (listing.kind === "partial" || listing.kind === "cursorLost") {
+    return;
+  }
+  if (listing.coverage.calendar.calendar.value !== scope.calendar.calendar.value) {
+    throw violated(
+      "CONF-O4",
+      "the listing proved coverage for a calendar other than the one it was asked about",
+    );
+  }
 };
 
 const assertCursorWithheld = (result: Result<ChangeListing>): void => {
-  throw new Error(`unimplemented: assertCursorWithheld(${result.ok})`);
+  if (!result.ok) {
+    return;
+  }
+  if (result.value.cursor) {
+    throw violated("CONF-O24", "a run that did not complete still returned a sync cursor");
+  }
 };
+
+const identifiersOf = (event: RemoteEvent): CanonicalValue => ({
+  id: event.id.value,
+  uid: event.uid.value,
+  deleteHandle: event.deleteHandle.value,
+  version: event.version.value,
+  fingerprint: event.fingerprint.value,
+});
+
+const loggableFacts = (listing: ChangeListing): CanonicalValue => ({
+  kind: listing.kind,
+  diagnostics: {
+    withheld: [...listing.diagnostics.withheld.sample],
+    selfAuthored: [...listing.diagnostics.selfAuthored.sample],
+    unrepresentable: [...listing.diagnostics.unrepresentable.sample],
+    pagesFetched: listing.diagnostics.pagesFetched,
+  },
+  events: (listing.events ?? []).map((event) => identifiersOf(event)),
+  withheld: (listing.withheld ?? []).map((entry) => ({
+    uid: entry.uid?.value ?? null,
+    id: entry.id?.value ?? null,
+    reason: entry.reason,
+  })),
+  removals: (listing.removals ?? []).map((removal) => ({
+    kind: removal.kind,
+    id: removal.id.value,
+  })),
+  cursor: listing.cursor?.value ?? null,
+});
 
 const assertNoContentInDiagnostics = (
   listing: ChangeListing,
   secrets: readonly string[],
 ): void => {
-  throw new Error(
-    `unimplemented: assertNoContentInDiagnostics(${listing.kind}, ${secrets.length})`,
-  );
+  const loggable = canonicalise(loggableFacts(listing));
+  const leaked = secrets.filter((secret) => loggable.includes(secret));
+  if (leaked.length > 0) {
+    throw violated(
+      "CONF-O19",
+      `${leaked.length} content value(s) reached the loggable half of the listing`,
+    );
+  }
 };
 
 export {
-  assertNoContentInDiagnostics,
   assertCoverageProven,
   assertCursorWithheld,
+  assertNoContentInDiagnostics,
   assertNotSnapshotUnderTruncation,
 };

--- a/packages/sync-kit/conformance/src/assertions/listing.ts
+++ b/packages/sync-kit/conformance/src/assertions/listing.ts
@@ -1,0 +1,29 @@
+import type { ChangeListing, ListingScope, Result } from "@keeper.sh/sync-protocol";
+
+const assertNotSnapshotUnderTruncation = (result: Result<ChangeListing>): void => {
+  throw new Error(`unimplemented: assertNotSnapshotUnderTruncation(${result.ok})`);
+};
+
+const assertCoverageProven = (listing: ChangeListing, scope: ListingScope): void => {
+  throw new Error(`unimplemented: assertCoverageProven(${listing.kind}, ${scope.calendar.provider})`);
+};
+
+const assertCursorWithheld = (result: Result<ChangeListing>): void => {
+  throw new Error(`unimplemented: assertCursorWithheld(${result.ok})`);
+};
+
+const assertNoContentInDiagnostics = (
+  listing: ChangeListing,
+  secrets: readonly string[],
+): void => {
+  throw new Error(
+    `unimplemented: assertNoContentInDiagnostics(${listing.kind}, ${secrets.length})`,
+  );
+};
+
+export {
+  assertNoContentInDiagnostics,
+  assertCoverageProven,
+  assertCursorWithheld,
+  assertNotSnapshotUnderTruncation,
+};

--- a/packages/sync-kit/conformance/src/assertions/listing.ts
+++ b/packages/sync-kit/conformance/src/assertions/listing.ts
@@ -1,4 +1,13 @@
-import type { ChangeListing, ListingScope, RemoteEvent, Result } from "@keeper.sh/sync-protocol";
+import type {
+  ChangeListing,
+  ListingDiagnostics,
+  ListingScope,
+  RemoteEvent,
+  Removal,
+  Result,
+  WithheldEvent,
+} from "@keeper.sh/sync-protocol";
+import { assertNever } from "@keeper.sh/sync-protocol";
 import type { CanonicalValue } from "../canonical";
 import { canonicalise } from "../canonical";
 import { violated } from "../violation";
@@ -44,26 +53,56 @@ const identifiersOf = (event: RemoteEvent): CanonicalValue => ({
   fingerprint: event.fingerprint.value,
 });
 
-const loggableFacts = (listing: ChangeListing): CanonicalValue => ({
-  kind: listing.kind,
-  diagnostics: {
-    withheld: [...listing.diagnostics.withheld.sample],
-    selfAuthored: [...listing.diagnostics.selfAuthored.sample],
-    unrepresentable: [...listing.diagnostics.unrepresentable.sample],
-    pagesFetched: listing.diagnostics.pagesFetched,
-  },
-  events: (listing.events ?? []).map((event) => identifiersOf(event)),
-  withheld: (listing.withheld ?? []).map((entry) => ({
+const loggableDiagnostics = (diagnostics: ListingDiagnostics): CanonicalValue => ({
+  withheld: [...diagnostics.withheld.sample],
+  selfAuthored: [...diagnostics.selfAuthored.sample],
+  unrepresentable: [...diagnostics.unrepresentable.sample],
+  pagesFetched: diagnostics.pagesFetched,
+});
+
+const loggableEvents = (events: readonly RemoteEvent[]): CanonicalValue =>
+  events.map((event) => identifiersOf(event));
+
+const loggableWithheld = (withheld: readonly WithheldEvent[]): CanonicalValue =>
+  withheld.map((entry) => ({
     uid: entry.uid?.value ?? null,
     id: entry.id?.value ?? null,
     reason: entry.reason,
-  })),
-  removals: (listing.removals ?? []).map((removal) => ({
-    kind: removal.kind,
-    id: removal.id.value,
-  })),
-  cursor: listing.cursor?.value ?? null,
-});
+  }));
+
+const loggableRemovals = (removals: readonly Removal[]): CanonicalValue =>
+  removals.map((removal) => ({ kind: removal.kind, id: removal.id.value }));
+
+const loggableFacts = (listing: ChangeListing): CanonicalValue => {
+  switch (listing.kind) {
+    case "snapshot":
+    case "delta": {
+      return {
+        kind: listing.kind,
+        diagnostics: loggableDiagnostics(listing.diagnostics),
+        events: loggableEvents(listing.events),
+        withheld: loggableWithheld(listing.withheld),
+        removals: loggableRemovals(listing.removals),
+        cursor: listing.cursor?.value ?? null,
+      };
+    }
+    case "partial": {
+      return {
+        kind: listing.kind,
+        diagnostics: loggableDiagnostics(listing.diagnostics),
+        events: loggableEvents(listing.events),
+        withheld: loggableWithheld(listing.withheld),
+        continuation: listing.continuation.value,
+      };
+    }
+    case "cursorLost": {
+      return { kind: listing.kind, diagnostics: loggableDiagnostics(listing.diagnostics) };
+    }
+    default: {
+      return assertNever(listing);
+    }
+  }
+};
 
 const assertNoContentInDiagnostics = (
   listing: ChangeListing,

--- a/packages/sync-kit/conformance/src/assertions/no-removal.ts
+++ b/packages/sync-kit/conformance/src/assertions/no-removal.ts
@@ -1,4 +1,12 @@
-import type { ChangeListing, KnownEvents, WindowMembership } from "@keeper.sh/sync-protocol";
+import type {
+  ChangeListing,
+  EventTime,
+  KnownEvents,
+  TimeWindow,
+  WindowMembership,
+} from "@keeper.sh/sync-protocol";
+import { assertNever } from "@keeper.sh/sync-protocol";
+import { violated } from "../violation";
 
 interface RemovalBasis {
   readonly listing: ChangeListing;
@@ -7,11 +15,90 @@ interface RemovalBasis {
 }
 
 const assertNoRemovalDerivable = (listing: ChangeListing): void => {
-  throw new Error(`unimplemented: assertNoRemovalDerivable(${listing.kind})`);
+  switch (listing.kind) {
+    case "partial":
+    case "cursorLost": {
+      return;
+    }
+    case "snapshot":
+    case "delta": {
+      throw violated(
+        "CONF-O1",
+        `a "${listing.kind}" listing carries deletion authority, so a removal is derivable from it`,
+      );
+    }
+    default: {
+      return assertNever(listing);
+    }
+  }
+};
+
+const spanning = (window: TimeWindow): EventTime => ({
+  kind: "timed",
+  start: window.start,
+  end: window.end,
+  zone: null,
+});
+
+const provesTheWholeRequest = (covered: TimeWindow, requested: TimeWindow): boolean =>
+  covered.start.value === requested.start.value && covered.end.value === requested.end.value;
+
+const presentIdentities = (
+  listing: Extract<ChangeListing, { kind: "snapshot" }>,
+): ReadonlySet<string> =>
+  new Set([
+    ...listing.events.map((event) => event.uid.value),
+    ...listing.withheld.flatMap((entry) => {
+      if (entry.uid === null) {
+        return [];
+      }
+      return [entry.uid.value];
+    }),
+  ]);
+
+const namedRemovals = (listing: Extract<ChangeListing, { kind: "delta" }>): readonly string[] =>
+  listing.removals.flatMap((removal) => {
+    if (removal.kind === "outOfScope") {
+      return [];
+    }
+    return [removal.uid.value];
+  });
+
+const absentFromSnapshot = (
+  listing: Extract<ChangeListing, { kind: "snapshot" }>,
+  basis: RemovalBasis,
+): readonly string[] => {
+  if (listing.coverage.calendar.calendar.value !== basis.known.calendar.calendar.value) {
+    return [];
+  }
+  if (!provesTheWholeRequest(listing.coverage.covered, listing.scope.window)) {
+    return [];
+  }
+  if (!basis.withinWindow(listing.coverage.covered, spanning(listing.coverage.covered))) {
+    return [];
+  }
+  const present = presentIdentities(listing);
+  return [...basis.known.ids.keys()].filter((uid) => !present.has(uid));
 };
 
 const derivableRemovals = (basis: RemovalBasis): readonly string[] => {
-  throw new Error(`unimplemented: derivableRemovals(${basis.listing.kind})`);
+  const { listing } = basis;
+  switch (listing.kind) {
+    case "partial":
+    case "cursorLost": {
+      return [];
+    }
+    case "delta": {
+      const named = new Set(namedRemovals(listing));
+      return [...basis.known.ids.keys()].filter((uid) => named.has(uid));
+    }
+    case "snapshot": {
+      return absentFromSnapshot(listing, basis);
+    }
+    default: {
+      return assertNever(listing);
+    }
+  }
 };
 
 export { assertNoRemovalDerivable, derivableRemovals };

--- a/packages/sync-kit/conformance/src/assertions/no-removal.ts
+++ b/packages/sync-kit/conformance/src/assertions/no-removal.ts
@@ -1,0 +1,18 @@
+import type { ChangeListing, KnownEvents, WindowMembership } from "@keeper.sh/sync-protocol";
+
+interface RemovalBasis {
+  readonly listing: ChangeListing;
+  readonly known: KnownEvents;
+  readonly withinWindow: WindowMembership;
+}
+
+const assertNoRemovalDerivable = (listing: ChangeListing): void => {
+  throw new Error(`unimplemented: assertNoRemovalDerivable(${listing.kind})`);
+};
+
+const derivableRemovals = (basis: RemovalBasis): readonly string[] => {
+  throw new Error(`unimplemented: derivableRemovals(${basis.listing.kind})`);
+};
+
+export { assertNoRemovalDerivable, derivableRemovals };
+export type { RemovalBasis };

--- a/packages/sync-kit/conformance/src/assertions/no-removal.ts
+++ b/packages/sync-kit/conformance/src/assertions/no-removal.ts
@@ -1,16 +1,28 @@
 import type {
+  CalendarKey,
   ChangeListing,
   EventTime,
-  KnownEvents,
+  RemoteEventId,
   TimeWindow,
   WindowMembership,
 } from "@keeper.sh/sync-protocol";
 import { assertNever } from "@keeper.sh/sync-protocol";
 import { violated } from "../violation";
 
+interface KnownIdentity {
+  readonly uid: string;
+  readonly id: RemoteEventId;
+  readonly time: EventTime;
+}
+
+interface KnownMirror {
+  readonly calendar: CalendarKey;
+  readonly entries: readonly KnownIdentity[];
+}
+
 interface RemovalBasis {
   readonly listing: ChangeListing;
-  readonly known: KnownEvents;
+  readonly known: KnownMirror;
   readonly withinWindow: WindowMembership;
 }
 
@@ -32,13 +44,6 @@ const assertNoRemovalDerivable = (listing: ChangeListing): void => {
     }
   }
 };
-
-const spanning = (window: TimeWindow): EventTime => ({
-  kind: "timed",
-  start: window.start,
-  end: window.end,
-  zone: null,
-});
 
 const provesTheWholeRequest = (covered: TimeWindow, requested: TimeWindow): boolean =>
   covered.start.value === requested.start.value && covered.end.value === requested.end.value;
@@ -74,11 +79,11 @@ const absentFromSnapshot = (
   if (!provesTheWholeRequest(listing.coverage.covered, listing.scope.window)) {
     return [];
   }
-  if (!basis.withinWindow(listing.coverage.covered, spanning(listing.coverage.covered))) {
-    return [];
-  }
   const present = presentIdentities(listing);
-  return [...basis.known.ids.keys()].filter((uid) => !present.has(uid));
+  const covered = basis.known.entries.filter((entry) =>
+    basis.withinWindow(listing.coverage.covered, entry.time),
+  );
+  return covered.filter((entry) => !present.has(entry.uid)).map((entry) => entry.uid);
 };
 
 const derivableRemovals = (basis: RemovalBasis): readonly string[] => {
@@ -90,7 +95,9 @@ const derivableRemovals = (basis: RemovalBasis): readonly string[] => {
     }
     case "delta": {
       const named = new Set(namedRemovals(listing));
-      return [...basis.known.ids.keys()].filter((uid) => named.has(uid));
+      return basis.known.entries
+        .filter((entry) => named.has(entry.uid))
+        .map((entry) => entry.uid);
     }
     case "snapshot": {
       return absentFromSnapshot(listing, basis);
@@ -102,4 +109,4 @@ const derivableRemovals = (basis: RemovalBasis): readonly string[] => {
 };
 
 export { assertNoRemovalDerivable, derivableRemovals };
-export type { RemovalBasis };
+export type { KnownIdentity, KnownMirror, RemovalBasis };

--- a/packages/sync-kit/conformance/src/assertions/outcome.ts
+++ b/packages/sync-kit/conformance/src/assertions/outcome.ts
@@ -1,8 +1,28 @@
 import type { Result, WriteIntent, WriteOutcome } from "@keeper.sh/sync-protocol";
+import { assertNever } from "@keeper.sh/sync-protocol";
 import type { WriteLogEntry } from "../options";
 import { violated } from "../violation";
 
-const overwritingKinds = new Set(["created", "updated", "deleted"]);
+const overwritesTheRemoteCopy = (outcome: WriteOutcome): boolean => {
+  switch (outcome.kind) {
+    case "created":
+    case "updated":
+    case "deleted": {
+      return true;
+    }
+    case "alreadyExists":
+    case "unchanged":
+    case "alreadyAbsent":
+    case "conflict":
+    case "unrepresentable":
+    case "notAttempted": {
+      return false;
+    }
+    default: {
+      return assertNever(outcome);
+    }
+  }
+};
 
 const assertConflictNotOverwrite = (result: Result<WriteOutcome>): void => {
   if (!result.ok) {
@@ -14,7 +34,7 @@ const assertConflictNotOverwrite = (result: Result<WriteOutcome>): void => {
       `a conflicting write failed as "${result.failure.kind}" instead of a typed conflict`,
     );
   }
-  if (overwritingKinds.has(result.value.kind)) {
+  if (overwritesTheRemoteCopy(result.value)) {
     throw violated(
       "CONF-O15",
       `a conflicting write answered "${result.value.kind}", which overwrote the differing remote copy`,
@@ -22,17 +42,30 @@ const assertConflictNotOverwrite = (result: Result<WriteOutcome>): void => {
   }
 };
 
-const isRemoval = (intent: WriteIntent): boolean =>
+type RemovalIntent = Extract<WriteIntent, { kind: "delete" } | { kind: "retire" }>;
+
+const isRemoval = (intent: WriteIntent): intent is RemovalIntent =>
   intent.kind === "delete" || intent.kind === "retire";
 
-const assertNoDeleteThenCreate = (writeLog: readonly WriteLogEntry[]): void => {
-  let removals = 0;
+const removedTargetOf = (intent: WriteIntent): string | null => {
+  if (!isRemoval(intent)) {
+    return null;
+  }
+  return intent.target.value;
+};
+
+const assertNoUnplannedRecreation = (
+  writeLog: readonly WriteLogEntry[],
+  plannedRemovals: readonly string[],
+): void => {
+  let unplannedRemovals = 0;
   for (const entry of writeLog) {
-    if (isRemoval(entry.intent)) {
-      removals += 1;
+    const removed = removedTargetOf(entry.intent);
+    if (removed !== null && !plannedRemovals.includes(removed)) {
+      unplannedRemovals += 1;
       continue;
     }
-    if (entry.intent.kind === "create" && removals > 0) {
+    if (entry.intent.kind === "create" && unplannedRemovals > 0) {
       throw violated(
         "CONF-O25",
         "the write log carries a delete followed by a create, which is a blind recreation",
@@ -61,4 +94,9 @@ const assertNoUnconditionalWrite = (writeLog: readonly WriteLogEntry[]): void =>
   }
 };
 
-export { assertConflictNotOverwrite, assertNoDeleteThenCreate, assertNoUnconditionalWrite };
+export {
+  assertConflictNotOverwrite,
+  assertNoUnconditionalWrite,
+  assertNoUnplannedRecreation,
+  overwritesTheRemoteCopy,
+};

--- a/packages/sync-kit/conformance/src/assertions/outcome.ts
+++ b/packages/sync-kit/conformance/src/assertions/outcome.ts
@@ -1,16 +1,64 @@
-import type { Result, WriteOutcome } from "@keeper.sh/sync-protocol";
+import type { Result, WriteIntent, WriteOutcome } from "@keeper.sh/sync-protocol";
 import type { WriteLogEntry } from "../options";
+import { violated } from "../violation";
+
+const overwritingKinds = new Set(["created", "updated", "deleted"]);
 
 const assertConflictNotOverwrite = (result: Result<WriteOutcome>): void => {
-  throw new Error(`unimplemented: assertConflictNotOverwrite(${result.ok})`);
+  if (!result.ok) {
+    if (result.failure.kind === "conflict" || result.failure.kind === "unrepresentable") {
+      return;
+    }
+    throw violated(
+      "CONF-O15",
+      `a conflicting write failed as "${result.failure.kind}" instead of a typed conflict`,
+    );
+  }
+  if (overwritingKinds.has(result.value.kind)) {
+    throw violated(
+      "CONF-O15",
+      `a conflicting write answered "${result.value.kind}", which overwrote the differing remote copy`,
+    );
+  }
 };
 
+const isRemoval = (intent: WriteIntent): boolean =>
+  intent.kind === "delete" || intent.kind === "retire";
+
 const assertNoDeleteThenCreate = (writeLog: readonly WriteLogEntry[]): void => {
-  throw new Error(`unimplemented: assertNoDeleteThenCreate(${writeLog.length})`);
+  let removals = 0;
+  for (const entry of writeLog) {
+    if (isRemoval(entry.intent)) {
+      removals += 1;
+      continue;
+    }
+    if (entry.intent.kind === "create" && removals > 0) {
+      throw violated(
+        "CONF-O25",
+        "the write log carries a delete followed by a create, which is a blind recreation",
+      );
+    }
+  }
 };
 
 const assertNoUnconditionalWrite = (writeLog: readonly WriteLogEntry[]): void => {
-  throw new Error(`unimplemented: assertNoUnconditionalWrite(${writeLog.length})`);
+  for (const entry of writeLog) {
+    if (entry.intent.kind === "create" && entry.intent.idempotencyKey.value.length === 0) {
+      throw violated("CONF-O36", "a create was issued without an idempotency key");
+    }
+    if (entry.intent.kind === "create") {
+      continue;
+    }
+    if (entry.intent.precondition.kind === "matchesVersion") {
+      if (entry.intent.precondition.version.value.length === 0) {
+        throw violated("CONF-O36", "a conditional write carried an empty version precondition");
+      }
+      continue;
+    }
+    if (entry.intent.precondition.fingerprint.value.length === 0) {
+      throw violated("CONF-O36", "a conditional write carried an empty fingerprint precondition");
+    }
+  }
 };
 
 export { assertConflictNotOverwrite, assertNoDeleteThenCreate, assertNoUnconditionalWrite };

--- a/packages/sync-kit/conformance/src/assertions/outcome.ts
+++ b/packages/sync-kit/conformance/src/assertions/outcome.ts
@@ -1,0 +1,16 @@
+import type { Result, WriteOutcome } from "@keeper.sh/sync-protocol";
+import type { WriteLogEntry } from "../options";
+
+const assertConflictNotOverwrite = (result: Result<WriteOutcome>): void => {
+  throw new Error(`unimplemented: assertConflictNotOverwrite(${result.ok})`);
+};
+
+const assertNoDeleteThenCreate = (writeLog: readonly WriteLogEntry[]): void => {
+  throw new Error(`unimplemented: assertNoDeleteThenCreate(${writeLog.length})`);
+};
+
+const assertNoUnconditionalWrite = (writeLog: readonly WriteLogEntry[]): void => {
+  throw new Error(`unimplemented: assertNoUnconditionalWrite(${writeLog.length})`);
+};
+
+export { assertConflictNotOverwrite, assertNoDeleteThenCreate, assertNoUnconditionalWrite };

--- a/packages/sync-kit/conformance/src/assertions/outcome.ts
+++ b/packages/sync-kit/conformance/src/assertions/outcome.ts
@@ -58,14 +58,14 @@ const assertNoUnplannedRecreation = (
   writeLog: readonly WriteLogEntry[],
   plannedRemovals: readonly string[],
 ): void => {
-  let unplannedRemovals = 0;
+  const seen = { unplannedRemovals: 0 };
   for (const entry of writeLog) {
     const removed = removedTargetOf(entry.intent);
     if (removed !== null && !plannedRemovals.includes(removed)) {
-      unplannedRemovals += 1;
+      seen.unplannedRemovals += 1;
       continue;
     }
-    if (entry.intent.kind === "create" && unplannedRemovals > 0) {
+    if (entry.intent.kind === "create" && seen.unplannedRemovals > 0) {
       throw violated(
         "CONF-O25",
         "the write log carries a delete followed by a create, which is a blind recreation",

--- a/packages/sync-kit/conformance/src/canonical.ts
+++ b/packages/sync-kit/conformance/src/canonical.ts
@@ -1,0 +1,18 @@
+type CanonicalValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly CanonicalValue[]
+  | { readonly [key: string]: CanonicalValue };
+
+const canonicalise = (value: CanonicalValue): string => {
+  throw new Error(`unimplemented: canonicalise(${typeof value})`);
+};
+
+const sortedKeys = (keys: readonly string[]): readonly string[] => {
+  throw new Error(`unimplemented: sortedKeys(${keys.length})`);
+};
+
+export { canonicalise, sortedKeys };
+export type { CanonicalValue };

--- a/packages/sync-kit/conformance/src/canonical.ts
+++ b/packages/sync-kit/conformance/src/canonical.ts
@@ -26,9 +26,6 @@ const insertionOrderKeys = (keys: readonly string[]): readonly string[] => keys;
 const isCanonicalArray = (value: CanonicalValue): value is readonly CanonicalValue[] =>
   Array.isArray(value);
 
-const presentMembers = (value: Record<string, CanonicalValue>): readonly string[] =>
-  Object.keys(value).filter((key) => (value[key] ?? null) !== null);
-
 const canonicaliseWith = (order: KeyOrder, value: CanonicalValue): string => {
   if (value === null) {
     return "null";
@@ -45,7 +42,7 @@ const canonicaliseWith = (order: KeyOrder, value: CanonicalValue): string => {
   if (isCanonicalArray(value)) {
     return `[${value.map((member) => canonicaliseWith(order, member)).join(",")}]`;
   }
-  return `{${order(presentMembers(value))
+  return `{${order(Object.keys(value))
     .map((key) => `${JSON.stringify(key)}:${canonicaliseWith(order, value[key] ?? null)}`)
     .join(",")}}`;
 };

--- a/packages/sync-kit/conformance/src/canonical.ts
+++ b/packages/sync-kit/conformance/src/canonical.ts
@@ -6,13 +6,57 @@ type CanonicalValue =
   | readonly CanonicalValue[]
   | { readonly [key: string]: CanonicalValue };
 
-const canonicalise = (value: CanonicalValue): string => {
-  throw new Error(`unimplemented: canonicalise(${typeof value})`);
+type KeyOrder = (keys: readonly string[]) => readonly string[];
+
+const compareCodeUnits = (left: string, right: string): number => {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
 };
 
-const sortedKeys = (keys: readonly string[]): readonly string[] => {
-  throw new Error(`unimplemented: sortedKeys(${keys.length})`);
+const sortedKeys = (keys: readonly string[]): readonly string[] =>
+  keys.toSorted(compareCodeUnits);
+
+const insertionOrderKeys = (keys: readonly string[]): readonly string[] => keys;
+
+const isCanonicalArray = (value: CanonicalValue): value is readonly CanonicalValue[] =>
+  Array.isArray(value);
+
+const presentMembers = (value: Record<string, CanonicalValue>): readonly string[] =>
+  Object.keys(value).filter((key) => (value[key] ?? null) !== null);
+
+const canonicaliseWith = (order: KeyOrder, value: CanonicalValue): string => {
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    return String(value);
+  }
+  if (typeof value === "boolean") {
+    return String(value);
+  }
+  if (isCanonicalArray(value)) {
+    return `[${value.map((member) => canonicaliseWith(order, member)).join(",")}]`;
+  }
+  return `{${order(presentMembers(value))
+    .map((key) => `${JSON.stringify(key)}:${canonicaliseWith(order, value[key] ?? null)}`)
+    .join(",")}}`;
 };
 
-export { canonicalise, sortedKeys };
-export type { CanonicalValue };
+const canonicalise = (value: CanonicalValue): string => canonicaliseWith(sortedKeys, value);
+
+export {
+  canonicalise,
+  canonicaliseWith,
+  compareCodeUnits,
+  insertionOrderKeys,
+  sortedKeys,
+};
+export type { CanonicalValue, KeyOrder };

--- a/packages/sync-kit/conformance/src/case-id.ts
+++ b/packages/sync-kit/conformance/src/case-id.ts
@@ -1,0 +1,73 @@
+const conformanceCaseIds = [
+  "CONF-O1",
+  "CONF-O2",
+  "CONF-O3",
+  "CONF-O4",
+  "CONF-O5",
+  "CONF-O6",
+  "CONF-O7",
+  "CONF-O8",
+  "CONF-O9",
+  "CONF-O10",
+  "CONF-O11",
+  "CONF-O12",
+  "CONF-O13",
+  "CONF-O14",
+  "CONF-O15",
+  "CONF-O16",
+  "CONF-O17",
+  "CONF-O18",
+  "CONF-O19",
+  "CONF-O20",
+  "CONF-O21",
+  "CONF-O22",
+  "CONF-O23",
+  "CONF-O24",
+  "CONF-O25",
+  "CONF-O26",
+  "CONF-O27",
+  "CONF-O28",
+  "CONF-O29",
+  "CONF-O30",
+  "CONF-O31",
+  "CONF-O32",
+  "CONF-O33",
+  "CONF-O34",
+  "CONF-O35",
+  "CONF-O36",
+  "CONF-O37",
+  "CONF-O38",
+  "CONF-O39",
+  "CONF-O40",
+  "CONF-O41",
+  "CONF-O42",
+  "CONF-O43",
+  "CONF-L1",
+  "CONF-L2",
+  "CONF-L3",
+  "CONF-L4",
+  "CONF-L5",
+  "CONF-L6",
+  "CONF-L7",
+  "CONF-L8",
+  "CONF-L9",
+  "CONF-L10",
+  "CONF-L11",
+  "CONF-L12",
+  "CONF-L13",
+] as const;
+
+type ConformanceCaseId = (typeof conformanceCaseIds)[number];
+
+type LedgerEntryId = `CONF-I${number}`;
+
+const ledgerEntryOf = (id: ConformanceCaseId): LedgerEntryId => {
+  throw new Error(`unimplemented: ledgerEntryOf(${id})`);
+};
+
+const caseIdsCitedBy = (entry: LedgerEntryId): readonly ConformanceCaseId[] => {
+  throw new Error(`unimplemented: caseIdsCitedBy(${entry})`);
+};
+
+export { caseIdsCitedBy, conformanceCaseIds, ledgerEntryOf };
+export type { ConformanceCaseId, LedgerEntryId };

--- a/packages/sync-kit/conformance/src/case-id.ts
+++ b/packages/sync-kit/conformance/src/case-id.ts
@@ -61,12 +61,80 @@ type ConformanceCaseId = (typeof conformanceCaseIds)[number];
 
 type LedgerEntryId = `CONF-I${number}`;
 
+interface LedgerCitation {
+  readonly entry: LedgerEntryId;
+  readonly cases: readonly ConformanceCaseId[];
+}
+
+const ledgerCitations: readonly LedgerCitation[] = [
+  { entry: "CONF-I1", cases: ["CONF-O1"] },
+  { entry: "CONF-I2", cases: ["CONF-O2"] },
+  { entry: "CONF-I3", cases: ["CONF-O3"] },
+  { entry: "CONF-I4", cases: ["CONF-O4"] },
+  { entry: "CONF-I5", cases: ["CONF-O5"] },
+  { entry: "CONF-I6", cases: ["CONF-O6"] },
+  { entry: "CONF-I7", cases: ["CONF-O7"] },
+  { entry: "CONF-I8", cases: ["CONF-O8"] },
+  { entry: "CONF-I9", cases: ["CONF-O9"] },
+  { entry: "CONF-I10", cases: ["CONF-O10"] },
+  { entry: "CONF-I11", cases: ["CONF-O11"] },
+  { entry: "CONF-I12", cases: ["CONF-O12"] },
+  { entry: "CONF-I13", cases: ["CONF-O13"] },
+  { entry: "CONF-I14", cases: ["CONF-O14", "CONF-O15"] },
+  { entry: "CONF-I15", cases: ["CONF-O16"] },
+  { entry: "CONF-I16", cases: ["CONF-O17"] },
+  { entry: "CONF-I17", cases: ["CONF-O18", "CONF-O19"] },
+  { entry: "CONF-I18", cases: ["CONF-O20"] },
+  { entry: "CONF-I19", cases: ["CONF-O21"] },
+  { entry: "CONF-I20", cases: ["CONF-O22"] },
+  { entry: "CONF-I21", cases: ["CONF-L1"] },
+  { entry: "CONF-I22", cases: ["CONF-L2", "CONF-L3"] },
+  { entry: "CONF-I23", cases: ["CONF-L4"] },
+  { entry: "CONF-I24", cases: ["CONF-L5"] },
+  { entry: "CONF-I25", cases: ["CONF-L6"] },
+  { entry: "CONF-I26", cases: ["CONF-L7", "CONF-L8"] },
+  { entry: "CONF-I27", cases: ["CONF-L9"] },
+  { entry: "CONF-I28", cases: ["CONF-L10"] },
+  { entry: "CONF-I29", cases: ["CONF-L11"] },
+  { entry: "CONF-I30", cases: ["CONF-O23"] },
+  { entry: "CONF-I31", cases: ["CONF-L12"] },
+  { entry: "CONF-I32", cases: ["CONF-O24"] },
+  { entry: "CONF-I33", cases: ["CONF-O25"] },
+  { entry: "CONF-I34", cases: ["CONF-O26"] },
+  { entry: "CONF-I35", cases: ["CONF-O27"] },
+  { entry: "CONF-I36", cases: ["CONF-O28"] },
+  { entry: "CONF-I37", cases: ["CONF-O29"] },
+  { entry: "CONF-I38", cases: ["CONF-O30"] },
+  { entry: "CONF-I39", cases: ["CONF-O31"] },
+  { entry: "CONF-I40", cases: ["CONF-O32"] },
+  { entry: "CONF-I41", cases: ["CONF-O33"] },
+  { entry: "CONF-I42", cases: ["CONF-O34"] },
+  { entry: "CONF-I43", cases: ["CONF-O35"] },
+  { entry: "CONF-I44", cases: ["CONF-O36"] },
+  { entry: "CONF-I45", cases: ["CONF-O37"] },
+  { entry: "CONF-I46", cases: ["CONF-O38"] },
+  { entry: "CONF-I47", cases: ["CONF-O39"] },
+  { entry: "CONF-I49", cases: ["CONF-O40"] },
+  { entry: "CONF-I50", cases: ["CONF-O41"] },
+  { entry: "CONF-I54", cases: ["CONF-L13"] },
+  { entry: "CONF-I56", cases: ["CONF-O42"] },
+  { entry: "CONF-I60", cases: ["CONF-O43"] },
+];
+
 const ledgerEntryOf = (id: ConformanceCaseId): LedgerEntryId => {
-  throw new Error(`unimplemented: ledgerEntryOf(${id})`);
+  const citation = ledgerCitations.find((entry) => entry.cases.includes(id));
+  if (!citation) {
+    throw new Error(`no ledger entry cites the conformance case "${id}"`);
+  }
+  return citation.entry;
 };
 
 const caseIdsCitedBy = (entry: LedgerEntryId): readonly ConformanceCaseId[] => {
-  throw new Error(`unimplemented: caseIdsCitedBy(${entry})`);
+  const citation = ledgerCitations.find((candidate) => candidate.entry === entry);
+  if (!citation) {
+    return [];
+  }
+  return citation.cases;
 };
 
 export { caseIdsCitedBy, conformanceCaseIds, ledgerEntryOf };

--- a/packages/sync-kit/conformance/src/case-id.ts
+++ b/packages/sync-kit/conformance/src/case-id.ts
@@ -42,6 +42,9 @@ const conformanceCaseIds = [
   "CONF-O41",
   "CONF-O42",
   "CONF-O43",
+  "CONF-O44",
+  "CONF-O45",
+  "CONF-O46",
   "CONF-L1",
   "CONF-L2",
   "CONF-L3",
@@ -119,6 +122,9 @@ const ledgerCitations: readonly LedgerCitation[] = [
   { entry: "CONF-I54", cases: ["CONF-L13"] },
   { entry: "CONF-I56", cases: ["CONF-O42"] },
   { entry: "CONF-I60", cases: ["CONF-O43"] },
+  { entry: "CONF-I79", cases: ["CONF-O44"] },
+  { entry: "CONF-I80", cases: ["CONF-O45"] },
+  { entry: "CONF-I81", cases: ["CONF-O46"] },
 ];
 
 const ledgerEntryOf = (id: ConformanceCaseId): LedgerEntryId => {

--- a/packages/sync-kit/conformance/src/cases/capabilities.ts
+++ b/packages/sync-kit/conformance/src/cases/capabilities.ts
@@ -1,0 +1,10 @@
+import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { ConformanceCase } from "../registry/case";
+
+const capabilityCases = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+): readonly ConformanceCase<Provider>[] => {
+  throw new Error(`unimplemented: capabilityCases(${supports.provider})`);
+};
+
+export { capabilityCases };

--- a/packages/sync-kit/conformance/src/cases/capabilities.ts
+++ b/packages/sync-kit/conformance/src/cases/capabilities.ts
@@ -1,8 +1,12 @@
 import type {
+  AllDayRepresentation,
   Capabilities,
+  ChangeListing,
   EditableContent,
+  EventTime,
   ProviderId,
   RepresentabilityConstraint,
+  RepresentableRange,
   Result,
   WriteOutcome,
 } from "@keeper.sh/sync-protocol";
@@ -12,6 +16,7 @@ import {
   caseScope,
   contentOf,
   defineCase,
+  failureKindOf,
   insist,
   listChanges,
   listingOf,
@@ -62,6 +67,70 @@ const zonedAs = (uid: string, zone: string): EditableContent => ({
     zone: { kind: "zoneId", value: zone },
   },
 });
+
+const seriesAnchoredIn = (uid: string, zone: string): EditableContent => ({
+  title: uid,
+  description: null,
+  location: null,
+  availability: "busy",
+  visibility: "default",
+  recurrence: { dialect: "rfc5545", value: "FREQ=WEEKLY;COUNT=2", exceptions: [] },
+  anchor: {
+    kind: "timed",
+    start: { kind: "instant", value: "2026-03-02T09:00:00.000Z" },
+    zone: { kind: "zoneId", value: zone },
+    duration: { kind: "exact", seconds: 3600 },
+  },
+});
+
+const allDayAs = (uid: string, representation: AllDayRepresentation): EditableContent => {
+  const described = {
+    title: uid,
+    description: null,
+    location: null,
+    availability: "busy",
+    visibility: "default",
+    recurrence: null,
+  } as const;
+  if (representation === "dateOnly") {
+    return {
+      ...described,
+      time: {
+        kind: "allDay",
+        startDate: { kind: "calendarDate", value: "2026-03-12" },
+        endDateExclusive: { kind: "calendarDate", value: "2026-03-13" },
+      },
+    };
+  }
+  return {
+    ...described,
+    time: {
+      kind: "timed",
+      start: { kind: "instant", value: "2026-03-12T00:00:00.000Z" },
+      end: { kind: "instant", value: "2026-03-13T00:00:00.000Z" },
+      zone: { kind: "zoneId", value: "UTC" },
+    },
+  };
+};
+
+const gridHoldsFor = (time: EventTime | null, grid: RepresentableRange["allDayGrid"]): boolean => {
+  if (time === null || time.kind === "allDay") {
+    return true;
+  }
+  if (grid !== "utcDay") {
+    return true;
+  }
+  return time.start.value.endsWith("T00:00:00.000Z") && time.end.value.endsWith("T00:00:00.000Z");
+};
+
+const carriesRetryAfter = (answered: Result<ChangeListing>): boolean => {
+  if (answered.ok || answered.failure.kind !== "rateLimited") {
+    return false;
+  }
+  return answered.failure.retryAfter !== null;
+};
+
+const undeclaredStatus = 599;
 
 const acceptedByIntl = (zone: string): boolean => {
   try {
@@ -208,8 +277,112 @@ const capabilityCases = <Provider extends ProviderId>(
         zones.every((zone) => acceptedByIntl(zone)),
         "a zone identifier no runtime can resolve reached a canonical event",
       );
+
+      const series = markedWith("CONF-O43", "series");
+      const recurring = await write(
+        context,
+        createIntent(
+          supports,
+          scope.calendar,
+          context.environment.installation,
+          series,
+          seriesAnchoredIn(series, "Pacific Standard Time"),
+        ),
+      );
+      insist(
+        "CONF-O43",
+        refusedWith(recurring, "zoneIdentifier"),
+        "a Windows zone identifier anchoring a series was accepted where a single occurrence was refused",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O45",
+    "an all-day event is never silently converted out of the representation it was written in",
+    async (context) => {
+      const scope = caseScope(context);
+      const key = markedWith("CONF-O45", "allDay");
+      await seedWith(context, []);
+      const submitted = allDayAs(key, supports.allDay);
+
+      const written = await write(
+        context,
+        createIntent(supports, scope.calendar, context.environment.installation, key, submitted),
+      );
+      const listing = listingOf("CONF-O45", await listChanges(context, scope));
+      const mirrored = (listing.events ?? []).find((event) => event.uid.value === key);
+
+      insist("CONF-O45", written.ok, "an all-day event in the declared representation was refused");
+      insist("CONF-O45", Boolean(mirrored), "an all-day event we wrote did not come back");
+      insist(
+        "CONF-O45",
+        mirrored?.content.time?.kind === submitted.time?.kind,
+        "an all-day event came back in a representation the adapter never declared",
+      );
+      insist(
+        "CONF-O45",
+        gridHoldsFor(mirrored?.content.time ?? null, supports.representableRange.allDayGrid),
+        "an all-day event came back off the day grid the adapter declared",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O46",
+    "every throttle signal the adapter declares is classified as a throttle, and no other status is",
+    async (context) => {
+      const scope = caseScope(context);
+      await seedWith(context, []);
+
+      for (const signal of supports.throttleSignals) {
+        context.environment.transport.answerWith({
+          kind: "status",
+          status: signal.status,
+          retryAfter: { kind: "instant", value: "2099-01-01T00:00:00.000Z" },
+          times: Number.MAX_SAFE_INTEGER,
+        });
+        const answered = await listChanges(context, scope, null, { maxAttempts: 1 });
+        context.environment.transport.answerWith({ kind: "pass" });
+
+        insist(
+          "CONF-O46",
+          failureKindOf(answered) === "rateLimited",
+          `a declared throttle signal (${signal.status}) was classified as "${failureKindOf(answered)}"`,
+        );
+        insist(
+          "CONF-O46",
+          carriesRetryAfter(answered) === signal.hasRetryAfter,
+          `a declared throttle signal (${signal.status}) disagreed with the retry-after it promised`,
+        );
+      }
+
+      context.environment.transport.answerWith({
+        kind: "status",
+        status: undeclaredStatus,
+        retryAfter: null,
+        times: Number.MAX_SAFE_INTEGER,
+      });
+      const undeclared = await listChanges(context, scope, null, { maxAttempts: 1 });
+      context.environment.transport.answerWith({ kind: "pass" });
+
+      insist(
+        "CONF-O46",
+        failureKindOf(undeclared) !== "rateLimited",
+        "a status the adapter never declared as a throttle signal was backed off as one anyway",
+      );
     },
   ),
 ];
 
-export { acceptedByIntl, capabilityCases, nativeRecurrence, refusedWith, zonedAs };
+export {
+  acceptedByIntl,
+  allDayAs,
+  capabilityCases,
+  nativeRecurrence,
+  refusedWith,
+  seriesAnchoredIn,
+  zonedAs,
+};

--- a/packages/sync-kit/conformance/src/cases/capabilities.ts
+++ b/packages/sync-kit/conformance/src/cases/capabilities.ts
@@ -1,10 +1,215 @@
-import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type {
+  Capabilities,
+  EditableContent,
+  ProviderId,
+  RepresentabilityConstraint,
+  Result,
+  WriteOutcome,
+} from "@keeper.sh/sync-protocol";
 import type { ConformanceCase } from "../registry/case";
+import { createIntent } from "./intents";
+import {
+  caseScope,
+  contentOf,
+  defineCase,
+  insist,
+  listChanges,
+  listingOf,
+  markedWith,
+  objectsMarked,
+  seedWith,
+  write,
+} from "./support";
+
+const refusedWith = (
+  answered: Result<WriteOutcome>,
+  constraint: RepresentabilityConstraint,
+): boolean => {
+  if (!answered.ok) {
+    return answered.failure.kind === "unrepresentable" && answered.failure.constraint === constraint;
+  }
+  return (
+    answered.value.kind === "unrepresentable" && answered.value.constraint === constraint
+  );
+};
+
+const nativeRecurrence = (uid: string): EditableContent => ({
+  title: uid,
+  description: null,
+  location: null,
+  availability: "busy",
+  visibility: "default",
+  recurrence: { dialect: "providerNative", value: "EVERY_WEEKDAY", exceptions: [] },
+  anchor: {
+    kind: "timed",
+    start: { kind: "instant", value: "2026-03-02T09:00:00.000Z" },
+    zone: { kind: "zoneId", value: "UTC" },
+    duration: { kind: "exact", seconds: 3600 },
+  },
+});
+
+const zonedAs = (uid: string, zone: string): EditableContent => ({
+  title: uid,
+  description: null,
+  location: null,
+  availability: "busy",
+  visibility: "default",
+  recurrence: null,
+  time: {
+    kind: "timed",
+    start: { kind: "instant", value: "2026-03-02T09:00:00.000Z" },
+    end: { kind: "instant", value: "2026-03-02T10:00:00.000Z" },
+    zone: { kind: "zoneId", value: zone },
+  },
+});
+
+const acceptedByIntl = (zone: string): boolean => {
+  try {
+    return (
+      new Intl.DateTimeFormat("en-US", { timeZone: zone }).resolvedOptions().timeZone.length > 0
+    );
+  } catch {
+    return false;
+  }
+};
 
 const capabilityCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
-): readonly ConformanceCase<Provider>[] => {
-  throw new Error(`unimplemented: capabilityCases(${supports.provider})`);
-};
+): readonly ConformanceCase<Provider>[] => [
+  defineCase(
+    supports,
+    "CONF-O29",
+    "a declared refusal actually refuses",
+    async (context) => {
+      const scope = caseScope(context);
+      const key = markedWith("CONF-O29", "inverted");
+      await seedWith(context, []);
+      const answered = await write(
+        context,
+        createIntent(
+          supports,
+          scope.calendar,
+          context.environment.installation,
+          key,
+          contentOf({
+            uid: key,
+            start: "2026-03-02T10:00:00.000Z",
+            end: "2026-03-02T09:00:00.000Z",
+          }),
+        ),
+      );
+      const stored = await objectsMarked(context.provider, "CONF-O29");
 
-export { capabilityCases };
+      if (supports.representableRange.invertedRange === "reject") {
+        insist(
+          "CONF-O29",
+          refusedWith(answered, "invertedRange"),
+          "an adapter that declares it rejects inverted ranges accepted one",
+        );
+        insist(
+          "CONF-O29",
+          stored.length === 0,
+          "a refused write still left an object on the calendar",
+        );
+        return;
+      }
+      insist(
+        "CONF-O29",
+        answered.ok,
+        "an adapter that declares it clamps inverted ranges refused one instead",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O35",
+    "an unsupported construct is withheld and counted, never approximated",
+    async (context) => {
+      const scope = caseScope(context);
+      const key = markedWith("CONF-O35", "native");
+      await seedWith(context, []);
+
+      const answered = await write(
+        context,
+        createIntent(
+          supports,
+          scope.calendar,
+          context.environment.installation,
+          key,
+          nativeRecurrence(key),
+        ),
+      );
+      const stored = await objectsMarked(context.provider, "CONF-O35");
+
+      if (supports.recurrenceWrite === "providerNative") {
+        insist("CONF-O35", answered.ok, "an adapter that speaks its own dialect refused it");
+        return;
+      }
+      insist(
+        "CONF-O35",
+        refusedWith(answered, "recurrenceDialect"),
+        "a recurrence dialect the adapter cannot speak was approximated instead of refused",
+      );
+      insist(
+        "CONF-O35",
+        stored.length === 0,
+        "an approximation of an unsupported recurrence was written anyway",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O43",
+    "a non-IANA zone identifier never reaches a canonical event",
+    async (context) => {
+      const scope = caseScope(context);
+      const refused = markedWith("CONF-O43", "windows");
+      const accepted = markedWith("CONF-O43", "iana");
+      await seedWith(context, []);
+
+      const windows = await write(
+        context,
+        createIntent(
+          supports,
+          scope.calendar,
+          context.environment.installation,
+          refused,
+          zonedAs(refused, "Pacific Standard Time"),
+        ),
+      );
+      insist(
+        "CONF-O43",
+        refusedWith(windows, "zoneIdentifier"),
+        "a Windows zone identifier was accepted as if it were an IANA zone",
+      );
+
+      await write(
+        context,
+        createIntent(
+          supports,
+          scope.calendar,
+          context.environment.installation,
+          accepted,
+          zonedAs(accepted, "UTC"),
+        ),
+      );
+      const listing = listingOf("CONF-O43", await listChanges(context, scope));
+      const zones = (listing.events ?? []).flatMap((event) => {
+        const { time } = event.content;
+        if (!time || time.kind === "allDay" || time.zone === null) {
+          return [];
+        }
+        return [time.zone.value];
+      });
+      insist(
+        "CONF-O43",
+        zones.every((zone) => acceptedByIntl(zone)),
+        "a zone identifier no runtime can resolve reached a canonical event",
+      );
+    },
+  ),
+];
+
+export { acceptedByIntl, capabilityCases, nativeRecurrence, refusedWith, zonedAs };

--- a/packages/sync-kit/conformance/src/cases/convergence.ts
+++ b/packages/sync-kit/conformance/src/cases/convergence.ts
@@ -1,10 +1,268 @@
-import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type {
+  Capabilities,
+  ChangeListing,
+  EditableContent,
+  ProviderId,
+  RemoteEvent,
+} from "@keeper.sh/sync-protocol";
+import { canonicalise } from "../canonical";
 import type { ConformanceCase } from "../registry/case";
+import { createIntent } from "./intents";
+import {
+  caseScope,
+  defineCase,
+  foreignEvent,
+  insist,
+  listChanges,
+  listingOf,
+  markedWith,
+  outcomeOf,
+  seedWith,
+  write,
+  writeLogLength,
+} from "./support";
+
+const marked = (listing: ChangeListing, prefix: string): readonly RemoteEvent[] =>
+  (listing.events ?? []).filter((event) => event.uid.value.startsWith(prefix));
+
+const summaryOfMarked = (listing: ChangeListing, prefix: string): string =>
+  canonicalise(
+    marked(listing, prefix).map((event) => ({
+      uid: event.uid.value,
+      revision: event.revision,
+      title: event.content.title,
+    })),
+  );
+
+const trailingWhitespaceContent = (): EditableContent => ({
+  title: "Design review \r\n",
+  description: null,
+  location: null,
+  availability: "busy",
+  visibility: "default",
+  recurrence: null,
+  time: {
+    kind: "timed",
+    start: { kind: "instant", value: "2026-03-02T09:00:00.000Z" },
+    end: { kind: "instant", value: "2026-03-02T10:00:00.000Z" },
+    zone: { kind: "zoneId", value: "UTC" },
+  },
+});
+
+const straightOrder = (): EditableContent => ({
+  title: "Permuted",
+  description: null,
+  location: null,
+  availability: "busy",
+  visibility: "default",
+  recurrence: null,
+  time: {
+    kind: "timed",
+    start: { kind: "instant", value: "2026-03-04T09:00:00.000Z" },
+    end: { kind: "instant", value: "2026-03-04T10:00:00.000Z" },
+    zone: { kind: "zoneId", value: "UTC" },
+  },
+});
+
+const permutedOrder = (): EditableContent => ({
+  visibility: "default",
+  availability: "busy",
+  location: null,
+  description: null,
+  title: "Permuted",
+  recurrence: null,
+  time: {
+    kind: "timed",
+    start: { kind: "instant", value: "2026-03-04T09:00:00.000Z" },
+    end: { kind: "instant", value: "2026-03-04T10:00:00.000Z" },
+    zone: { kind: "zoneId", value: "UTC" },
+  },
+});
 
 const convergenceCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
-): readonly ConformanceCase<Provider>[] => {
-  throw new Error(`unimplemented: convergenceCases(${supports.provider})`);
-};
+): readonly ConformanceCase<Provider>[] => [
+  defineCase(
+    supports,
+    "CONF-O8",
+    "the same colliding pair produces the same winner in either feed order",
+    async (context) => {
+      const scope = caseScope(context);
+      const uid = markedWith("CONF-O8", "collider");
+      const older = foreignEvent(scope.calendar, {
+        uid,
+        title: "Older",
+        start: "2026-03-02T09:00:00.000Z",
+        end: "2026-03-02T10:00:00.000Z",
+        revision: 1,
+      });
+      const newer = foreignEvent(scope.calendar, {
+        uid,
+        title: "Newer",
+        start: "2026-03-02T11:00:00.000Z",
+        end: "2026-03-02T12:00:00.000Z",
+        revision: 2,
+      });
 
-export { convergenceCases };
+      await seedWith(context, [older, newer]);
+      const forward = listingOf("CONF-O8", await listChanges(context, scope));
+      await seedWith(context, [newer, older]);
+      const backward = listingOf("CONF-O8", await listChanges(context, scope));
+
+      insist(
+        "CONF-O8",
+        summaryOfMarked(forward, "CONF-O8") === summaryOfMarked(backward, "CONF-O8"),
+        "the winner between two revisions depended on the order the feed happened to deliver them",
+      );
+    },
+  ),
+
+  defineCase(supports, "CONF-O9", "re-running against unchanged input is zero writes", async (context) => {
+    const scope = caseScope(context);
+    await seedWith(context, [
+      foreignEvent(scope.calendar, {
+        uid: markedWith("CONF-O9", "quiet"),
+        start: "2026-03-02T09:00:00.000Z",
+        end: "2026-03-02T10:00:00.000Z",
+      }),
+    ]);
+
+    const before = await writeLogLength(context.provider);
+    await listChanges(context, scope);
+    await listChanges(context, scope);
+    const after = await writeLogLength(context.provider);
+
+    insist("CONF-O9", after === before, "reading a calendar twice wrote to it");
+  }),
+
+  defineCase(
+    supports,
+    "CONF-O20",
+    "a provider's own lossless rewrite does not read as drift",
+    async (context) => {
+      const scope = caseScope(context);
+      const key = markedWith("CONF-O20", "rewritten");
+      await seedWith(context, []);
+
+      const created = outcomeOf(
+        "CONF-O20",
+        await write(
+          context,
+          createIntent(
+            supports,
+            scope.calendar,
+            context.environment.installation,
+            key,
+            trailingWhitespaceContent(),
+          ),
+        ),
+      );
+      const replayed = outcomeOf(
+        "CONF-O20",
+        await write(
+          context,
+          createIntent(
+            supports,
+            scope.calendar,
+            context.environment.installation,
+            key,
+            trailingWhitespaceContent(),
+          ),
+        ),
+      );
+
+      insist("CONF-O20", created.kind === "created", "the first write did not create anything");
+      insist(
+        "CONF-O20",
+        replayed.kind === "alreadyExists" || replayed.kind === "unchanged",
+        "the provider's own lossless rewrite of what we submitted read back as a change",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O21",
+    "permuted key order is one identity, not two",
+    async (context) => {
+      const scope = caseScope(context);
+      const key = markedWith("CONF-O21", "permuted");
+      await seedWith(context, []);
+
+      const straight = outcomeOf(
+        "CONF-O21",
+        await write(
+          context,
+          createIntent(
+            supports,
+            scope.calendar,
+            context.environment.installation,
+            key,
+            straightOrder(),
+          ),
+        ),
+      );
+      const permuted = outcomeOf(
+        "CONF-O21",
+        await write(
+          context,
+          createIntent(
+            supports,
+            scope.calendar,
+            context.environment.installation,
+            key,
+            permutedOrder(),
+          ),
+        ),
+      );
+
+      insist("CONF-O21", straight.kind === "created", "the first write did not create anything");
+      insist(
+        "CONF-O21",
+        permuted.kind === "alreadyExists" || permuted.kind === "unchanged",
+        "the same content spelled in a different key order read as a second identity",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O22",
+    "one identity repeated in a listing is one entry, last observation wins",
+    async (context) => {
+      const scope = caseScope(context);
+      const uid = markedWith("CONF-O22", "repeated");
+      const older = foreignEvent(scope.calendar, {
+        uid,
+        title: "Older",
+        start: "2026-03-02T09:00:00.000Z",
+        end: "2026-03-02T10:00:00.000Z",
+        revision: 1,
+      });
+      const newer = foreignEvent(scope.calendar, {
+        uid,
+        title: "Newer",
+        start: "2026-03-02T11:00:00.000Z",
+        end: "2026-03-02T12:00:00.000Z",
+        revision: 2,
+      });
+
+      await seedWith(context, [older, newer, older]);
+      const listing = listingOf("CONF-O22", await listChanges(context, scope));
+      const collided = marked(listing, "CONF-O22");
+
+      insist(
+        "CONF-O22",
+        collided.length === 1,
+        "one identity reported several times in one listing became several entries",
+      );
+      insist(
+        "CONF-O22",
+        collided.at(0)?.revision === 2,
+        "the winner between repeated observations was not the newest one",
+      );
+    },
+  ),
+];
+
+export { convergenceCases, marked, summaryOfMarked };

--- a/packages/sync-kit/conformance/src/cases/convergence.ts
+++ b/packages/sync-kit/conformance/src/cases/convergence.ts
@@ -1,0 +1,10 @@
+import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { ConformanceCase } from "../registry/case";
+
+const convergenceCases = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+): readonly ConformanceCase<Provider>[] => {
+  throw new Error(`unimplemented: convergenceCases(${supports.provider})`);
+};
+
+export { convergenceCases };

--- a/packages/sync-kit/conformance/src/cases/cursor.ts
+++ b/packages/sync-kit/conformance/src/cases/cursor.ts
@@ -1,0 +1,10 @@
+import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { ConformanceCase } from "../registry/case";
+
+const cursorCases = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+): readonly ConformanceCase<Provider>[] => {
+  throw new Error(`unimplemented: cursorCases(${supports.provider})`);
+};
+
+export { cursorCases };

--- a/packages/sync-kit/conformance/src/cases/cursor.ts
+++ b/packages/sync-kit/conformance/src/cases/cursor.ts
@@ -6,7 +6,8 @@ import type {
   Result,
   SyncCursor,
 } from "@keeper.sh/sync-protocol";
-import type { ConformanceCase } from "../registry/case";
+import type { ConformanceCaseId } from "../case-id";
+import type { CaseContext, ConformanceCase } from "../registry/case";
 import {
   caseScope,
   decadeWindow,
@@ -32,6 +33,28 @@ const isLostOrRefused = (answered: Result<ChangeListing>): boolean => {
 const eventNamed = (listing: ChangeListing, uid: string): RemoteEvent | undefined =>
   (listing.events ?? []).find((event) => event.uid.value === uid);
 
+const mintedBy = <Provider extends ProviderId>(
+  id: ConformanceCaseId,
+  context: CaseContext<Provider>,
+  listing: ChangeListing,
+): SyncCursor | null => {
+  const cursor = cursorOf(listing);
+  if (context.supports.delta.kind === "none") {
+    insist(
+      id,
+      cursor === null,
+      "an adapter that declares no delta support handed back a sync cursor to resume from",
+    );
+    return null;
+  }
+  insist(
+    id,
+    cursor !== null,
+    "an adapter that declares tokenized delta support proved coverage without minting a cursor",
+  );
+  return cursor;
+};
+
 const cursorCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
 ): readonly ConformanceCase<Provider>[] => [
@@ -49,7 +72,7 @@ const cursorCases = <Provider extends ProviderId>(
         }),
       ]);
 
-      const first = cursorOf(listingOf("CONF-O10", await listChanges(context, scope)));
+      const first = mintedBy("CONF-O10", context, listingOf("CONF-O10", await listChanges(context, scope)));
       if (first === null) {
         return;
       }
@@ -90,7 +113,7 @@ const cursorCases = <Provider extends ProviderId>(
           end: "2026-03-02T10:00:00.000Z",
         }),
       ]);
-      const minted = cursorOf(listingOf("CONF-O11", await listChanges(context, scope)));
+      const minted = mintedBy("CONF-O11", context, listingOf("CONF-O11", await listChanges(context, scope)));
       if (minted === null) {
         return;
       }
@@ -126,7 +149,7 @@ const cursorCases = <Provider extends ProviderId>(
         end: "2026-03-02T10:00:00.000Z",
       });
       await seedWith(context, [alpha]);
-      const minted = cursorOf(listingOf("CONF-O24", await listChanges(context, scope)));
+      const minted = mintedBy("CONF-O24", context, listingOf("CONF-O24", await listChanges(context, scope)));
       if (minted === null) {
         return;
       }
@@ -169,7 +192,7 @@ const cursorCases = <Provider extends ProviderId>(
           end: "2026-03-02T10:00:00.000Z",
         }),
       ]);
-      const minted = cursorOf(listingOf("CONF-O37", await listChanges(context, scope)));
+      const minted = mintedBy("CONF-O37", context, listingOf("CONF-O37", await listChanges(context, scope)));
       if (minted === null) {
         return;
       }
@@ -206,7 +229,7 @@ const cursorCases = <Provider extends ProviderId>(
         location: "the location the patch omits",
       };
       await seedWith(context, [foreignEvent(scope.calendar, { ...draft, title: "Before" })]);
-      const minted = cursorOf(listingOf("CONF-O38", await listChanges(context, scope)));
+      const minted = mintedBy("CONF-O38", context, listingOf("CONF-O38", await listChanges(context, scope)));
       if (minted === null) {
         return;
       }
@@ -241,7 +264,7 @@ const cursorCases = <Provider extends ProviderId>(
           end: "2026-03-02T10:00:00.000Z",
         }),
       ]);
-      const minted = cursorOf(listingOf("CONF-O40", await listChanges(context, scope)));
+      const minted = mintedBy("CONF-O40", context, listingOf("CONF-O40", await listChanges(context, scope)));
       if (minted === null) {
         return;
       }

--- a/packages/sync-kit/conformance/src/cases/cursor.ts
+++ b/packages/sync-kit/conformance/src/cases/cursor.ts
@@ -1,10 +1,261 @@
-import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type {
+  Capabilities,
+  ChangeListing,
+  ProviderId,
+  RemoteEvent,
+  Result,
+  SyncCursor,
+} from "@keeper.sh/sync-protocol";
 import type { ConformanceCase } from "../registry/case";
+import {
+  caseScope,
+  decadeWindow,
+  defineCase,
+  failureKindOf,
+  foreignEvent,
+  insist,
+  listChanges,
+  listingOf,
+  markedWith,
+  seedWith,
+} from "./support";
+
+const cursorOf = (listing: ChangeListing): SyncCursor | null => listing.cursor ?? null;
+
+const isLostOrRefused = (answered: Result<ChangeListing>): boolean => {
+  if (!answered.ok) {
+    return answered.failure.kind === "cursorInvalid";
+  }
+  return answered.value.kind === "cursorLost";
+};
+
+const eventNamed = (listing: ChangeListing, uid: string): RemoteEvent | undefined =>
+  (listing.events ?? []).find((event) => event.uid.value === uid);
 
 const cursorCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
-): readonly ConformanceCase<Provider>[] => {
-  throw new Error(`unimplemented: cursorCases(${supports.provider})`);
-};
+): readonly ConformanceCase<Provider>[] => [
+  defineCase(
+    supports,
+    "CONF-O10",
+    "a cursor the adapter can no longer honour discards the pagination and carries no tombstones",
+    async (context) => {
+      const scope = caseScope(context);
+      await seedWith(context, [
+        foreignEvent(scope.calendar, {
+          uid: markedWith("CONF-O10", "alpha"),
+          start: "2026-03-02T09:00:00.000Z",
+          end: "2026-03-02T10:00:00.000Z",
+        }),
+      ]);
 
-export { cursorCases };
+      const first = cursorOf(listingOf("CONF-O10", await listChanges(context, scope)));
+      if (first === null) {
+        return;
+      }
+      await listChanges(context, scope);
+      const replayed = await listChanges(context, scope, first);
+
+      insist(
+        "CONF-O10",
+        isLostOrRefused(replayed),
+        "a cursor the adapter had already superseded was still honoured",
+      );
+      if (!replayed.ok) {
+        return;
+      }
+      insist(
+        "CONF-O10",
+        (replayed.value.events ?? []).length === 0 && (replayed.value.removals ?? []).length === 0,
+        "a lost cursor leaked events or tombstones from a pagination it abandoned",
+      );
+      insist(
+        "CONF-O10",
+        !replayed.value.cursor,
+        "a lost cursor was answered with a fresh cursor rather than a demand to resync",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O11",
+    "a cursor minted under one window is refused when the window changes",
+    async (context) => {
+      const scope = caseScope(context);
+      await seedWith(context, [
+        foreignEvent(scope.calendar, {
+          uid: markedWith("CONF-O11", "alpha"),
+          start: "2026-03-02T09:00:00.000Z",
+          end: "2026-03-02T10:00:00.000Z",
+        }),
+      ]);
+      const minted = cursorOf(listingOf("CONF-O11", await listChanges(context, scope)));
+      if (minted === null) {
+        return;
+      }
+
+      const widened = await listChanges(context, caseScope(context, decadeWindow), minted);
+      if (supports.delta.kind === "tokenized" && supports.delta.windowBoundToCursor) {
+        insist(
+          "CONF-O11",
+          isLostOrRefused(widened),
+          "a cursor minted under a narrower window was replayed against a wider one",
+        );
+        return;
+      }
+      insist(
+        "CONF-O11",
+        widened.ok || failureKindOf(widened) === "cursorInvalid",
+        "a window-free cursor answered with an untyped failure",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O24",
+    "a run that did not complete never advances the sync frontier",
+    async (context) => {
+      const scope = caseScope(context);
+      const first = markedWith("CONF-O24", "first");
+      const second = markedWith("CONF-O24", "second");
+      const alpha = foreignEvent(scope.calendar, {
+        uid: first,
+        start: "2026-03-02T09:00:00.000Z",
+        end: "2026-03-02T10:00:00.000Z",
+      });
+      await seedWith(context, [alpha]);
+      const minted = cursorOf(listingOf("CONF-O24", await listChanges(context, scope)));
+      if (minted === null) {
+        return;
+      }
+
+      await seedWith(context, [
+        alpha,
+        foreignEvent(scope.calendar, {
+          uid: second,
+          start: "2026-03-03T09:00:00.000Z",
+          end: "2026-03-03T10:00:00.000Z",
+        }),
+      ]);
+      context.environment.transport.answerWith({
+        kind: "reject",
+        failure: { kind: "transport", status: 500, disposition: "permanent" },
+        times: 1,
+      });
+      await listChanges(context, scope, minted);
+      context.environment.transport.answerWith({ kind: "pass" });
+
+      const resumed = listingOf("CONF-O24", await listChanges(context, scope, minted));
+      insist(
+        "CONF-O24",
+        resumed.kind !== "delta" || Boolean(eventNamed(resumed, second)),
+        "the frontier moved past a change the failed run never delivered",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O37",
+    "a quiet calendar still advances its cursor",
+    async (context) => {
+      const scope = caseScope(context);
+      await seedWith(context, [
+        foreignEvent(scope.calendar, {
+          uid: markedWith("CONF-O37", "alpha"),
+          start: "2026-03-02T09:00:00.000Z",
+          end: "2026-03-02T10:00:00.000Z",
+        }),
+      ]);
+      const minted = cursorOf(listingOf("CONF-O37", await listChanges(context, scope)));
+      if (minted === null) {
+        return;
+      }
+      const before = await context.provider.inspect();
+
+      const quiet = listingOf("CONF-O37", await listChanges(context, scope, minted));
+      const after = await context.provider.inspect();
+
+      insist(
+        "CONF-O37",
+        cursorOf(quiet)?.value !== minted.value,
+        "a poll that found nothing handed back the cursor it was given, so the feed never moves on",
+      );
+      insist(
+        "CONF-O37",
+        after.writeLog.length === before.writeLog.length,
+        "a quiet poll wrote to the calendar",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O38",
+    "a delta item is a patch and never blanks the fields it omits",
+    async (context) => {
+      const scope = caseScope(context);
+      const uid = markedWith("CONF-O38", "patched");
+      const draft = {
+        uid,
+        start: "2026-03-02T09:00:00.000Z",
+        end: "2026-03-02T10:00:00.000Z",
+        description: "the description the patch omits",
+        location: "the location the patch omits",
+      };
+      await seedWith(context, [foreignEvent(scope.calendar, { ...draft, title: "Before" })]);
+      const minted = cursorOf(listingOf("CONF-O38", await listChanges(context, scope)));
+      if (minted === null) {
+        return;
+      }
+
+      await seedWith(context, [
+        foreignEvent(scope.calendar, { ...draft, title: "After", revision: 2 }),
+      ]);
+      const delta = listingOf("CONF-O38", await listChanges(context, scope, minted));
+      const patched = eventNamed(delta, uid);
+      if (!patched) {
+        return;
+      }
+      insist(
+        "CONF-O38",
+        patched.content.description === draft.description &&
+          patched.content.location === draft.location,
+        "a sparse delta item blanked the fields it never carried",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O40",
+    "an unrecognised cursor is answered, never thrown and never an empty delta",
+    async (context) => {
+      const scope = caseScope(context);
+      await seedWith(context, [
+        foreignEvent(scope.calendar, {
+          uid: markedWith("CONF-O40", "alpha"),
+          start: "2026-03-02T09:00:00.000Z",
+          end: "2026-03-02T10:00:00.000Z",
+        }),
+      ]);
+      const minted = cursorOf(listingOf("CONF-O40", await listChanges(context, scope)));
+      if (minted === null) {
+        return;
+      }
+
+      const tampered: SyncCursor = { ...minted, value: `${minted.value}-tampered` };
+      const replayed = await listChanges(context, scope, tampered);
+
+      insist(
+        "CONF-O40",
+        isLostOrRefused(replayed),
+        "a cursor the adapter cannot read was answered as if it still meant something",
+      );
+    },
+  ),
+];
+
+export { cursorCases, cursorOf, eventNamed, isLostOrRefused };

--- a/packages/sync-kit/conformance/src/cases/deletion-safety.ts
+++ b/packages/sync-kit/conformance/src/cases/deletion-safety.ts
@@ -33,6 +33,8 @@ const knownAt = (uid: string, day: string): KnownIdentity => ({
   },
 });
 
+const RESUME_CEILING = 50;
+
 const knownOf = (calendar: CalendarKey, uids: readonly string[]): KnownMirror => ({
   calendar,
   entries: uids.map((uid) => knownAt(uid, "2026-03-02")),
@@ -418,32 +420,53 @@ const deletionSafetyCases = <Provider extends ProviderId>(
   defineCase(
     supports,
     "CONF-O41",
-    "a truncated page's resumable token is a continuation, never a cursor",
+    "a resumed walk accounts for the pages it already handed back",
     async (context) => {
       const scope = caseScope(context);
-      await seedWith(context, [
-        foreignEvent(scope.calendar, {
-          uid: markedWith("CONF-O41", "only"),
-          start: "2026-03-02T09:00:00.000Z",
-          end: "2026-03-02T10:00:00.000Z",
-        }),
-      ]);
+      const seeded = Array.from({ length: 12 }, (unused, index) =>
+        markedWith("CONF-O41", `seed-${index}`));
 
-      const first = listingOf("CONF-O41", await listChanges(context, scope));
-      if (first.kind !== "partial") {
-        insist("CONF-O41", Boolean(first.coverage), "a complete read proved no coverage");
-        return;
+      await seedWith(context, seeded.map((uid, index) => foreignEvent(scope.calendar, {
+        uid,
+        start: `2026-03-${String((index % 27) + 1).padStart(2, "0")}T09:00:00.000Z`,
+        end: `2026-03-${String((index % 27) + 1).padStart(2, "0")}T10:00:00.000Z`,
+      })));
+
+      /*
+       * Walking to the end is the point. A listing that ends the walk claims authority over
+       * the window, so every seeded identity must still be accounted for — an adapter that
+       * resumes and reports only the pages after the resume point turns the earlier ones into
+       * derivable deletions of events that are plainly still there.
+       */
+      let listing = listingOf("CONF-O41", await listChanges(context, scope));
+      let walked = 0;
+      while (listing.kind === "partial" && walked < RESUME_CEILING) {
+        insist(
+          "CONF-O41",
+          listing.continuation.kind === "continuation" && !listing.cursor,
+          "a truncated page handed back a sync cursor instead of a continuation",
+        );
+        walked += 1;
+        listing = listingOf("CONF-O41", await listChanges(context, scope, listing.continuation));
       }
+
       insist(
         "CONF-O41",
-        first.continuation.kind === "continuation" && !first.cursor,
-        "a truncated page handed back a sync cursor instead of a continuation",
-      );
-      const resumed = listingOf("CONF-O41", await listChanges(context, scope, first.continuation));
-      insist(
-        "CONF-O41",
-        resumed.kind !== "partial",
+        listing.kind !== "partial",
         "resuming from the continuation never reached a listing that proves coverage",
+      );
+
+      const derivable = derivableRemovals({
+        listing,
+        known: knownOf(scope.calendar, seeded),
+        withinWindow: context.withinWindow,
+      });
+
+      insist(
+        "CONF-O41",
+        derivable.length === 0,
+        `a completed walk made ${derivable.length} still-present identities derivable as`
+        + ` removals, after ${walked} resumption(s)`,
       );
     },
   ),

--- a/packages/sync-kit/conformance/src/cases/deletion-safety.ts
+++ b/packages/sync-kit/conformance/src/cases/deletion-safety.ts
@@ -1,0 +1,10 @@
+import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { ConformanceCase } from "../registry/case";
+
+const deletionSafetyCases = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+): readonly ConformanceCase<Provider>[] => {
+  throw new Error(`unimplemented: deletionSafetyCases(${supports.provider})`);
+};
+
+export { deletionSafetyCases };

--- a/packages/sync-kit/conformance/src/cases/deletion-safety.ts
+++ b/packages/sync-kit/conformance/src/cases/deletion-safety.ts
@@ -438,26 +438,32 @@ const deletionSafetyCases = <Provider extends ProviderId>(
        * resumes and reports only the pages after the resume point turns the earlier ones into
        * derivable deletions of events that are plainly still there.
        */
-      let listing = listingOf("CONF-O41", await listChanges(context, scope));
-      let walked = 0;
-      while (listing.kind === "partial" && walked < RESUME_CEILING) {
+      const walk = {
+        listing: listingOf("CONF-O41", await listChanges(context, scope)),
+        walked: 0,
+      };
+      while (walk.listing.kind === "partial" && walk.walked < RESUME_CEILING) {
+        const { listing: partial } = walk;
         insist(
           "CONF-O41",
-          listing.continuation.kind === "continuation" && !listing.cursor,
+          partial.continuation.kind === "continuation" && !partial.cursor,
           "a truncated page handed back a sync cursor instead of a continuation",
         );
-        walked += 1;
-        listing = listingOf("CONF-O41", await listChanges(context, scope, listing.continuation));
+        walk.walked += 1;
+        walk.listing = listingOf(
+          "CONF-O41",
+          await listChanges(context, scope, partial.continuation),
+        );
       }
 
       insist(
         "CONF-O41",
-        listing.kind !== "partial",
+        walk.listing.kind !== "partial",
         "resuming from the continuation never reached a listing that proves coverage",
       );
 
       const derivable = derivableRemovals({
-        listing,
+        listing: walk.listing,
         known: knownOf(scope.calendar, seeded),
         withinWindow: context.withinWindow,
       });
@@ -466,7 +472,7 @@ const deletionSafetyCases = <Provider extends ProviderId>(
         "CONF-O41",
         derivable.length === 0,
         `a completed walk made ${derivable.length} still-present identities derivable as`
-        + ` removals, after ${walked} resumption(s)`,
+        + ` removals, after ${walk.walked} resumption(s)`,
       );
     },
   ),

--- a/packages/sync-kit/conformance/src/cases/deletion-safety.ts
+++ b/packages/sync-kit/conformance/src/cases/deletion-safety.ts
@@ -1,11 +1,12 @@
 import type {
+  CalendarKey,
   Capabilities,
   ChangeListing,
-  KnownEvents,
   ProviderId,
   RemoteEvent,
 } from "@keeper.sh/sync-protocol";
 import { assertNoRemovalDerivable, derivableRemovals } from "../assertions/no-removal";
+import type { KnownIdentity, KnownMirror } from "../assertions/no-removal";
 import type { ConformanceCase } from "../registry/case";
 import {
   caseScope,
@@ -21,9 +22,20 @@ import {
   uidsOf,
 } from "./support";
 
-const knownOf = (calendar: KnownEvents["calendar"], uids: readonly string[]): KnownEvents => ({
+const knownAt = (uid: string, day: string): KnownIdentity => ({
+  uid,
+  id: { kind: "remoteEventId", value: `id-${uid}` },
+  time: {
+    kind: "timed",
+    start: { kind: "instant", value: `${day}T09:00:00.000Z` },
+    end: { kind: "instant", value: `${day}T10:00:00.000Z` },
+    zone: null,
+  },
+});
+
+const knownOf = (calendar: CalendarKey, uids: readonly string[]): KnownMirror => ({
   calendar,
-  ids: new Map(uids.map((uid) => [uid, { kind: "remoteEventId", value: `id-${uid}` }])),
+  entries: uids.map((uid) => knownAt(uid, "2026-03-02")),
 });
 
 const presentIdentities = (listing: ChangeListing): readonly string[] => [
@@ -187,6 +199,7 @@ const deletionSafetyCases = <Provider extends ProviderId>(
         }).length === 0,
         "a removal was derived inside a band the listing never covered",
       );
+      await context.provider.contract.conformance.deletionInputsShareOneCalendar();
     },
   ),
 
@@ -225,19 +238,19 @@ const deletionSafetyCases = <Provider extends ProviderId>(
     async (context) => {
       const scope = caseScope(context);
       const uid = markedWith("CONF-O12", "row");
-      await seedWith(
-        context,
-        [
-          foreignEvent(scope.calendar, {
-            uid,
-            start: "2026-03-02T09:00:00.000Z",
-            end: "2026-03-02T10:00:00.000Z",
-          }),
-        ],
-        [uid],
-      );
+      const feed = [
+        foreignEvent(scope.calendar, {
+          uid,
+          start: "2026-03-02T09:00:00.000Z",
+          end: "2026-03-02T10:00:00.000Z",
+        }),
+      ];
+      await seedWith(context, feed);
+      await listChanges(context, scope);
+      await seedWith(context, feed, { corruptKnownRows: [uid] });
 
       const listing = listingOf("CONF-O12", await listChanges(context, scope));
+      const repeated = listingOf("CONF-O12", await listChanges(context, scope));
       await seedWith(context, []);
       insist(
         "CONF-O12",
@@ -249,6 +262,11 @@ const deletionSafetyCases = <Provider extends ProviderId>(
         (listing.removals ?? []).length === 0,
         "corrupt known state produced removals",
       );
+      insist(
+        "CONF-O12",
+        repeated.kind === "cursorLost",
+        "a feed identical to the previous poll was short-circuited past the corrupt row it had to recover",
+      );
     },
   ),
 
@@ -256,6 +274,7 @@ const deletionSafetyCases = <Provider extends ProviderId>(
     const scope = caseScope(context);
     const kept = markedWith("CONF-O13", "kept");
     const gone = markedWith("CONF-O13", "gone");
+    const ambiguous = `id-${markedWith("CONF-O13", "ambiguous")}`;
     const seeded = [
       foreignEvent(scope.calendar, {
         uid: kept,
@@ -270,22 +289,34 @@ const deletionSafetyCases = <Provider extends ProviderId>(
     ];
     await seedWith(context, seeded);
     await listChanges(context, scope);
-    await seedWith(context, withoutUid(seeded, gone));
+    await seedWith(context, withoutUid(seeded, gone), {
+      unattributableRemovals: [ambiguous],
+    });
 
     const listing = listingOf("CONF-O13", await listChanges(context, scope));
     const named = namedRemovalUids(listing);
     if (supports.removalsAreAmbiguous) {
       insist(
         "CONF-O13",
-        named.length === 0,
+        named.length === 0 || listing.kind === "cursorLost",
         "an adapter whose removals are ambiguous still emitted an authoritative deletion",
       );
       return;
     }
     insist(
       "CONF-O13",
+      named.includes(gone),
+      "an identity the source really dropped was not named as removed",
+    );
+    insist(
+      "CONF-O13",
       named.every((uid) => uid.length > 0),
       "an authoritative removal arrived without the identity it removes",
+    );
+    insist(
+      "CONF-O13",
+      !named.includes(ambiguous),
+      "a tombstone the adapter could not attribute was still reported as an authoritative removal",
     );
   }),
 
@@ -346,20 +377,40 @@ const deletionSafetyCases = <Provider extends ProviderId>(
           end: "2026-03-03T10:00:00.000Z",
         }),
       ];
+      const unnamed = `id-${markedWith("CONF-O34", "unnamed")}`;
       await seedWith(context, seeded);
       await listChanges(context, scope);
-      await seedWith(context, withoutUid(seeded, cancelled));
+      await seedWith(context, seeded, {
+        cancelled: [cancelled],
+        unattributableRemovals: [unnamed],
+      });
 
       const listing = listingOf("CONF-O34", await listChanges(context, scope));
+      const removals = listing.removals ?? [];
+      const outOfScope = removals.filter((removal) => removal.kind === "outOfScope");
       insist(
         "CONF-O34",
-        (listing.removals ?? []).every((removal) => removal.kind !== "outOfScope"),
-        "an out-of-scope marker was mixed into the authoritative removals",
+        removals.some((removal) => removal.kind === "cancelled" && removal.uid.value === cancelled),
+        "an identity the source reported as cancelled was not removed as a cancellation",
       );
       insist(
         "CONF-O34",
-        namedRemovalUids(listing).includes(cancelled),
-        "an identity the source really dropped was not named as removed",
+        !namedRemovalUids(listing).includes(kept),
+        "an identity the source still reports was named as removed",
+      );
+      insist(
+        "CONF-O34",
+        outOfScope.every((removal) => removal.id.value === unnamed),
+        "an identity the adapter could name was demoted to an out-of-scope marker",
+      );
+      insist(
+        "CONF-O34",
+        derivableRemovals({
+          listing,
+          known: knownOf(scope.calendar, [kept]),
+          withinWindow: context.withinWindow,
+        }).length === 0,
+        "an out-of-scope marker drove a deletion of an identity the source still holds",
       );
     },
   ),

--- a/packages/sync-kit/conformance/src/cases/deletion-safety.ts
+++ b/packages/sync-kit/conformance/src/cases/deletion-safety.ts
@@ -1,10 +1,401 @@
-import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type {
+  Capabilities,
+  ChangeListing,
+  KnownEvents,
+  ProviderId,
+  RemoteEvent,
+} from "@keeper.sh/sync-protocol";
+import { assertNoRemovalDerivable, derivableRemovals } from "../assertions/no-removal";
 import type { ConformanceCase } from "../registry/case";
+import {
+  caseScope,
+  decadeWindow,
+  defineCase,
+  foreignEvent,
+  insist,
+  listChanges,
+  listingOf,
+  markedWith,
+  objectsMarked,
+  seedWith,
+  uidsOf,
+} from "./support";
+
+const knownOf = (calendar: KnownEvents["calendar"], uids: readonly string[]): KnownEvents => ({
+  calendar,
+  ids: new Map(uids.map((uid) => [uid, { kind: "remoteEventId", value: `id-${uid}` }])),
+});
+
+const presentIdentities = (listing: ChangeListing): readonly string[] => [
+  ...uidsOf(listing),
+  ...(listing.withheld ?? []).flatMap((entry) => {
+    if (entry.uid === null) {
+      return [];
+    }
+    return [entry.uid.value];
+  }),
+];
+
+const namedRemovalUids = (listing: ChangeListing): readonly string[] =>
+  (listing.removals ?? []).flatMap((removal) => {
+    if (removal.kind === "outOfScope") {
+      return [];
+    }
+    return [removal.uid.value];
+  });
+
+const withoutUid = (events: readonly RemoteEvent[], uid: string): readonly RemoteEvent[] =>
+  events.filter((event) => event.uid.value !== uid);
 
 const deletionSafetyCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
-): readonly ConformanceCase<Provider>[] => {
-  throw new Error(`unimplemented: deletionSafetyCases(${supports.provider})`);
-};
+): readonly ConformanceCase<Provider>[] => [
+  defineCase(supports, "CONF-O1", "a truncated read can never produce a removal", async (context) => {
+    const scope = caseScope(context);
+    const uids = ["alpha", "bravo", "charlie"].map((name) => markedWith("CONF-O1", name));
+    await seedWith(
+      context,
+      uids.map((uid, index) =>
+        foreignEvent(scope.calendar, {
+          uid,
+          start: `2026-03-0${index + 2}T09:00:00.000Z`,
+          end: `2026-03-0${index + 2}T10:00:00.000Z`,
+        }),
+      ),
+    );
 
-export { deletionSafetyCases };
+    const answered = await listChanges(context, scope);
+    if (!answered.ok) {
+      return;
+    }
+    const listing = answered.value;
+    if (listing.kind === "partial" || listing.kind === "cursorLost") {
+      assertNoRemovalDerivable(listing);
+      insist("CONF-O1", !listing.cursor, "an incomplete read still handed back a sync cursor");
+      return;
+    }
+    const present = new Set(presentIdentities(listing));
+    insist(
+      "CONF-O1",
+      uids.every((uid) => present.has(uid)),
+      "a listing that claims coverage silently dropped events it never proved absent",
+    );
+  }),
+
+  defineCase(
+    supports,
+    "CONF-O2",
+    "a failed read and an empty calendar are distinguishable",
+    async (context) => {
+      const scope = caseScope(context);
+      await seedWith(context, []);
+      context.environment.transport.answerWith({
+        kind: "reject",
+        failure: { kind: "transport", status: 503, disposition: "transient" },
+        times: 4,
+      });
+      const failed = await listChanges(context, scope);
+      context.environment.transport.answerWith({ kind: "pass" });
+      const empty = await listChanges(context, scope);
+
+      insist("CONF-O2", !failed.ok, "a transport failure was answered as an authoritative listing");
+      insist("CONF-O2", empty.ok, "an empty calendar was answered as a failure");
+      insist(
+        "CONF-O2",
+        listingOf("CONF-O2", empty).kind === "snapshot",
+        "an empty calendar must still prove the coverage it read",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O3",
+    "deletion authority follows the declared discriminant",
+    async (context) => {
+      const scope = caseScope(context);
+      const present = markedWith("CONF-O3", "present");
+      const ghost = markedWith("CONF-O3", "ghost");
+      await seedWith(context, [
+        foreignEvent(scope.calendar, {
+          uid: present,
+          start: "2026-03-02T09:00:00.000Z",
+          end: "2026-03-02T10:00:00.000Z",
+        }),
+      ]);
+
+      const listing = listingOf("CONF-O3", await listChanges(context, scope));
+      const derivable = derivableRemovals({
+        listing,
+        known: knownOf(scope.calendar, [present, ghost]),
+        withinWindow: context.withinWindow,
+      });
+
+      if (supports.deletionAuthority === "snapshotAbsence") {
+        insist(
+          "CONF-O3",
+          derivable.includes(ghost),
+          "an identity absent from a proven snapshot was not treated as removed",
+        );
+        insist(
+          "CONF-O3",
+          !derivable.includes(present),
+          "an identity the snapshot reported was treated as removed",
+        );
+        return;
+      }
+      insist(
+        "CONF-O3",
+        derivable.length === 0,
+        "an adapter that only names its removals derived one from absence",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O4",
+    "a requested window wider than proven coverage is never substituted for it",
+    async (context) => {
+      const scope = caseScope(context, decadeWindow);
+      const seeded = markedWith("CONF-O4", "inside");
+      await seedWith(context, [
+        foreignEvent(scope.calendar, {
+          uid: seeded,
+          start: "2026-03-02T09:00:00.000Z",
+          end: "2026-03-02T10:00:00.000Z",
+        }),
+      ]);
+
+      const listing = listingOf("CONF-O4", await listChanges(context, scope));
+      insist(
+        "CONF-O4",
+        listing.coverage?.calendar.calendar.value === scope.calendar.calendar.value,
+        "coverage was proven for a calendar other than the one requested",
+      );
+      insist(
+        "CONF-O4",
+        listing.coverage?.covered.end.value !== scope.window.end.value,
+        "the adapter claimed to cover a decade it never read",
+      );
+      insist(
+        "CONF-O4",
+        derivableRemovals({
+          listing,
+          known: knownOf(scope.calendar, [markedWith("CONF-O4", "ancient")]),
+          withinWindow: context.withinWindow,
+        }).length === 0,
+        "a removal was derived inside a band the listing never covered",
+      );
+    },
+  ),
+
+  defineCase(supports, "CONF-O5", "a withheld event is present, not absent", async (context) => {
+    const scope = caseScope(context);
+    const withheld = markedWith("CONF-O5", "inverted");
+    await seedWith(context, [
+      foreignEvent(scope.calendar, {
+        uid: withheld,
+        start: "2026-03-05T10:00:00.000Z",
+        end: "2026-03-05T09:00:00.000Z",
+      }),
+    ]);
+
+    const listing = listingOf("CONF-O5", await listChanges(context, scope));
+    insist(
+      "CONF-O5",
+      (listing.withheld ?? []).some((entry) => entry.uid?.value === withheld),
+      "an unrepresentable event vanished from the listing instead of being withheld",
+    );
+    insist(
+      "CONF-O5",
+      derivableRemovals({
+        listing,
+        known: knownOf(scope.calendar, [withheld]),
+        withinWindow: context.withinWindow,
+      }).length === 0,
+      "a withheld identity was derivable as a removal",
+    );
+  }),
+
+  defineCase(
+    supports,
+    "CONF-O12",
+    "corrupt known state demands a resync and emits zero removals",
+    async (context) => {
+      const scope = caseScope(context);
+      const uid = markedWith("CONF-O12", "row");
+      await seedWith(
+        context,
+        [
+          foreignEvent(scope.calendar, {
+            uid,
+            start: "2026-03-02T09:00:00.000Z",
+            end: "2026-03-02T10:00:00.000Z",
+          }),
+        ],
+        [uid],
+      );
+
+      const listing = listingOf("CONF-O12", await listChanges(context, scope));
+      await seedWith(context, []);
+      insist(
+        "CONF-O12",
+        listing.kind === "cursorLost",
+        "corrupt known state was answered with an authoritative listing",
+      );
+      insist(
+        "CONF-O12",
+        (listing.removals ?? []).length === 0,
+        "corrupt known state produced removals",
+      );
+    },
+  ),
+
+  defineCase(supports, "CONF-O13", "an ambiguous removal is never a deletion", async (context) => {
+    const scope = caseScope(context);
+    const kept = markedWith("CONF-O13", "kept");
+    const gone = markedWith("CONF-O13", "gone");
+    const seeded = [
+      foreignEvent(scope.calendar, {
+        uid: kept,
+        start: "2026-03-02T09:00:00.000Z",
+        end: "2026-03-02T10:00:00.000Z",
+      }),
+      foreignEvent(scope.calendar, {
+        uid: gone,
+        start: "2026-03-03T09:00:00.000Z",
+        end: "2026-03-03T10:00:00.000Z",
+      }),
+    ];
+    await seedWith(context, seeded);
+    await listChanges(context, scope);
+    await seedWith(context, withoutUid(seeded, gone));
+
+    const listing = listingOf("CONF-O13", await listChanges(context, scope));
+    const named = namedRemovalUids(listing);
+    if (supports.removalsAreAmbiguous) {
+      insist(
+        "CONF-O13",
+        named.length === 0,
+        "an adapter whose removals are ambiguous still emitted an authoritative deletion",
+      );
+      return;
+    }
+    insist(
+      "CONF-O13",
+      named.every((uid) => uid.length > 0),
+      "an authoritative removal arrived without the identity it removes",
+    );
+  }),
+
+  defineCase(
+    supports,
+    "CONF-O33",
+    "a withheld identity does not cost the user its existing mirror",
+    async (context) => {
+      const scope = caseScope(context);
+      const source = markedWith("CONF-O33", "source");
+      const mirror = markedWith("CONF-O33", "mirror");
+      await seedWith(context, [
+        foreignEvent(scope.calendar, {
+          uid: source,
+          start: "2026-03-05T10:00:00.000Z",
+          end: "2026-03-05T09:00:00.000Z",
+        }),
+        foreignEvent(scope.calendar, {
+          uid: mirror,
+          start: "2026-03-05T09:00:00.000Z",
+          end: "2026-03-05T10:00:00.000Z",
+        }),
+      ]);
+
+      const listing = listingOf("CONF-O33", await listChanges(context, scope));
+      const survivors = await objectsMarked(context.provider, "CONF-O33");
+
+      insist(
+        "CONF-O33",
+        (listing.withheld ?? []).some((entry) => entry.uid?.value === source),
+        "the unrepresentable source was not withheld",
+      );
+      insist(
+        "CONF-O33",
+        survivors.some((event) => event.uid.value === mirror),
+        "withholding a source destroyed the mirror the user still has",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O34",
+    "cancelled, unnamed and out of scope are three different verdicts",
+    async (context) => {
+      const scope = caseScope(context);
+      const kept = markedWith("CONF-O34", "kept");
+      const cancelled = markedWith("CONF-O34", "cancelled");
+      const seeded = [
+        foreignEvent(scope.calendar, {
+          uid: kept,
+          start: "2026-03-02T09:00:00.000Z",
+          end: "2026-03-02T10:00:00.000Z",
+        }),
+        foreignEvent(scope.calendar, {
+          uid: cancelled,
+          start: "2026-03-03T09:00:00.000Z",
+          end: "2026-03-03T10:00:00.000Z",
+        }),
+      ];
+      await seedWith(context, seeded);
+      await listChanges(context, scope);
+      await seedWith(context, withoutUid(seeded, cancelled));
+
+      const listing = listingOf("CONF-O34", await listChanges(context, scope));
+      insist(
+        "CONF-O34",
+        (listing.removals ?? []).every((removal) => removal.kind !== "outOfScope"),
+        "an out-of-scope marker was mixed into the authoritative removals",
+      );
+      insist(
+        "CONF-O34",
+        namedRemovalUids(listing).includes(cancelled),
+        "an identity the source really dropped was not named as removed",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O41",
+    "a truncated page's resumable token is a continuation, never a cursor",
+    async (context) => {
+      const scope = caseScope(context);
+      await seedWith(context, [
+        foreignEvent(scope.calendar, {
+          uid: markedWith("CONF-O41", "only"),
+          start: "2026-03-02T09:00:00.000Z",
+          end: "2026-03-02T10:00:00.000Z",
+        }),
+      ]);
+
+      const first = listingOf("CONF-O41", await listChanges(context, scope));
+      if (first.kind !== "partial") {
+        insist("CONF-O41", Boolean(first.coverage), "a complete read proved no coverage");
+        return;
+      }
+      insist(
+        "CONF-O41",
+        first.continuation.kind === "continuation" && !first.cursor,
+        "a truncated page handed back a sync cursor instead of a continuation",
+      );
+      const resumed = listingOf("CONF-O41", await listChanges(context, scope, first.continuation));
+      insist(
+        "CONF-O41",
+        resumed.kind !== "partial",
+        "resuming from the continuation never reached a listing that proves coverage",
+      );
+    },
+  ),
+];
+
+export { deletionSafetyCases, knownOf, namedRemovalUids, presentIdentities, withoutUid };

--- a/packages/sync-kit/conformance/src/cases/diagnostics.ts
+++ b/packages/sync-kit/conformance/src/cases/diagnostics.ts
@@ -1,0 +1,10 @@
+import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { ConformanceCase } from "../registry/case";
+
+const diagnosticCases = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+): readonly ConformanceCase<Provider>[] => {
+  throw new Error(`unimplemented: diagnosticCases(${supports.provider})`);
+};
+
+export { diagnosticCases };

--- a/packages/sync-kit/conformance/src/cases/diagnostics.ts
+++ b/packages/sync-kit/conformance/src/cases/diagnostics.ts
@@ -1,10 +1,226 @@
-import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type {
+  BoundedSample,
+  Capabilities,
+  ListingDiagnostics,
+  ProviderId,
+  RemoteEvent,
+} from "@keeper.sh/sync-protocol";
+import { assertNoContentInDiagnostics } from "../assertions/listing";
+import { canonicalise } from "../canonical";
+import { conformanceLimits } from "../limits";
 import type { ConformanceCase } from "../registry/case";
+import { createIntent } from "./intents";
+import {
+  caseScope,
+  defineCase,
+  foreignEvent,
+  insist,
+  listChanges,
+  listingOf,
+  markedWith,
+  seedWith,
+  write,
+} from "./support";
+import { meetingAt } from "./writes";
 
-const diagnosticCases = <Provider extends ProviderId>(
+const totalsOf = (diagnostics: ListingDiagnostics): readonly number[] => [
+  diagnostics.withheld.total,
+  diagnostics.selfAuthored.total,
+  diagnostics.unrepresentable.total,
+];
+
+const utf16LengthOf = (sample: BoundedSample): number =>
+  sample.sample.reduce((total, entry) => total + entry.length, 0);
+
+const unrepresentableAt = (
+  calendar: RemoteEvent["calendar"],
+  uid: string,
+  title: string,
+): RemoteEvent =>
+  foreignEvent(calendar, {
+    uid,
+    title,
+    start: "2026-03-05T10:00:00.000Z",
+    end: "2026-03-05T09:00:00.000Z",
+  });
+
+const diagnosticsCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
-): readonly ConformanceCase<Provider>[] => {
-  throw new Error(`unimplemented: diagnosticCases(${supports.provider})`);
-};
+): readonly ConformanceCase<Provider>[] => [
+  defineCase(
+    supports,
+    "CONF-O19",
+    "no event content ever appears in the loggable half of a listing",
+    async (context) => {
+      const scope = caseScope(context);
+      const secret = "Board comp review with Alex";
+      await seedWith(context, [
+        unrepresentableAt(scope.calendar, markedWith("CONF-O19", "secretive"), secret),
+      ]);
 
-export { diagnosticCases };
+      const listing = listingOf("CONF-O19", await listChanges(context, scope));
+      assertNoContentInDiagnostics(listing, [secret]);
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O30",
+    "counters are separated, zero on a clean run, and stable across identical polls",
+    async (context) => {
+      const scope = caseScope(context);
+      await seedWith(context, [
+        foreignEvent(scope.calendar, {
+          uid: markedWith("CONF-O30", "benign"),
+          start: "2026-03-03T09:00:00.000Z",
+          end: "2026-03-03T10:00:00.000Z",
+        }),
+      ]);
+      const clean = listingOf("CONF-O30", await listChanges(context, scope));
+      insist(
+        "CONF-O30",
+        totalsOf(clean.diagnostics).every((total) => total === 0),
+        "a listing with nothing to report still counted something",
+      );
+
+      const key = markedWith("CONF-O30", "ours");
+      await seedWith(context, [
+        unrepresentableAt(scope.calendar, markedWith("CONF-O30", "inverted"), "Inverted"),
+      ]);
+      await write(
+        context,
+        createIntent(
+          supports,
+          scope.calendar,
+          context.environment.installation,
+          key,
+          meetingAt(key, "09"),
+        ),
+      );
+
+      const mixed = listingOf("CONF-O30", await listChanges(context, scope));
+      insist(
+        "CONF-O30",
+        mixed.diagnostics.selfAuthored.total === 1,
+        "our own mirror was not counted separately from what the adapter could not represent",
+      );
+      insist(
+        "CONF-O30",
+        mixed.diagnostics.unrepresentable.total === 1,
+        "the unrepresentable counter folded in something that was not unrepresentable",
+      );
+
+      const repeated = listingOf("CONF-O30", await listChanges(context, scope));
+      insist(
+        "CONF-O30",
+        canonicalise(totalsOf(repeated.diagnostics)) === canonicalise(totalsOf(mixed.diagnostics)),
+        "two identical polls reported two different sets of counters",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O31",
+    "diagnostics are a bounded sample beside an exact total",
+    async (context) => {
+      const scope = caseScope(context);
+      const many = [...Array.from({ length: 200 }).keys()].map((index) =>
+        unrepresentableAt(
+          scope.calendar,
+          markedWith("CONF-O31", `withheld-${index}`),
+          `Withheld ${index}`,
+        ),
+      );
+      await seedWith(context, [
+        ...many,
+        unrepresentableAt(
+          scope.calendar,
+          markedWith("CONF-O31", "x".repeat(50_000)),
+          "Pathological identifier",
+        ),
+      ]);
+
+      const listing = listingOf("CONF-O31", await listChanges(context, scope));
+      insist(
+        "CONF-O31",
+        listing.diagnostics.withheld.total === many.length + 1,
+        "the total beside the sample was capped along with the sample",
+      );
+      insist(
+        "CONF-O31",
+        listing.diagnostics.withheld.sample.length <= conformanceLimits.diagnosticSampleEntries,
+        "the diagnostic sample was not bounded by its entry count",
+      );
+      insist(
+        "CONF-O31",
+        utf16LengthOf(listing.diagnostics.withheld) <=
+          conformanceLimits.diagnosticSampleUtf16Length,
+        "one pathological identifier pushed the diagnostic sample past its length budget",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O32",
+    "a discard the adapter cannot name is still reported",
+    async (context) => {
+      const scope = caseScope(context);
+      await seedWith(context, [
+        foreignEvent(scope.calendar, {
+          uid: "",
+          title: "No identity at all",
+          start: "2026-03-06T09:00:00.000Z",
+          end: "2026-03-06T10:00:00.000Z",
+        }),
+      ]);
+
+      const listing = listingOf("CONF-O32", await listChanges(context, scope));
+      insist(
+        "CONF-O32",
+        (listing.withheld ?? []).some(
+          (entry) => entry.uid === null && entry.reason === "missingIdentity",
+        ),
+        "an event with no identity was dropped without being reported",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O42",
+    "a failed run leaks no state into the run that follows it",
+    async (context) => {
+      const scope = caseScope(context);
+      await seedWith(context, [
+        foreignEvent(scope.calendar, {
+          uid: markedWith("CONF-O42", "benign"),
+          start: "2026-03-03T09:00:00.000Z",
+          end: "2026-03-03T10:00:00.000Z",
+        }),
+      ]);
+      context.environment.transport.answerWith({
+        kind: "reject",
+        failure: { kind: "transport", status: 500, disposition: "permanent" },
+        times: 1,
+      });
+      await listChanges(context, scope);
+      context.environment.transport.answerWith({ kind: "pass" });
+
+      const recovered = listingOf("CONF-O42", await listChanges(context, scope));
+      insist(
+        "CONF-O42",
+        recovered.diagnostics.pagesFetched === 1,
+        "the run that followed a failure counted the failed run's pages as its own",
+      );
+      insist(
+        "CONF-O42",
+        totalsOf(recovered.diagnostics).every((total) => total === 0),
+        "the run that followed a failure inherited its counters",
+      );
+    },
+  ),
+];
+
+export { diagnosticsCases, totalsOf, unrepresentableAt, utf16LengthOf };

--- a/packages/sync-kit/conformance/src/cases/hostile-content.ts
+++ b/packages/sync-kit/conformance/src/cases/hostile-content.ts
@@ -1,0 +1,10 @@
+import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { ConformanceCase } from "../registry/case";
+
+const hostileContentCases = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+): readonly ConformanceCase<Provider>[] => {
+  throw new Error(`unimplemented: hostileContentCases(${supports.provider})`);
+};
+
+export { hostileContentCases };

--- a/packages/sync-kit/conformance/src/cases/hostile-content.ts
+++ b/packages/sync-kit/conformance/src/cases/hostile-content.ts
@@ -1,10 +1,73 @@
 import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
 import type { ConformanceCase } from "../registry/case";
+import {
+  caseScope,
+  defineCase,
+  failureKindOf,
+  foreignEvent,
+  insist,
+  listChanges,
+  listingOf,
+  markedWith,
+  seedWith,
+  uidsOf,
+} from "./support";
+
+const hostileTitles = [
+  "rate limit exceeded",
+  "410 Gone",
+  "Precondition Failed",
+  "HTTP 429 Too Many Requests",
+  "fullSyncRequired",
+  "\u0000 NUL byte",
+];
 
 const hostileContentCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
-): readonly ConformanceCase<Provider>[] => {
-  throw new Error(`unimplemented: hostileContentCases(${supports.provider})`);
-};
+): readonly ConformanceCase<Provider>[] => [
+  defineCase(
+    supports,
+    "CONF-O23",
+    "event content cannot change how a failure is classified",
+    async (context) => {
+      const scope = caseScope(context);
+      const seeded = hostileTitles.map((title, index) =>
+        foreignEvent(scope.calendar, {
+          uid: markedWith("CONF-O23", `hostile\u0000${index}`),
+          title,
+          start: "2026-03-02T09:00:00.000Z",
+          end: "2026-03-02T10:00:00.000Z",
+        }),
+      );
+      await seedWith(context, seeded);
 
-export { hostileContentCases };
+      const listing = listingOf("CONF-O23", await listChanges(context, scope));
+      insist(
+        "CONF-O23",
+        uidsOf(listing).length === seeded.length,
+        "hostile titles turned a healthy listing into something else",
+      );
+      insist(
+        "CONF-O23",
+        new Set(uidsOf(listing)).size === seeded.length,
+        "a NUL byte in a title collapsed two identities into one",
+      );
+
+      context.environment.transport.answerWith({
+        kind: "reject",
+        failure: { kind: "rateLimited", retryAfter: null, scope: supports.quotaScope },
+        times: Number.MAX_SAFE_INTEGER,
+      });
+      const throttled = await listChanges(context, scope);
+      context.environment.transport.answerWith({ kind: "pass" });
+
+      insist(
+        "CONF-O23",
+        failureKindOf(throttled) === "rateLimited",
+        "a real throttle was reclassified once customer data was in the payload",
+      );
+    },
+  ),
+];
+
+export { hostileContentCases, hostileTitles };

--- a/packages/sync-kit/conformance/src/cases/injection.ts
+++ b/packages/sync-kit/conformance/src/cases/injection.ts
@@ -1,10 +1,49 @@
 import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
 import type { ConformanceCase } from "../registry/case";
+import {
+  caseScope,
+  defineCase,
+  foreignEvent,
+  insist,
+  listChanges,
+  markedWith,
+  seedWith,
+} from "./support";
 
 const injectionCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
-): readonly ConformanceCase<Provider>[] => {
-  throw new Error(`unimplemented: injectionCases(${supports.provider})`);
-};
+): readonly ConformanceCase<Provider>[] => [
+  defineCase(
+    supports,
+    "CONF-L13",
+    "the injected clock and transport were the ones the adapter actually used",
+    async (context) => {
+      const scope = caseScope(context);
+      await seedWith(context, [
+        foreignEvent(scope.calendar, {
+          uid: markedWith("CONF-L13", "alpha"),
+          start: "2026-03-02T09:00:00.000Z",
+          end: "2026-03-02T10:00:00.000Z",
+        }),
+      ]);
+      const frozen = context.environment.clock.now();
+      const callsBefore = context.environment.transport.callCount();
+      const readsBefore = context.environment.clock.nowCount();
+
+      await listChanges(context, scope, null, { now: () => frozen });
+
+      insist(
+        "CONF-L13",
+        context.environment.transport.callCount() > callsBefore,
+        "the adapter answered without ever reaching the injected transport",
+      );
+      insist(
+        "CONF-L13",
+        context.environment.clock.nowCount() > readsBefore,
+        "the adapter never read the injected clock, so every deadline case below is vacuous",
+      );
+    },
+  ),
+];
 
 export { injectionCases };

--- a/packages/sync-kit/conformance/src/cases/injection.ts
+++ b/packages/sync-kit/conformance/src/cases/injection.ts
@@ -1,0 +1,10 @@
+import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { ConformanceCase } from "../registry/case";
+
+const injectionCases = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+): readonly ConformanceCase<Provider>[] => {
+  throw new Error(`unimplemented: injectionCases(${supports.provider})`);
+};
+
+export { injectionCases };

--- a/packages/sync-kit/conformance/src/cases/intents.ts
+++ b/packages/sync-kit/conformance/src/cases/intents.ts
@@ -52,4 +52,16 @@ const updateIntent = <Provider extends ProviderId>(
   precondition: { kind: "matchesVersion", version },
 });
 
-export { createIntent, updateIntent, writableOf };
+const deleteIntent = <Provider extends ProviderId>(
+  calendar: CalendarKey,
+  handle: string,
+  version: RemoteVersion,
+): WriteIntent<Provider> => ({
+  kind: "delete",
+  calendar: writableOf(calendar),
+  target: { kind: "deleteHandle", value: handle },
+  precondition: { kind: "matchesVersion", version },
+  reason: "sourceDeleted",
+});
+
+export { createIntent, deleteIntent, updateIntent, writableOf };

--- a/packages/sync-kit/conformance/src/cases/intents.ts
+++ b/packages/sync-kit/conformance/src/cases/intents.ts
@@ -1,0 +1,55 @@
+import type {
+  CalendarKey,
+  Capabilities,
+  EditableContent,
+  InstallationId,
+  ProviderId,
+  RemoteVersion,
+  WriteIntent,
+} from "@keeper.sh/sync-protocol";
+
+const writableOf = (calendar: CalendarKey): WriteIntent["calendar"] => ({
+  key: calendar,
+  access: "readWrite",
+});
+
+const createIntent = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+  calendar: CalendarKey,
+  installation: InstallationId,
+  key: string,
+  content: EditableContent,
+): WriteIntent<Provider> => ({
+  kind: "create",
+  calendar: writableOf(calendar),
+  idempotencyKey: { kind: "idempotencyKey", value: key },
+  content: {
+    kind: "normalized",
+    provider: supports.provider,
+    content,
+    fingerprint: { kind: "fingerprint", value: `submitted-${key}` },
+  },
+  provenance: { kind: "ours", installation },
+  precondition: { kind: "absent" },
+});
+
+const updateIntent = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+  calendar: CalendarKey,
+  target: string,
+  content: EditableContent,
+  version: RemoteVersion,
+): WriteIntent<Provider> => ({
+  kind: "update",
+  calendar: writableOf(calendar),
+  target: { kind: "remoteEventId", value: target },
+  content: {
+    kind: "normalized",
+    provider: supports.provider,
+    content,
+    fingerprint: { kind: "fingerprint", value: `submitted-${target}` },
+  },
+  precondition: { kind: "matchesVersion", version },
+});
+
+export { createIntent, updateIntent, writableOf };

--- a/packages/sync-kit/conformance/src/cases/isolation.ts
+++ b/packages/sync-kit/conformance/src/cases/isolation.ts
@@ -1,10 +1,86 @@
-import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { Capabilities, ChangeListing, ProviderId } from "@keeper.sh/sync-protocol";
+import { canonicalise } from "../canonical";
 import type { ConformanceCase } from "../registry/case";
+import { namedRemovalUids, withoutUid } from "./deletion-safety";
+import {
+  caseScope,
+  defineCase,
+  foreignEvent,
+  insist,
+  listChanges,
+  listingOf,
+  markedWith,
+  seedWith,
+  uidsOf,
+} from "./support";
+
+const repeatableShapeOf = (listing: ChangeListing): string =>
+  canonicalise({
+    withheld: (listing.withheld ?? []).map((entry) => ({
+      uid: entry.uid?.value ?? null,
+      reason: entry.reason,
+    })),
+    diagnostics: {
+      withheld: [...listing.diagnostics.withheld.sample],
+      total: listing.diagnostics.withheld.total,
+      pagesFetched: listing.diagnostics.pagesFetched,
+    },
+  });
 
 const isolationCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
-): readonly ConformanceCase<Provider>[] => {
-  throw new Error(`unimplemented: isolationCases(${supports.provider})`);
-};
+): readonly ConformanceCase<Provider>[] => [
+  defineCase(
+    supports,
+    "CONF-O6",
+    "one unusable item does not stall the feed, and a real deletion in the same payload still applies",
+    async (context) => {
+      const scope = caseScope(context);
+      const usable = markedWith("CONF-O6", "usable");
+      const unusable = markedWith("CONF-O6", "unusable");
+      const doomed = markedWith("CONF-O6", "doomed");
+      const seeded = [
+        foreignEvent(scope.calendar, {
+          uid: usable,
+          start: "2026-03-02T09:00:00.000Z",
+          end: "2026-03-02T10:00:00.000Z",
+        }),
+        foreignEvent(scope.calendar, {
+          uid: unusable,
+          start: "2026-03-03T10:00:00.000Z",
+          end: "2026-03-03T09:00:00.000Z",
+        }),
+        foreignEvent(scope.calendar, {
+          uid: doomed,
+          start: "2026-03-04T09:00:00.000Z",
+          end: "2026-03-04T10:00:00.000Z",
+        }),
+      ];
+
+      await seedWith(context, seeded);
+      const first = listingOf("CONF-O6", await listChanges(context, scope));
+      insist(
+        "CONF-O6",
+        uidsOf(first).includes(usable),
+        "one unusable item threw the usable items out of the listing",
+      );
+
+      await seedWith(context, withoutUid(seeded, doomed));
+      const second = listingOf("CONF-O6", await listChanges(context, scope));
+      insist(
+        "CONF-O6",
+        namedRemovalUids(second).includes(doomed),
+        "a real deletion delivered beside an unusable item was never expressed",
+      );
+
+      const third = listingOf("CONF-O6", await listChanges(context, scope));
+      insist(
+        "CONF-O6",
+        repeatableShapeOf(third) === repeatableShapeOf(second),
+        "polling the same malformed feed twice produced two different answers",
+      );
+    },
+  ),
+];
 
 export { isolationCases };

--- a/packages/sync-kit/conformance/src/cases/isolation.ts
+++ b/packages/sync-kit/conformance/src/cases/isolation.ts
@@ -1,0 +1,10 @@
+import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { ConformanceCase } from "../registry/case";
+
+const isolationCases = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+): readonly ConformanceCase<Provider>[] => {
+  throw new Error(`unimplemented: isolationCases(${supports.provider})`);
+};
+
+export { isolationCases };

--- a/packages/sync-kit/conformance/src/cases/lockups.ts
+++ b/packages/sync-kit/conformance/src/cases/lockups.ts
@@ -1,0 +1,10 @@
+import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { ConformanceCase } from "../registry/case";
+
+const lockupCases = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+): readonly ConformanceCase<Provider>[] => {
+  throw new Error(`unimplemented: lockupCases(${supports.provider})`);
+};
+
+export { lockupCases };

--- a/packages/sync-kit/conformance/src/cases/lockups.ts
+++ b/packages/sync-kit/conformance/src/cases/lockups.ts
@@ -40,6 +40,8 @@ const abortedSignal = (): AbortSignal => {
 
 const dayMs = 24 * 60 * 60 * 1000;
 
+const retryCeiling = { maxAttempts: 3, retryDelayCeilingMs: 2 } as const;
+
 const windowFor = (id: ConformanceCaseId): TimeWindow => {
   const start = Date.parse("2026-06-01T00:00:00.000Z") + conformanceCaseIds.indexOf(id) * 40 * dayMs;
   return {
@@ -79,61 +81,103 @@ const lockupCases = <Provider extends ProviderId>(
     "a retry path stops at the attempt ceiling it was given",
     async (context) => {
       const scope = await seedOne(context, "CONF-L1");
+      const callsBefore = context.environment.transport.callCount();
+      const startedAt = Date.parse(context.environment.clock.now().value);
       context.environment.transport.answerWith({
         kind: "reject",
-        failure: { kind: "rateLimited", retryAfter: null, scope: supports.quotaScope },
-        times: 1,
+        failure: {
+          kind: "rateLimited",
+          retryAfter: { kind: "instant", value: "2099-01-01T00:00:00.000Z" },
+          scope: supports.quotaScope,
+        },
+        times: Number.MAX_SAFE_INTEGER,
       });
 
       const answered = await listChanges(context, scope, null, {
-        maxAttempts: 1,
-        retryDelayCeilingMs: 1,
+        maxAttempts: retryCeiling.maxAttempts,
+        retryDelayCeilingMs: retryCeiling.retryDelayCeilingMs,
       });
       context.environment.transport.answerWith({ kind: "pass" });
+      const spent = context.environment.transport.callCount() - callsBefore;
+      const elapsed = Date.parse(context.environment.clock.now().value) - startedAt;
 
       insist(
         "CONF-L1",
         failureKindOf(answered) === "rateLimited",
-        "an operation given a single attempt tried again anyway",
+        "a transport that never stopped rate limiting was answered as something else",
       );
+      insist(
+        "CONF-L1",
+        spent === retryCeiling.maxAttempts,
+        `an operation given ${retryCeiling.maxAttempts} attempts reached the transport ${spent} times`,
+      );
+      insist(
+        "CONF-L1",
+        elapsed <= retryCeiling.maxAttempts * retryCeiling.retryDelayCeilingMs,
+        "a provider-supplied retry delay was obeyed instead of capped by the budget",
+      );
+      await context.provider.contract.conformance.retryCeilingProven();
     },
   ),
 
   defineCase(
     supports,
     "CONF-L2",
-    "an operation with no budget left settles instead of waiting on a transport that never answers",
+    "an operation waiting on a transport that never answers settles at its deadline",
     async (context) => {
       const scope = await seedOne(context, "CONF-L2");
+      const callsBefore = context.environment.transport.callCount();
       context.environment.transport.stall();
 
-      const answered = await listChanges(context, scope, null, { deadlineMs: 0 });
+      const answered = await listChanges(context, scope, null, {
+        deadlineMs: conformanceLimits.stallDeadlineMs,
+      });
       context.environment.transport.resume();
 
+      insist(
+        "CONF-L2",
+        context.environment.transport.callCount() > callsBefore,
+        "the operation never reached the transport, so its deadline proved nothing",
+      );
       insist(
         "CONF-L2",
         notAttemptedReasonOf(answered) === "budgetExhausted",
         "an exhausted budget was reported as something other than an exhausted budget",
       );
+      await context.provider.contract.conformance.deadlineOnNeverResolvingStub();
     },
   ),
 
   defineCase(
     supports,
     "CONF-L3",
-    "a caller's abort is reported as an abort, never as a provider timeout",
+    "a caller's abort mid-flight is reported as an abort, never as a provider timeout",
     async (context) => {
       const scope = await seedOne(context, "CONF-L3");
+      const caller = new AbortController();
+      const callsBefore = context.environment.transport.callCount();
       context.environment.transport.stall();
 
-      const answered = await listChanges(context, scope, null, { signal: abortedSignal() });
+      const pending = listChanges(context, scope, null, {
+        signal: caller.signal,
+        deadlineMs: conformanceLimits.stallDeadlineMs,
+      });
+      await Promise.resolve();
+      caller.abort();
+      const answered = await pending;
       context.environment.transport.resume();
 
+      insist(
+        "CONF-L3",
+        context.environment.transport.callCount() > callsBefore,
+        "the caller was cancelled before it ever reached the transport it claims to have left",
+      );
       insist(
         "CONF-L3",
         notAttemptedReasonOf(answered) === "aborted",
         "a caller's cancellation was misattributed to the provider",
       );
+      await context.provider.contract.conformance.abortMidFlightCleansUp();
     },
   ),
 
@@ -158,6 +202,7 @@ const lockupCases = <Provider extends ProviderId>(
         settled.every((entry) => entry.status === "fulfilled" && !entry.value.ok),
         "a follower behind a failed leader was told the run succeeded",
       );
+      await context.provider.contract.conformance.followerRejectsWhenLeaderFails();
     },
   ),
 
@@ -216,6 +261,7 @@ const lockupCases = <Provider extends ProviderId>(
         ),
         "two concurrent calls over different windows were answered with each other's listing",
       );
+      await context.provider.contract.conformance.concurrentSameKeyDoesNotDeadlock();
     },
   ),
 
@@ -236,6 +282,7 @@ const lockupCases = <Provider extends ProviderId>(
         afterwards.ok,
         "the operation after a throwing one inherited the dead attempt instead of starting its own",
       );
+      await context.provider.contract.conformance.leaseReleasedOnThrow();
     },
   ),
 
@@ -335,8 +382,8 @@ const lockupCases = <Provider extends ProviderId>(
       );
       insist(
         "CONF-L11",
-        context.environment.transport.inFlightPeak() <= conformanceLimits.concurrency,
-        "the fan-out ran more work at once than the concurrency it declared",
+        context.environment.transport.inFlightPeak() <= context.environment.concurrency,
+        "the fan-out ran more work at once than the concurrency the suite handed it",
       );
     },
   ),

--- a/packages/sync-kit/conformance/src/cases/lockups.ts
+++ b/packages/sync-kit/conformance/src/cases/lockups.ts
@@ -1,10 +1,368 @@
-import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type {
+  Capabilities,
+  ChangeListing,
+  ListingScope,
+  TimeWindow,
+  ProviderId,
+  Result,
+} from "@keeper.sh/sync-protocol";
+import type { ConformanceCaseId } from "../case-id";
+import { conformanceCaseIds } from "../case-id";
+import { conformanceLimits } from "../limits";
+import type { CaseContext } from "../registry/case";
 import type { ConformanceCase } from "../registry/case";
+import {
+  caseScope,
+  defineCase,
+  failureKindOf,
+  foreignEvent,
+  insist,
+  listChanges,
+  seedWith,
+} from "./support";
+
+const notAttemptedReasonOf = (answered: Result<ChangeListing>): string => {
+  if (answered.ok) {
+    return "ok";
+  }
+  const { failure } = answered;
+  if (failure.kind !== "notAttempted") {
+    return `not-a-notAttempted:${failure.kind}`;
+  }
+  return failure.reason;
+};
+
+const abortedSignal = (): AbortSignal => {
+  const controller = new AbortController();
+  controller.abort();
+  return controller.signal;
+};
+
+const dayMs = 24 * 60 * 60 * 1000;
+
+const windowFor = (id: ConformanceCaseId): TimeWindow => {
+  const start = Date.parse("2026-06-01T00:00:00.000Z") + conformanceCaseIds.indexOf(id) * 40 * dayMs;
+  return {
+    start: { kind: "instant", value: new Date(start).toISOString() },
+    end: { kind: "instant", value: new Date(start + 31 * dayMs).toISOString() },
+  };
+};
+
+const seedOne = async <Provider extends ProviderId>(
+  context: CaseContext<Provider>,
+  name: ConformanceCaseId,
+): Promise<ListingScope> => {
+  const scope = caseScope(context, windowFor(name));
+  await seedWith(context, [
+    foreignEvent(scope.calendar, {
+      uid: `${name}:alpha`,
+      start: "2026-03-02T09:00:00.000Z",
+      end: "2026-03-02T10:00:00.000Z",
+    }),
+  ]);
+  return scope;
+};
+
+const concurrently = <Provider extends ProviderId>(
+  context: CaseContext<Provider>,
+  scope: ListingScope,
+  callers: number,
+): readonly Promise<Result<ChangeListing>>[] =>
+  Array.from({ length: callers }, () => listChanges(context, scope));
 
 const lockupCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
-): readonly ConformanceCase<Provider>[] => {
-  throw new Error(`unimplemented: lockupCases(${supports.provider})`);
-};
+): readonly ConformanceCase<Provider>[] => [
+  defineCase(
+    supports,
+    "CONF-L1",
+    "a retry path stops at the attempt ceiling it was given",
+    async (context) => {
+      const scope = await seedOne(context, "CONF-L1");
+      context.environment.transport.answerWith({
+        kind: "reject",
+        failure: { kind: "rateLimited", retryAfter: null, scope: supports.quotaScope },
+        times: 1,
+      });
 
-export { lockupCases };
+      const answered = await listChanges(context, scope, null, {
+        maxAttempts: 1,
+        retryDelayCeilingMs: 1,
+      });
+      context.environment.transport.answerWith({ kind: "pass" });
+
+      insist(
+        "CONF-L1",
+        failureKindOf(answered) === "rateLimited",
+        "an operation given a single attempt tried again anyway",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-L2",
+    "an operation with no budget left settles instead of waiting on a transport that never answers",
+    async (context) => {
+      const scope = await seedOne(context, "CONF-L2");
+      context.environment.transport.stall();
+
+      const answered = await listChanges(context, scope, null, { deadlineMs: 0 });
+      context.environment.transport.resume();
+
+      insist(
+        "CONF-L2",
+        notAttemptedReasonOf(answered) === "budgetExhausted",
+        "an exhausted budget was reported as something other than an exhausted budget",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-L3",
+    "a caller's abort is reported as an abort, never as a provider timeout",
+    async (context) => {
+      const scope = await seedOne(context, "CONF-L3");
+      context.environment.transport.stall();
+
+      const answered = await listChanges(context, scope, null, { signal: abortedSignal() });
+      context.environment.transport.resume();
+
+      insist(
+        "CONF-L3",
+        notAttemptedReasonOf(answered) === "aborted",
+        "a caller's cancellation was misattributed to the provider",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-L4",
+    "a single-flight leader's failure reaches every follower",
+    async (context) => {
+      const scope = await seedOne(context, "CONF-L4");
+      context.environment.transport.answerWith({ kind: "throw", times: 1 });
+
+      const settled = await Promise.allSettled(concurrently(context, scope, 3));
+      context.environment.transport.answerWith({ kind: "pass" });
+
+      insist(
+        "CONF-L4",
+        settled.length === 3,
+        "a coalesced caller never received an answer at all",
+      );
+      insist(
+        "CONF-L4",
+        settled.every((entry) => entry.status === "fulfilled" && !entry.value.ok),
+        "a follower behind a failed leader was told the run succeeded",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-L5",
+    "coalesced callers each get their own diagnostics",
+    async (context) => {
+      const scope = await seedOne(context, "CONF-L5");
+
+      const [leading, following] = await Promise.all(concurrently(context, scope, 2));
+      if (!leading?.ok || !following?.ok) {
+        throw new Error("CONF-L5 needs two successful listings to compare");
+      }
+
+      insist(
+        "CONF-L5",
+        leading.value.diagnostics !== following.value.diagnostics,
+        "two coalesced callers were handed one diagnostics object to share",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-L6",
+    "concurrent calls over overlapping key sets do not deadlock or cross answers",
+    async (context) => {
+      const scope = await seedOne(context, "CONF-L6");
+      const other = caseScope(context, {
+        start: scope.window.end,
+        end: { kind: "instant", value: new Date(Date.parse(scope.window.end.value) + dayMs).toISOString() },
+      });
+
+      const forward = Promise.all([listChanges(context, scope), listChanges(context, other)]);
+      const backward = Promise.all([listChanges(context, other), listChanges(context, scope)]);
+      const [firstPair, secondPair] = await Promise.all([forward, backward]);
+      const answers = [
+        { answered: firstPair[0], asked: scope },
+        { answered: firstPair[1], asked: other },
+        { answered: secondPair[0], asked: other },
+        { answered: secondPair[1], asked: scope },
+      ];
+
+      insist(
+        "CONF-L6",
+        answers.every((entry) => entry.answered.ok),
+        "a caller in one of the two orders never got an answer it could use",
+      );
+      insist(
+        "CONF-L6",
+        answers.every(
+          (entry) =>
+            !entry.answered.ok ||
+            entry.answered.value.scope.window.start.value === entry.asked.window.start.value,
+        ),
+        "two concurrent calls over different windows were answered with each other's listing",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-L7",
+    "a lease taken by a throwing body is released",
+    async (context) => {
+      const scope = await seedOne(context, "CONF-L7");
+      context.environment.transport.answerWith({ kind: "throw", times: 1 });
+      await listChanges(context, scope);
+
+      context.environment.transport.answerWith({ kind: "pass" });
+      const afterwards = await listChanges(context, scope);
+
+      insist(
+        "CONF-L7",
+        afterwards.ok,
+        "the operation after a throwing one inherited the dead attempt instead of starting its own",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-L8",
+    "no timer survives a completed operation",
+    async (context) => {
+      const scope = await seedOne(context, "CONF-L8");
+
+      await listChanges(context, scope);
+
+      insist(
+        "CONF-L8",
+        context.environment.clock.pendingTimers() === 0,
+        "an operation that has already answered left a timer armed behind it",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-L9",
+    "an aborted waiter does not strand the waiters beside it",
+    async (context) => {
+      const scope = await seedOne(context, "CONF-L9");
+
+      const first = listChanges(context, scope);
+      const second = listChanges(context, scope);
+      const cancelled = listChanges(context, scope, null, { signal: abortedSignal() });
+      const settled = await Promise.all([first, second, cancelled]);
+
+      const [first_, second_, cancelled_] = settled;
+      insist(
+        "CONF-L9",
+        first_?.ok === true && second_?.ok === true,
+        "one caller's cancellation was charged to the callers beside it",
+      );
+      insist(
+        "CONF-L9",
+        cancelled_?.ok === false,
+        "the aborted caller was answered as if it had run",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-L10",
+    "an aborted task in a fan-out does not cost the tasks beside it their turn",
+    async (context) => {
+      const scope = await seedOne(context, "CONF-L10");
+
+      const beside = concurrently(context, scope, conformanceLimits.fanOutTasks - 1);
+      const cancelled = listChanges(context, scope, null, { signal: abortedSignal() });
+      const settled = await Promise.allSettled([...beside, cancelled]);
+      const afterwards = await listChanges(context, scope);
+
+      insist(
+        "CONF-L10",
+        settled.length === conformanceLimits.fanOutTasks,
+        "the fan-out lost a task",
+      );
+      insist(
+        "CONF-L10",
+        settled.slice(0, -1).every((entry) => entry.status === "fulfilled" && entry.value.ok),
+        "an aborted task cost the tasks beside it their turn",
+      );
+      insist(
+        "CONF-L10",
+        afterwards.ok,
+        "an aborted task leaked the permit the operation after it needed",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-L11",
+    "a fan-out returns one result per task and never exceeds the declared concurrency",
+    async (context) => {
+      const scope = await seedOne(context, "CONF-L11");
+
+      const settled = await Promise.allSettled(
+        concurrently(context, scope, conformanceLimits.fanOutTasks),
+      );
+
+      insist(
+        "CONF-L11",
+        settled.length === conformanceLimits.fanOutTasks,
+        "the fan-out returned fewer results than it was given tasks",
+      );
+      insist(
+        "CONF-L11",
+        settled.every((entry) => entry.status === "fulfilled"),
+        "one task in the fan-out rejected instead of answering",
+      );
+      insist(
+        "CONF-L11",
+        context.environment.transport.inFlightPeak() <= conformanceLimits.concurrency,
+        "the fan-out ran more work at once than the concurrency it declared",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-L12",
+    "an unattempted run is a third state, not a success and not a failure",
+    async (context) => {
+      const scope = await seedOne(context, "CONF-L12");
+      const callsBefore = context.environment.transport.callCount();
+
+      const answered = await listChanges(context, scope, null, { signal: abortedSignal() });
+
+      insist(
+        "CONF-L12",
+        !answered.ok && answered.failure.kind === "notAttempted",
+        "a run aborted before it began was reported as an attempt",
+      );
+      insist(
+        "CONF-L12",
+        context.environment.transport.callCount() === callsBefore,
+        "a run aborted before it began still reached the transport",
+      );
+    },
+  ),
+];
+
+export { abortedSignal, lockupCases, notAttemptedReasonOf };

--- a/packages/sync-kit/conformance/src/cases/provenance.ts
+++ b/packages/sync-kit/conformance/src/cases/provenance.ts
@@ -1,10 +1,132 @@
-import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { Capabilities, ProviderId, RemoteEvent } from "@keeper.sh/sync-protocol";
+import { canonicalise } from "../canonical";
 import type { ConformanceCase } from "../registry/case";
+import { derivableRemovals } from "../assertions/no-removal";
+import { knownOf } from "./deletion-safety";
+import { createIntent } from "./intents";
+import {
+  caseScope,
+  defineCase,
+  foreignEvent,
+  insist,
+  listChanges,
+  listingOf,
+  markedWith,
+  objectsMarked,
+  seedWith,
+  write,
+} from "./support";
+import { meetingAt } from "./writes";
+
+const summaryOf = (events: readonly RemoteEvent[]): string =>
+  canonicalise(
+    events.map((event) => ({
+      uid: event.uid.value,
+      revision: event.revision,
+      version: event.version.value,
+      fingerprint: event.fingerprint.value,
+      title: event.content.title,
+    })),
+  );
 
 const provenanceCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
-): readonly ConformanceCase<Provider>[] => {
-  throw new Error(`unimplemented: provenanceCases(${supports.provider})`);
-};
+): readonly ConformanceCase<Provider>[] => [
+  defineCase(
+    supports,
+    "CONF-O16",
+    "our own provenance survives a round trip through the adapter",
+    async (context) => {
+      const scope = caseScope(context);
+      const key = markedWith("CONF-O16", "mirror");
+      await seedWith(context, []);
+      await write(
+        context,
+        createIntent(
+          supports,
+          scope.calendar,
+          context.environment.installation,
+          key,
+          meetingAt(key, "09"),
+        ),
+      );
 
-export { provenanceCases };
+      const listing = listingOf("CONF-O16", await listChanges(context, scope));
+      const mirrored = (listing.events ?? []).find((event) => event.uid.value === key);
+      insist("CONF-O16", Boolean(mirrored), "an event we wrote did not come back through the adapter");
+      if (!mirrored) {
+        return;
+      }
+      if (supports.provenanceChannel === "none") {
+        insist(
+          "CONF-O16",
+          mirrored.provenance.kind === "indeterminate",
+          "an adapter with no provenance channel claimed to know who authored the event",
+        );
+        insist(
+          "CONF-O16",
+          derivableRemovals({
+            listing,
+            known: knownOf(scope.calendar, [key]),
+            withinWindow: context.withinWindow,
+          }).length === 0,
+          "an event of indeterminate provenance was derivable as a removal",
+        );
+        return;
+      }
+      insist(
+        "CONF-O16",
+        mirrored.provenance.kind === "ours",
+        "an event we wrote came back without our provenance, so we would mirror it again",
+      );
+      insist(
+        "CONF-O16",
+        mirrored.provenance.kind !== "ours" ||
+          mirrored.provenance.installation.value === context.environment.installation.value,
+        "an event we wrote came back carrying somebody else's installation",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O17",
+    "a foreign event survives every reconciliation the suite can generate",
+    async (context) => {
+      const scope = caseScope(context);
+      const canary = markedWith("CONF-O17", "canary");
+      const mine = markedWith("CONF-O17", "mine");
+      await seedWith(context, [
+        foreignEvent(scope.calendar, {
+          uid: canary,
+          start: "2026-03-06T09:00:00.000Z",
+          end: "2026-03-06T10:00:00.000Z",
+        }),
+      ]);
+      const before = await objectsMarked(context.provider, "CONF-O17");
+
+      await write(
+        context,
+        createIntent(
+          supports,
+          scope.calendar,
+          context.environment.installation,
+          mine,
+          meetingAt(mine, "09"),
+        ),
+      );
+      await listChanges(context, scope);
+      const after = await objectsMarked(context.provider, "CONF-O17");
+      const survivors = after.filter((event) => event.uid.value === canary);
+
+      insist("CONF-O17", survivors.length === 1, "the foreign canary did not survive the run");
+      insist(
+        "CONF-O17",
+        summaryOf(survivors) === summaryOf(before.filter((event) => event.uid.value === canary)),
+        "the foreign canary came out of the run changed",
+      );
+    },
+  ),
+];
+
+export { provenanceCases, summaryOf };

--- a/packages/sync-kit/conformance/src/cases/provenance.ts
+++ b/packages/sync-kit/conformance/src/cases/provenance.ts
@@ -1,0 +1,10 @@
+import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { ConformanceCase } from "../registry/case";
+
+const provenanceCases = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+): readonly ConformanceCase<Provider>[] => {
+  throw new Error(`unimplemented: provenanceCases(${supports.provider})`);
+};
+
+export { provenanceCases };

--- a/packages/sync-kit/conformance/src/cases/support.ts
+++ b/packages/sync-kit/conformance/src/cases/support.ts
@@ -177,11 +177,26 @@ const foreignEvent = (calendar: CalendarKey, draft: EventDraft): RemoteEvent => 
   };
 };
 
+interface SeedOptions {
+  readonly corruptKnownRows?: readonly string[];
+  readonly cancelled?: readonly string[];
+  readonly unattributableRemovals?: readonly string[];
+}
+
 const seedWith = <Provider extends ProviderId>(
   context: CaseContext<Provider>,
   events: readonly RemoteEvent[],
-  corruptKnownRows: readonly string[] = [],
-): Promise<void> => context.provider.seed({ events, corruptKnownRows });
+  options: SeedOptions = {},
+): Promise<void> =>
+  context.provider.seed({
+    events,
+    corruptKnownRows: options.corruptKnownRows ?? [],
+    cancelled: (options.cancelled ?? []).map((uid) => ({ kind: "eventUid", value: uid })),
+    unattributableRemovals: (options.unattributableRemovals ?? []).map((id) => ({
+      kind: "remoteEventId",
+      value: id,
+    })),
+  });
 
 const writeLogSince = async <Provider extends ProviderId>(
   provider: ProviderUnderTest<Provider>,
@@ -249,4 +264,4 @@ export {
   writeLogLength,
   writeLogSince,
 };
-export type { ContextOptions, EventDraft };
+export type { ContextOptions, EventDraft, SeedOptions };

--- a/packages/sync-kit/conformance/src/cases/support.ts
+++ b/packages/sync-kit/conformance/src/cases/support.ts
@@ -1,0 +1,252 @@
+import type {
+  CalendarKey,
+  Capabilities,
+  ChangeListing,
+  Continuation,
+  EditableContent,
+  Instant,
+  ListingScope,
+  OperationContext,
+  ProviderId,
+  RemoteEvent,
+  Result,
+  SyncCursor,
+  TimeWindow,
+  WriteIntent,
+  WriteOutcome,
+} from "@keeper.sh/sync-protocol";
+import type { ConformanceCaseId } from "../case-id";
+import { ledgerEntryOf } from "../case-id";
+import type { ConformanceEnvironment, ProviderUnderTest, WriteLogEntry } from "../options";
+import { violated } from "../violation";
+import type { CaseContext, ConformanceCase } from "../registry/case";
+import { gateFor } from "../registry/gates";
+
+const marchWindow: TimeWindow = {
+  start: { kind: "instant", value: "2026-03-01T00:00:00.000Z" },
+  end: { kind: "instant", value: "2026-04-01T00:00:00.000Z" },
+};
+
+const decadeWindow: TimeWindow = {
+  start: { kind: "instant", value: "2020-01-01T00:00:00.000Z" },
+  end: { kind: "instant", value: "2030-01-01T00:00:00.000Z" },
+};
+
+const invertedWindow: TimeWindow = {
+  start: marchWindow.end,
+  end: marchWindow.start,
+};
+
+const conformanceCalendar = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+): CalendarKey => ({
+  provider: supports.provider,
+  account: { kind: "accountId", value: "conformance-account" },
+  calendar: { kind: "calendarId", value: "conformance-calendar" },
+});
+
+const scopeOver = (calendar: CalendarKey, window: TimeWindow): ListingScope => ({
+  calendar,
+  window,
+  expandRecurrences: true,
+});
+
+const caseScope = <Provider extends ProviderId>(
+  context: CaseContext<Provider>,
+  window: TimeWindow = marchWindow,
+): ListingScope => scopeOver(conformanceCalendar(context.supports), window);
+
+interface ContextOptions {
+  readonly signal?: AbortSignal;
+  readonly now?: () => Instant;
+  readonly deadlineMs?: number;
+  readonly maxAttempts?: number;
+  readonly retryDelayCeilingMs?: number;
+}
+
+const neverAborts = (): AbortSignal => new AbortController().signal;
+
+const operationContext = (
+  environment: ConformanceEnvironment,
+  options: ContextOptions = {},
+): OperationContext => {
+  const readNow = options.now ?? environment.clock.now;
+  const now = readNow();
+  const budget = options.deadlineMs ?? 250;
+  return {
+    signal: options.signal ?? neverAborts(),
+    now: readNow,
+    deadline: { kind: "instant", value: new Date(Date.parse(now.value) + budget).toISOString() },
+    retryBudget: {
+      maxAttempts: options.maxAttempts ?? 1,
+      retryDelayCeilingMs: options.retryDelayCeilingMs ?? 1,
+    },
+  };
+};
+
+const listChanges = <Provider extends ProviderId>(
+  context: CaseContext<Provider>,
+  scope: ListingScope,
+  resume: SyncCursor | Continuation | null = null,
+  options: ContextOptions = {},
+): Promise<Result<ChangeListing>> =>
+  context.provider.contract.provider.listChanges(
+    { scope, resume },
+    operationContext(context.environment, options),
+  );
+
+const write = <Provider extends ProviderId>(
+  context: CaseContext<Provider>,
+  intent: WriteIntent<Provider>,
+  options: ContextOptions = {},
+): Promise<Result<WriteOutcome>> =>
+  context.provider.contract.provider.write(
+    intent,
+    operationContext(context.environment, options),
+  );
+
+const insist = (id: ConformanceCaseId, held: boolean, message: string): void => {
+  if (!held) {
+    throw violated(id, message);
+  }
+};
+
+const listingOf = (id: ConformanceCaseId, result: Result<ChangeListing>): ChangeListing => {
+  if (!result.ok) {
+    throw violated(id, `the listing failed as "${result.failure.kind}" where it had to succeed`);
+  }
+  return result.value;
+};
+
+const outcomeOf = (id: ConformanceCaseId, result: Result<WriteOutcome>): WriteOutcome => {
+  if (!result.ok) {
+    throw violated(id, `the write failed as "${result.failure.kind}" where it had to succeed`);
+  }
+  return result.value;
+};
+
+const failureKindOf = (result: Result<unknown>): string => {
+  if (result.ok) {
+    return "ok";
+  }
+  return result.failure.kind;
+};
+
+const uidsOf = (listing: ChangeListing): readonly string[] =>
+  (listing.events ?? []).map((event) => event.uid.value);
+
+const markedWith = (id: ConformanceCaseId, name: string): string => `${id}:${name}`;
+
+interface EventDraft {
+  readonly uid: string;
+  readonly start: string;
+  readonly end: string;
+  readonly title?: string;
+  readonly revision?: number;
+  readonly description?: string | null;
+  readonly location?: string | null;
+}
+
+const contentOf = (draft: EventDraft): EditableContent => ({
+  title: draft.title ?? draft.uid,
+  description: draft.description ?? null,
+  location: draft.location ?? null,
+  availability: "busy",
+  visibility: "default",
+  recurrence: null,
+  time: {
+    kind: "timed",
+    start: { kind: "instant", value: draft.start },
+    end: { kind: "instant", value: draft.end },
+    zone: { kind: "zoneId", value: "UTC" },
+  },
+});
+
+const foreignEvent = (calendar: CalendarKey, draft: EventDraft): RemoteEvent => {
+  const revision = draft.revision ?? 1;
+  return {
+    id: { kind: "remoteEventId", value: `id-${draft.uid}` },
+    deleteHandle: { kind: "deleteHandle", value: `handle-${draft.uid}` },
+    uid: { kind: "eventUid", value: draft.uid },
+    calendar,
+    revision,
+    version: { kind: "remoteVersion", value: `v${revision}-${draft.uid}` },
+    content: contentOf(draft),
+    fingerprint: { kind: "fingerprint", value: `fp-${draft.uid}-${revision}` },
+  provenance: { kind: "foreign" },
+  };
+};
+
+const seedWith = <Provider extends ProviderId>(
+  context: CaseContext<Provider>,
+  events: readonly RemoteEvent[],
+  corruptKnownRows: readonly string[] = [],
+): Promise<void> => context.provider.seed({ events, corruptKnownRows });
+
+const writeLogSince = async <Provider extends ProviderId>(
+  provider: ProviderUnderTest<Provider>,
+  from: number,
+): Promise<readonly WriteLogEntry[]> => {
+  const inspection = await provider.inspect();
+  return inspection.writeLog.slice(from);
+};
+
+const writeLogLength = async <Provider extends ProviderId>(
+  provider: ProviderUnderTest<Provider>,
+): Promise<number> => {
+  const inspection = await provider.inspect();
+  return inspection.writeLog.length;
+};
+
+const objectsMarked = async <Provider extends ProviderId>(
+  provider: ProviderUnderTest<Provider>,
+  id: ConformanceCaseId,
+): Promise<readonly RemoteEvent[]> => {
+  const inspection = await provider.inspect();
+  return inspection.objects.filter((event) => event.uid.value.startsWith(`${id}:`));
+};
+
+const instantAfter = (from: Instant, milliseconds: number): Instant => ({
+  kind: "instant",
+  value: new Date(Date.parse(from.value) + milliseconds).toISOString(),
+});
+
+const defineCase = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+  id: ConformanceCaseId,
+  title: string,
+  run: (context: CaseContext<Provider>) => Promise<void>,
+): ConformanceCase<Provider> => ({
+  id,
+  title: `${id}: ${title}`,
+  ledger: ledgerEntryOf(id),
+  gate: gateFor(id, supports),
+  run,
+});
+
+export {
+  caseScope,
+  defineCase,
+  conformanceCalendar,
+  contentOf,
+  decadeWindow,
+  failureKindOf,
+  foreignEvent,
+  insist,
+  instantAfter,
+  invertedWindow,
+  listChanges,
+  listingOf,
+  marchWindow,
+  markedWith,
+  objectsMarked,
+  operationContext,
+  outcomeOf,
+  scopeOver,
+  seedWith,
+  uidsOf,
+  write,
+  writeLogLength,
+  writeLogSince,
+};
+export type { ContextOptions, EventDraft };

--- a/packages/sync-kit/conformance/src/cases/window.ts
+++ b/packages/sync-kit/conformance/src/cases/window.ts
@@ -1,10 +1,137 @@
-import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { Capabilities, EventTime, ProviderId, RemoteEvent } from "@keeper.sh/sync-protocol";
+import { derivableRemovals } from "../assertions/no-removal";
 import type { ConformanceCase } from "../registry/case";
+import { knownOf } from "./deletion-safety";
+import {
+  caseScope,
+  defineCase,
+  foreignEvent,
+  insist,
+  invertedWindow,
+  listChanges,
+  listingOf,
+  markedWith,
+  seedWith,
+  uidsOf,
+} from "./support";
+
+const timeOf = (event: RemoteEvent): EventTime | null => event.content.time ?? null;
 
 const windowCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
-): readonly ConformanceCase<Provider>[] => {
-  throw new Error(`unimplemented: windowCases(${supports.provider})`);
-};
+): readonly ConformanceCase<Provider>[] => [
+  defineCase(
+    supports,
+    "CONF-O26",
+    "an event outside the requested window is returned and never removed",
+    async (context) => {
+      const scope = caseScope(context);
+      const outside = markedWith("CONF-O26", "outside");
+      await seedWith(context, [
+        foreignEvent(scope.calendar, {
+          uid: outside,
+          start: "2026-05-02T09:00:00.000Z",
+          end: "2026-05-02T10:00:00.000Z",
+        }),
+      ]);
+
+      const listing = listingOf("CONF-O26", await listChanges(context, scope));
+      insist(
+        "CONF-O26",
+        uidsOf(listing).includes(outside),
+        "an event the source still holds outside the window was dropped from the listing",
+      );
+      insist(
+        "CONF-O26",
+        derivableRemovals({
+          listing,
+          known: knownOf(scope.calendar, [outside]),
+          withinWindow: context.withinWindow,
+        }).length === 0,
+        "an event outside the requested window was derivable as a removal",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O27",
+    "one window predicate, agreeing at every boundary",
+    async (context) => {
+      const scope = caseScope(context);
+      const lower = markedWith("CONF-O27", "lower");
+      const upper = markedWith("CONF-O27", "upper");
+      const edges = [
+        foreignEvent(scope.calendar, {
+          uid: lower,
+          start: "2026-03-01T00:00:00.000Z",
+          end: "2026-03-01T01:00:00.000Z",
+        }),
+        foreignEvent(scope.calendar, {
+          uid: upper,
+          start: "2026-03-31T23:00:00.000Z",
+          end: "2026-04-01T00:00:00.000Z",
+        }),
+      ];
+      await seedWith(context, edges);
+
+      const listing = listingOf("CONF-O27", await listChanges(context, scope));
+      const listed = new Set(uidsOf(listing));
+      for (const event of edges) {
+        const time = timeOf(event);
+        if (time === null) {
+          continue;
+        }
+        insist(
+          "CONF-O27",
+          !context.withinWindow(scope.window, time) || listed.has(event.uid.value),
+          "an event the window predicate admits was left out of the listing that predicate scoped",
+        );
+      }
+
+      const degenerate = listingOf(
+        "CONF-O27",
+        await listChanges(context, caseScope(context, invertedWindow)),
+      );
+      insist(
+        "CONF-O27",
+        (degenerate.events ?? []).length === 0,
+        "an inverted window admitted events it could never have proven",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O28",
+    "a degenerate range is preserved rather than silently widened",
+    async (context) => {
+      const scope = caseScope(context);
+      const uid = markedWith("CONF-O28", "degenerate");
+      await seedWith(context, [
+        foreignEvent(scope.calendar, {
+          uid,
+          start: "2026-03-10T09:00:00.000Z",
+          end: "2026-03-10T09:00:00.000Z",
+        }),
+      ]);
+
+      const listing = listingOf("CONF-O28", await listChanges(context, scope));
+      if (supports.representableRange.zeroDuration === "accept") {
+        insist(
+          "CONF-O28",
+          uidsOf(listing).includes(uid),
+          "a zero-duration event the adapter accepts was dropped from the listing",
+        );
+        return;
+      }
+      insist(
+        "CONF-O28",
+        (listing.withheld ?? []).some((entry) => entry.uid?.value === uid),
+        "a zero-duration event the adapter cannot represent was silently widened",
+      );
+    },
+  ),
+];
 
 export { windowCases };

--- a/packages/sync-kit/conformance/src/cases/window.ts
+++ b/packages/sync-kit/conformance/src/cases/window.ts
@@ -1,9 +1,20 @@
-import type { Capabilities, EventTime, ProviderId, RemoteEvent } from "@keeper.sh/sync-protocol";
+import type {
+  Capabilities,
+  ChangeListing,
+  EventTime,
+  ProviderId,
+  RemoteEvent,
+  TimeWindow,
+} from "@keeper.sh/sync-protocol";
 import { derivableRemovals } from "../assertions/no-removal";
-import type { ConformanceCase } from "../registry/case";
-import { knownOf } from "./deletion-safety";
+import type { KnownIdentity } from "../assertions/no-removal";
+import type { CaseContext, ConformanceCase } from "../registry/case";
+import { createIntent } from "./intents";
+import { refusedWith } from "./capabilities";
+import type { EventDraft } from "./support";
 import {
   caseScope,
+  contentOf,
   defineCase,
   foreignEvent,
   insist,
@@ -11,11 +22,66 @@ import {
   listChanges,
   listingOf,
   markedWith,
+  objectsMarked,
   seedWith,
   uidsOf,
+  write,
 } from "./support";
 
 const timeOf = (event: RemoteEvent): EventTime | null => event.content.time ?? null;
+
+const meetsMinimumSpan = (time: EventTime | null, seconds: number): boolean => {
+  if (time === null) {
+    return false;
+  }
+  if (time.kind === "allDay") {
+    return true;
+  }
+  return Date.parse(time.end.value) - Date.parse(time.start.value) >= seconds * 1000;
+};
+
+const knownFrom = (events: readonly RemoteEvent[]): readonly KnownIdentity[] =>
+  events.flatMap((event) => {
+    const time = timeOf(event);
+    if (time === null) {
+      return [];
+    }
+    return [{ uid: event.uid.value, id: event.id, time }];
+  });
+
+const coveredWindowOf = (listing: ChangeListing, requested: TimeWindow): TimeWindow =>
+  listing.coverage?.covered ?? requested;
+
+const hourMs = 60 * 60 * 1000;
+
+const draftSpanning = (name: string, startMs: number, endMs: number): EventDraft => ({
+  uid: markedWith("CONF-O27", name),
+  start: new Date(startMs).toISOString(),
+  end: new Date(endMs).toISOString(),
+});
+
+const boundaryDrafts = (window: TimeWindow): readonly EventDraft[] => {
+  const lower = Date.parse(window.start.value);
+  const upper = Date.parse(window.end.value);
+  return [
+    draftSpanning("onLowerEdge", lower, lower + hourMs),
+    draftSpanning("beforeLowerEdge", lower - 2 * hourMs, lower - hourMs),
+    draftSpanning("onUpperEdge", upper - hourMs, upper),
+    draftSpanning("pastUpperEdge", upper + hourMs, upper + 2 * hourMs),
+    draftSpanning("zeroDuration", lower + hourMs, lower + hourMs),
+  ];
+};
+
+const degenerateSeed = <Provider extends ProviderId>(
+  context: CaseContext<Provider>,
+  uid: string,
+): readonly RemoteEvent[] => [
+  foreignEvent(caseScope(context).calendar, {
+    uid,
+    start: "2026-03-10T09:00:00.000Z",
+    end: "2026-03-10T09:00:00.000Z",
+  }),
+];
 
 const windowCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
@@ -23,29 +89,35 @@ const windowCases = <Provider extends ProviderId>(
   defineCase(
     supports,
     "CONF-O26",
-    "an event outside the requested window is returned and never removed",
+    "an event the source still holds outside the window is never removed by its absence",
     async (context) => {
       const scope = caseScope(context);
       const outside = markedWith("CONF-O26", "outside");
-      await seedWith(context, [
+      const seeded = [
         foreignEvent(scope.calendar, {
           uid: outside,
           start: "2026-05-02T09:00:00.000Z",
           end: "2026-05-02T10:00:00.000Z",
         }),
-      ]);
+      ];
+      await seedWith(context, seeded);
 
       const listing = listingOf("CONF-O26", await listChanges(context, scope));
+      const covered = coveredWindowOf(listing, scope.window);
+      const reported = uidsOf(listing).includes(outside);
+      const known = knownFrom(seeded);
+      const outsideCoverage = known.every((entry) => !context.withinWindow(covered, entry.time));
+
       insist(
         "CONF-O26",
-        uidsOf(listing).includes(outside),
-        "an event the source still holds outside the window was dropped from the listing",
+        reported || outsideCoverage,
+        "an event the source still holds was neither reported nor left outside the proven coverage",
       );
       insist(
         "CONF-O26",
         derivableRemovals({
           listing,
-          known: knownOf(scope.calendar, [outside]),
+          known: { calendar: scope.calendar, entries: known },
           withinWindow: context.withinWindow,
         }).length === 0,
         "an event outside the requested window was derivable as a removal",
@@ -56,27 +128,17 @@ const windowCases = <Provider extends ProviderId>(
   defineCase(
     supports,
     "CONF-O27",
-    "one window predicate, agreeing at every boundary",
+    "one window predicate, agreeing at every boundary and at removal time",
     async (context) => {
       const scope = caseScope(context);
-      const lower = markedWith("CONF-O27", "lower");
-      const upper = markedWith("CONF-O27", "upper");
-      const edges = [
-        foreignEvent(scope.calendar, {
-          uid: lower,
-          start: "2026-03-01T00:00:00.000Z",
-          end: "2026-03-01T01:00:00.000Z",
-        }),
-        foreignEvent(scope.calendar, {
-          uid: upper,
-          start: "2026-03-31T23:00:00.000Z",
-          end: "2026-04-01T00:00:00.000Z",
-        }),
-      ];
+      const edges = boundaryDrafts(scope.window).map((draft) =>
+        foreignEvent(scope.calendar, draft),
+      );
       await seedWith(context, edges);
 
       const listing = listingOf("CONF-O27", await listChanges(context, scope));
       const listed = new Set(uidsOf(listing));
+      const covered = coveredWindowOf(listing, scope.window);
       for (const event of edges) {
         const time = timeOf(event);
         if (time === null) {
@@ -87,7 +149,24 @@ const windowCases = <Provider extends ProviderId>(
           !context.withinWindow(scope.window, time) || listed.has(event.uid.value),
           "an event the window predicate admits was left out of the listing that predicate scoped",
         );
+        insist(
+          "CONF-O27",
+          context.withinWindow(covered, time) ||
+            !derivableRemovals({
+              listing,
+              known: { calendar: scope.calendar, entries: knownFrom([event]) },
+              withinWindow: context.withinWindow,
+            }).includes(event.uid.value),
+          "an event the window predicate excludes was still derivable as a removal",
+        );
       }
+
+      const second = listingOf("CONF-O27", await listChanges(context, scope));
+      insist(
+        "CONF-O27",
+        new Set(uidsOf(second)).size === listed.size,
+        "two polls of the same boundary set disagreed about which events the window admits",
+      );
 
       const degenerate = listingOf(
         "CONF-O27",
@@ -104,31 +183,82 @@ const windowCases = <Provider extends ProviderId>(
   defineCase(
     supports,
     "CONF-O28",
-    "a degenerate range is preserved rather than silently widened",
+    "a degenerate range is preserved or refused, never silently widened at the source",
     async (context) => {
       const scope = caseScope(context);
       const uid = markedWith("CONF-O28", "degenerate");
-      await seedWith(context, [
-        foreignEvent(scope.calendar, {
-          uid,
-          start: "2026-03-10T09:00:00.000Z",
-          end: "2026-03-10T09:00:00.000Z",
-        }),
-      ]);
+      const written = markedWith("CONF-O28", "mirrored");
+      await seedWith(context, degenerateSeed(context, uid));
 
       const listing = listingOf("CONF-O28", await listChanges(context, scope));
-      if (supports.representableRange.zeroDuration === "accept") {
+      const zeroDuration = contentOf({
+        uid: written,
+        start: "2026-03-11T09:00:00.000Z",
+        end: "2026-03-11T09:00:00.000Z",
+      });
+      const mirrored = await write(
+        context,
+        createIntent(
+          supports,
+          scope.calendar,
+          context.environment.installation,
+          written,
+          zeroDuration,
+        ),
+      );
+
+      if (supports.representableRange.zeroDuration === "reject") {
         insist(
           "CONF-O28",
-          uidsOf(listing).includes(uid),
-          "a zero-duration event the adapter accepts was dropped from the listing",
+          (listing.withheld ?? []).some((entry) => entry.uid?.value === uid),
+          "a zero-duration event the adapter cannot represent was silently widened",
+        );
+        insist(
+          "CONF-O28",
+          refusedWith(mirrored, "minimumSpan"),
+          "an adapter that cannot represent a zero-duration span accepted one anyway",
         );
         return;
       }
+
       insist(
         "CONF-O28",
-        (listing.withheld ?? []).some((entry) => entry.uid?.value === uid),
-        "a zero-duration event the adapter cannot represent was silently widened",
+        uidsOf(listing).includes(uid),
+        "a zero-duration event the adapter accepts was dropped from the listing",
+      );
+      insist("CONF-O28", mirrored.ok, "a zero-duration event the adapter accepts was refused");
+      const stored = await objectsMarked(context.provider, "CONF-O28");
+      const widened = stored.find((event) => event.uid.value === written);
+      insist(
+        "CONF-O28",
+        meetsMinimumSpan(
+          widened?.content.time ?? null,
+          supports.representableRange.minimumSpanSeconds,
+        ),
+        "the destination copy was stored below the minimum span the adapter declared",
+      );
+
+      const replayed = await write(
+        context,
+        createIntent(
+          supports,
+          scope.calendar,
+          context.environment.installation,
+          written,
+          zeroDuration,
+        ),
+      );
+      const afterwards = await objectsMarked(context.provider, "CONF-O28");
+      const unchanged = afterwards.find((event) => event.uid.value === written);
+      insist(
+        "CONF-O28",
+        replayed.ok && replayed.value.kind !== "created",
+        "the widening the destination performed read back as a change and was written again",
+      );
+      insist(
+        "CONF-O28",
+        unchanged?.revision === widened?.revision,
+        "a second run against a widened mirror revised the copy it had already written",
       );
     },
   ),

--- a/packages/sync-kit/conformance/src/cases/window.ts
+++ b/packages/sync-kit/conformance/src/cases/window.ts
@@ -1,0 +1,10 @@
+import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { ConformanceCase } from "../registry/case";
+
+const windowCases = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+): readonly ConformanceCase<Provider>[] => {
+  throw new Error(`unimplemented: windowCases(${supports.provider})`);
+};
+
+export { windowCases };

--- a/packages/sync-kit/conformance/src/cases/writes.ts
+++ b/packages/sync-kit/conformance/src/cases/writes.ts
@@ -1,10 +1,349 @@
-import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type {
+  Capabilities,
+  EditableContent,
+  ProviderId,
+  RemoteVersion,
+  WriteOutcome,
+} from "@keeper.sh/sync-protocol";
+import { assertNoDeleteThenCreate, assertNoUnconditionalWrite } from "../assertions/outcome";
 import type { ConformanceCase } from "../registry/case";
+import { createIntent, updateIntent } from "./intents";
+import {
+  caseScope,
+  contentOf,
+  defineCase,
+  foreignEvent,
+  insist,
+  listChanges,
+  listingOf,
+  markedWith,
+  objectsMarked,
+  outcomeOf,
+  seedWith,
+  uidsOf,
+  write,
+  writeLogLength,
+  writeLogSince,
+} from "./support";
+
+const versionOf = (outcome: WriteOutcome): RemoteVersion => {
+  if ("version" in outcome) {
+    return outcome.version;
+  }
+  return { kind: "remoteVersion", value: "no-version" };
+};
+
+const remoteIdOf = (outcome: WriteOutcome): string => {
+  if ("remote" in outcome) {
+    return outcome.remote.id.value;
+  }
+  return "no-remote";
+};
+
+const echoKindOf = (outcome: WriteOutcome): string => {
+  if ("echo" in outcome) {
+    return outcome.echo.kind;
+  }
+  return "no-echo";
+};
+
+const meetingAt = (uid: string, hour: string): EditableContent =>
+  contentOf({ uid, start: `2026-03-02T${hour}:00:00.000Z`, end: `2026-03-02T${hour}:30:00.000Z` });
 
 const writeCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
-): readonly ConformanceCase<Provider>[] => {
-  throw new Error(`unimplemented: writeCases(${supports.provider})`);
-};
+): readonly ConformanceCase<Provider>[] => [
+  defineCase(
+    supports,
+    "CONF-O7",
+    "an unbuildable newest revision withholds its identity instead of falling back",
+    async (context) => {
+      const scope = caseScope(context);
+      const uid = markedWith("CONF-O7", "superseded");
+      await seedWith(context, [
+        foreignEvent(scope.calendar, {
+          uid,
+          start: "2026-03-02T09:00:00.000Z",
+          end: "2026-03-02T10:00:00.000Z",
+          revision: 1,
+        }),
+        foreignEvent(scope.calendar, {
+          uid,
+          start: "2026-03-02T12:00:00.000Z",
+          end: "2026-03-02T11:00:00.000Z",
+          revision: 2,
+        }),
+      ]);
 
-export { writeCases };
+      const listing = listingOf("CONF-O7", await listChanges(context, scope));
+      insist(
+        "CONF-O7",
+        !uidsOf(listing).includes(uid),
+        "an identity whose newest revision is unbuildable was published at its stale time",
+      );
+      insist(
+        "CONF-O7",
+        (listing.withheld ?? []).some((entry) => entry.uid?.value === uid),
+        "an identity whose newest revision is unbuildable vanished instead of being withheld",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O14",
+    "a replayed create with the same identity is a no-op, never a duplicate",
+    async (context) => {
+      const scope = caseScope(context);
+      const key = markedWith("CONF-O14", "replayed");
+      const intent = createIntent(
+        supports,
+        scope.calendar,
+        context.environment.installation,
+        key,
+        meetingAt(key, "09"),
+      );
+      await seedWith(context, []);
+
+      const first = outcomeOf("CONF-O14", await write(context, intent));
+      const second = outcomeOf("CONF-O14", await write(context, intent));
+      const objects = await objectsMarked(context.provider, "CONF-O14");
+
+      insist("CONF-O14", first.kind === "created", "the first create did not create anything");
+      insist(
+        "CONF-O14",
+        second.kind === "alreadyExists" || second.kind === "unchanged",
+        "a replayed create was treated as a fresh write",
+      );
+      insist(
+        "CONF-O14",
+        remoteIdOf(second) === remoteIdOf(first),
+        "a replayed create answered with a different remote reference",
+      );
+      insist("CONF-O14", objects.length === 1, "a replayed create left two objects behind");
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O15",
+    "a conflicting create is a typed refusal, never a blind recreation",
+    async (context) => {
+      const scope = caseScope(context);
+      const key = markedWith("CONF-O15", "contended");
+      await seedWith(context, []);
+      const before = await writeLogLength(context.provider);
+      await write(
+        context,
+        createIntent(
+          supports,
+          scope.calendar,
+          context.environment.installation,
+          key,
+          meetingAt(key, "09"),
+        ),
+      );
+
+      const answered = await write(
+        context,
+        createIntent(
+          supports,
+          scope.calendar,
+          context.environment.installation,
+          key,
+          meetingAt(key, "11"),
+        ),
+      );
+      assertNoDeleteThenCreate(await writeLogSince(context.provider, before));
+
+      if (!answered.ok) {
+        insist(
+          "CONF-O15",
+          answered.failure.kind === "conflict",
+          `a differing remote copy answered "${answered.failure.kind}" instead of a conflict`,
+        );
+        return;
+      }
+      insist(
+        "CONF-O15",
+        answered.value.kind === "conflict",
+        `a differing remote copy answered "${answered.value.kind}" instead of a conflict`,
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O18",
+    "an adapter that cannot observe its own write says so",
+    async (context) => {
+      const scope = caseScope(context);
+      const key = markedWith("CONF-O18", "echoed");
+      await seedWith(context, []);
+
+      const created = outcomeOf(
+        "CONF-O18",
+        await write(
+          context,
+          createIntent(
+            supports,
+            scope.calendar,
+            context.environment.installation,
+            key,
+            meetingAt(key, "09"),
+          ),
+        ),
+      );
+
+      insist("CONF-O18", echoKindOf(created) !== "no-echo", "a create reported no echo verdict");
+      if (supports.echoesWrites) {
+        insist(
+          "CONF-O18",
+          echoKindOf(created) !== "notObserved",
+          "an adapter that declares it echoes writes reported the echo as unobserved",
+        );
+        return;
+      }
+      insist(
+        "CONF-O18",
+        echoKindOf(created) === "notObserved",
+        "an adapter that cannot observe its writes claimed the echo matched",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O25",
+    "a replace whose second half fails leaves a recoverable state",
+    async (context) => {
+      const scope = caseScope(context);
+      const key = markedWith("CONF-O25", "replaced");
+      await seedWith(context, []);
+      const before = await writeLogLength(context.provider);
+      const created = outcomeOf(
+        "CONF-O25",
+        await write(
+          context,
+          createIntent(
+            supports,
+            scope.calendar,
+            context.environment.installation,
+            key,
+            meetingAt(key, "09"),
+          ),
+        ),
+      );
+
+      await write(
+        context,
+        createIntent(
+          supports,
+          scope.calendar,
+          context.environment.installation,
+          key,
+          meetingAt(key, "11"),
+        ),
+      );
+      const survivors = await objectsMarked(context.provider, "CONF-O25");
+      const logged = await writeLogSince(context.provider, before);
+
+      insist(
+        "CONF-O25",
+        survivors.length === 1,
+        "the half that had already succeeded was destroyed by the half that failed",
+      );
+      insist(
+        "CONF-O25",
+        logged.some((entry) => entry.outcome.kind === created.kind),
+        "the successful half was no longer reported separately once the second half failed",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O36",
+    "moving an occurrence is one conditional write, not a delete plus an add",
+    async (context) => {
+      const scope = caseScope(context);
+      const key = markedWith("CONF-O36", "occurrence");
+      await seedWith(context, []);
+      const before = await writeLogLength(context.provider);
+      const created = outcomeOf(
+        "CONF-O36",
+        await write(
+          context,
+          createIntent(
+            supports,
+            scope.calendar,
+            context.environment.installation,
+            key,
+            meetingAt(key, "09"),
+          ),
+        ),
+      );
+
+      await write(
+        context,
+        updateIntent(
+          supports,
+          scope.calendar,
+          `id-${key}`,
+          meetingAt(key, "11"),
+          versionOf(created),
+        ),
+      );
+      const logged = await writeLogSince(context.provider, before);
+      assertNoUnconditionalWrite(logged);
+
+      insist(
+        "CONF-O36",
+        logged.every((entry) => entry.intent.kind !== "delete"),
+        "moving an occurrence was expressed as a delete followed by an add",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O39",
+    "a stale precondition is a typed conflict, never a silent overwrite",
+    async (context) => {
+      const scope = caseScope(context);
+      const key = markedWith("CONF-O39", "contended");
+      await seedWith(context, []);
+      const created = outcomeOf(
+        "CONF-O39",
+        await write(
+          context,
+          createIntent(
+            supports,
+            scope.calendar,
+            context.environment.installation,
+            key,
+            meetingAt(key, "09"),
+          ),
+        ),
+      );
+      const stale = versionOf(created);
+
+      await write(
+        context,
+        updateIntent(supports, scope.calendar, `id-${key}`, meetingAt(key, "11"), stale),
+      );
+      const replayed = await write(
+        context,
+        updateIntent(supports, scope.calendar, `id-${key}`, meetingAt(key, "13"), stale),
+      );
+
+      insist(
+        "CONF-O39",
+        !replayed.ok && replayed.failure.kind === "conflict",
+        "a write whose precondition was already spent was accepted a second time",
+      );
+    },
+  ),
+];
+
+export { echoKindOf, meetingAt, remoteIdOf, versionOf, writeCases };

--- a/packages/sync-kit/conformance/src/cases/writes.ts
+++ b/packages/sync-kit/conformance/src/cases/writes.ts
@@ -1,0 +1,10 @@
+import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { ConformanceCase } from "../registry/case";
+
+const writeCases = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+): readonly ConformanceCase<Provider>[] => {
+  throw new Error(`unimplemented: writeCases(${supports.provider})`);
+};
+
+export { writeCases };

--- a/packages/sync-kit/conformance/src/cases/writes.ts
+++ b/packages/sync-kit/conformance/src/cases/writes.ts
@@ -1,13 +1,19 @@
 import type {
+  CalendarKey,
   Capabilities,
   EditableContent,
   ProviderId,
   RemoteVersion,
+  WriteIntent,
   WriteOutcome,
 } from "@keeper.sh/sync-protocol";
-import { assertNoDeleteThenCreate, assertNoUnconditionalWrite } from "../assertions/outcome";
-import type { ConformanceCase } from "../registry/case";
-import { createIntent, updateIntent } from "./intents";
+import {
+  assertConflictNotOverwrite,
+  assertNoUnconditionalWrite,
+  assertNoUnplannedRecreation,
+} from "../assertions/outcome";
+import type { CaseContext, ConformanceCase } from "../registry/case";
+import { createIntent, deleteIntent, updateIntent } from "./intents";
 import {
   caseScope,
   contentOf,
@@ -49,6 +55,36 @@ const echoKindOf = (outcome: WriteOutcome): string => {
 
 const meetingAt = (uid: string, hour: string): EditableContent =>
   contentOf({ uid, start: `2026-03-02T${hour}:00:00.000Z`, end: `2026-03-02T${hour}:30:00.000Z` });
+
+const seriesAnchoredAt = (uid: string, hour: string): EditableContent => ({
+  title: uid,
+  description: null,
+  location: null,
+  availability: "busy",
+  visibility: "default",
+  recurrence: { dialect: "rfc5545", value: "FREQ=WEEKLY;COUNT=3", exceptions: [] },
+  anchor: {
+    kind: "timed",
+    start: { kind: "instant", value: `2026-03-02T${hour}:00:00.000Z` },
+    zone: { kind: "zoneId", value: "UTC" },
+    duration: { kind: "exact", seconds: 1800 },
+  },
+});
+
+const createFor = <Provider extends ProviderId>(
+  context: CaseContext<Provider>,
+  supports: Capabilities<Provider>,
+  calendar: CalendarKey,
+  key: string,
+  hour: string,
+): WriteIntent<Provider> =>
+  createIntent(
+    supports,
+    calendar,
+    context.environment.installation,
+    key,
+    meetingAt(key, hour),
+  );
 
 const writeCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
@@ -154,7 +190,7 @@ const writeCases = <Provider extends ProviderId>(
           meetingAt(key, "11"),
         ),
       );
-      assertNoDeleteThenCreate(await writeLogSince(context.provider, before));
+      assertNoUnplannedRecreation(await writeLogSince(context.provider, before), []);
 
       if (!answered.ok) {
         insist(
@@ -218,45 +254,60 @@ const writeCases = <Provider extends ProviderId>(
     "a replace whose second half fails leaves a recoverable state",
     async (context) => {
       const scope = caseScope(context);
-      const key = markedWith("CONF-O25", "replaced");
+      const replaced = markedWith("CONF-O25", "replaced");
+      const blocker = markedWith("CONF-O25", "blocker");
       await seedWith(context, []);
+      const blocking = outcomeOf(
+        "CONF-O25",
+        await write(context, createFor(context, supports, scope.calendar, blocker, "07")),
+      );
+      const original = outcomeOf(
+        "CONF-O25",
+        await write(context, createFor(context, supports, scope.calendar, replaced, "09")),
+      );
       const before = await writeLogLength(context.provider);
-      const created = outcomeOf(
-        "CONF-O25",
-        await write(
-          context,
-          createIntent(
-            supports,
-            scope.calendar,
-            context.environment.installation,
-            key,
-            meetingAt(key, "09"),
-          ),
-        ),
-      );
+      const removed = `handle-${replaced}`;
 
-      await write(
+      const deleted = await write(
         context,
-        createIntent(
-          supports,
-          scope.calendar,
-          context.environment.installation,
-          key,
-          meetingAt(key, "11"),
-        ),
+        deleteIntent(scope.calendar, removed, versionOf(original)),
       );
-      const survivors = await objectsMarked(context.provider, "CONF-O25");
+      const recreated = await write(
+        context,
+        createFor(context, supports, scope.calendar, blocker, "11"),
+      );
       const logged = await writeLogSince(context.provider, before);
+      const survivors = await objectsMarked(context.provider, "CONF-O25");
+      assertConflictNotOverwrite(recreated);
+      assertNoUnplannedRecreation(logged, [removed]);
 
       insist(
         "CONF-O25",
-        survivors.length === 1,
-        "the half that had already succeeded was destroyed by the half that failed",
+        deleted.ok && deleted.value.kind === "deleted",
+        "the first half of the replace did not remove the copy it was pointed at",
       );
       insist(
         "CONF-O25",
-        logged.some((entry) => entry.outcome.kind === created.kind),
-        "the successful half was no longer reported separately once the second half failed",
+        logged.some((entry) => entry.intent.kind === "delete" && entry.intent.target.value === removed),
+        "the write log no longer names the target the failed replace had already deleted",
+      );
+      insist(
+        "CONF-O25",
+        survivors.some(
+          (event) =>
+            event.uid.value === blocker && event.version.value === versionOf(blocking).value,
+        ),
+        "the copy that blocked the second half was destroyed by the half that failed",
+      );
+
+      const retried = await write(
+        context,
+        createFor(context, supports, scope.calendar, replaced, "11"),
+      );
+      insist(
+        "CONF-O25",
+        retried.ok && retried.value.kind === "created",
+        "the state after a half-completed replace could not be recovered on the next run",
       );
     },
   ),
@@ -264,12 +315,11 @@ const writeCases = <Provider extends ProviderId>(
   defineCase(
     supports,
     "CONF-O36",
-    "moving an occurrence is one conditional write, not a delete plus an add",
+    "moving an occurrence is one conditional write against a target that is still ours",
     async (context) => {
       const scope = caseScope(context);
       const key = markedWith("CONF-O36", "occurrence");
       await seedWith(context, []);
-      const before = await writeLogLength(context.provider);
       const created = outcomeOf(
         "CONF-O36",
         await write(
@@ -279,10 +329,24 @@ const writeCases = <Provider extends ProviderId>(
             scope.calendar,
             context.environment.installation,
             key,
-            meetingAt(key, "09"),
+            seriesAnchoredAt(key, "09"),
           ),
         ),
       );
+      const listed = listingOf("CONF-O36", await listChanges(context, scope));
+      const mirrored = (listed.events ?? []).find((event) => event.uid.value === key);
+      const before = await writeLogLength(context.provider);
+      insist("CONF-O36", Boolean(mirrored), "the series we wrote did not come back through the adapter");
+      if (!mirrored) {
+        return;
+      }
+      if (supports.provenanceChannel !== "none") {
+        insist(
+          "CONF-O36",
+          mirrored.provenance.kind === "ours",
+          "an occurrence was reassigned against a target the adapter could not prove was ours",
+        );
+      }
 
       await write(
         context,
@@ -290,11 +354,13 @@ const writeCases = <Provider extends ProviderId>(
           supports,
           scope.calendar,
           `id-${key}`,
-          meetingAt(key, "11"),
+          seriesAnchoredAt(key, "11"),
           versionOf(created),
         ),
       );
       const logged = await writeLogSince(context.provider, before);
+      const moved = listingOf("CONF-O36", await listChanges(context, scope));
+      const reassigned = (moved.events ?? []).find((event) => event.uid.value === key);
       assertNoUnconditionalWrite(logged);
 
       insist(
@@ -302,6 +368,55 @@ const writeCases = <Provider extends ProviderId>(
         logged.every((entry) => entry.intent.kind !== "delete"),
         "moving an occurrence was expressed as a delete followed by an add",
       );
+      insist(
+        "CONF-O36",
+        logged.filter((entry) => entry.intent.kind === "update").length === 1,
+        "moving one occurrence took more than the single conditional write it needs",
+      );
+      insist(
+        "CONF-O36",
+        reassigned?.fingerprint.value !== mirrored.fingerprint.value,
+        "a series moved to a new anchor kept the fingerprint of the anchor it left",
+      );
+    },
+  ),
+
+  defineCase(
+    supports,
+    "CONF-O44",
+    "two writers holding the same precondition cannot both win",
+    async (context) => {
+      const scope = caseScope(context);
+      const key = markedWith("CONF-O44", "contended");
+      await seedWith(context, []);
+      const created = outcomeOf(
+        "CONF-O44",
+        await write(context, createFor(context, supports, scope.calendar, key, "09")),
+      );
+      const held = versionOf(created);
+
+      const [earlier, later] = await Promise.all([
+        write(context, updateIntent(supports, scope.calendar, `id-${key}`, meetingAt(key, "11"), held)),
+        write(context, updateIntent(supports, scope.calendar, `id-${key}`, meetingAt(key, "13"), held)),
+      ]);
+      const stored = await objectsMarked(context.provider, "CONF-O44");
+      const answers = [earlier, later];
+      const winners = answers.filter((answered) => answered.ok && answered.value.kind === "updated");
+      const losers = answers.filter((answered) => !winners.includes(answered));
+
+      insist(
+        "CONF-O44",
+        winners.length === 1,
+        `${winners.length} of two writers holding the same precondition were told they had won`,
+      );
+      insist(
+        "CONF-O44",
+        stored.length === 1 && stored.at(0)?.revision === 2,
+        "two concurrent writers left the calendar holding something other than one applied write",
+      );
+      for (const answered of losers) {
+        assertConflictNotOverwrite(answered);
+      }
     },
   ),
 
@@ -346,4 +461,4 @@ const writeCases = <Provider extends ProviderId>(
   ),
 ];
 
-export { echoKindOf, meetingAt, remoteIdOf, versionOf, writeCases };
+export { echoKindOf, meetingAt, remoteIdOf, seriesAnchoredAt, versionOf, writeCases };

--- a/packages/sync-kit/conformance/src/clock.ts
+++ b/packages/sync-kit/conformance/src/clock.ts
@@ -5,9 +5,72 @@ interface TestClockOptions {
   readonly start: Instant;
 }
 
+const instantAt = (milliseconds: number): Instant => ({
+  kind: "instant",
+  value: new Date(milliseconds).toISOString(),
+});
+
+class SleepAborted extends Error {
+  constructor() {
+    super("the injected clock's sleep was aborted before its deadline");
+    this.name = "SleepAborted";
+  }
+}
+
+interface TimerHolder {
+  current: ReturnType<typeof setTimeout> | null;
+}
+
 const createTestClock = (options: TestClockOptions): TestClock => {
-  throw new Error(`unimplemented: createTestClock(${options.start.value})`);
+  let currentMs = Date.parse(options.start.value);
+  let reads = 0;
+  const armed = new Set<ReturnType<typeof setTimeout>>();
+
+  const sleep = async (milliseconds: number, signal: AbortSignal): Promise<void> => {
+    if (signal.aborted) {
+      throw new SleepAborted();
+    }
+    const wakeAt = currentMs + milliseconds;
+    const pending = Promise.withResolvers<null>();
+    const armedTimer: TimerHolder = { current: null };
+    const disarm = (): void => {
+      if (armedTimer.current === null) {
+        return;
+      }
+      clearTimeout(armedTimer.current);
+      armed.delete(armedTimer.current);
+    };
+    armedTimer.current = setTimeout(() => {
+      currentMs = Math.max(currentMs, wakeAt);
+      disarm();
+      pending.resolve(null);
+    }, milliseconds);
+    armed.add(armedTimer.current);
+    signal.addEventListener(
+      "abort",
+      () => {
+        disarm();
+        pending.reject(new SleepAborted());
+      },
+      { once: true },
+    );
+    await pending.promise;
+  };
+
+  return {
+    now: () => {
+      reads += 1;
+      return instantAt(currentMs);
+    },
+    sleep,
+    advance: (milliseconds: number) => {
+      currentMs += milliseconds;
+      return Promise.resolve();
+    },
+    nowCount: () => reads,
+    pendingTimers: () => armed.size,
+  };
 };
 
-export { createTestClock };
+export { createTestClock, instantAt };
 export type { TestClockOptions };

--- a/packages/sync-kit/conformance/src/clock.ts
+++ b/packages/sync-kit/conformance/src/clock.ts
@@ -33,7 +33,9 @@ const createTestClock = (options: TestClockOptions): TestClock => {
     const wakeAt = currentMs + milliseconds;
     const pending = Promise.withResolvers<null>();
     const armedTimer: TimerHolder = { current: null };
+    const listening = new AbortController();
     const disarm = (): void => {
+      listening.abort();
       if (armedTimer.current === null) {
         return;
       }
@@ -52,7 +54,7 @@ const createTestClock = (options: TestClockOptions): TestClock => {
         disarm();
         pending.reject(new SleepAborted());
       },
-      { once: true },
+      { once: true, signal: listening.signal },
     );
     await pending.promise;
   };

--- a/packages/sync-kit/conformance/src/clock.ts
+++ b/packages/sync-kit/conformance/src/clock.ts
@@ -22,15 +22,14 @@ interface TimerHolder {
 }
 
 const createTestClock = (options: TestClockOptions): TestClock => {
-  let currentMs = Date.parse(options.start.value);
-  let reads = 0;
+  const state = { currentMs: Date.parse(options.start.value), reads: 0 };
   const armed = new Set<ReturnType<typeof setTimeout>>();
 
   const sleep = async (milliseconds: number, signal: AbortSignal): Promise<void> => {
     if (signal.aborted) {
       throw new SleepAborted();
     }
-    const wakeAt = currentMs + milliseconds;
+    const wakeAt = state.currentMs + milliseconds;
     const pending = Promise.withResolvers<null>();
     const armedTimer: TimerHolder = { current: null };
     const listening = new AbortController();
@@ -43,7 +42,7 @@ const createTestClock = (options: TestClockOptions): TestClock => {
       armed.delete(armedTimer.current);
     };
     armedTimer.current = setTimeout(() => {
-      currentMs = Math.max(currentMs, wakeAt);
+      state.currentMs = Math.max(state.currentMs, wakeAt);
       disarm();
       pending.resolve(null);
     }, milliseconds);
@@ -61,15 +60,15 @@ const createTestClock = (options: TestClockOptions): TestClock => {
 
   return {
     now: () => {
-      reads += 1;
-      return instantAt(currentMs);
+      state.reads += 1;
+      return instantAt(state.currentMs);
     },
     sleep,
     advance: (milliseconds: number) => {
-      currentMs += milliseconds;
+      state.currentMs += milliseconds;
       return Promise.resolve();
     },
-    nowCount: () => reads,
+    nowCount: () => state.reads,
     pendingTimers: () => armed.size,
   };
 };

--- a/packages/sync-kit/conformance/src/clock.ts
+++ b/packages/sync-kit/conformance/src/clock.ts
@@ -1,0 +1,13 @@
+import type { Instant } from "@keeper.sh/sync-protocol";
+import type { TestClock } from "./options";
+
+interface TestClockOptions {
+  readonly start: Instant;
+}
+
+const createTestClock = (options: TestClockOptions): TestClock => {
+  throw new Error(`unimplemented: createTestClock(${options.start.value})`);
+};
+
+export { createTestClock };
+export type { TestClockOptions };

--- a/packages/sync-kit/conformance/src/deadline.ts
+++ b/packages/sync-kit/conformance/src/deadline.ts
@@ -1,0 +1,49 @@
+import type { OperationContext, ProviderFailure, Result } from "@keeper.sh/sync-protocol";
+
+const abortedFailure: ProviderFailure = { kind: "notAttempted", reason: "aborted" };
+const exhaustedFailure: ProviderFailure = { kind: "notAttempted", reason: "budgetExhausted" };
+
+const remainingMilliseconds = (context: OperationContext): number =>
+  Date.parse(context.deadline.value) - Date.parse(context.now().value);
+
+const settledAs = <Value>(failure: ProviderFailure): Result<Value> => ({ ok: false, failure });
+
+interface DeadlineAnswers {
+  readonly onDeadline: ProviderFailure;
+  readonly onAbort: ProviderFailure;
+}
+
+const raceDeadline = async <Value>(
+  context: OperationContext,
+  answers: DeadlineAnswers,
+  work: () => Promise<Result<Value>>,
+): Promise<Result<Value>> => {
+  if (context.signal.aborted) {
+    return settledAs(answers.onAbort);
+  }
+  if (remainingMilliseconds(context) <= 0) {
+    return settledAs(answers.onDeadline);
+  }
+  const expired = Promise.withResolvers<Result<Value>>();
+  const onCallerAbort = (): void => {
+    expired.resolve(settledAs(answers.onAbort));
+  };
+  const timer = setTimeout(() => {
+    expired.resolve(settledAs(answers.onDeadline));
+  }, remainingMilliseconds(context));
+  context.signal.addEventListener("abort", onCallerAbort, { once: true });
+  try {
+    return await Promise.race([expired.promise, work()]);
+  } finally {
+    clearTimeout(timer);
+    context.signal.removeEventListener("abort", onCallerAbort);
+  }
+};
+
+const standardAnswers: DeadlineAnswers = {
+  onDeadline: exhaustedFailure,
+  onAbort: abortedFailure,
+};
+
+export { abortedFailure, exhaustedFailure, raceDeadline, remainingMilliseconds, standardAnswers };
+export type { DeadlineAnswers };

--- a/packages/sync-kit/conformance/src/environment.ts
+++ b/packages/sync-kit/conformance/src/environment.ts
@@ -1,0 +1,15 @@
+import type { InstallationId, Instant } from "@keeper.sh/sync-protocol";
+import type { ConformanceEnvironment } from "./options";
+
+interface EnvironmentOptions {
+  readonly start: Instant;
+  readonly installation: InstallationId;
+  readonly hash: (input: string) => string;
+}
+
+const createConformanceEnvironment = (options: EnvironmentOptions): ConformanceEnvironment => {
+  throw new Error(`unimplemented: createConformanceEnvironment(${options.installation.value})`);
+};
+
+export { createConformanceEnvironment };
+export type { EnvironmentOptions };

--- a/packages/sync-kit/conformance/src/environment.ts
+++ b/packages/sync-kit/conformance/src/environment.ts
@@ -1,5 +1,7 @@
 import type { InstallationId, Instant } from "@keeper.sh/sync-protocol";
+import { createTestClock } from "./clock";
 import type { ConformanceEnvironment } from "./options";
+import { createTransportStub } from "./transport";
 
 interface EnvironmentOptions {
   readonly start: Instant;
@@ -7,9 +9,12 @@ interface EnvironmentOptions {
   readonly hash: (input: string) => string;
 }
 
-const createConformanceEnvironment = (options: EnvironmentOptions): ConformanceEnvironment => {
-  throw new Error(`unimplemented: createConformanceEnvironment(${options.installation.value})`);
-};
+const createConformanceEnvironment = (options: EnvironmentOptions): ConformanceEnvironment => ({
+  clock: createTestClock({ start: options.start }),
+  hash: options.hash,
+  installation: options.installation,
+  transport: createTransportStub(),
+});
 
 export { createConformanceEnvironment };
 export type { EnvironmentOptions };

--- a/packages/sync-kit/conformance/src/environment.ts
+++ b/packages/sync-kit/conformance/src/environment.ts
@@ -1,5 +1,6 @@
 import type { InstallationId, Instant } from "@keeper.sh/sync-protocol";
 import { createTestClock } from "./clock";
+import { conformanceLimits } from "./limits";
 import type { ConformanceEnvironment } from "./options";
 import { createTransportStub } from "./transport";
 
@@ -11,6 +12,7 @@ interface EnvironmentOptions {
 
 const createConformanceEnvironment = (options: EnvironmentOptions): ConformanceEnvironment => ({
   clock: createTestClock({ start: options.start }),
+  concurrency: conformanceLimits.concurrency,
   hash: options.hash,
   installation: options.installation,
   transport: createTransportStub(),

--- a/packages/sync-kit/conformance/src/fixtures/conflict.ts
+++ b/packages/sync-kit/conformance/src/fixtures/conflict.ts
@@ -1,8 +1,49 @@
-import type { WriteIntent } from "@keeper.sh/sync-protocol";
+import type { ProviderId, RemoteRef, WriteIntent } from "@keeper.sh/sync-protocol";
+import type { ProviderUnderTest } from "../options";
 import type { ProviderDecorator } from "./decorate";
+import { withWrite } from "./decorate";
+
+const remoteRefOf = (intent: WriteIntent): RemoteRef => {
+  if (intent.kind === "create") {
+    return {
+      id: { kind: "remoteEventId", value: `id-${intent.idempotencyKey.value}` },
+      deleteHandle: { kind: "deleteHandle", value: `handle-${intent.idempotencyKey.value}` },
+    };
+  }
+  if (intent.kind === "update") {
+    return {
+      id: intent.target,
+      deleteHandle: { kind: "deleteHandle", value: `handle-${intent.target.value}` },
+    };
+  }
+  return {
+    id: { kind: "remoteEventId", value: `id-${intent.target.value}` },
+    deleteHandle: intent.target,
+  };
+};
 
 const conflictingOn = (matches: (intent: WriteIntent) => boolean): ProviderDecorator => {
-  throw new Error(`unimplemented: conflictingOn(${typeof matches})`);
+  const decorate = <Provider extends ProviderId>(
+    provider: ProviderUnderTest<Provider>,
+  ): ProviderUnderTest<Provider> =>
+    withWrite(provider, (intent, context, inner) => {
+      if (!matches(intent)) {
+        return inner();
+      }
+      const remote = remoteRefOf(intent);
+      return Promise.resolve({
+        ok: true,
+        value: {
+          kind: "conflict",
+          remote,
+          observed: {
+            kind: "matchesVersion",
+            version: { kind: "remoteVersion", value: `conflicting-${remote.id.value}` },
+          },
+        },
+      });
+    });
+  return decorate;
 };
 
 export { conflictingOn };

--- a/packages/sync-kit/conformance/src/fixtures/conflict.ts
+++ b/packages/sync-kit/conformance/src/fixtures/conflict.ts
@@ -1,0 +1,8 @@
+import type { WriteIntent } from "@keeper.sh/sync-protocol";
+import type { ProviderDecorator } from "./decorate";
+
+const conflictingOn = (matches: (intent: WriteIntent) => boolean): ProviderDecorator => {
+  throw new Error(`unimplemented: conflictingOn(${typeof matches})`);
+};
+
+export { conflictingOn };

--- a/packages/sync-kit/conformance/src/fixtures/decorate.ts
+++ b/packages/sync-kit/conformance/src/fixtures/decorate.ts
@@ -1,0 +1,19 @@
+import type { ProviderId } from "@keeper.sh/sync-protocol";
+import type { ProviderUnderTest } from "../options";
+
+type ProviderDecorator = <Provider extends ProviderId>(
+  provider: ProviderUnderTest<Provider>,
+) => ProviderUnderTest<Provider>;
+
+const composeDecorators = (
+  decorators: readonly ProviderDecorator[],
+): ProviderDecorator => {
+  throw new Error(`unimplemented: composeDecorators(${decorators.length})`);
+};
+
+const undecorated: ProviderDecorator = <Provider extends ProviderId>(
+  provider: ProviderUnderTest<Provider>,
+): ProviderUnderTest<Provider> => provider;
+
+export { composeDecorators, undecorated };
+export type { ProviderDecorator };

--- a/packages/sync-kit/conformance/src/fixtures/decorate.ts
+++ b/packages/sync-kit/conformance/src/fixtures/decorate.ts
@@ -59,11 +59,11 @@ const composeDecorators = (decorators: readonly ProviderDecorator[]): ProviderDe
   const composed = <Provider extends ProviderId>(
     provider: ProviderUnderTest<Provider>,
   ): ProviderUnderTest<Provider> => {
-    let decorated = provider;
+    const carried = { provider };
     for (const decorate of decorators) {
-      decorated = decorate(decorated);
+      carried.provider = decorate(carried.provider);
     }
-    return decorated;
+    return carried.provider;
   };
   return composed;
 };

--- a/packages/sync-kit/conformance/src/fixtures/decorate.ts
+++ b/packages/sync-kit/conformance/src/fixtures/decorate.ts
@@ -1,19 +1,76 @@
-import type { ProviderId } from "@keeper.sh/sync-protocol";
+import type {
+  ChangeListing,
+  ListChangesRequest,
+  OperationContext,
+  ProviderId,
+  Result,
+  WriteIntent,
+  WriteOutcome,
+} from "@keeper.sh/sync-protocol";
 import type { ProviderUnderTest } from "../options";
 
 type ProviderDecorator = <Provider extends ProviderId>(
   provider: ProviderUnderTest<Provider>,
 ) => ProviderUnderTest<Provider>;
 
-const composeDecorators = (
-  decorators: readonly ProviderDecorator[],
-): ProviderDecorator => {
-  throw new Error(`unimplemented: composeDecorators(${decorators.length})`);
+type ListingAnswer = (
+  request: ListChangesRequest,
+  context: OperationContext,
+  inner: () => Promise<Result<ChangeListing>>,
+) => Promise<Result<ChangeListing>>;
+
+type WriteAnswer<Provider extends ProviderId> = (
+  intent: WriteIntent<Provider>,
+  context: OperationContext,
+  inner: () => Promise<Result<WriteOutcome>>,
+) => Promise<Result<WriteOutcome>>;
+
+const withListChanges = <Provider extends ProviderId>(
+  provider: ProviderUnderTest<Provider>,
+  answer: ListingAnswer,
+): ProviderUnderTest<Provider> => ({
+  ...provider,
+  contract: {
+    ...provider.contract,
+    provider: {
+      ...provider.contract.provider,
+      listChanges: (request, context) =>
+        answer(request, context, () => provider.contract.provider.listChanges(request, context)),
+    },
+  },
+});
+
+const withWrite = <Provider extends ProviderId>(
+  provider: ProviderUnderTest<Provider>,
+  answer: WriteAnswer<Provider>,
+): ProviderUnderTest<Provider> => ({
+  ...provider,
+  contract: {
+    ...provider.contract,
+    provider: {
+      ...provider.contract.provider,
+      write: (intent, context) =>
+        answer(intent, context, () => provider.contract.provider.write(intent, context)),
+    },
+  },
+});
+
+const composeDecorators = (decorators: readonly ProviderDecorator[]): ProviderDecorator => {
+  const composed = <Provider extends ProviderId>(
+    provider: ProviderUnderTest<Provider>,
+  ): ProviderUnderTest<Provider> => {
+    let decorated = provider;
+    for (const decorate of decorators) {
+      decorated = decorate(decorated);
+    }
+    return decorated;
+  };
+  return composed;
 };
 
 const undecorated: ProviderDecorator = <Provider extends ProviderId>(
   provider: ProviderUnderTest<Provider>,
 ): ProviderUnderTest<Provider> => provider;
 
-export { composeDecorators, undecorated };
-export type { ProviderDecorator };
+export { composeDecorators, undecorated, withListChanges, withWrite };
+export type { ListingAnswer, ProviderDecorator, WriteAnswer };

--- a/packages/sync-kit/conformance/src/fixtures/expire-cursor.ts
+++ b/packages/sync-kit/conformance/src/fixtures/expire-cursor.ts
@@ -8,11 +8,11 @@ const expiringCursorAfter = (pages: number): ProviderDecorator => {
   const decorate = <Provider extends ProviderId>(
     provider: ProviderUnderTest<Provider>,
   ): ProviderUnderTest<Provider> => {
-    let drained = 0;
+    const walk = { drained: 0 };
     return withListChanges(provider, async (request, context, inner) => {
-      drained += 1;
+      walk.drained += 1;
       const answered = await inner();
-      if (drained <= pages || request.resume === null) {
+      if (walk.drained <= pages || request.resume === null) {
         return answered;
       }
       return { ok: true, value: cursorLostListing(request.scope) };

--- a/packages/sync-kit/conformance/src/fixtures/expire-cursor.ts
+++ b/packages/sync-kit/conformance/src/fixtures/expire-cursor.ts
@@ -1,7 +1,24 @@
+import type { ProviderId } from "@keeper.sh/sync-protocol";
+import type { ProviderUnderTest } from "../options";
+import { cursorLostListing } from "../reference/listing";
 import type { ProviderDecorator } from "./decorate";
+import { withListChanges } from "./decorate";
 
 const expiringCursorAfter = (pages: number): ProviderDecorator => {
-  throw new Error(`unimplemented: expiringCursorAfter(${pages})`);
+  const decorate = <Provider extends ProviderId>(
+    provider: ProviderUnderTest<Provider>,
+  ): ProviderUnderTest<Provider> => {
+    let drained = 0;
+    return withListChanges(provider, async (request, context, inner) => {
+      drained += 1;
+      const answered = await inner();
+      if (drained <= pages || request.resume === null) {
+        return answered;
+      }
+      return { ok: true, value: cursorLostListing(request.scope) };
+    });
+  };
+  return decorate;
 };
 
 export { expiringCursorAfter };

--- a/packages/sync-kit/conformance/src/fixtures/expire-cursor.ts
+++ b/packages/sync-kit/conformance/src/fixtures/expire-cursor.ts
@@ -1,0 +1,7 @@
+import type { ProviderDecorator } from "./decorate";
+
+const expiringCursorAfter = (pages: number): ProviderDecorator => {
+  throw new Error(`unimplemented: expiringCursorAfter(${pages})`);
+};
+
+export { expiringCursorAfter };

--- a/packages/sync-kit/conformance/src/fixtures/index.ts
+++ b/packages/sync-kit/conformance/src/fixtures/index.ts
@@ -1,0 +1,6 @@
+export { composeDecorators, undecorated } from "./decorate";
+export type { ProviderDecorator } from "./decorate";
+export { conflictingOn } from "./conflict";
+export { expiringCursorAfter } from "./expire-cursor";
+export { stallingOn } from "./stall";
+export { truncatingAfter } from "./truncate-page";

--- a/packages/sync-kit/conformance/src/fixtures/stall.ts
+++ b/packages/sync-kit/conformance/src/fixtures/stall.ts
@@ -1,8 +1,29 @@
-import type { OperationName } from "@keeper.sh/sync-protocol";
+import type { OperationName, ProviderId } from "@keeper.sh/sync-protocol";
+import { raceDeadline, standardAnswers } from "../deadline";
+import type { ProviderUnderTest } from "../options";
 import type { ProviderDecorator } from "./decorate";
+import { withListChanges, withWrite } from "./decorate";
+
+const neverAnswers = <Value>(): Promise<Value> => Promise.withResolvers<Value>().promise;
 
 const stallingOn = (matches: (operation: OperationName) => boolean): ProviderDecorator => {
-  throw new Error(`unimplemented: stallingOn(${typeof matches})`);
+  const decorate = <Provider extends ProviderId>(
+    provider: ProviderUnderTest<Provider>,
+  ): ProviderUnderTest<Provider> => {
+    const stallingListings = withListChanges(provider, (request, context, inner) => {
+      if (!matches("listChanges")) {
+        return inner();
+      }
+      return raceDeadline(context, standardAnswers, neverAnswers);
+    });
+    return withWrite(stallingListings, (intent, context, inner) => {
+      if (!matches("write")) {
+        return inner();
+      }
+      return raceDeadline(context, standardAnswers, neverAnswers);
+    });
+  };
+  return decorate;
 };
 
 export { stallingOn };

--- a/packages/sync-kit/conformance/src/fixtures/stall.ts
+++ b/packages/sync-kit/conformance/src/fixtures/stall.ts
@@ -1,0 +1,8 @@
+import type { OperationName } from "@keeper.sh/sync-protocol";
+import type { ProviderDecorator } from "./decorate";
+
+const stallingOn = (matches: (operation: OperationName) => boolean): ProviderDecorator => {
+  throw new Error(`unimplemented: stallingOn(${typeof matches})`);
+};
+
+export { stallingOn };

--- a/packages/sync-kit/conformance/src/fixtures/truncate-page.ts
+++ b/packages/sync-kit/conformance/src/fixtures/truncate-page.ts
@@ -1,0 +1,7 @@
+import type { ProviderDecorator } from "./decorate";
+
+const truncatingAfter = (events: number): ProviderDecorator => {
+  throw new Error(`unimplemented: truncatingAfter(${events})`);
+};
+
+export { truncatingAfter };

--- a/packages/sync-kit/conformance/src/fixtures/truncate-page.ts
+++ b/packages/sync-kit/conformance/src/fixtures/truncate-page.ts
@@ -1,7 +1,38 @@
+import type { ChangeListing, ProviderId, Result } from "@keeper.sh/sync-protocol";
+import type { ProviderUnderTest } from "../options";
 import type { ProviderDecorator } from "./decorate";
+import { withListChanges } from "./decorate";
+
+const truncated = (
+  listing: Extract<ChangeListing, { kind: "snapshot" }>,
+  events: number,
+): Result<ChangeListing> => ({
+  ok: true,
+  value: {
+    kind: "partial",
+    scope: listing.scope,
+    events: listing.events.slice(0, events),
+    withheld: listing.withheld,
+    continuation: { kind: "continuation", value: `truncated-${events}`, scope: listing.scope },
+    diagnostics: listing.diagnostics,
+  },
+});
 
 const truncatingAfter = (events: number): ProviderDecorator => {
-  throw new Error(`unimplemented: truncatingAfter(${events})`);
+  const decorate = <Provider extends ProviderId>(
+    provider: ProviderUnderTest<Provider>,
+  ): ProviderUnderTest<Provider> =>
+    withListChanges(provider, async (request, context, inner) => {
+      const answered = await inner();
+      if (request.resume !== null || !answered.ok) {
+        return answered;
+      }
+      if (answered.value.kind !== "snapshot" || answered.value.events.length <= events) {
+        return answered;
+      }
+      return truncated(answered.value, events);
+    });
+  return decorate;
 };
 
 export { truncatingAfter };

--- a/packages/sync-kit/conformance/src/index.ts
+++ b/packages/sync-kit/conformance/src/index.ts
@@ -1,0 +1,68 @@
+export { planConformanceRun, runConformance } from "./run-conformance";
+export type { ConformanceRunPlan, PlannedCase } from "./run-conformance";
+
+export { caseIdsCitedBy, conformanceCaseIds, ledgerEntryOf } from "./case-id";
+export type { ConformanceCaseId, LedgerEntryId } from "./case-id";
+
+export { ConformanceViolation } from "./violation";
+export type { ViolationDetail } from "./violation";
+
+export { ungatedCaseIds } from "./report";
+export type { ConformanceReport, SelectedCase, SkippedCase } from "./report";
+
+export type {
+  ConformanceEnvironment,
+  CreateProvider,
+  ProviderInspection,
+  ProviderSeed,
+  ProviderUnderTest,
+  RunConformanceOptions,
+  TestClock,
+  TransportBehaviour,
+  TransportStub,
+  WriteLogEntry,
+} from "./options";
+
+export { createTestClock } from "./clock";
+export type { TestClockOptions } from "./clock";
+
+export { createConformanceEnvironment } from "./environment";
+export type { EnvironmentOptions } from "./environment";
+
+export { conformanceLimits } from "./limits";
+export type { ConformanceLimits } from "./limits";
+
+export { canonicalise, sortedKeys } from "./canonical";
+export type { CanonicalValue } from "./canonical";
+
+export { conformanceCaseOf, selectConformanceCases } from "./registry/suite";
+export type { CaseSelection } from "./registry/suite";
+export type { CaseContext, CaseFamily, CaseGate, ConformanceCase } from "./registry/case";
+
+export { assertNoRemovalDerivable, derivableRemovals } from "./assertions/no-removal";
+export type { RemovalBasis } from "./assertions/no-removal";
+export {
+  assertCoverageProven,
+  assertCursorWithheld,
+  assertNoContentInDiagnostics,
+  assertNotSnapshotUnderTruncation,
+} from "./assertions/listing";
+export {
+  assertConflictNotOverwrite,
+  assertNoDeleteThenCreate,
+  assertNoUnconditionalWrite,
+} from "./assertions/outcome";
+
+export { createReferenceProvider, referenceCalendar } from "./reference/provider";
+export { createMutantReferenceProvider } from "./reference/mutants";
+export { referenceCapabilities } from "./reference/capabilities";
+
+export {
+  composeDecorators,
+  conflictingOn,
+  expiringCursorAfter,
+  stallingOn,
+  truncatingAfter,
+  undecorated,
+} from "./fixtures";
+export type { ProviderDecorator } from "./fixtures";

--- a/packages/sync-kit/conformance/src/index.ts
+++ b/packages/sync-kit/conformance/src/index.ts
@@ -1,4 +1,4 @@
-export { planConformanceRun, runConformance } from "./run-conformance";
+export { conformanceHash, planConformanceRun, runConformance } from "./run-conformance";
 export type { ConformanceRunPlan, PlannedCase } from "./run-conformance";
 
 export { caseIdsCitedBy, conformanceCaseIds, ledgerEntryOf } from "./case-id";
@@ -8,7 +8,7 @@ export { ConformanceViolation } from "./violation";
 export type { ViolationDetail } from "./violation";
 
 export { ungatedCaseIds } from "./report";
-export type { ConformanceReport, SelectedCase, SkippedCase } from "./report";
+export type { ConformanceReport, SelectedCase } from "./report";
 
 export type {
   ConformanceEnvironment,
@@ -17,6 +17,7 @@ export type {
   ProviderSeed,
   ProviderUnderTest,
   RunConformanceOptions,
+  SuiteRunner,
   TestClock,
   TransportBehaviour,
   TransportStub,
@@ -40,7 +41,7 @@ export type { CaseSelection } from "./registry/suite";
 export type { CaseContext, CaseFamily, CaseGate, ConformanceCase } from "./registry/case";
 
 export { assertNoRemovalDerivable, derivableRemovals } from "./assertions/no-removal";
-export type { RemovalBasis } from "./assertions/no-removal";
+export type { KnownIdentity, KnownMirror, RemovalBasis } from "./assertions/no-removal";
 export {
   assertCoverageProven,
   assertCursorWithheld,
@@ -49,13 +50,13 @@ export {
 } from "./assertions/listing";
 export {
   assertConflictNotOverwrite,
-  assertNoDeleteThenCreate,
+  assertNoUnplannedRecreation,
   assertNoUnconditionalWrite,
 } from "./assertions/outcome";
 
 export { createReferenceProvider, referenceCalendar } from "./reference/provider";
 export { createMutantReferenceProvider } from "./reference/mutants";
-export { referenceCapabilities } from "./reference/capabilities";
+export { referenceCapabilities, referenceMinimumSpanSeconds } from "./reference/capabilities";
 
 export {
   composeDecorators,

--- a/packages/sync-kit/conformance/src/limits.ts
+++ b/packages/sync-kit/conformance/src/limits.ts
@@ -4,6 +4,7 @@ const conformanceLimits = {
   diagnosticSampleEntries: 20,
   diagnosticSampleUtf16Length: 2048,
   deadlineMs: 30_000,
+  stallDeadlineMs: 50,
 } as const;
 
 type ConformanceLimits = typeof conformanceLimits;

--- a/packages/sync-kit/conformance/src/limits.ts
+++ b/packages/sync-kit/conformance/src/limits.ts
@@ -1,0 +1,12 @@
+const conformanceLimits = {
+  concurrency: 4,
+  fanOutTasks: 9,
+  diagnosticSampleEntries: 20,
+  diagnosticSampleUtf16Length: 2048,
+  deadlineMs: 30_000,
+} as const;
+
+type ConformanceLimits = typeof conformanceLimits;
+
+export { conformanceLimits };
+export type { ConformanceLimits };

--- a/packages/sync-kit/conformance/src/options.ts
+++ b/packages/sync-kit/conformance/src/options.ts
@@ -1,5 +1,6 @@
 import type {
   Capabilities,
+  EventUid,
   Instant,
   InstallationId,
   OperationName,
@@ -7,6 +8,7 @@ import type {
   ProviderFailure,
   ProviderId,
   RemoteEvent,
+  RemoteEventId,
   WindowMembership,
   WriteIntent,
   WriteOutcome,
@@ -24,6 +26,12 @@ type TransportBehaviour =
   | { readonly kind: "pass" }
   | { readonly kind: "stall" }
   | { readonly kind: "reject"; readonly failure: ProviderFailure; readonly times: number }
+  | {
+      readonly kind: "status";
+      readonly status: number;
+      readonly retryAfter: Instant | null;
+      readonly times: number;
+    }
   | { readonly kind: "throw"; readonly times: number };
 
 interface TransportStub {
@@ -37,6 +45,7 @@ interface TransportStub {
 
 interface ConformanceEnvironment {
   readonly clock: TestClock;
+  readonly concurrency: number;
   readonly hash: (input: string) => string;
   readonly installation: InstallationId;
   readonly transport: TransportStub;
@@ -56,6 +65,8 @@ interface ProviderInspection {
 interface ProviderSeed {
   readonly events: readonly RemoteEvent[];
   readonly corruptKnownRows: readonly string[];
+  readonly cancelled: readonly EventUid[];
+  readonly unattributableRemovals: readonly RemoteEventId[];
 }
 
 interface ProviderUnderTest<Provider extends ProviderId = ProviderId> {
@@ -74,10 +85,17 @@ interface RunConformanceOptions<Provider extends ProviderId = ProviderId> {
   readonly supports: Capabilities<Provider>;
   readonly create: CreateProvider<Provider>;
   readonly withinWindow: WindowMembership;
+  readonly hash?: (input: string) => string;
+}
+
+interface SuiteRunner {
+  readonly describe: (name: string, body: () => void) => void;
+  readonly it: (name: string, body: () => Promise<void>) => void;
 }
 
 export type {
   ConformanceEnvironment,
+  SuiteRunner,
   CreateProvider,
   ProviderInspection,
   ProviderSeed,

--- a/packages/sync-kit/conformance/src/options.ts
+++ b/packages/sync-kit/conformance/src/options.ts
@@ -1,0 +1,90 @@
+import type {
+  Capabilities,
+  Instant,
+  InstallationId,
+  OperationName,
+  ProviderContract,
+  ProviderFailure,
+  ProviderId,
+  RemoteEvent,
+  WindowMembership,
+  WriteIntent,
+  WriteOutcome,
+} from "@keeper.sh/sync-protocol";
+
+interface TestClock {
+  readonly now: () => Instant;
+  readonly sleep: (milliseconds: number, signal: AbortSignal) => Promise<void>;
+  readonly advance: (milliseconds: number) => Promise<void>;
+  readonly nowCount: () => number;
+  readonly pendingTimers: () => number;
+}
+
+type TransportBehaviour =
+  | { readonly kind: "pass" }
+  | { readonly kind: "stall" }
+  | { readonly kind: "reject"; readonly failure: ProviderFailure; readonly times: number }
+  | { readonly kind: "throw"; readonly times: number };
+
+interface TransportStub {
+  readonly run: <Value>(operation: OperationName, execute: () => Promise<Value>) => Promise<Value>;
+  readonly callCount: () => number;
+  readonly inFlightPeak: () => number;
+  readonly stall: () => void;
+  readonly resume: () => void;
+  readonly answerWith: (behaviour: TransportBehaviour) => void;
+}
+
+interface ConformanceEnvironment {
+  readonly clock: TestClock;
+  readonly hash: (input: string) => string;
+  readonly installation: InstallationId;
+  readonly transport: TransportStub;
+}
+
+interface WriteLogEntry {
+  readonly at: Instant;
+  readonly intent: WriteIntent;
+  readonly outcome: WriteOutcome;
+}
+
+interface ProviderInspection {
+  readonly objects: readonly RemoteEvent[];
+  readonly writeLog: readonly WriteLogEntry[];
+}
+
+interface ProviderSeed {
+  readonly events: readonly RemoteEvent[];
+  readonly corruptKnownRows: readonly string[];
+}
+
+interface ProviderUnderTest<Provider extends ProviderId = ProviderId> {
+  readonly contract: ProviderContract<Provider>;
+  readonly seed: (seed: ProviderSeed) => Promise<void>;
+  readonly inspect: () => Promise<ProviderInspection>;
+  readonly dispose: () => Promise<void>;
+}
+
+type CreateProvider<Provider extends ProviderId = ProviderId> = (
+  environment: ConformanceEnvironment,
+) => Promise<ProviderUnderTest<Provider>>;
+
+interface RunConformanceOptions<Provider extends ProviderId = ProviderId> {
+  readonly name: string;
+  readonly supports: Capabilities<Provider>;
+  readonly create: CreateProvider<Provider>;
+  readonly withinWindow: WindowMembership;
+}
+
+export type {
+  ConformanceEnvironment,
+  CreateProvider,
+  ProviderInspection,
+  ProviderSeed,
+  ProviderUnderTest,
+  RunConformanceOptions,
+  TestClock,
+  TransportBehaviour,
+  TransportStub,
+  WriteLogEntry,
+};

--- a/packages/sync-kit/conformance/src/reference/build.ts
+++ b/packages/sync-kit/conformance/src/reference/build.ts
@@ -134,6 +134,8 @@ const truncatedAsPartial = (
   diagnostics,
 });
 
+const RESUMED_TAIL_FROM = 1;
+
 const noop = (): null => null;
 
 const holds = (held: boolean, complaint: string): Promise<void> => {
@@ -460,7 +462,11 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     return coverageOver(scope);
   };
 
-  const snapshotListing = (scope: ListingScope, at: Instant): ChangeListing => {
+  const snapshotListing = (
+    scope: ListingScope,
+    at: Instant,
+    resuming = false,
+  ): ChangeListing => {
     const coverage = provenCoverageOf(scope);
     if (!admitsAnything(coverage.covered)) {
       return emptySnapshot(scope, null);
@@ -471,7 +477,7 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     store.setReported(present);
     recordSpuriousWrite();
     const diagnostics = diagnosticsFor(feed);
-    if (defectIs(defect, "CONF-O41") && markedIn("CONF-O41").length > 0) {
+    if (!resuming && defectIs(defect, "CONF-O41") && markedIn("CONF-O41").length > 0) {
       return truncatedAsPartial(scope, feed, diagnostics);
     }
     return {
@@ -535,7 +541,20 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     at: Instant,
   ): Result<ChangeListing> => {
     if (resume.kind === "continuation") {
-      return { ok: true, value: snapshotListing(scope, at) };
+      const whole = snapshotListing(scope, at, true);
+      /*
+       * The defect this models is the one a real adapter reaches for: resume where the walk
+       * left off and report the tail as though it covered the whole window. The pages
+       * already handed back become derivable deletions of events that are plainly present,
+       * while every earlier assertion in the case still passes.
+       */
+      if (defectIs(defect, "CONF-O41") && whole.kind === "snapshot") {
+        return {
+          ok: true,
+          value: { ...whole, events: whole.events.slice(RESUMED_TAIL_FROM) },
+        };
+      }
+      return { ok: true, value: whole };
     }
     const verdict = mint.verify(resume, scope);
     switch (verdict.kind) {

--- a/packages/sync-kit/conformance/src/reference/build.ts
+++ b/packages/sync-kit/conformance/src/reference/build.ts
@@ -1,0 +1,1056 @@
+import type {
+  AccountId,
+  CalendarEnumeration,
+  ChangeListing,
+  Continuation,
+  CoverageWindow,
+  EchoVerdict,
+  EditableContent,
+  EventUid,
+  Instant,
+  ListChangesRequest,
+  ListingDiagnostics,
+  ListingScope,
+  NormalizedContent,
+  OperationContext,
+  ProviderFailure,
+  RemoteEvent,
+  RemoteRef,
+  Removal,
+  Result,
+  SyncCursor,
+  WithheldEvent,
+  WriteIntent,
+  WriteOutcome,
+} from "@keeper.sh/sync-protocol";
+import { assertNever } from "@keeper.sh/sync-protocol";
+import type { ConformanceCaseId } from "../case-id";
+import type { KeyOrder } from "../canonical";
+import { canonicalise, insertionOrderKeys, sortedKeys } from "../canonical";
+import type { DeadlineAnswers } from "../deadline";
+import { raceDeadline, standardAnswers } from "../deadline";
+import { conformanceLimits } from "../limits";
+import type { ConformanceEnvironment, ProviderSeed, ProviderUnderTest } from "../options";
+import { createSingleFlight } from "../single-flight";
+import { failureOfTransportError } from "../transport";
+import { referenceCalendar } from "./calendar";
+import { referenceCapabilities } from "./capabilities";
+import { createCursorMint, scopeKeyOf } from "./cursor";
+import type { Defect } from "./defect";
+import { defectIs, isMarked } from "./defect";
+import { encodeIdentity, fingerprintWith, referenceFingerprintContract } from "./fingerprint";
+import type { ResolvedFeed } from "./listing";
+import {
+  admitsAnything,
+  coverageOver,
+  cursorLostListing,
+  diagnosticsOf,
+  emptySnapshot,
+  identitiesOf,
+  removalsAgainst,
+  resolveFeed,
+} from "./listing";
+import { constraintViolatedBy, rewriteAsProviderWould } from "./normalize";
+import type { ReportedIdentity } from "./store";
+import { createReferenceStore } from "./store";
+
+interface ReferenceOptions {
+  readonly environment: ConformanceEnvironment;
+  readonly defect: Defect;
+}
+
+const remoteRefFor = (uid: string): RemoteRef => ({
+  id: { kind: "remoteEventId", value: `id-${uid}` },
+  deleteHandle: { kind: "deleteHandle", value: `handle-${uid}` },
+});
+
+const versionFor = (uid: string, revision: number): string => `v${revision}-${uid}`;
+
+const isRetryable = (failure: ProviderFailure): boolean => failure.kind === "rateLimited";
+
+const retryDelayFor = (failure: ProviderFailure, context: OperationContext): number => {
+  const ceiling = context.retryBudget.retryDelayCeilingMs;
+  if (failure.kind !== "rateLimited" || failure.retryAfter === null) {
+    return ceiling;
+  }
+  const asked = Date.parse(failure.retryAfter.value) - Date.parse(context.now().value);
+  return Math.max(0, Math.min(ceiling, asked));
+};
+
+const aborted: ProviderFailure = { kind: "notAttempted", reason: "aborted" };
+const exhausted: ProviderFailure = { kind: "notAttempted", reason: "budgetExhausted" };
+
+const withheldExcept = (
+  withheld: readonly WithheldEvent[],
+  excluded: (entry: WithheldEvent) => boolean,
+): readonly WithheldEvent[] => withheld.filter((entry) => !excluded(entry));
+
+const unnamedRemoval = (): Removal => ({
+  kind: "outOfScope",
+  id: { kind: "remoteEventId", value: "id-unnamed" },
+});
+
+const truncatedAsPartial = (
+  scope: ListingScope,
+  feed: ResolvedFeed,
+  diagnostics: ListingDiagnostics,
+): ChangeListing => ({
+  kind: "partial",
+  scope,
+  events: feed.events,
+  withheld: feed.withheld,
+  continuation: { kind: "continuation", value: "defective", scope },
+  diagnostics,
+});
+
+const noop = (): null => null;
+
+const answeredWith = <Value>(value: Value): Promise<Value> => Promise.resolve(value);
+
+const staleConflict = (existing: RemoteEvent): Result<WriteOutcome> => ({
+  ok: false,
+  failure: {
+    kind: "conflict",
+    observed: { kind: "matchesVersion", version: existing.version },
+  },
+});
+
+const createReference = (options: ReferenceOptions): ProviderUnderTest<"reference"> => {
+  const { environment, defect } = options;
+  const store = createReferenceStore(referenceCalendar);
+  const mint = createCursorMint(environment.hash);
+  const flights = createSingleFlight<Result<ChangeListing>>({
+    retain: (settled) =>
+      defectIs(defect, "CONF-L7") &&
+      !settled.ok &&
+      settled.failure.kind === "transport" &&
+      settled.failure.status === null,
+  });
+  const lifetime = new AbortController();
+  const poisoned = new Set<string>();
+  let deltaFloor = 0;
+  let carriedPages = 0;
+  let leakedPermits = 0;
+  let callersInFlight = 0;
+  let abortsInBurst = 0;
+
+  const observedAt = (): Instant => {
+    if (defectIs(defect, "CONF-L13")) {
+      return { kind: "instant", value: "1970-01-01T00:00:00.000Z" };
+    }
+    return environment.clock.now();
+  };
+
+  const indeterminate = (event: RemoteEvent): RemoteEvent => {
+    if (!isMarked(event.uid.value, "CONF-O16")) {
+      return event;
+    }
+    return {
+      id: event.id,
+      deleteHandle: event.deleteHandle,
+      uid: event.uid,
+      calendar: event.calendar,
+      revision: event.revision,
+      version: event.version,
+      content: event.content,
+      fingerprint: event.fingerprint,
+      provenance: { kind: "indeterminate" },
+    };
+  };
+
+  const phantom = (): RemoteEvent => ({
+    ...remoteRefFor("CONF-O3:ghost"),
+    uid: { kind: "eventUid", value: "CONF-O3:ghost" },
+    calendar: referenceCalendar,
+    revision: 1,
+    version: { kind: "remoteVersion", value: "v1-phantom" },
+    content: {
+      title: "Phantom",
+      description: null,
+      location: null,
+      availability: "busy",
+      visibility: "default",
+      recurrence: null,
+      time: {
+        kind: "timed",
+        start: { kind: "instant", value: "2026-03-15T09:00:00.000Z" },
+        end: { kind: "instant", value: "2026-03-15T10:00:00.000Z" },
+        zone: null,
+      },
+    },
+    fingerprint: { kind: "fingerprint", value: "phantom" },
+    provenance: { kind: "foreign" },
+  });
+
+  const markedIn = (id: ConformanceCaseId): readonly RemoteEvent[] =>
+    store.objects().filter((event) => isMarked(event.uid.value, id));
+
+  const unmarkedFeed = (id: ConformanceCaseId): ResolvedFeed =>
+    resolveFeed(store.objects().filter((event) => !isMarked(event.uid.value, id)));
+
+  const resolvedFeed = (): ResolvedFeed => {
+    if (defectIs(defect, "CONF-O22")) {
+      const resolved = resolveFeed(store.objects());
+      return {
+        events: [...resolved.events, ...markedIn("CONF-O22")],
+        withheld: resolved.withheld,
+      };
+    }
+    if (defectIs(defect, "CONF-O8")) {
+      const rest = unmarkedFeed("CONF-O8");
+      const last = markedIn("CONF-O8").at(-1);
+      if (!last) {
+        return rest;
+      }
+      return { events: [...rest.events, last], withheld: rest.withheld };
+    }
+    if (defectIs(defect, "CONF-O7")) {
+      const rest = unmarkedFeed("CONF-O7");
+      const oldest = markedIn("CONF-O7").filter((event) => event.revision === 1);
+      return { events: [...rest.events, ...oldest], withheld: rest.withheld };
+    }
+    return resolveFeed(store.objects());
+  };
+
+  const defectiveFeed = (feed: ResolvedFeed): ResolvedFeed => {
+    if (defectIs(defect, "CONF-O1")) {
+      const marked = feed.events.filter((event) => isMarked(event.uid.value, "CONF-O1"));
+      const kept = feed.events.filter((event) => !isMarked(event.uid.value, "CONF-O1"));
+      return { events: [...kept, ...marked.slice(0, 1)], withheld: feed.withheld };
+    }
+    if (defectIs(defect, "CONF-O3") && markedIn("CONF-O3").length > 0) {
+      return { events: [...feed.events, phantom()], withheld: feed.withheld };
+    }
+    if (defectIs(defect, "CONF-O5")) {
+      return {
+        events: feed.events,
+        withheld: withheldExcept(feed.withheld, (entry) =>
+          isMarked(entry.uid?.value ?? "", "CONF-O5"),
+        ),
+      };
+    }
+    if (defectIs(defect, "CONF-O16")) {
+      return { events: feed.events.map(indeterminate), withheld: feed.withheld };
+    }
+    if (defectIs(defect, "CONF-O26")) {
+      return {
+        events: feed.events.filter((event) => !isMarked(event.uid.value, "CONF-O26")),
+        withheld: feed.withheld,
+      };
+    }
+    if (defectIs(defect, "CONF-O27")) {
+      return {
+        events: feed.events.filter((event) => !event.uid.value.endsWith(":lower")),
+        withheld: feed.withheld,
+      };
+    }
+    if (defectIs(defect, "CONF-O28")) {
+      const degenerate = feed.events.filter((event) => isMarked(event.uid.value, "CONF-O28"));
+      return {
+        events: feed.events.filter((event) => !isMarked(event.uid.value, "CONF-O28")),
+        withheld: [
+          ...feed.withheld,
+          ...degenerate.map((event) => ({
+            uid: event.uid,
+            id: event.id,
+            reason: "unrepresentableTime" as const,
+          })),
+        ],
+      };
+    }
+    if (defectIs(defect, "CONF-O32")) {
+      return {
+        events: feed.events,
+        withheld: withheldExcept(feed.withheld, (entry) => entry.uid === null),
+      };
+    }
+    return feed;
+  };
+
+  const evictedMirror = (feed: ResolvedFeed): ResolvedFeed => {
+    if (!defectIs(defect, "CONF-O33") || feed.withheld.length === 0) {
+      return feed;
+    }
+    store.replaceObjects(
+      store.objects().filter((event) => !event.uid.value.endsWith(":mirror")),
+    );
+    return defectiveFeed(resolvedFeed());
+  };
+
+  const feedNow = (): ResolvedFeed => evictedMirror(defectiveFeed(resolvedFeed()));
+
+  const titleBehind = (id: string): string => {
+    const found = store.objects().find((event) => event.id.value === id);
+    if (!found) {
+      return id;
+    }
+    return found.content.title;
+  };
+
+  const diagnosticsFor = (feed: ResolvedFeed): ListingDiagnostics => {
+    const honest = diagnosticsOf(feed, environment.installation);
+    if (defectIs(defect, "CONF-O19")) {
+      return {
+        ...honest,
+        withheld: {
+          sample: feed.withheld
+            .filter((entry) => isMarked(entry.uid?.value ?? "", "CONF-O19"))
+            .map((entry) => titleBehind(entry.id?.value ?? ""))
+            .toSpliced(-0, 0, ...honest.withheld.sample),
+          total: honest.withheld.total,
+        },
+      };
+    }
+    if (defectIs(defect, "CONF-O30")) {
+      return {
+        ...honest,
+        unrepresentable: {
+          sample: [...honest.unrepresentable.sample, ...honest.selfAuthored.sample],
+          total: honest.unrepresentable.total + honest.selfAuthored.total,
+        },
+      };
+    }
+    if (defectIs(defect, "CONF-O31")) {
+      return {
+        ...honest,
+        withheld: {
+          sample: feed.withheld.map((entry) => entry.uid?.value ?? entry.id?.value ?? ""),
+          total: honest.withheld.total,
+        },
+      };
+    }
+    if (defectIs(defect, "CONF-O42")) {
+      return { ...honest, pagesFetched: honest.pagesFetched + carriedPages };
+    }
+    return honest;
+  };
+
+  const anonymised = (removal: Removal): Removal => {
+    if (removal.kind === "outOfScope") {
+      return removal;
+    }
+    const blanked: EventUid = { kind: "eventUid", value: "" };
+    return { ...removal, uid: blanked };
+  };
+
+  const marksCase = (removal: Removal, id: ConformanceCaseId): boolean => {
+    if (removal.kind === "outOfScope") {
+      return false;
+    }
+    return isMarked(removal.uid.value, id);
+  };
+
+  const removalsFor = (present: readonly ReportedIdentity[]): readonly Removal[] => {
+    const honest = removalsAgainst(store.reported(), present);
+    if (defectIs(defect, "CONF-O13")) {
+      return honest.map((removal) => {
+        if (!marksCase(removal, "CONF-O13")) {
+          return removal;
+        }
+        return anonymised(removal);
+      });
+    }
+    if (defectIs(defect, "CONF-O34") && honest.some((removal) => marksCase(removal, "CONF-O34"))) {
+      return [...honest, unnamedRemoval()];
+    }
+    return honest;
+  };
+
+  const recordSpuriousWrite = (): void => {
+    if (!defectIs(defect, "CONF-O9") || markedIn("CONF-O9").length === 0) {
+      return;
+    }
+    store.record({
+      at: observedAt(),
+      intent: {
+        kind: "retire",
+        calendar: { key: referenceCalendar, access: "readWrite" },
+        target: { kind: "deleteHandle", value: "handle-spurious" },
+        precondition: { kind: "matchesVersion", version: { kind: "remoteVersion", value: "v1" } },
+        reason: "outsideWindow",
+      },
+      outcome: { kind: "deleted", remote: remoteRefFor("spurious") },
+    });
+  };
+
+  const provenCoverageOf = (scope: ListingScope): CoverageWindow => {
+    if (defectIs(defect, "CONF-O4")) {
+      return { covered: scope.window, calendar: scope.calendar };
+    }
+    return coverageOver(scope);
+  };
+
+  const snapshotListing = (scope: ListingScope, at: Instant): ChangeListing => {
+    const coverage = provenCoverageOf(scope);
+    if (!admitsAnything(coverage.covered)) {
+      return emptySnapshot(scope, null);
+    }
+    const feed = feedNow();
+    const present = identitiesOf(feed);
+    const removals = removalsFor(present);
+    store.setReported(present);
+    recordSpuriousWrite();
+    const diagnostics = diagnosticsFor(feed);
+    if (defectIs(defect, "CONF-O41") && markedIn("CONF-O41").length > 0) {
+      return truncatedAsPartial(scope, feed, diagnostics);
+    }
+    return {
+      kind: "snapshot",
+      scope,
+      coverage,
+      events: feed.events,
+      removals,
+      withheld: feed.withheld,
+      cursor: mint.mint(scope, store.currentSequence(), at),
+      diagnostics,
+    };
+  };
+
+  const blanked = (event: RemoteEvent): RemoteEvent => {
+    if (!defectIs(defect, "CONF-O38") || event.content.recurrence !== null) {
+      return event;
+    }
+    return { ...event, content: { ...event.content, description: null, location: null } };
+  };
+
+  const advancedCursor = (
+    scope: ListingScope,
+    at: Instant,
+    resumed: SyncCursor | null,
+  ): SyncCursor => {
+    if (defectIs(defect, "CONF-O37") && resumed !== null) {
+      return resumed;
+    }
+    return mint.mint(scope, store.currentSequence(), at);
+  };
+
+  const deltaListing = (
+    scope: ListingScope,
+    since: number,
+    at: Instant,
+    resumed: SyncCursor | null,
+  ): ChangeListing => {
+    const feed = feedNow();
+    const floor = Math.max(since, deltaFloor);
+    const present = identitiesOf(feed);
+    const removals = removalsFor(present);
+    store.setReported(present);
+    return {
+      kind: "delta",
+      scope,
+      coverage: coverageOver(scope),
+      events: feed.events
+        .filter((event) => store.sequenceOf(event.uid.value) > floor)
+        .map((event) => blanked(event)),
+      removals,
+      withheld: feed.withheld,
+      cursor: advancedCursor(scope, at, resumed),
+      diagnostics: diagnosticsFor(feed),
+    };
+  };
+
+  const resumedListing = (
+    resume: SyncCursor | Continuation,
+    scope: ListingScope,
+    at: Instant,
+  ): Result<ChangeListing> => {
+    if (resume.kind === "continuation") {
+      return { ok: true, value: snapshotListing(scope, at) };
+    }
+    const verdict = mint.verify(resume, scope);
+    switch (verdict.kind) {
+      case "current": {
+        return { ok: true, value: deltaListing(scope, verdict.sequence, at, resume) };
+      }
+      case "superseded": {
+        if (defectIs(defect, "CONF-O10")) {
+          return { ok: true, value: snapshotListing(scope, at) };
+        }
+        return { ok: true, value: cursorLostListing(scope) };
+      }
+      case "foreignScope": {
+        if (defectIs(defect, "CONF-O11")) {
+          return { ok: true, value: deltaListing(scope, 0, at, resume) };
+        }
+        return { ok: true, value: cursorLostListing(scope) };
+      }
+      case "unknown": {
+        if (defectIs(defect, "CONF-O40")) {
+          throw new Error("the reference mutant cannot read the cursor it was handed");
+        }
+        return { ok: true, value: cursorLostListing(scope) };
+      }
+      default: {
+        return assertNever(verdict);
+      }
+    }
+  };
+
+  const corruptAnswer = (scope: ListingScope, at: Instant): Result<ChangeListing> => {
+    if (defectIs(defect, "CONF-O12")) {
+      return { ok: true, value: snapshotListing(scope, at) };
+    }
+    return { ok: true, value: cursorLostListing(scope) };
+  };
+
+  const isUnusable = (event: RemoteEvent): boolean =>
+    constraintViolatedBy(event.content) !== null;
+
+  const contentProvokedFailure = (): ProviderFailure | null => {
+    if (defectIs(defect, "CONF-O23")) {
+      const provoking = store
+        .objects()
+        .some((event) => event.content.title.toLowerCase().includes("rate limit"));
+      if (provoking) {
+        return { kind: "rateLimited", retryAfter: null, scope: "perUser" };
+      }
+    }
+    if (defectIs(defect, "CONF-O6") && markedIn("CONF-O6").some((event) => isUnusable(event))) {
+      return { kind: "transport", status: 500, disposition: "permanent" };
+    }
+    return null;
+  };
+
+  const buildListing = (request: ListChangesRequest): Result<ChangeListing> => {
+    const at = observedAt();
+    const provoked = contentProvokedFailure();
+    if (provoked !== null) {
+      return { ok: false, failure: provoked };
+    }
+    if (store.corruptKnownRows().length > 0) {
+      return corruptAnswer(request.scope, at);
+    }
+    if (request.resume === null) {
+      return { ok: true, value: snapshotListing(request.scope, at) };
+    }
+    return resumedListing(request.resume, request.scope, at);
+  };
+
+  const attemptListing = async (request: ListChangesRequest): Promise<Result<ChangeListing>> => {
+    try {
+      return await environment.transport.run("listChanges", () =>
+        Promise.resolve(buildListing(request)),
+      );
+    } catch (error) {
+      const failure = failureOfTransportError(error);
+      if (defectIs(defect, "CONF-O2") && failure.kind === "transport" && failure.status === 503) {
+        return { ok: true, value: emptySnapshot(request.scope, null) };
+      }
+      return { ok: false, failure };
+    }
+  };
+
+  const sleptBetweenAttempts = async (milliseconds: number): Promise<boolean> => {
+    try {
+      await environment.clock.sleep(milliseconds, lifetime.signal);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const attemptCeiling = (context: OperationContext): number => {
+    if (defectIs(defect, "CONF-L1")) {
+      return context.retryBudget.maxAttempts + 1;
+    }
+    return context.retryBudget.maxAttempts;
+  };
+
+  const leadListing = async (
+    key: string,
+    request: ListChangesRequest,
+    context: OperationContext,
+  ): Promise<Result<ChangeListing>> => {
+    const ceiling = attemptCeiling(context);
+    for (let attempt = 1; attempt <= ceiling; attempt += 1) {
+      const answered = await attemptListing(request);
+      if (poisoned.has(key)) {
+        poisoned.delete(key);
+        return { ok: false, failure: aborted };
+      }
+      if (answered.ok || !isRetryable(answered.failure) || attempt === ceiling) {
+        return answered;
+      }
+      const slept = await sleptBetweenAttempts(retryDelayFor(answered.failure, context));
+      if (!slept) {
+        return { ok: false, failure: aborted };
+      }
+    }
+    return { ok: false, failure: exhausted };
+  };
+
+  const flightKeyOf = (request: ListChangesRequest): string => {
+    if (defectIs(defect, "CONF-L6")) {
+      return request.scope.calendar.calendar.value;
+    }
+    return canonicalise({
+      scope: scopeKeyOf(request.scope),
+      resume: request.resume?.value ?? "",
+    });
+  };
+
+  const cloned = (answered: Result<ChangeListing>): Result<ChangeListing> => {
+    if (defectIs(defect, "CONF-L5")) {
+      return answered;
+    }
+    return structuredClone(answered);
+  };
+
+  const deadlineAnswers = (): DeadlineAnswers => {
+    if (defectIs(defect, "CONF-L2")) {
+      return { onDeadline: aborted, onAbort: aborted };
+    }
+    if (defectIs(defect, "CONF-L3")) {
+      return { onDeadline: exhausted, onAbort: exhausted };
+    }
+    return standardAnswers;
+  };
+
+  const reattemptedAlone = (
+    request: ListChangesRequest,
+    answered: Result<ChangeListing>,
+  ): Promise<Result<ChangeListing>> => {
+    if (answered.ok || !defectIs(defect, "CONF-L4") || answered.failure.kind !== "transport") {
+      return Promise.resolve(answered);
+    }
+    return attemptListing(request);
+  };
+
+  const rememberFailure = (answered: Result<ChangeListing>): Result<ChangeListing> => {
+    if (answered.ok) {
+      return answered;
+    }
+    if (defectIs(defect, "CONF-O24")) {
+      deltaFloor = store.currentSequence();
+    }
+    if (defectIs(defect, "CONF-O42")) {
+      carriedPages += 1;
+    }
+    return answered;
+  };
+
+  const noteAbortedCaller = (key: string, context: OperationContext): void => {
+    if (!context.signal.aborted) {
+      return;
+    }
+    if (defectIs(defect, "CONF-L9") && callersInFlight === 3) {
+      poisoned.add(key);
+    }
+    if (defectIs(defect, "CONF-L10") && callersInFlight > conformanceLimits.concurrency) {
+      leakedPermits += 1;
+    }
+  };
+
+  const listChanges = async (
+    request: ListChangesRequest,
+    context: OperationContext,
+  ): Promise<Result<ChangeListing>> => {
+    callersInFlight += 1;
+    if (callersInFlight === 1) {
+      abortsInBurst = 0;
+    }
+    if (context.signal.aborted) {
+      abortsInBurst += 1;
+    }
+    const key = flightKeyOf(request);
+    try {
+      noteAbortedCaller(key, context);
+      if (leakedPermits > 0 && !context.signal.aborted) {
+        leakedPermits -= 1;
+        return { ok: false, failure: exhausted };
+      }
+      if (defectIs(defect, "CONF-L11") && callersInFlight > conformanceLimits.concurrency) {
+        await Promise.resolve();
+        if (abortsInBurst === 0) {
+          throw new Error("the reference mutant dropped a task out of its fan-out");
+        }
+      }
+      if (defectIs(defect, "CONF-L12") && context.signal.aborted) {
+        environment.transport.run("listChanges", () => answeredWith(null)).catch(noop);
+      }
+      const answered = await raceDeadline(context, deadlineAnswers(), () =>
+        flights.run(key, () => leadListing(key, request, context)),
+      );
+      return cloned(rememberFailure(await reattemptedAlone(request, answered)));
+    } finally {
+      callersInFlight -= 1;
+    }
+  };
+
+  const normalized = (content: EditableContent): NormalizedContent<"reference"> => {
+    if (defectIs(defect, "CONF-O20")) {
+      return {
+        kind: "normalized",
+        provider: "reference",
+        content: rewriteAsProviderWould(content),
+        fingerprint: fingerprintWith(sortedKeys, content, environment.hash),
+      };
+    }
+    const rewritten = rewriteAsProviderWould(content);
+    if (defectIs(defect, "CONF-O21")) {
+      return {
+        kind: "normalized",
+        provider: "reference",
+        content: rewritten,
+        fingerprint: fingerprintWith(insertionOrderKeys, rewritten, environment.hash),
+      };
+    }
+    return {
+      kind: "normalized",
+      provider: "reference",
+      content: rewritten,
+      fingerprint: fingerprintWith(sortedKeys, rewritten, environment.hash),
+    };
+  };
+
+  const refusalFor = (content: EditableContent): ProviderFailure | null => {
+    const constraint = constraintViolatedBy(content);
+    if (constraint === null) {
+      return null;
+    }
+    if (defectIs(defect, "CONF-O29") && constraint === "invertedRange") {
+      return null;
+    }
+    if (defectIs(defect, "CONF-O35") && constraint === "recurrenceDialect") {
+      return null;
+    }
+    if (defectIs(defect, "CONF-O43") && constraint === "zoneIdentifier") {
+      return null;
+    }
+    return { kind: "unrepresentable", constraint };
+  };
+
+  const objectFor = (
+    uid: string,
+    content: NormalizedContent<"reference">,
+    revision: number,
+  ): RemoteEvent => ({
+    ...remoteRefFor(uid),
+    uid: { kind: "eventUid", value: uid },
+    calendar: referenceCalendar,
+    revision,
+    version: { kind: "remoteVersion", value: versionFor(uid, revision) },
+    content: content.content,
+    fingerprint: content.fingerprint,
+    provenance: { kind: "ours", installation: environment.installation },
+  });
+
+  const replaceObject = (uid: string, next: RemoteEvent | null): void => {
+    const remaining = store.objects().filter((event) => event.uid.value !== uid);
+    if (next === null) {
+      store.replaceObjects(remaining);
+      return;
+    }
+    store.replaceObjects([...remaining, next]);
+  };
+
+  const disturbCanary = (): void => {
+    if (!defectIs(defect, "CONF-O17")) {
+      return;
+    }
+    const canary = markedIn("CONF-O17").at(0);
+    if (!canary) {
+      return;
+    }
+    replaceObject(canary.uid.value, { ...canary, revision: canary.revision + 1 });
+  };
+
+  const echoFor = (uid: string): EchoVerdict => {
+    if (defectIs(defect, "CONF-O18") && isMarked(uid, "CONF-O18")) {
+      return { kind: "notObserved" };
+    }
+    return { kind: "matched" };
+  };
+
+  const keyOrder = (): KeyOrder => {
+    if (defectIs(defect, "CONF-O21")) {
+      return insertionOrderKeys;
+    }
+    return sortedKeys;
+  };
+
+  const submittedEncoding = (content: EditableContent): string =>
+    encodeIdentity(keyOrder(), !defectIs(defect, "CONF-O20"), content);
+
+  const storedEncoding = (content: EditableContent): string =>
+    encodeIdentity(keyOrder(), true, content);
+
+  const createOutcome = (
+    intent: Extract<WriteIntent<"reference">, { kind: "create" }>,
+  ): Result<WriteOutcome> => {
+    const refusal = refusalFor(intent.content.content);
+    if (refusal !== null) {
+      return { ok: false, failure: refusal };
+    }
+    const content = normalized(intent.content.content);
+    const uid = intent.idempotencyKey.value;
+    const existing = store.objects().find((event) => event.uid.value === uid);
+    if (existing && storedEncoding(existing.content) === submittedEncoding(intent.content.content)) {
+      if (!defectIs(defect, "CONF-O14") || !isMarked(uid, "CONF-O14")) {
+        return {
+          ok: true,
+          value: { kind: "alreadyExists", remote: remoteRefFor(uid), version: existing.version },
+        };
+      }
+      const duplicate = objectFor(`${uid}-duplicate`, content, 1);
+      store.replaceObjects([...store.objects(), duplicate]);
+      return {
+        ok: true,
+        value: {
+          kind: "created",
+          remote: remoteRefFor(duplicate.uid.value),
+          version: duplicate.version,
+          echo: echoFor(uid),
+        },
+      };
+    }
+    if (existing) {
+      if (defectIs(defect, "CONF-O25")) {
+        replaceObject(uid, null);
+      }
+      if (defectIs(defect, "CONF-O15")) {
+        return {
+          ok: true,
+          value: { kind: "unchanged", remote: remoteRefFor(uid), version: existing.version },
+        };
+      }
+      return {
+        ok: true,
+        value: {
+          kind: "conflict",
+          remote: remoteRefFor(uid),
+          observed: { kind: "matchesVersion", version: existing.version },
+        },
+      };
+    }
+    const created = objectFor(uid, content, 1);
+    store.replaceObjects([...store.objects(), created]);
+    disturbCanary();
+    return {
+      ok: true,
+      value: {
+        kind: "created",
+        remote: remoteRefFor(uid),
+        version: created.version,
+        echo: echoFor(uid),
+      },
+    };
+  };
+
+  const preconditionHolds = (
+    existing: RemoteEvent,
+    precondition: Extract<WriteIntent<"reference">, { kind: "update" }>["precondition"],
+  ): boolean => {
+    if (defectIs(defect, "CONF-O39")) {
+      return true;
+    }
+    if (precondition.kind === "matchesVersion") {
+      return precondition.version.value === existing.version.value;
+    }
+    return precondition.fingerprint.value === existing.fingerprint.value;
+  };
+
+  const updateOutcome = (
+    intent: Extract<WriteIntent<"reference">, { kind: "update" }>,
+  ): Result<WriteOutcome> => {
+    const existing = store.objects().find((event) => event.id.value === intent.target.value);
+    if (!existing) {
+      return {
+        ok: false,
+        failure: { kind: "notFound", calendar: referenceCalendar, event: intent.target },
+      };
+    }
+    if (!preconditionHolds(existing, intent.precondition)) {
+      return staleConflict(existing);
+    }
+    const refusal = refusalFor(intent.content.content);
+    if (refusal !== null) {
+      return { ok: false, failure: refusal };
+    }
+    const next = objectFor(
+      existing.uid.value,
+      normalized(intent.content.content),
+      existing.revision + 1,
+    );
+    replaceObject(existing.uid.value, next);
+    disturbCanary();
+    return {
+      ok: true,
+      value: {
+        kind: "updated",
+        remote: remoteRefFor(existing.uid.value),
+        version: next.version,
+        echo: echoFor(existing.uid.value),
+      },
+    };
+  };
+
+  const removalOutcome = (
+    intent: Extract<WriteIntent<"reference">, { kind: "delete" } | { kind: "retire" }>,
+  ): Result<WriteOutcome> => {
+    const existing = store
+      .objects()
+      .find((event) => event.deleteHandle.value === intent.target.value);
+    if (!existing) {
+      return {
+        ok: true,
+        value: {
+          kind: "alreadyAbsent",
+          remote: { id: { kind: "remoteEventId", value: "absent" }, deleteHandle: intent.target },
+        },
+      };
+    }
+    if (!preconditionHolds(existing, intent.precondition)) {
+      return staleConflict(existing);
+    }
+    replaceObject(existing.uid.value, null);
+    return { ok: true, value: { kind: "deleted", remote: remoteRefFor(existing.uid.value) } };
+  };
+
+  const applyWrite = (intent: WriteIntent<"reference">): Result<WriteOutcome> => {
+    switch (intent.kind) {
+      case "create": {
+        return createOutcome(intent);
+      }
+      case "update": {
+        return updateOutcome(intent);
+      }
+      case "delete":
+      case "retire": {
+        return removalOutcome(intent);
+      }
+      default: {
+        return assertNever(intent);
+      }
+    }
+  };
+
+  const logWrite = (intent: WriteIntent<"reference">, answered: Result<WriteOutcome>): void => {
+    if (!answered.ok) {
+      return;
+    }
+    const at = observedAt();
+    if (defectIs(defect, "CONF-O36") && intent.kind === "update") {
+      store.record({
+        at,
+        intent: {
+          kind: "delete",
+          calendar: intent.calendar,
+          target: { kind: "deleteHandle", value: `handle-${intent.target.value}` },
+          precondition: intent.precondition,
+          reason: "sourceDeleted",
+        },
+        outcome: { kind: "deleted", remote: remoteRefFor(intent.target.value) },
+      });
+    }
+    store.record({ at, intent, outcome: answered.value });
+  };
+
+  const attemptWrite = async (intent: WriteIntent<"reference">): Promise<Result<WriteOutcome>> => {
+    try {
+      return await environment.transport.run("write", () => {
+        const answered = applyWrite(intent);
+        logWrite(intent, answered);
+        return Promise.resolve(answered);
+      });
+    } catch (error) {
+      return { ok: false, failure: failureOfTransportError(error) };
+    }
+  };
+
+  const write = (
+    intent: WriteIntent<"reference">,
+    context: OperationContext,
+  ): Promise<Result<WriteOutcome>> =>
+    raceDeadline(context, deadlineAnswers(), () => attemptWrite(intent));
+
+  const enumerateCalendars = (account: AccountId): CalendarEnumeration => ({
+    kind: "snapshot",
+    account,
+    calendars: [
+      {
+        key: referenceCalendar,
+        displayName: "Reference calendar",
+        timeZone: { kind: "zoneId", value: "UTC" },
+        access: "readWrite",
+      },
+    ],
+  });
+
+  const listCalendars = (
+    account: AccountId,
+    context: OperationContext,
+  ): Promise<Result<CalendarEnumeration>> =>
+    raceDeadline(context, deadlineAnswers(), async () => {
+      try {
+        return await environment.transport.run("listCalendars", () =>
+          Promise.resolve({ ok: true, value: enumerateCalendars(account) }),
+        );
+      } catch (error) {
+        return { ok: false, failure: failureOfTransportError(error) };
+      }
+    });
+
+  const armAbandonedTimer = (): void => {
+    if (!defectIs(defect, "CONF-L8")) {
+      return;
+    }
+    environment.clock.sleep(conformanceLimits.deadlineMs, lifetime.signal).catch(() => null);
+  };
+
+  const listChangesWithDefect = (
+    request: ListChangesRequest,
+    context: OperationContext,
+  ): Promise<Result<ChangeListing>> => {
+    armAbandonedTimer();
+    return listChanges(request, context);
+  };
+
+  const obligationHolds = (): Promise<void> => {
+    if (environment.clock.pendingTimers() > 0) {
+      throw new Error("the reference provider left a timer armed");
+    }
+    return Promise.resolve();
+  };
+
+  return {
+    contract: {
+      provider: {
+        capabilities: referenceCapabilities,
+        listCalendars,
+        listChanges: listChangesWithDefect,
+        normalize: (content: EditableContent) => {
+          const refusal = refusalFor(content);
+          if (refusal !== null) {
+            return { ok: false, failure: refusal };
+          }
+          return { ok: true, value: normalized(content) };
+        },
+        write,
+      },
+      fingerprint: referenceFingerprintContract,
+      conformance: {
+        leaseReleasedOnThrow: obligationHolds,
+        followerRejectsWhenLeaderFails: obligationHolds,
+        deadlineOnNeverResolvingStub: obligationHolds,
+        abortMidFlightCleansUp: obligationHolds,
+        retryCeilingProven: obligationHolds,
+        concurrentSameKeyDoesNotDeadlock: obligationHolds,
+        deletionInputsShareOneCalendar: obligationHolds,
+      },
+    },
+    seed: (seed: ProviderSeed) => {
+      store.seed(seed);
+      return Promise.resolve();
+    },
+    inspect: () =>
+      Promise.resolve({ objects: store.objects(), writeLog: store.writeLog() }),
+    dispose: () => {
+      lifetime.abort();
+      return Promise.resolve();
+    },
+  };
+};
+
+export { createReference, remoteRefFor, versionFor };
+export type { ReferenceOptions };

--- a/packages/sync-kit/conformance/src/reference/build.ts
+++ b/packages/sync-kit/conformance/src/reference/build.ts
@@ -155,19 +155,34 @@ const staleConflict = (existing: RemoteEvent): Result<WriteOutcome> => ({
   },
 });
 
+interface ReferenceCounters {
+  deltaFloor: number;
+  carriedPages: number;
+  leakedPermits: number;
+  callersInFlight: number;
+  abortsInBurst: number;
+  attemptsSpent: number;
+  attemptsAllowed: number;
+}
+
+const attemptsUpTo = (ceiling: number): readonly number[] =>
+  Array.from({ length: Math.max(0, ceiling) }, (unused, index) => index + 1);
+
 const createReference = (options: ReferenceOptions): ProviderUnderTest<"reference"> => {
   const { environment, defect } = options;
   const store = createReferenceStore(referenceCalendar);
   const mint = createCursorMint(environment.hash);
   const lifetime = new AbortController();
   const poisoned = new Set<string>();
-  let deltaFloor = 0;
-  let carriedPages = 0;
-  let leakedPermits = 0;
-  let callersInFlight = 0;
-  let abortsInBurst = 0;
-  let attemptsSpent = 0;
-  let attemptsAllowed = 0;
+  const counters: ReferenceCounters = {
+    deltaFloor: 0,
+    carriedPages: 0,
+    leakedPermits: 0,
+    callersInFlight: 0,
+    abortsInBurst: 0,
+    attemptsSpent: 0,
+    attemptsAllowed: 0,
+  };
 
   const observedAt = (): Instant => {
     if (defectIs(defect, "CONF-L13")) {
@@ -373,7 +388,7 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
       };
     }
     if (defectIs(defect, "CONF-O42")) {
-      return { ...honest, pagesFetched: honest.pagesFetched + carriedPages };
+      return { ...honest, pagesFetched: honest.pagesFetched + counters.carriedPages };
     }
     return honest;
   };
@@ -517,7 +532,7 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     resumed: SyncCursor | null,
   ): ChangeListing => {
     const feed = feedNow();
-    const floor = Math.max(since, deltaFloor);
+    const floor = Math.max(since, counters.deltaFloor);
     const present = identitiesOf(feed);
     const removals = removalsFor(present);
     store.setReported(present);
@@ -690,9 +705,9 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     context: OperationContext,
   ): Promise<Result<ChangeListing>> => {
     const ceiling = attemptCeiling(context);
-    for (let attempt = 1; attempt <= ceiling; attempt += 1) {
-      attemptsSpent = Math.max(attemptsSpent, attempt);
-      attemptsAllowed = context.retryBudget.maxAttempts;
+    for (const attempt of attemptsUpTo(ceiling)) {
+      counters.attemptsSpent = Math.max(counters.attemptsSpent, attempt);
+      counters.attemptsAllowed = context.retryBudget.maxAttempts;
       const answered = await attemptListing(request);
       if (poisoned.has(key)) {
         poisoned.delete(key);
@@ -751,10 +766,10 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
       return answered;
     }
     if (defectIs(defect, "CONF-O24")) {
-      deltaFloor = store.currentSequence();
+      counters.deltaFloor = store.currentSequence();
     }
     if (defectIs(defect, "CONF-O42")) {
-      carriedPages += 1;
+      counters.carriedPages += 1;
     }
     return answered;
   };
@@ -763,11 +778,11 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     if (!context.signal.aborted) {
       return;
     }
-    if (defectIs(defect, "CONF-L9") && callersInFlight === 3) {
+    if (defectIs(defect, "CONF-L9") && counters.callersInFlight === 3) {
       poisoned.add(key);
     }
-    if (defectIs(defect, "CONF-L10") && callersInFlight > environment.concurrency) {
-      leakedPermits += 1;
+    if (defectIs(defect, "CONF-L10") && counters.callersInFlight > environment.concurrency) {
+      counters.leakedPermits += 1;
     }
   };
 
@@ -775,23 +790,23 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     request: ListChangesRequest,
     context: OperationContext,
   ): Promise<Result<ChangeListing>> => {
-    callersInFlight += 1;
-    if (callersInFlight === 1) {
-      abortsInBurst = 0;
+    counters.callersInFlight += 1;
+    if (counters.callersInFlight === 1) {
+      counters.abortsInBurst = 0;
     }
     if (context.signal.aborted) {
-      abortsInBurst += 1;
+      counters.abortsInBurst += 1;
     }
     const key = flightKeyOf(request);
     try {
       noteAbortedCaller(key, context);
-      if (leakedPermits > 0 && !context.signal.aborted) {
-        leakedPermits -= 1;
+      if (counters.leakedPermits > 0 && !context.signal.aborted) {
+        counters.leakedPermits -= 1;
         return { ok: false, failure: exhausted };
       }
-      if (defectIs(defect, "CONF-L11") && callersInFlight > environment.concurrency) {
+      if (defectIs(defect, "CONF-L11") && counters.callersInFlight > environment.concurrency) {
         await Promise.resolve();
-        if (abortsInBurst === 0) {
+        if (counters.abortsInBurst === 0) {
           throw new Error("the reference mutant dropped a task out of its fan-out");
         }
       }
@@ -808,7 +823,7 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
       }
       return cloned(rememberFailure(await reattemptedAlone(request, answered)));
     } finally {
-      callersInFlight -= 1;
+      counters.callersInFlight -= 1;
     }
   };
 
@@ -1203,7 +1218,7 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     holds(flights.inFlightKeys() === 0, "the reference provider still holds a coalescing lease");
 
   const noCallerOutstanding = (): Promise<void> =>
-    holds(callersInFlight === 0, "the reference provider still counts a caller as in flight");
+    holds(counters.callersInFlight === 0, "the reference provider still counts a caller as in flight");
 
   const noAbandonedFlight = (): Promise<void> =>
     holds(
@@ -1213,19 +1228,19 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
 
   const noCancellationResidue = (): Promise<void> =>
     holds(
-      poisoned.size === 0 && leakedPermits === 0,
+      poisoned.size === 0 && counters.leakedPermits === 0,
       "an aborted caller left a poisoned key or a leaked permit behind",
     );
 
   const attemptsWithinBudget = (): Promise<void> =>
     holds(
-      attemptsSpent <= attemptsAllowed,
-      `the reference provider spent ${attemptsSpent} attempts of ${attemptsAllowed}`,
+      counters.attemptsSpent <= counters.attemptsAllowed,
+      `the reference provider spent ${counters.attemptsSpent} attempts of ${counters.attemptsAllowed}`,
     );
 
   const noKeyStillHeld = (): Promise<void> =>
     holds(
-      flights.inFlightKeys() === 0 && callersInFlight === 0,
+      flights.inFlightKeys() === 0 && counters.callersInFlight === 0,
       "concurrent callers over one key left the key held after they all settled",
     );
 

--- a/packages/sync-kit/conformance/src/reference/build.ts
+++ b/packages/sync-kit/conformance/src/reference/build.ts
@@ -23,6 +23,7 @@ import type {
   WriteIntent,
   WriteOutcome,
 } from "@keeper.sh/sync-protocol";
+import type { ThrottleSignal } from "@keeper.sh/sync-protocol";
 import { assertNever } from "@keeper.sh/sync-protocol";
 import type { ConformanceCaseId } from "../case-id";
 import type { KeyOrder } from "../canonical";
@@ -32,7 +33,7 @@ import { raceDeadline, standardAnswers } from "../deadline";
 import { conformanceLimits } from "../limits";
 import type { ConformanceEnvironment, ProviderSeed, ProviderUnderTest } from "../options";
 import { createSingleFlight } from "../single-flight";
-import { failureOfTransportError } from "../transport";
+import { failureOfTransportError, TransportStatus } from "../transport";
 import { referenceCalendar } from "./calendar";
 import { referenceCapabilities } from "./capabilities";
 import { createCursorMint, scopeKeyOf } from "./cursor";
@@ -59,12 +60,19 @@ interface ReferenceOptions {
   readonly defect: Defect;
 }
 
+interface DecidedWrite {
+  readonly outcome: Result<WriteOutcome>;
+  readonly commit: () => void;
+}
+
 const remoteRefFor = (uid: string): RemoteRef => ({
   id: { kind: "remoteEventId", value: `id-${uid}` },
   deleteHandle: { kind: "deleteHandle", value: `handle-${uid}` },
 });
 
 const versionFor = (uid: string, revision: number): string => `v${revision}-${uid}`;
+
+const dayMs = 24 * 60 * 60 * 1000;
 
 const isRetryable = (failure: ProviderFailure): boolean => failure.kind === "rateLimited";
 
@@ -85,10 +93,33 @@ const withheldExcept = (
   excluded: (entry: WithheldEvent) => boolean,
 ): readonly WithheldEvent[] => withheld.filter((entry) => !excluded(entry));
 
-const unnamedRemoval = (): Removal => ({
-  kind: "outOfScope",
-  id: { kind: "remoteEventId", value: "id-unnamed" },
-});
+const midnightOf = (date: string): Instant => ({ kind: "instant", value: `${date}T00:00:00.000Z` });
+
+const asMidnightPair = (event: RemoteEvent): RemoteEvent => {
+  const { content } = event;
+  if (content.recurrence !== null || content.time.kind !== "allDay") {
+    return event;
+  }
+  return {
+    ...event,
+    content: {
+      ...content,
+      time: {
+        kind: "timed",
+        start: midnightOf(content.time.startDate.value),
+        end: midnightOf(content.time.endDateExclusive.value),
+        zone: { kind: "zoneId", value: "UTC" },
+      },
+    },
+  };
+};
+
+const plainlyDeleted = (removal: Removal): Removal => {
+  if (removal.kind !== "cancelled") {
+    return removal;
+  }
+  return { kind: "deleted", id: removal.id, uid: removal.uid };
+};
 
 const truncatedAsPartial = (
   scope: ListingScope,
@@ -105,6 +136,13 @@ const truncatedAsPartial = (
 
 const noop = (): null => null;
 
+const holds = (held: boolean, complaint: string): Promise<void> => {
+  if (!held) {
+    throw new Error(complaint);
+  }
+  return Promise.resolve();
+};
+
 const answeredWith = <Value>(value: Value): Promise<Value> => Promise.resolve(value);
 
 const staleConflict = (existing: RemoteEvent): Result<WriteOutcome> => ({
@@ -119,13 +157,6 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
   const { environment, defect } = options;
   const store = createReferenceStore(referenceCalendar);
   const mint = createCursorMint(environment.hash);
-  const flights = createSingleFlight<Result<ChangeListing>>({
-    retain: (settled) =>
-      defectIs(defect, "CONF-L7") &&
-      !settled.ok &&
-      settled.failure.kind === "transport" &&
-      settled.failure.status === null,
-  });
   const lifetime = new AbortController();
   const poisoned = new Set<string>();
   let deltaFloor = 0;
@@ -133,6 +164,8 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
   let leakedPermits = 0;
   let callersInFlight = 0;
   let abortsInBurst = 0;
+  let attemptsSpent = 0;
+  let attemptsAllowed = 0;
 
   const observedAt = (): Instant => {
     if (defectIs(defect, "CONF-L13")) {
@@ -182,15 +215,30 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     provenance: { kind: "foreign" },
   });
 
+  const isCancelled = (event: RemoteEvent): boolean =>
+    store.cancelled().some((uid) => uid.value === event.uid.value);
+
+  const liveObjects = (): readonly RemoteEvent[] =>
+    store.objects().filter((event) => !isCancelled(event));
+
   const markedIn = (id: ConformanceCaseId): readonly RemoteEvent[] =>
-    store.objects().filter((event) => isMarked(event.uid.value, id));
+    liveObjects().filter((event) => isMarked(event.uid.value, id));
 
   const unmarkedFeed = (id: ConformanceCaseId): ResolvedFeed =>
-    resolveFeed(store.objects().filter((event) => !isMarked(event.uid.value, id)));
+    resolveFeed(liveObjects().filter((event) => !isMarked(event.uid.value, id)));
+
+  const flights = createSingleFlight<Result<ChangeListing>>({
+    retain: (settled) =>
+      defectIs(defect, "CONF-L7") &&
+      markedIn("CONF-L7").length > 0 &&
+      !settled.ok &&
+      settled.failure.kind === "transport" &&
+      settled.failure.status === null,
+  });
 
   const resolvedFeed = (): ResolvedFeed => {
     if (defectIs(defect, "CONF-O22")) {
-      const resolved = resolveFeed(store.objects());
+      const resolved = resolveFeed(liveObjects());
       return {
         events: [...resolved.events, ...markedIn("CONF-O22")],
         withheld: resolved.withheld,
@@ -209,7 +257,7 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
       const oldest = markedIn("CONF-O7").filter((event) => event.revision === 1);
       return { events: [...rest.events, ...oldest], withheld: rest.withheld };
     }
-    return resolveFeed(store.objects());
+    return resolveFeed(liveObjects());
   };
 
   const defectiveFeed = (feed: ResolvedFeed): ResolvedFeed => {
@@ -240,7 +288,7 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     }
     if (defectIs(defect, "CONF-O27")) {
       return {
-        events: feed.events.filter((event) => !event.uid.value.endsWith(":lower")),
+        events: feed.events.filter((event) => !event.uid.value.endsWith(":onLowerEdge")),
         withheld: feed.withheld,
       };
     }
@@ -257,6 +305,9 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
           })),
         ],
       };
+    }
+    if (defectIs(defect, "CONF-O45")) {
+      return { events: feed.events.map((event) => asMidnightPair(event)), withheld: feed.withheld };
     }
     if (defectIs(defect, "CONF-O32")) {
       return {
@@ -340,8 +391,24 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     return isMarked(removal.uid.value, id);
   };
 
+  const cancelledRather = (removal: Removal): Removal => {
+    if (removal.kind === "outOfScope") {
+      return removal;
+    }
+    if (!store.cancelled().some((uid) => uid.value === removal.uid.value)) {
+      return removal;
+    }
+    return { kind: "cancelled", id: removal.id, uid: removal.uid };
+  };
+
+  const unattributableTombstones = (): readonly Removal[] =>
+    store.unattributableRemovals().map((id) => ({ kind: "outOfScope", id }));
+
   const removalsFor = (present: readonly ReportedIdentity[]): readonly Removal[] => {
-    const honest = removalsAgainst(store.reported(), present);
+    const honest = [
+      ...removalsAgainst(store.reported(), present).map((removal) => cancelledRather(removal)),
+      ...unattributableTombstones(),
+    ];
     if (defectIs(defect, "CONF-O13")) {
       return honest.map((removal) => {
         if (!marksCase(removal, "CONF-O13")) {
@@ -350,8 +417,8 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
         return anonymised(removal);
       });
     }
-    if (defectIs(defect, "CONF-O34") && honest.some((removal) => marksCase(removal, "CONF-O34"))) {
-      return [...honest, unnamedRemoval()];
+    if (defectIs(defect, "CONF-O34")) {
+      return honest.map((removal) => plainlyDeleted(removal));
     }
     return honest;
   };
@@ -376,6 +443,19 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
   const provenCoverageOf = (scope: ListingScope): CoverageWindow => {
     if (defectIs(defect, "CONF-O4")) {
       return { covered: scope.window, calendar: scope.calendar };
+    }
+    if (defectIs(defect, "CONF-O26") && markedIn("CONF-O26").length > 0) {
+      const honest = coverageOver(scope);
+      return {
+        covered: {
+          start: honest.covered.start,
+          end: {
+            kind: "instant",
+            value: new Date(Date.parse(honest.covered.end.value) + 90 * dayMs).toISOString(),
+          },
+        },
+        calendar: honest.calendar,
+      };
     }
     return coverageOver(scope);
   };
@@ -526,13 +606,38 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     return resumedListing(request.resume, request.scope, at);
   };
 
+  const declaredThrottleFor = (status: number): ThrottleSignal | null => {
+    if (defectIs(defect, "CONF-O46")) {
+      return null;
+    }
+    return referenceCapabilities.throttleSignals.find((signal) => signal.status === status) ?? null;
+  };
+
+  const failureOfError = (error: unknown): ProviderFailure => {
+    if (!(error instanceof TransportStatus)) {
+      return failureOfTransportError(error);
+    }
+    const signal = declaredThrottleFor(error.status);
+    if (signal === null) {
+      return { kind: "transport", status: error.status, disposition: "permanent" };
+    }
+    if (!signal.hasRetryAfter) {
+      return { kind: "rateLimited", retryAfter: null, scope: referenceCapabilities.quotaScope };
+    }
+    return {
+      kind: "rateLimited",
+      retryAfter: error.retryAfter,
+      scope: referenceCapabilities.quotaScope,
+    };
+  };
+
   const attemptListing = async (request: ListChangesRequest): Promise<Result<ChangeListing>> => {
     try {
       return await environment.transport.run("listChanges", () =>
         Promise.resolve(buildListing(request)),
       );
     } catch (error) {
-      const failure = failureOfTransportError(error);
+      const failure = failureOfError(error);
       if (defectIs(defect, "CONF-O2") && failure.kind === "transport" && failure.status === 503) {
         return { ok: true, value: emptySnapshot(request.scope, null) };
       }
@@ -540,9 +645,13 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     }
   };
 
-  const sleptBetweenAttempts = async (milliseconds: number): Promise<boolean> => {
+  const sleptBetweenAttempts = async (
+    milliseconds: number,
+    context: OperationContext,
+  ): Promise<boolean> => {
+    const waking = AbortSignal.any([lifetime.signal, context.signal]);
     try {
-      await environment.clock.sleep(milliseconds, lifetime.signal);
+      await environment.clock.sleep(milliseconds, waking);
       return true;
     } catch {
       return false;
@@ -563,6 +672,8 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
   ): Promise<Result<ChangeListing>> => {
     const ceiling = attemptCeiling(context);
     for (let attempt = 1; attempt <= ceiling; attempt += 1) {
+      attemptsSpent = Math.max(attemptsSpent, attempt);
+      attemptsAllowed = context.retryBudget.maxAttempts;
       const answered = await attemptListing(request);
       if (poisoned.has(key)) {
         poisoned.delete(key);
@@ -571,7 +682,7 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
       if (answered.ok || !isRetryable(answered.failure) || attempt === ceiling) {
         return answered;
       }
-      const slept = await sleptBetweenAttempts(retryDelayFor(answered.failure, context));
+      const slept = await sleptBetweenAttempts(retryDelayFor(answered.failure, context), context);
       if (!slept) {
         return { ok: false, failure: aborted };
       }
@@ -636,7 +747,7 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     if (defectIs(defect, "CONF-L9") && callersInFlight === 3) {
       poisoned.add(key);
     }
-    if (defectIs(defect, "CONF-L10") && callersInFlight > conformanceLimits.concurrency) {
+    if (defectIs(defect, "CONF-L10") && callersInFlight > environment.concurrency) {
       leakedPermits += 1;
     }
   };
@@ -659,7 +770,7 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
         leakedPermits -= 1;
         return { ok: false, failure: exhausted };
       }
-      if (defectIs(defect, "CONF-L11") && callersInFlight > conformanceLimits.concurrency) {
+      if (defectIs(defect, "CONF-L11") && callersInFlight > environment.concurrency) {
         await Promise.resolve();
         if (abortsInBurst === 0) {
           throw new Error("the reference mutant dropped a task out of its fan-out");
@@ -668,9 +779,14 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
       if (defectIs(defect, "CONF-L12") && context.signal.aborted) {
         environment.transport.run("listChanges", () => answeredWith(null)).catch(noop);
       }
+      const leadWithinItsOwnBudget = (): Promise<Result<ChangeListing>> =>
+        raceDeadline(context, deadlineAnswers(), () => leadListing(key, request, context));
       const answered = await raceDeadline(context, deadlineAnswers(), () =>
-        flights.run(key, () => leadListing(key, request, context)),
+        flights.run(key, leadWithinItsOwnBudget),
       );
+      if (!answered.ok && answered.failure.kind === "notAttempted") {
+        flights.abandon(key);
+      }
       return cloned(rememberFailure(await reattemptedAlone(request, answered)));
     } finally {
       callersInFlight -= 1;
@@ -769,32 +885,35 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     return sortedKeys;
   };
 
-  const submittedEncoding = (content: EditableContent): string =>
-    encodeIdentity(keyOrder(), !defectIs(defect, "CONF-O20"), content);
+  const submittedEncoding = (content: EditableContent): string => {
+    if (defectIs(defect, "CONF-O20")) {
+      return encodeIdentity(keyOrder(), false, content);
+    }
+    if (defectIs(defect, "CONF-O21")) {
+      return encodeIdentity(keyOrder(), true, content);
+    }
+    return encodeIdentity(keyOrder(), true, rewriteAsProviderWould(content));
+  };
 
   const storedEncoding = (content: EditableContent): string =>
     encodeIdentity(keyOrder(), true, content);
 
-  const createOutcome = (
-    intent: Extract<WriteIntent<"reference">, { kind: "create" }>,
-  ): Result<WriteOutcome> => {
-    const refusal = refusalFor(intent.content.content);
-    if (refusal !== null) {
-      return { ok: false, failure: refusal };
+  const decidedAs = (outcome: Result<WriteOutcome>): DecidedWrite => ({ outcome, commit: noop });
+
+  const decidedReplay = (
+    uid: string,
+    existing: RemoteEvent,
+    content: NormalizedContent<"reference">,
+  ): DecidedWrite => {
+    if (!defectIs(defect, "CONF-O14") || !isMarked(uid, "CONF-O14")) {
+      return decidedAs({
+        ok: true,
+        value: { kind: "alreadyExists", remote: remoteRefFor(uid), version: existing.version },
+      });
     }
-    const content = normalized(intent.content.content);
-    const uid = intent.idempotencyKey.value;
-    const existing = store.objects().find((event) => event.uid.value === uid);
-    if (existing && storedEncoding(existing.content) === submittedEncoding(intent.content.content)) {
-      if (!defectIs(defect, "CONF-O14") || !isMarked(uid, "CONF-O14")) {
-        return {
-          ok: true,
-          value: { kind: "alreadyExists", remote: remoteRefFor(uid), version: existing.version },
-        };
-      }
-      const duplicate = objectFor(`${uid}-duplicate`, content, 1);
-      store.replaceObjects([...store.objects(), duplicate]);
-      return {
+    const duplicate = objectFor(`${uid}-duplicate`, content, 1);
+    return {
+      outcome: {
         ok: true,
         value: {
           kind: "created",
@@ -802,37 +921,72 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
           version: duplicate.version,
           echo: echoFor(uid),
         },
-      };
-    }
-    if (existing) {
-      if (defectIs(defect, "CONF-O25")) {
-        replaceObject(uid, null);
+      },
+      commit: () => {
+        store.replaceObjects([...store.objects(), duplicate]);
+      },
+    };
+  };
+
+  const decidedContention = (uid: string, existing: RemoteEvent): DecidedWrite => {
+    const commit = (): void => {
+      if (!defectIs(defect, "CONF-O25")) {
+        return;
       }
-      if (defectIs(defect, "CONF-O15")) {
-        return {
+      replaceObject(uid, null);
+    };
+    if (defectIs(defect, "CONF-O15")) {
+      return {
+        outcome: {
           ok: true,
           value: { kind: "unchanged", remote: remoteRefFor(uid), version: existing.version },
-        };
-      }
-      return {
+        },
+        commit,
+      };
+    }
+    return {
+      outcome: {
         ok: true,
         value: {
           kind: "conflict",
           remote: remoteRefFor(uid),
           observed: { kind: "matchesVersion", version: existing.version },
         },
-      };
+      },
+      commit,
+    };
+  };
+
+  const decideCreate = (
+    intent: Extract<WriteIntent<"reference">, { kind: "create" }>,
+  ): DecidedWrite => {
+    const refusal = refusalFor(intent.content.content);
+    if (refusal !== null) {
+      return decidedAs({ ok: false, failure: refusal });
+    }
+    const content = normalized(intent.content.content);
+    const uid = intent.idempotencyKey.value;
+    const existing = store.objects().find((event) => event.uid.value === uid);
+    if (existing && storedEncoding(existing.content) === submittedEncoding(intent.content.content)) {
+      return decidedReplay(uid, existing, content);
+    }
+    if (existing) {
+      return decidedContention(uid, existing);
     }
     const created = objectFor(uid, content, 1);
-    store.replaceObjects([...store.objects(), created]);
-    disturbCanary();
     return {
-      ok: true,
-      value: {
-        kind: "created",
-        remote: remoteRefFor(uid),
-        version: created.version,
-        echo: echoFor(uid),
+      outcome: {
+        ok: true,
+        value: {
+          kind: "created",
+          remote: remoteRefFor(uid),
+          version: created.version,
+          echo: echoFor(uid),
+        },
+      },
+      commit: () => {
+        store.replaceObjects([...store.objects(), created]);
+        disturbCanary();
       },
     };
   };
@@ -841,7 +995,7 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     existing: RemoteEvent,
     precondition: Extract<WriteIntent<"reference">, { kind: "update" }>["precondition"],
   ): boolean => {
-    if (defectIs(defect, "CONF-O39")) {
+    if (defectIs(defect, "CONF-O39") && isMarked(existing.uid.value, "CONF-O39")) {
       return true;
     }
     if (precondition.kind === "matchesVersion") {
@@ -850,74 +1004,82 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     return precondition.fingerprint.value === existing.fingerprint.value;
   };
 
-  const updateOutcome = (
+  const decideUpdate = (
     intent: Extract<WriteIntent<"reference">, { kind: "update" }>,
-  ): Result<WriteOutcome> => {
+  ): DecidedWrite => {
     const existing = store.objects().find((event) => event.id.value === intent.target.value);
     if (!existing) {
-      return {
+      return decidedAs({
         ok: false,
         failure: { kind: "notFound", calendar: referenceCalendar, event: intent.target },
-      };
+      });
     }
     if (!preconditionHolds(existing, intent.precondition)) {
-      return staleConflict(existing);
+      return decidedAs(staleConflict(existing));
     }
     const refusal = refusalFor(intent.content.content);
     if (refusal !== null) {
-      return { ok: false, failure: refusal };
+      return decidedAs({ ok: false, failure: refusal });
     }
     const next = objectFor(
       existing.uid.value,
       normalized(intent.content.content),
       existing.revision + 1,
     );
-    replaceObject(existing.uid.value, next);
-    disturbCanary();
     return {
-      ok: true,
-      value: {
-        kind: "updated",
-        remote: remoteRefFor(existing.uid.value),
-        version: next.version,
-        echo: echoFor(existing.uid.value),
+      outcome: {
+        ok: true,
+        value: {
+          kind: "updated",
+          remote: remoteRefFor(existing.uid.value),
+          version: next.version,
+          echo: echoFor(existing.uid.value),
+        },
+      },
+      commit: () => {
+        replaceObject(existing.uid.value, next);
+        disturbCanary();
       },
     };
   };
 
-  const removalOutcome = (
+  const decideRemoval = (
     intent: Extract<WriteIntent<"reference">, { kind: "delete" } | { kind: "retire" }>,
-  ): Result<WriteOutcome> => {
+  ): DecidedWrite => {
     const existing = store
       .objects()
       .find((event) => event.deleteHandle.value === intent.target.value);
     if (!existing) {
-      return {
+      return decidedAs({
         ok: true,
         value: {
           kind: "alreadyAbsent",
           remote: { id: { kind: "remoteEventId", value: "absent" }, deleteHandle: intent.target },
         },
-      };
+      });
     }
     if (!preconditionHolds(existing, intent.precondition)) {
-      return staleConflict(existing);
+      return decidedAs(staleConflict(existing));
     }
-    replaceObject(existing.uid.value, null);
-    return { ok: true, value: { kind: "deleted", remote: remoteRefFor(existing.uid.value) } };
+    return {
+      outcome: { ok: true, value: { kind: "deleted", remote: remoteRefFor(existing.uid.value) } },
+      commit: () => {
+        replaceObject(existing.uid.value, null);
+      },
+    };
   };
 
-  const applyWrite = (intent: WriteIntent<"reference">): Result<WriteOutcome> => {
+  const decideWrite = (intent: WriteIntent<"reference">): DecidedWrite => {
     switch (intent.kind) {
       case "create": {
-        return createOutcome(intent);
+        return decideCreate(intent);
       }
       case "update": {
-        return updateOutcome(intent);
+        return decideUpdate(intent);
       }
       case "delete":
       case "retire": {
-        return removalOutcome(intent);
+        return decideRemoval(intent);
       }
       default: {
         return assertNever(intent);
@@ -946,15 +1108,27 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     store.record({ at, intent, outcome: answered.value });
   };
 
+  const committed = (decided: DecidedWrite, intent: WriteIntent<"reference">): DecidedWrite => {
+    decided.commit();
+    logWrite(intent, decided.outcome);
+    return decided;
+  };
+
+  const interleavesItsCommit = (): boolean => defectIs(defect, "CONF-O44");
+
   const attemptWrite = async (intent: WriteIntent<"reference">): Promise<Result<WriteOutcome>> => {
     try {
-      return await environment.transport.run("write", () => {
-        const answered = applyWrite(intent);
-        logWrite(intent, answered);
-        return Promise.resolve(answered);
+      return await environment.transport.run("write", (): Promise<Result<WriteOutcome>> => {
+        const decided = decideWrite(intent);
+        if (!interleavesItsCommit()) {
+          return Promise.resolve(committed(decided, intent).outcome);
+        }
+        return Promise.resolve()
+          .then(() => committed(decided, intent))
+          .then((settled) => settled.outcome);
       });
     } catch (error) {
-      return { ok: false, failure: failureOfTransportError(error) };
+      return { ok: false, failure: failureOfError(error) };
     }
   };
 
@@ -1006,12 +1180,41 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
     return listChanges(request, context);
   };
 
-  const obligationHolds = (): Promise<void> => {
-    if (environment.clock.pendingTimers() > 0) {
-      throw new Error("the reference provider left a timer armed");
-    }
-    return Promise.resolve();
-  };
+  const noLeaseOutstanding = (): Promise<void> =>
+    holds(flights.inFlightKeys() === 0, "the reference provider still holds a coalescing lease");
+
+  const noCallerOutstanding = (): Promise<void> =>
+    holds(callersInFlight === 0, "the reference provider still counts a caller as in flight");
+
+  const noAbandonedFlight = (): Promise<void> =>
+    holds(
+      flights.inFlightKeys() === 0,
+      "a flight abandoned at its deadline is still registered against its key",
+    );
+
+  const noCancellationResidue = (): Promise<void> =>
+    holds(
+      poisoned.size === 0 && leakedPermits === 0,
+      "an aborted caller left a poisoned key or a leaked permit behind",
+    );
+
+  const attemptsWithinBudget = (): Promise<void> =>
+    holds(
+      attemptsSpent <= attemptsAllowed,
+      `the reference provider spent ${attemptsSpent} attempts of ${attemptsAllowed}`,
+    );
+
+  const noKeyStillHeld = (): Promise<void> =>
+    holds(
+      flights.inFlightKeys() === 0 && callersInFlight === 0,
+      "concurrent callers over one key left the key held after they all settled",
+    );
+
+  const oneCalendarBehindEveryDeletion = (): Promise<void> =>
+    holds(
+      new Set(store.objects().map((event) => event.calendar.calendar.value)).size <= 1,
+      "the reference store holds objects from two calendars, so a deletion could cross between them",
+    );
 
   return {
     contract: {
@@ -1030,13 +1233,13 @@ const createReference = (options: ReferenceOptions): ProviderUnderTest<"referenc
       },
       fingerprint: referenceFingerprintContract,
       conformance: {
-        leaseReleasedOnThrow: obligationHolds,
-        followerRejectsWhenLeaderFails: obligationHolds,
-        deadlineOnNeverResolvingStub: obligationHolds,
-        abortMidFlightCleansUp: obligationHolds,
-        retryCeilingProven: obligationHolds,
-        concurrentSameKeyDoesNotDeadlock: obligationHolds,
-        deletionInputsShareOneCalendar: obligationHolds,
+        leaseReleasedOnThrow: noLeaseOutstanding,
+        followerRejectsWhenLeaderFails: noCallerOutstanding,
+        deadlineOnNeverResolvingStub: noAbandonedFlight,
+        abortMidFlightCleansUp: noCancellationResidue,
+        retryCeilingProven: attemptsWithinBudget,
+        concurrentSameKeyDoesNotDeadlock: noKeyStillHeld,
+        deletionInputsShareOneCalendar: oneCalendarBehindEveryDeletion,
       },
     },
     seed: (seed: ProviderSeed) => {

--- a/packages/sync-kit/conformance/src/reference/calendar.ts
+++ b/packages/sync-kit/conformance/src/reference/calendar.ts
@@ -1,0 +1,14 @@
+import type { CalendarKey, WritableCalendar } from "@keeper.sh/sync-protocol";
+
+const referenceCalendar: CalendarKey = {
+  provider: "reference",
+  account: { kind: "accountId", value: "reference-account" },
+  calendar: { kind: "calendarId", value: "reference-calendar" },
+};
+
+const referenceWritableCalendar: WritableCalendar = {
+  key: referenceCalendar,
+  access: "readWrite",
+};
+
+export { referenceCalendar, referenceWritableCalendar };

--- a/packages/sync-kit/conformance/src/reference/capabilities.ts
+++ b/packages/sync-kit/conformance/src/reference/capabilities.ts
@@ -1,5 +1,7 @@
 import type { Capabilities } from "@keeper.sh/sync-protocol";
 
+const referenceMinimumSpanSeconds = 900;
+
 const referenceCapabilities: Capabilities<"reference"> = {
   provider: "reference",
   delta: { kind: "tokenized", windowBoundToCursor: true },
@@ -8,9 +10,12 @@ const referenceCapabilities: Capabilities<"reference"> = {
   precondition: "matchesVersion",
   provenanceChannel: "extendedProperty",
   quotaScope: "perUser",
-  throttleSignals: [{ status: 429, hasRetryAfter: true }],
+  throttleSignals: [
+    { status: 429, hasRetryAfter: true },
+    { status: 503, hasRetryAfter: false },
+  ],
   representableRange: {
-    minimumSpanSeconds: 0,
+    minimumSpanSeconds: referenceMinimumSpanSeconds,
     zeroDuration: "accept",
     invertedRange: "reject",
     allDayGrid: "utcDay",
@@ -20,4 +25,4 @@ const referenceCapabilities: Capabilities<"reference"> = {
   echoesWrites: true,
 };
 
-export { referenceCapabilities };
+export { referenceCapabilities, referenceMinimumSpanSeconds };

--- a/packages/sync-kit/conformance/src/reference/capabilities.ts
+++ b/packages/sync-kit/conformance/src/reference/capabilities.ts
@@ -1,0 +1,23 @@
+import type { Capabilities } from "@keeper.sh/sync-protocol";
+
+const referenceCapabilities: Capabilities<"reference"> = {
+  provider: "reference",
+  delta: { kind: "tokenized", windowBoundToCursor: true },
+  deletionAuthority: "snapshotAbsence",
+  removalsAreAmbiguous: false,
+  precondition: "matchesVersion",
+  provenanceChannel: "extendedProperty",
+  quotaScope: "perUser",
+  throttleSignals: [{ status: 429, hasRetryAfter: true }],
+  representableRange: {
+    minimumSpanSeconds: 0,
+    zeroDuration: "accept",
+    invertedRange: "reject",
+    allDayGrid: "utcDay",
+  },
+  allDay: "dateOnly",
+  recurrenceWrite: "rfc5545",
+  echoesWrites: true,
+};
+
+export { referenceCapabilities };

--- a/packages/sync-kit/conformance/src/reference/cursor.ts
+++ b/packages/sync-kit/conformance/src/reference/cursor.ts
@@ -1,0 +1,15 @@
+import type { ListingScope, Result, SyncCursor } from "@keeper.sh/sync-protocol";
+
+interface CursorMint {
+  readonly mint: (scope: ListingScope) => SyncCursor;
+  readonly verify: (cursor: SyncCursor, scope: ListingScope) => Result<SyncCursor>;
+  readonly generations: () => number;
+  readonly expireAll: () => void;
+}
+
+const createCursorMint = (secret: string): CursorMint => {
+  throw new Error(`unimplemented: createCursorMint(${secret.length})`);
+};
+
+export { createCursorMint };
+export type { CursorMint };

--- a/packages/sync-kit/conformance/src/reference/cursor.ts
+++ b/packages/sync-kit/conformance/src/reference/cursor.ts
@@ -32,11 +32,12 @@ const scopeKeyOf = (scope: ListingScope): string =>
 const createCursorMint = (hash: (input: string) => string): CursorMint => {
   const minted = new Map<string, MintedCursor>();
   const latest = new Map<string, number>();
-  let generation = 0;
+  const counter = { generation: 0 };
 
   const mint = (scope: ListingScope, sequence: number, at: Instant): SyncCursor => {
-    generation += 1;
+    counter.generation += 1;
     const scopeKey = scopeKeyOf(scope);
+    const { generation } = counter;
     const value = `${hash(`reference-cursor|${scopeKey}|${at.value}`)}.${generation}`;
     minted.set(value, { scopeKey, sequence, generation });
     latest.set(scopeKey, generation);
@@ -57,7 +58,7 @@ const createCursorMint = (hash: (input: string) => string): CursorMint => {
     return { kind: "current", sequence: record.sequence };
   };
 
-  return { mint, verify, generations: () => generation };
+  return { mint, verify, generations: () => counter.generation };
 };
 
 export { createCursorMint, scopeKeyOf };

--- a/packages/sync-kit/conformance/src/reference/cursor.ts
+++ b/packages/sync-kit/conformance/src/reference/cursor.ts
@@ -1,15 +1,64 @@
-import type { ListingScope, Result, SyncCursor } from "@keeper.sh/sync-protocol";
+import type { Instant, ListingScope, SyncCursor } from "@keeper.sh/sync-protocol";
+import { canonicalise } from "../canonical";
 
-interface CursorMint {
-  readonly mint: (scope: ListingScope) => SyncCursor;
-  readonly verify: (cursor: SyncCursor, scope: ListingScope) => Result<SyncCursor>;
-  readonly generations: () => number;
-  readonly expireAll: () => void;
+type CursorVerdict =
+  | { readonly kind: "current"; readonly sequence: number }
+  | { readonly kind: "superseded" }
+  | { readonly kind: "foreignScope" }
+  | { readonly kind: "unknown" };
+
+interface MintedCursor {
+  readonly scopeKey: string;
+  readonly sequence: number;
+  readonly generation: number;
 }
 
-const createCursorMint = (secret: string): CursorMint => {
-  throw new Error(`unimplemented: createCursorMint(${secret.length})`);
+interface CursorMint {
+  readonly mint: (scope: ListingScope, sequence: number, at: Instant) => SyncCursor;
+  readonly verify: (cursor: SyncCursor, scope: ListingScope) => CursorVerdict;
+  readonly generations: () => number;
+}
+
+const scopeKeyOf = (scope: ListingScope): string =>
+  canonicalise({
+    provider: scope.calendar.provider,
+    account: scope.calendar.account.value,
+    calendar: scope.calendar.calendar.value,
+    start: scope.window.start.value,
+    end: scope.window.end.value,
+    expandRecurrences: scope.expandRecurrences,
+  });
+
+const createCursorMint = (hash: (input: string) => string): CursorMint => {
+  const minted = new Map<string, MintedCursor>();
+  const latest = new Map<string, number>();
+  let generation = 0;
+
+  const mint = (scope: ListingScope, sequence: number, at: Instant): SyncCursor => {
+    generation += 1;
+    const scopeKey = scopeKeyOf(scope);
+    const value = `${hash(`reference-cursor|${scopeKey}|${at.value}`)}.${generation}`;
+    minted.set(value, { scopeKey, sequence, generation });
+    latest.set(scopeKey, generation);
+    return { kind: "syncCursor", value, scope };
+  };
+
+  const verify = (cursor: SyncCursor, scope: ListingScope): CursorVerdict => {
+    const record = minted.get(cursor.value);
+    if (!record) {
+      return { kind: "unknown" };
+    }
+    if (record.scopeKey !== scopeKeyOf(scope)) {
+      return { kind: "foreignScope" };
+    }
+    if (latest.get(record.scopeKey) !== record.generation) {
+      return { kind: "superseded" };
+    }
+    return { kind: "current", sequence: record.sequence };
+  };
+
+  return { mint, verify, generations: () => generation };
 };
 
-export { createCursorMint };
-export type { CursorMint };
+export { createCursorMint, scopeKeyOf };
+export type { CursorMint, CursorVerdict };

--- a/packages/sync-kit/conformance/src/reference/defect.ts
+++ b/packages/sync-kit/conformance/src/reference/defect.ts
@@ -1,0 +1,13 @@
+import type { ConformanceCaseId } from "../case-id";
+
+type Defect = ConformanceCaseId | null;
+
+const defectIs = (defect: Defect, id: ConformanceCaseId): boolean => defect === id;
+
+const markerOf = (id: ConformanceCaseId): string => `${id}:`;
+
+const isMarked = (value: string, id: ConformanceCaseId): boolean =>
+  value.startsWith(markerOf(id));
+
+export { defectIs, isMarked, markerOf };
+export type { Defect };

--- a/packages/sync-kit/conformance/src/reference/fingerprint.ts
+++ b/packages/sync-kit/conformance/src/reference/fingerprint.ts
@@ -1,15 +1,144 @@
-import type { EditableContent, Fingerprint, FingerprintContract } from "@keeper.sh/sync-protocol";
+import type {
+  EditableContent,
+  EventTime,
+  Fingerprint,
+  FingerprintContract,
+  RecurrencePayload,
+} from "@keeper.sh/sync-protocol";
+import { assertNever } from "@keeper.sh/sync-protocol";
+import type { CanonicalValue, KeyOrder } from "../canonical";
+import { canonicaliseWith, sortedKeys } from "../canonical";
+
+const comparableFields = [
+  "title",
+  "description",
+  "location",
+  "availability",
+  "visibility",
+] as const;
+
+type ComparableField = (typeof comparableFields)[number];
 
 const referenceFingerprintContract: FingerprintContract = {
   canonicalisation: "rfc8785",
-  comparableFields: ["title", "description", "location", "availability", "visibility"],
+  comparableFields: [...comparableFields],
 };
+
+const isComparableField = (key: string): key is ComparableField =>
+  comparableFields.some((field) => field === key);
+
+const comparableValueOf = (
+  content: EditableContent,
+  field: ComparableField,
+): CanonicalValue => {
+  switch (field) {
+    case "title": {
+      return content.title;
+    }
+    case "description": {
+      return content.description;
+    }
+    case "location": {
+      return content.location;
+    }
+    case "availability": {
+      return content.availability;
+    }
+    case "visibility": {
+      return content.visibility;
+    }
+    default: {
+      return assertNever(field);
+    }
+  }
+};
+
+const wholeSeconds = (value: string): string =>
+  new Date(Math.floor(Date.parse(value) / 1000) * 1000).toISOString();
+
+const identityText = (value: string, normalise: boolean): string => {
+  if (!normalise) {
+    return value;
+  }
+  return value.replaceAll("\r\n", "\n").trimEnd();
+};
+
+const identityInstant = (value: string, normalise: boolean): string => {
+  if (!normalise) {
+    return value;
+  }
+  return wholeSeconds(value);
+};
+
+const timeProjection = (time: EventTime, normalise: boolean): CanonicalValue => {
+  if (time.kind === "allDay") {
+    return {
+      kind: time.kind,
+      startDate: time.startDate.value,
+      endDateExclusive: time.endDateExclusive.value,
+    };
+  }
+  return {
+    kind: time.kind,
+    start: identityInstant(time.start.value, normalise),
+    end: identityInstant(time.end.value, normalise),
+    zone: time.zone?.value ?? null,
+  };
+};
+
+const recurrenceProjection = (recurrence: RecurrencePayload): CanonicalValue => ({
+  dialect: recurrence.dialect,
+  value: recurrence.value,
+  exceptions: recurrence.exceptions,
+});
+
+const normalisedValue = (value: CanonicalValue, normalise: boolean): CanonicalValue => {
+  if (typeof value !== "string") {
+    return value;
+  }
+  return identityText(value, normalise);
+};
+
+const describedProjection = (
+  content: EditableContent,
+  normalise: boolean,
+): Record<string, CanonicalValue> => {
+  const projection: Record<string, CanonicalValue> = {};
+  for (const key of Object.keys(content)) {
+    if (isComparableField(key)) {
+      projection[key] = normalisedValue(comparableValueOf(content, key), normalise);
+    }
+  }
+  return projection;
+};
+
+const contentProjection = (content: EditableContent, normalise: boolean): CanonicalValue => {
+  const described = describedProjection(content, normalise);
+  if (content.recurrence === null) {
+    return { ...described, time: timeProjection(content.time, normalise) };
+  }
+  return { ...described, recurrence: recurrenceProjection(content.recurrence) };
+};
+
+const encodeIdentity = (
+  order: KeyOrder,
+  normalise: boolean,
+  content: EditableContent,
+): string =>
+  `reference-fingerprint:${canonicaliseWith(order, contentProjection(content, normalise))}`;
+
+const fingerprintWith = (
+  order: KeyOrder,
+  content: EditableContent,
+  hash: (input: string) => string,
+): Fingerprint => ({
+  kind: "fingerprint",
+  value: hash(encodeIdentity(order, true, content)),
+});
 
 const fingerprintOf = (
   content: EditableContent,
   hash: (input: string) => string,
-): Fingerprint => {
-  throw new Error(`unimplemented: fingerprintOf(${content.title.length}, ${typeof hash})`);
-};
+): Fingerprint => fingerprintWith(sortedKeys, content, hash);
 
-export { fingerprintOf, referenceFingerprintContract };
+export { encodeIdentity, fingerprintOf, fingerprintWith, referenceFingerprintContract };

--- a/packages/sync-kit/conformance/src/reference/fingerprint.ts
+++ b/packages/sync-kit/conformance/src/reference/fingerprint.ts
@@ -1,0 +1,15 @@
+import type { EditableContent, Fingerprint, FingerprintContract } from "@keeper.sh/sync-protocol";
+
+const referenceFingerprintContract: FingerprintContract = {
+  canonicalisation: "rfc8785",
+  comparableFields: ["title", "description", "location", "availability", "visibility"],
+};
+
+const fingerprintOf = (
+  content: EditableContent,
+  hash: (input: string) => string,
+): Fingerprint => {
+  throw new Error(`unimplemented: fingerprintOf(${content.title.length}, ${typeof hash})`);
+};
+
+export { fingerprintOf, referenceFingerprintContract };

--- a/packages/sync-kit/conformance/src/reference/fingerprint.ts
+++ b/packages/sync-kit/conformance/src/reference/fingerprint.ts
@@ -3,6 +3,8 @@ import type {
   EventTime,
   Fingerprint,
   FingerprintContract,
+  OccurrenceDuration,
+  RecurrenceAnchor,
   RecurrencePayload,
 } from "@keeper.sh/sync-protocol";
 import { assertNever } from "@keeper.sh/sync-protocol";
@@ -92,6 +94,43 @@ const recurrenceProjection = (recurrence: RecurrencePayload): CanonicalValue => 
   exceptions: recurrence.exceptions,
 });
 
+const durationProjection = (duration: OccurrenceDuration): CanonicalValue => {
+  switch (duration.kind) {
+    case "exact": {
+      return { kind: duration.kind, seconds: duration.seconds };
+    }
+    case "nominal": {
+      return { kind: duration.kind, days: duration.days };
+    }
+    default: {
+      return assertNever(duration);
+    }
+  }
+};
+
+const anchorProjection = (anchor: RecurrenceAnchor, normalise: boolean): CanonicalValue => {
+  switch (anchor.kind) {
+    case "timed": {
+      return {
+        kind: anchor.kind,
+        start: identityInstant(anchor.start.value, normalise),
+        zone: anchor.zone.value,
+        duration: durationProjection(anchor.duration),
+      };
+    }
+    case "allDay": {
+      return {
+        kind: anchor.kind,
+        startDate: anchor.startDate.value,
+        duration: durationProjection(anchor.duration),
+      };
+    }
+    default: {
+      return assertNever(anchor);
+    }
+  }
+};
+
 const normalisedValue = (value: CanonicalValue, normalise: boolean): CanonicalValue => {
   if (typeof value !== "string") {
     return value;
@@ -117,7 +156,11 @@ const contentProjection = (content: EditableContent, normalise: boolean): Canoni
   if (content.recurrence === null) {
     return { ...described, time: timeProjection(content.time, normalise) };
   }
-  return { ...described, recurrence: recurrenceProjection(content.recurrence) };
+  return {
+    ...described,
+    recurrence: recurrenceProjection(content.recurrence),
+    anchor: anchorProjection(content.anchor, normalise),
+  };
 };
 
 const encodeIdentity = (

--- a/packages/sync-kit/conformance/src/reference/listing.ts
+++ b/packages/sync-kit/conformance/src/reference/listing.ts
@@ -1,0 +1,224 @@
+import type {
+  BoundedSample,
+  ChangeListing,
+  CoverageWindow,
+  InstallationId,
+  ListingDiagnostics,
+  ListingScope,
+  RemoteEvent,
+  Removal,
+  SyncCursor,
+  TimeWindow,
+  WithheldEvent,
+  WithholdReason,
+} from "@keeper.sh/sync-protocol";
+import { compareCodeUnits } from "../canonical";
+import { conformanceLimits } from "../limits";
+import { constraintViolatedBy } from "./normalize";
+import type { ReportedIdentity } from "./store";
+
+const maximumCoverageMs = 366 * 24 * 60 * 60 * 1000;
+
+interface IdentifiedGroup {
+  readonly uid: string;
+  readonly revisions: readonly RemoteEvent[];
+}
+
+interface ResolvedFeed {
+  readonly events: readonly RemoteEvent[];
+  readonly withheld: readonly WithheldEvent[];
+}
+
+const groupByUid = (events: readonly RemoteEvent[]): readonly IdentifiedGroup[] => {
+  const grouped = new Map<string, RemoteEvent[]>();
+  for (const event of events) {
+    const bucket = grouped.get(event.uid.value);
+    if (bucket) {
+      bucket.push(event);
+      continue;
+    }
+    grouped.set(event.uid.value, [event]);
+  }
+  return [...grouped.entries()]
+    .map(([uid, revisions]) => ({ uid, revisions }))
+    .toSorted((left, right) => compareCodeUnits(left.uid, right.uid));
+};
+
+const winnerOf = (revisions: readonly RemoteEvent[]): RemoteEvent => {
+  const ordered = revisions.toSorted((left, right) => {
+    if (left.revision !== right.revision) {
+      return left.revision - right.revision;
+    }
+    return compareCodeUnits(left.fingerprint.value, right.fingerprint.value);
+  });
+  const winner = ordered.at(-1);
+  if (!winner) {
+    throw new Error("a grouped identity must carry at least one revision");
+  }
+  return winner;
+};
+
+const withholdReasonFor = (
+  group: IdentifiedGroup,
+  winner: RemoteEvent,
+): WithholdReason | null => {
+  if (group.uid.length === 0) {
+    return "missingIdentity";
+  }
+  if (constraintViolatedBy(winner.content) === null) {
+    return null;
+  }
+  if (group.revisions.length > 1) {
+    return "supersededRevisionUnbuildable";
+  }
+  return "unrepresentableTime";
+};
+
+const withheldEntryOf = (winner: RemoteEvent, reason: WithholdReason): WithheldEvent => {
+  if (winner.uid.value.length === 0) {
+    return { uid: null, id: winner.id, reason };
+  }
+  return { uid: winner.uid, id: winner.id, reason };
+};
+
+const resolveFeed = (events: readonly RemoteEvent[]): ResolvedFeed => {
+  const present: RemoteEvent[] = [];
+  const withheld: WithheldEvent[] = [];
+  for (const group of groupByUid(events)) {
+    const winner = winnerOf(group.revisions);
+    const reason = withholdReasonFor(group, winner);
+    if (reason === null) {
+      present.push(winner);
+      continue;
+    }
+    withheld.push(withheldEntryOf(winner, reason));
+  }
+  return { events: present, withheld };
+};
+
+const boundedSample = (identifiers: readonly string[]): BoundedSample => {
+  const sample: string[] = [];
+  let length = 0;
+  for (const identifier of identifiers) {
+    if (sample.length >= conformanceLimits.diagnosticSampleEntries) {
+      break;
+    }
+    if (length + identifier.length > conformanceLimits.diagnosticSampleUtf16Length) {
+      continue;
+    }
+    sample.push(identifier);
+    length += identifier.length;
+  }
+  return { sample, total: identifiers.length };
+};
+
+const identifierOf = (entry: WithheldEvent): string => {
+  if (entry.uid === null) {
+    return entry.id.value;
+  }
+  return entry.uid.value;
+};
+
+const isSelfAuthored = (event: RemoteEvent, installation: InstallationId): boolean =>
+  event.provenance.kind === "ours" && event.provenance.installation.value === installation.value;
+
+const withheldFor = (
+  withheld: readonly WithheldEvent[],
+  reason: WithholdReason,
+): readonly WithheldEvent[] => withheld.filter((entry) => entry.reason === reason);
+
+const diagnosticsOf = (feed: ResolvedFeed, installation: InstallationId): ListingDiagnostics => ({
+  withheld: boundedSample(feed.withheld.map((entry) => identifierOf(entry))),
+  selfAuthored: boundedSample(
+    feed.events.filter((event) => isSelfAuthored(event, installation)).map((event) => event.uid.value),
+  ),
+  unrepresentable: boundedSample(
+    withheldFor(feed.withheld, "unrepresentableTime").map((entry) => identifierOf(entry)),
+  ),
+  pagesFetched: 1,
+});
+
+const emptyDiagnostics: ListingDiagnostics = {
+  withheld: { sample: [], total: 0 },
+  selfAuthored: { sample: [], total: 0 },
+  unrepresentable: { sample: [], total: 0 },
+  pagesFetched: 1,
+};
+
+const provenCoverage = (window: TimeWindow): TimeWindow => {
+  const start = Date.parse(window.start.value);
+  const end = Date.parse(window.end.value);
+  if (end <= start) {
+    return { start: window.start, end: window.start };
+  }
+  if (end - start <= maximumCoverageMs) {
+    return window;
+  }
+  return {
+    start: window.start,
+    end: { kind: "instant", value: new Date(start + maximumCoverageMs).toISOString() },
+  };
+};
+
+const admitsAnything = (covered: TimeWindow): boolean =>
+  Date.parse(covered.end.value) > Date.parse(covered.start.value);
+
+const identitiesOf = (feed: ResolvedFeed): readonly ReportedIdentity[] => [
+  ...feed.events.map((event) => ({ uid: event.uid, id: event.id })),
+  ...feed.withheld.flatMap((entry) => {
+    if (entry.uid === null || entry.id === null) {
+      return [];
+    }
+    return [{ uid: entry.uid, id: entry.id }];
+  }),
+];
+
+const removalsAgainst = (
+  reported: readonly ReportedIdentity[],
+  present: readonly ReportedIdentity[],
+): readonly Removal[] => {
+  const known = new Set(present.map((identity) => identity.uid.value));
+  return reported
+    .filter((identity) => !known.has(identity.uid.value))
+    .map((identity) => ({ kind: "deleted", id: identity.id, uid: identity.uid }));
+};
+
+const coverageOver = (scope: ListingScope): CoverageWindow => ({
+  covered: provenCoverage(scope.window),
+  calendar: scope.calendar,
+});
+
+const emptySnapshot = (scope: ListingScope, cursor: SyncCursor | null): ChangeListing => ({
+  kind: "snapshot",
+  scope,
+  coverage: coverageOver(scope),
+  events: [],
+  removals: [],
+  withheld: [],
+  cursor,
+  diagnostics: emptyDiagnostics,
+});
+
+const cursorLostListing = (scope: ListingScope): ChangeListing => ({
+  kind: "cursorLost",
+  scope,
+  diagnostics: emptyDiagnostics,
+});
+
+export {
+  admitsAnything,
+  boundedSample,
+  coverageOver,
+  cursorLostListing,
+  diagnosticsOf,
+  emptyDiagnostics,
+  emptySnapshot,
+  identifierOf,
+  identitiesOf,
+  isSelfAuthored,
+  maximumCoverageMs,
+  provenCoverage,
+  removalsAgainst,
+  resolveFeed,
+};
+export type { ResolvedFeed };

--- a/packages/sync-kit/conformance/src/reference/listing.ts
+++ b/packages/sync-kit/conformance/src/reference/listing.ts
@@ -98,16 +98,16 @@ const resolveFeed = (events: readonly RemoteEvent[]): ResolvedFeed => {
 
 const boundedSample = (identifiers: readonly string[]): BoundedSample => {
   const sample: string[] = [];
-  let length = 0;
+  const budget = { length: 0 };
   for (const identifier of identifiers) {
     if (sample.length >= conformanceLimits.diagnosticSampleEntries) {
       break;
     }
-    if (length + identifier.length > conformanceLimits.diagnosticSampleUtf16Length) {
+    if (budget.length + identifier.length > conformanceLimits.diagnosticSampleUtf16Length) {
       continue;
     }
     sample.push(identifier);
-    length += identifier.length;
+    budget.length += identifier.length;
   }
   return { sample, total: identifiers.length };
 };

--- a/packages/sync-kit/conformance/src/reference/mutants.ts
+++ b/packages/sync-kit/conformance/src/reference/mutants.ts
@@ -1,0 +1,13 @@
+import type { ConformanceCaseId } from "../case-id";
+import type { ConformanceEnvironment, ProviderUnderTest } from "../options";
+
+const createMutantReferenceProvider = (
+  environment: ConformanceEnvironment,
+  defect: ConformanceCaseId,
+): Promise<ProviderUnderTest<"reference">> => {
+  throw new Error(
+    `unimplemented: createMutantReferenceProvider(${environment.installation.value}, ${defect})`,
+  );
+};
+
+export { createMutantReferenceProvider };

--- a/packages/sync-kit/conformance/src/reference/mutants.ts
+++ b/packages/sync-kit/conformance/src/reference/mutants.ts
@@ -1,13 +1,11 @@
 import type { ConformanceCaseId } from "../case-id";
 import type { ConformanceEnvironment, ProviderUnderTest } from "../options";
+import { createReference } from "./build";
 
 const createMutantReferenceProvider = (
   environment: ConformanceEnvironment,
   defect: ConformanceCaseId,
-): Promise<ProviderUnderTest<"reference">> => {
-  throw new Error(
-    `unimplemented: createMutantReferenceProvider(${environment.installation.value}, ${defect})`,
-  );
-};
+): Promise<ProviderUnderTest<"reference">> =>
+  Promise.resolve(createReference({ environment, defect }));
 
 export { createMutantReferenceProvider };

--- a/packages/sync-kit/conformance/src/reference/normalize.ts
+++ b/packages/sync-kit/conformance/src/reference/normalize.ts
@@ -1,14 +1,99 @@
-import type { EditableContent, NormalizedContent, Result } from "@keeper.sh/sync-protocol";
+import type {
+  EditableContent,
+  EventTime,
+  NormalizedContent,
+  RepresentabilityConstraint,
+  Result,
+  ZoneId,
+} from "@keeper.sh/sync-protocol";
+import { fingerprintOf } from "./fingerprint";
+
+const wholeSeconds = (value: string): string =>
+  new Date(Math.floor(Date.parse(value) / 1000) * 1000).toISOString();
+
+const tidy = (value: string): string => value.replaceAll("\r\n", "\n").trimEnd();
+
+const tidyOptional = (value: string | null): string | null => {
+  if (value === null) {
+    return null;
+  }
+  return tidy(value);
+};
+
+const rewriteTime = (time: EventTime): EventTime => {
+  if (time.kind === "allDay") {
+    return time;
+  }
+  return {
+    kind: "timed",
+    start: { kind: "instant", value: wholeSeconds(time.start.value) },
+    end: { kind: "instant", value: wholeSeconds(time.end.value) },
+    zone: time.zone,
+  };
+};
+
+const rewriteAsProviderWould = (content: EditableContent): EditableContent => {
+  const described = {
+    title: tidy(content.title),
+    description: tidyOptional(content.description),
+    location: tidyOptional(content.location),
+    availability: content.availability,
+    visibility: content.visibility,
+  };
+  if (content.recurrence === null) {
+    return { ...described, recurrence: null, time: rewriteTime(content.time) };
+  }
+  return { ...described, recurrence: content.recurrence, anchor: content.anchor };
+};
+
+const isResolvableZone = (zone: ZoneId): boolean => {
+  try {
+    return new Intl.DateTimeFormat("en-US", { timeZone: zone.value }).resolvedOptions()
+      .timeZone.length > 0;
+  } catch {
+    return false;
+  }
+};
+
+const constraintViolatedBy = (
+  content: EditableContent,
+): RepresentabilityConstraint | null => {
+  if (content.recurrence !== null) {
+    if (content.recurrence.dialect === "rfc5545") {
+      return null;
+    }
+    return "recurrenceDialect";
+  }
+  if (content.time.kind === "allDay") {
+    return null;
+  }
+  if (content.time.zone !== null && !isResolvableZone(content.time.zone)) {
+    return "zoneIdentifier";
+  }
+  if (Date.parse(content.time.end.value) < Date.parse(content.time.start.value)) {
+    return "invertedRange";
+  }
+  return null;
+};
 
 const normalizeForReference = (
   content: EditableContent,
   hash: (input: string) => string,
 ): Result<NormalizedContent<"reference">> => {
-  throw new Error(`unimplemented: normalizeForReference(${content.title.length}, ${typeof hash})`);
+  const constraint = constraintViolatedBy(content);
+  if (constraint !== null) {
+    return { ok: false, failure: { kind: "unrepresentable", constraint } };
+  }
+  const rewritten = rewriteAsProviderWould(content);
+  return {
+    ok: true,
+    value: {
+      kind: "normalized",
+      provider: "reference",
+      content: rewritten,
+      fingerprint: fingerprintOf(rewritten, hash),
+    },
+  };
 };
 
-const rewriteAsProviderWould = (content: EditableContent): EditableContent => {
-  throw new Error(`unimplemented: rewriteAsProviderWould(${content.title.length})`);
-};
-
-export { normalizeForReference, rewriteAsProviderWould };
+export { constraintViolatedBy, isResolvableZone, normalizeForReference, rewriteAsProviderWould };

--- a/packages/sync-kit/conformance/src/reference/normalize.ts
+++ b/packages/sync-kit/conformance/src/reference/normalize.ts
@@ -1,0 +1,14 @@
+import type { EditableContent, NormalizedContent, Result } from "@keeper.sh/sync-protocol";
+
+const normalizeForReference = (
+  content: EditableContent,
+  hash: (input: string) => string,
+): Result<NormalizedContent<"reference">> => {
+  throw new Error(`unimplemented: normalizeForReference(${content.title.length}, ${typeof hash})`);
+};
+
+const rewriteAsProviderWould = (content: EditableContent): EditableContent => {
+  throw new Error(`unimplemented: rewriteAsProviderWould(${content.title.length})`);
+};
+
+export { normalizeForReference, rewriteAsProviderWould };

--- a/packages/sync-kit/conformance/src/reference/normalize.ts
+++ b/packages/sync-kit/conformance/src/reference/normalize.ts
@@ -2,10 +2,12 @@ import type {
   EditableContent,
   EventTime,
   NormalizedContent,
+  RecurrenceAnchor,
   RepresentabilityConstraint,
   Result,
   ZoneId,
 } from "@keeper.sh/sync-protocol";
+import { referenceMinimumSpanSeconds } from "./capabilities";
 import { fingerprintOf } from "./fingerprint";
 
 const wholeSeconds = (value: string): string =>
@@ -20,14 +22,24 @@ const tidyOptional = (value: string | null): string | null => {
   return tidy(value);
 };
 
+const widenedEnd = (start: string, end: string): string => {
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  if (endMs - startMs >= referenceMinimumSpanSeconds * 1000) {
+    return end;
+  }
+  return new Date(startMs + referenceMinimumSpanSeconds * 1000).toISOString();
+};
+
 const rewriteTime = (time: EventTime): EventTime => {
   if (time.kind === "allDay") {
     return time;
   }
+  const start = wholeSeconds(time.start.value);
   return {
     kind: "timed",
-    start: { kind: "instant", value: wholeSeconds(time.start.value) },
-    end: { kind: "instant", value: wholeSeconds(time.end.value) },
+    start: { kind: "instant", value: start },
+    end: { kind: "instant", value: widenedEnd(start, wholeSeconds(time.end.value)) },
     zone: time.zone,
   };
 };
@@ -55,14 +67,24 @@ const isResolvableZone = (zone: ZoneId): boolean => {
   }
 };
 
+const anchorZoneViolation = (anchor: RecurrenceAnchor): RepresentabilityConstraint | null => {
+  if (anchor.kind === "allDay") {
+    return null;
+  }
+  if (isResolvableZone(anchor.zone)) {
+    return null;
+  }
+  return "zoneIdentifier";
+};
+
 const constraintViolatedBy = (
   content: EditableContent,
 ): RepresentabilityConstraint | null => {
   if (content.recurrence !== null) {
-    if (content.recurrence.dialect === "rfc5545") {
-      return null;
+    if (content.recurrence.dialect !== "rfc5545") {
+      return "recurrenceDialect";
     }
-    return "recurrenceDialect";
+    return anchorZoneViolation(content.anchor);
   }
   if (content.time.kind === "allDay") {
     return null;

--- a/packages/sync-kit/conformance/src/reference/provider.ts
+++ b/packages/sync-kit/conformance/src/reference/provider.ts
@@ -1,0 +1,16 @@
+import type { CalendarKey } from "@keeper.sh/sync-protocol";
+import type { ConformanceEnvironment, ProviderUnderTest } from "../options";
+
+const referenceCalendar: CalendarKey = {
+  provider: "reference",
+  account: { kind: "accountId", value: "reference-account" },
+  calendar: { kind: "calendarId", value: "reference-calendar" },
+};
+
+const createReferenceProvider = (
+  environment: ConformanceEnvironment,
+): Promise<ProviderUnderTest<"reference">> => {
+  throw new Error(`unimplemented: createReferenceProvider(${environment.installation.value})`);
+};
+
+export { createReferenceProvider, referenceCalendar };

--- a/packages/sync-kit/conformance/src/reference/provider.ts
+++ b/packages/sync-kit/conformance/src/reference/provider.ts
@@ -1,16 +1,10 @@
-import type { CalendarKey } from "@keeper.sh/sync-protocol";
 import type { ConformanceEnvironment, ProviderUnderTest } from "../options";
-
-const referenceCalendar: CalendarKey = {
-  provider: "reference",
-  account: { kind: "accountId", value: "reference-account" },
-  calendar: { kind: "calendarId", value: "reference-calendar" },
-};
+import { createReference } from "./build";
+import { referenceCalendar, referenceWritableCalendar } from "./calendar";
 
 const createReferenceProvider = (
   environment: ConformanceEnvironment,
-): Promise<ProviderUnderTest<"reference">> => {
-  throw new Error(`unimplemented: createReferenceProvider(${environment.installation.value})`);
-};
+): Promise<ProviderUnderTest<"reference">> =>
+  Promise.resolve(createReference({ environment, defect: null }));
 
-export { createReferenceProvider, referenceCalendar };
+export { createReferenceProvider, referenceCalendar, referenceWritableCalendar };

--- a/packages/sync-kit/conformance/src/reference/store.ts
+++ b/packages/sync-kit/conformance/src/reference/store.ts
@@ -27,20 +27,31 @@ interface ReferenceStore {
 const signatureOf = (event: RemoteEvent): string =>
   `${event.revision}|${event.version.value}|${event.fingerprint.value}`;
 
+interface ReferenceStoreState {
+  stored: readonly RemoteEvent[];
+  corrupt: readonly string[];
+  cancellations: readonly EventUid[];
+  unattributable: readonly RemoteEventId[];
+  reported: readonly ReportedIdentity[];
+  sequence: number;
+}
+
 const createReferenceStore = (calendar: CalendarKey): ReferenceStore => {
-  let stored: readonly RemoteEvent[] = [];
-  let corrupt: readonly string[] = [];
-  let cancellations: readonly EventUid[] = [];
-  let unattributable: readonly RemoteEventId[] = [];
-  let reported: readonly ReportedIdentity[] = [];
+  const state: ReferenceStoreState = {
+    stored: [],
+    corrupt: [],
+    cancellations: [],
+    unattributable: [],
+    reported: [],
+    sequence: 0,
+  };
   const log: WriteLogEntry[] = [];
   const sequences = new Map<string, number>();
   const signatures = new Map<string, string>();
-  let sequence = 0;
 
   const touch = (uid: string): void => {
-    sequence += 1;
-    sequences.set(uid, sequence);
+    state.sequence += 1;
+    sequences.set(uid, state.sequence);
   };
 
   const replaceObjects = (events: readonly RemoteEvent[]): void => {
@@ -51,36 +62,36 @@ const createReferenceStore = (calendar: CalendarKey): ReferenceStore => {
         touch(event.uid.value);
       }
     }
-    stored = events;
+    state.stored = events;
   };
 
   return {
     seed: (next: ProviderSeed) => {
       const { cancelled, corruptKnownRows, events, unattributableRemovals } = next;
-      corrupt = corruptKnownRows;
-      cancellations = cancelled;
-      unattributable = unattributableRemovals;
+      state.corrupt = corruptKnownRows;
+      state.cancellations = cancelled;
+      state.unattributable = unattributableRemovals;
       replaceObjects(events);
     },
-    objects: () => stored,
+    objects: () => state.stored,
     writeLog: () => log,
-    corruptKnownRows: () => corrupt,
-    cancelled: () => cancellations,
-    unattributableRemovals: () => unattributable,
+    corruptKnownRows: () => state.corrupt,
+    cancelled: () => state.cancellations,
+    unattributableRemovals: () => state.unattributable,
     calendar: () => calendar,
     replaceObjects,
     record: (entry: WriteLogEntry) => {
       log.push(entry);
     },
-    reported: () => reported,
+    reported: () => state.reported,
     setReported: (identities: readonly ReportedIdentity[]) => {
-      reported = identities;
+      state.reported = identities;
     },
     sequenceOf: (uid: string) => sequences.get(uid) ?? 0,
     touch,
-    currentSequence: () => sequence,
+    currentSequence: () => state.sequence,
     clearCorruption: () => {
-      corrupt = [];
+      state.corrupt = [];
     },
   };
 };

--- a/packages/sync-kit/conformance/src/reference/store.ts
+++ b/packages/sync-kit/conformance/src/reference/store.ts
@@ -11,6 +11,8 @@ interface ReferenceStore {
   readonly objects: () => readonly RemoteEvent[];
   readonly writeLog: () => readonly WriteLogEntry[];
   readonly corruptKnownRows: () => readonly string[];
+  readonly cancelled: () => readonly EventUid[];
+  readonly unattributableRemovals: () => readonly RemoteEventId[];
   readonly calendar: () => CalendarKey;
   readonly replaceObjects: (events: readonly RemoteEvent[]) => void;
   readonly record: (entry: WriteLogEntry) => void;
@@ -28,6 +30,8 @@ const signatureOf = (event: RemoteEvent): string =>
 const createReferenceStore = (calendar: CalendarKey): ReferenceStore => {
   let stored: readonly RemoteEvent[] = [];
   let corrupt: readonly string[] = [];
+  let cancellations: readonly EventUid[] = [];
+  let unattributable: readonly RemoteEventId[] = [];
   let reported: readonly ReportedIdentity[] = [];
   const log: WriteLogEntry[] = [];
   const sequences = new Map<string, number>();
@@ -52,12 +56,17 @@ const createReferenceStore = (calendar: CalendarKey): ReferenceStore => {
 
   return {
     seed: (next: ProviderSeed) => {
-      corrupt = next.corruptKnownRows;
-      replaceObjects(next.events);
+      const { cancelled, corruptKnownRows, events, unattributableRemovals } = next;
+      corrupt = corruptKnownRows;
+      cancellations = cancelled;
+      unattributable = unattributableRemovals;
+      replaceObjects(events);
     },
     objects: () => stored,
     writeLog: () => log,
     corruptKnownRows: () => corrupt,
+    cancelled: () => cancellations,
+    unattributableRemovals: () => unattributable,
     calendar: () => calendar,
     replaceObjects,
     record: (entry: WriteLogEntry) => {

--- a/packages/sync-kit/conformance/src/reference/store.ts
+++ b/packages/sync-kit/conformance/src/reference/store.ts
@@ -1,5 +1,10 @@
-import type { CalendarKey, RemoteEvent } from "@keeper.sh/sync-protocol";
+import type { CalendarKey, EventUid, RemoteEvent, RemoteEventId } from "@keeper.sh/sync-protocol";
 import type { ProviderSeed, WriteLogEntry } from "../options";
+
+interface ReportedIdentity {
+  readonly uid: EventUid;
+  readonly id: RemoteEventId;
+}
 
 interface ReferenceStore {
   readonly seed: (seed: ProviderSeed) => void;
@@ -7,11 +12,69 @@ interface ReferenceStore {
   readonly writeLog: () => readonly WriteLogEntry[];
   readonly corruptKnownRows: () => readonly string[];
   readonly calendar: () => CalendarKey;
+  readonly replaceObjects: (events: readonly RemoteEvent[]) => void;
+  readonly record: (entry: WriteLogEntry) => void;
+  readonly reported: () => readonly ReportedIdentity[];
+  readonly setReported: (identities: readonly ReportedIdentity[]) => void;
+  readonly sequenceOf: (uid: string) => number;
+  readonly touch: (uid: string) => void;
+  readonly currentSequence: () => number;
+  readonly clearCorruption: () => void;
 }
 
+const signatureOf = (event: RemoteEvent): string =>
+  `${event.revision}|${event.version.value}|${event.fingerprint.value}`;
+
 const createReferenceStore = (calendar: CalendarKey): ReferenceStore => {
-  throw new Error(`unimplemented: createReferenceStore(${calendar.calendar.value})`);
+  let stored: readonly RemoteEvent[] = [];
+  let corrupt: readonly string[] = [];
+  let reported: readonly ReportedIdentity[] = [];
+  const log: WriteLogEntry[] = [];
+  const sequences = new Map<string, number>();
+  const signatures = new Map<string, string>();
+  let sequence = 0;
+
+  const touch = (uid: string): void => {
+    sequence += 1;
+    sequences.set(uid, sequence);
+  };
+
+  const replaceObjects = (events: readonly RemoteEvent[]): void => {
+    for (const event of events) {
+      const signature = signatureOf(event);
+      if (signatures.get(event.uid.value) !== signature) {
+        signatures.set(event.uid.value, signature);
+        touch(event.uid.value);
+      }
+    }
+    stored = events;
+  };
+
+  return {
+    seed: (next: ProviderSeed) => {
+      corrupt = next.corruptKnownRows;
+      replaceObjects(next.events);
+    },
+    objects: () => stored,
+    writeLog: () => log,
+    corruptKnownRows: () => corrupt,
+    calendar: () => calendar,
+    replaceObjects,
+    record: (entry: WriteLogEntry) => {
+      log.push(entry);
+    },
+    reported: () => reported,
+    setReported: (identities: readonly ReportedIdentity[]) => {
+      reported = identities;
+    },
+    sequenceOf: (uid: string) => sequences.get(uid) ?? 0,
+    touch,
+    currentSequence: () => sequence,
+    clearCorruption: () => {
+      corrupt = [];
+    },
+  };
 };
 
 export { createReferenceStore };
-export type { ReferenceStore };
+export type { ReferenceStore, ReportedIdentity };

--- a/packages/sync-kit/conformance/src/reference/store.ts
+++ b/packages/sync-kit/conformance/src/reference/store.ts
@@ -1,0 +1,17 @@
+import type { CalendarKey, RemoteEvent } from "@keeper.sh/sync-protocol";
+import type { ProviderSeed, WriteLogEntry } from "../options";
+
+interface ReferenceStore {
+  readonly seed: (seed: ProviderSeed) => void;
+  readonly objects: () => readonly RemoteEvent[];
+  readonly writeLog: () => readonly WriteLogEntry[];
+  readonly corruptKnownRows: () => readonly string[];
+  readonly calendar: () => CalendarKey;
+}
+
+const createReferenceStore = (calendar: CalendarKey): ReferenceStore => {
+  throw new Error(`unimplemented: createReferenceStore(${calendar.calendar.value})`);
+};
+
+export { createReferenceStore };
+export type { ReferenceStore };

--- a/packages/sync-kit/conformance/src/registry/case.ts
+++ b/packages/sync-kit/conformance/src/registry/case.ts
@@ -1,0 +1,29 @@
+import type { Capabilities, ProviderId, WindowMembership } from "@keeper.sh/sync-protocol";
+import type { ConformanceCaseId, LedgerEntryId } from "../case-id";
+import type { ConformanceEnvironment, ProviderUnderTest } from "../options";
+
+interface CaseContext<Provider extends ProviderId = ProviderId> {
+  readonly provider: ProviderUnderTest<Provider>;
+  readonly environment: ConformanceEnvironment;
+  readonly supports: Capabilities<Provider>;
+  readonly withinWindow: WindowMembership;
+}
+
+type CaseGate =
+  | { readonly kind: "ungated" }
+  | { readonly kind: "branch"; readonly capability: keyof Capabilities; readonly branch: string }
+  | { readonly kind: "skip"; readonly capability: keyof Capabilities; readonly reason: string };
+
+interface ConformanceCase<Provider extends ProviderId = ProviderId> {
+  readonly id: ConformanceCaseId;
+  readonly title: string;
+  readonly ledger: LedgerEntryId;
+  readonly gate: CaseGate;
+  readonly run: (context: CaseContext<Provider>) => Promise<void>;
+}
+
+type CaseFamily = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+) => readonly ConformanceCase<Provider>[];
+
+export type { CaseContext, CaseFamily, CaseGate, ConformanceCase };

--- a/packages/sync-kit/conformance/src/registry/case.ts
+++ b/packages/sync-kit/conformance/src/registry/case.ts
@@ -11,8 +11,7 @@ interface CaseContext<Provider extends ProviderId = ProviderId> {
 
 type CaseGate =
   | { readonly kind: "ungated" }
-  | { readonly kind: "branch"; readonly capability: keyof Capabilities; readonly branch: string }
-  | { readonly kind: "skip"; readonly capability: keyof Capabilities; readonly reason: string };
+  | { readonly kind: "branch"; readonly capability: keyof Capabilities; readonly branch: string };
 
 interface ConformanceCase<Provider extends ProviderId = ProviderId> {
   readonly id: ConformanceCaseId;

--- a/packages/sync-kit/conformance/src/registry/gates.ts
+++ b/packages/sync-kit/conformance/src/registry/gates.ts
@@ -1,21 +1,10 @@
 import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import { assertNever } from "@keeper.sh/sync-protocol";
 import type { ConformanceCaseId } from "../case-id";
 import { conformanceCaseIds } from "../case-id";
 import type { CaseGate } from "./case";
 
-const gatedCaseIds: readonly ConformanceCaseId[] = [
-  "CONF-O3",
-  "CONF-O11",
-  "CONF-O13",
-  "CONF-O14",
-  "CONF-O16",
-  "CONF-O18",
-  "CONF-O28",
-  "CONF-O35",
-  "CONF-O38",
-];
-
-const ungated: CaseGate = { kind: "ungated" };
+type GateFactory = (supports: Capabilities) => CaseGate;
 
 const branchOn = (capability: keyof Capabilities, branch: string): CaseGate => ({
   kind: "branch",
@@ -23,17 +12,9 @@ const branchOn = (capability: keyof Capabilities, branch: string): CaseGate => (
   branch,
 });
 
-const deltaGate = <Provider extends ProviderId>(
-  supports: Capabilities<Provider>,
-  boundBranch: string,
-  freeBranch: string,
-): CaseGate => {
+const deltaGate = (supports: Capabilities, boundBranch: string, freeBranch: string): CaseGate => {
   if (supports.delta.kind === "none") {
-    return {
-      kind: "skip",
-      capability: "delta",
-      reason: "the adapter declares no delta support, so no cursor case applies",
-    };
+    return branchOn("delta", "noDelta");
   }
   if (supports.delta.windowBoundToCursor) {
     return branchOn("delta", boundBranch);
@@ -41,58 +22,59 @@ const deltaGate = <Provider extends ProviderId>(
   return branchOn("delta", freeBranch);
 };
 
-const ambiguityGate = <Provider extends ProviderId>(
-  supports: Capabilities<Provider>,
-): CaseGate => {
+const ambiguityGate = (supports: Capabilities): CaseGate => {
   if (supports.removalsAreAmbiguous) {
     return branchOn("removalsAreAmbiguous", "ambiguous");
   }
   return branchOn("removalsAreAmbiguous", "unambiguous");
 };
 
-const echoGate = <Provider extends ProviderId>(supports: Capabilities<Provider>): CaseGate => {
+const echoGate = (supports: Capabilities): CaseGate => {
   if (supports.echoesWrites) {
     return branchOn("echoesWrites", "echoes");
   }
   return branchOn("echoesWrites", "blind");
 };
 
+const gateFactories = {
+  "CONF-O3": (supports) => branchOn("deletionAuthority", supports.deletionAuthority),
+  "CONF-O11": (supports) => deltaGate(supports, "windowBoundToCursor", "windowFreeCursor"),
+  "CONF-O13": ambiguityGate,
+  "CONF-O14": (supports) => branchOn("precondition", supports.precondition),
+  "CONF-O16": (supports) => branchOn("provenanceChannel", supports.provenanceChannel),
+  "CONF-O18": echoGate,
+  "CONF-O26": (supports) => branchOn("deletionAuthority", supports.deletionAuthority),
+  "CONF-O28": (supports) => branchOn("representableRange", supports.representableRange.zeroDuration),
+  "CONF-O35": (supports) => branchOn("recurrenceWrite", supports.recurrenceWrite),
+  "CONF-O38": (supports) => deltaGate(supports, "tokenizedDelta", "tokenizedDelta"),
+  "CONF-O45": (supports) => branchOn("allDay", supports.allDay),
+} as const satisfies Partial<Record<ConformanceCaseId, GateFactory>>;
+
+const gatedCaseIds: readonly ConformanceCaseId[] = Object.keys(gateFactories).flatMap((key) => {
+  const found = conformanceCaseIds.find((id) => id === key);
+  if (!found) {
+    return [];
+  }
+  return [found];
+});
+
+const factoryFor = (id: ConformanceCaseId): GateFactory | null => {
+  const entry = Object.entries(gateFactories).find(([key]) => key === id);
+  if (!entry) {
+    return null;
+  }
+  return entry[1];
+};
+
 const gateFor = <Provider extends ProviderId>(
   id: ConformanceCaseId,
   supports: Capabilities<Provider>,
 ): CaseGate => {
-  switch (id) {
-    case "CONF-O3": {
-      return branchOn("deletionAuthority", supports.deletionAuthority);
-    }
-    case "CONF-O11": {
-      return deltaGate(supports, "windowBoundToCursor", "windowFreeCursor");
-    }
-    case "CONF-O13": {
-      return ambiguityGate(supports);
-    }
-    case "CONF-O14": {
-      return branchOn("precondition", supports.precondition);
-    }
-    case "CONF-O16": {
-      return branchOn("provenanceChannel", supports.provenanceChannel);
-    }
-    case "CONF-O18": {
-      return echoGate(supports);
-    }
-    case "CONF-O28": {
-      return branchOn("representableRange", supports.representableRange.zeroDuration);
-    }
-    case "CONF-O35": {
-      return branchOn("recurrenceWrite", supports.recurrenceWrite);
-    }
-    case "CONF-O38": {
-      return deltaGate(supports, "tokenizedDelta", "tokenizedDelta");
-    }
-    default: {
-      return ungated;
-    }
+  const factory = factoryFor(id);
+  if (factory === null) {
+    return { kind: "ungated" };
   }
+  return factory(supports);
 };
 
 const branchNameOf = (gate: CaseGate): string | null => {
@@ -100,12 +82,11 @@ const branchNameOf = (gate: CaseGate): string | null => {
     case "branch": {
       return gate.branch;
     }
-    case "ungated":
-    case "skip": {
+    case "ungated": {
       return null;
     }
     default: {
-      return null;
+      return assertNever(gate);
     }
   }
 };

--- a/packages/sync-kit/conformance/src/registry/gates.ts
+++ b/packages/sync-kit/conformance/src/registry/gates.ts
@@ -1,16 +1,116 @@
 import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
 import type { ConformanceCaseId } from "../case-id";
+import { conformanceCaseIds } from "../case-id";
 import type { CaseGate } from "./case";
+
+const gatedCaseIds: readonly ConformanceCaseId[] = [
+  "CONF-O3",
+  "CONF-O11",
+  "CONF-O13",
+  "CONF-O14",
+  "CONF-O16",
+  "CONF-O18",
+  "CONF-O28",
+  "CONF-O35",
+  "CONF-O38",
+];
+
+const ungated: CaseGate = { kind: "ungated" };
+
+const branchOn = (capability: keyof Capabilities, branch: string): CaseGate => ({
+  kind: "branch",
+  capability,
+  branch,
+});
+
+const deltaGate = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+  boundBranch: string,
+  freeBranch: string,
+): CaseGate => {
+  if (supports.delta.kind === "none") {
+    return {
+      kind: "skip",
+      capability: "delta",
+      reason: "the adapter declares no delta support, so no cursor case applies",
+    };
+  }
+  if (supports.delta.windowBoundToCursor) {
+    return branchOn("delta", boundBranch);
+  }
+  return branchOn("delta", freeBranch);
+};
+
+const ambiguityGate = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+): CaseGate => {
+  if (supports.removalsAreAmbiguous) {
+    return branchOn("removalsAreAmbiguous", "ambiguous");
+  }
+  return branchOn("removalsAreAmbiguous", "unambiguous");
+};
+
+const echoGate = <Provider extends ProviderId>(supports: Capabilities<Provider>): CaseGate => {
+  if (supports.echoesWrites) {
+    return branchOn("echoesWrites", "echoes");
+  }
+  return branchOn("echoesWrites", "blind");
+};
 
 const gateFor = <Provider extends ProviderId>(
   id: ConformanceCaseId,
   supports: Capabilities<Provider>,
 ): CaseGate => {
-  throw new Error(`unimplemented: gateFor(${id}, ${supports.provider})`);
+  switch (id) {
+    case "CONF-O3": {
+      return branchOn("deletionAuthority", supports.deletionAuthority);
+    }
+    case "CONF-O11": {
+      return deltaGate(supports, "windowBoundToCursor", "windowFreeCursor");
+    }
+    case "CONF-O13": {
+      return ambiguityGate(supports);
+    }
+    case "CONF-O14": {
+      return branchOn("precondition", supports.precondition);
+    }
+    case "CONF-O16": {
+      return branchOn("provenanceChannel", supports.provenanceChannel);
+    }
+    case "CONF-O18": {
+      return echoGate(supports);
+    }
+    case "CONF-O28": {
+      return branchOn("representableRange", supports.representableRange.zeroDuration);
+    }
+    case "CONF-O35": {
+      return branchOn("recurrenceWrite", supports.recurrenceWrite);
+    }
+    case "CONF-O38": {
+      return deltaGate(supports, "tokenizedDelta", "tokenizedDelta");
+    }
+    default: {
+      return ungated;
+    }
+  }
 };
 
 const branchNameOf = (gate: CaseGate): string | null => {
-  throw new Error(`unimplemented: branchNameOf(${gate.kind})`);
+  switch (gate.kind) {
+    case "branch": {
+      return gate.branch;
+    }
+    case "ungated":
+    case "skip": {
+      return null;
+    }
+    default: {
+      return null;
+    }
+  }
 };
 
-export { branchNameOf, gateFor };
+const ungatedCaseIdsOf = (): readonly ConformanceCaseId[] =>
+  conformanceCaseIds.filter((id) => !gatedCaseIds.includes(id));
+
+export { branchNameOf, gateFor, gatedCaseIds, ungatedCaseIdsOf };

--- a/packages/sync-kit/conformance/src/registry/gates.ts
+++ b/packages/sync-kit/conformance/src/registry/gates.ts
@@ -1,0 +1,16 @@
+import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { ConformanceCaseId } from "../case-id";
+import type { CaseGate } from "./case";
+
+const gateFor = <Provider extends ProviderId>(
+  id: ConformanceCaseId,
+  supports: Capabilities<Provider>,
+): CaseGate => {
+  throw new Error(`unimplemented: gateFor(${id}, ${supports.provider})`);
+};
+
+const branchNameOf = (gate: CaseGate): string | null => {
+  throw new Error(`unimplemented: branchNameOf(${gate.kind})`);
+};
+
+export { branchNameOf, gateFor };

--- a/packages/sync-kit/conformance/src/registry/suite.ts
+++ b/packages/sync-kit/conformance/src/registry/suite.ts
@@ -12,12 +12,10 @@ import { lockupCases } from "../cases/lockups";
 import { provenanceCases } from "../cases/provenance";
 import { windowCases } from "../cases/window";
 import { writeCases } from "../cases/writes";
-import type { SkippedCase } from "../report";
 import type { ConformanceCase } from "./case";
 
 interface CaseSelection<Provider extends ProviderId = ProviderId> {
   readonly selected: readonly ConformanceCase<Provider>[];
-  readonly skipped: readonly SkippedCase[];
 }
 
 const allCases = <Provider extends ProviderId>(
@@ -37,25 +35,9 @@ const allCases = <Provider extends ProviderId>(
   ...lockupCases(supports),
 ];
 
-const skippedFrom = <Provider extends ProviderId>(
-  records: readonly ConformanceCase<Provider>[],
-): readonly SkippedCase[] =>
-  records.flatMap((record) => {
-    if (record.gate.kind !== "skip") {
-      return [];
-    }
-    return [{ id: record.id, capability: record.gate.capability, reason: record.gate.reason }];
-  });
-
 const selectConformanceCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
-): CaseSelection<Provider> => {
-  const records = allCases(supports);
-  return {
-    selected: records.filter((record) => record.gate.kind !== "skip"),
-    skipped: skippedFrom(records),
-  };
-};
+): CaseSelection<Provider> => ({ selected: allCases(supports) });
 
 const conformanceCaseOf = <Provider extends ProviderId>(
   id: ConformanceCaseId,

--- a/packages/sync-kit/conformance/src/registry/suite.ts
+++ b/packages/sync-kit/conformance/src/registry/suite.ts
@@ -1,5 +1,17 @@
 import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
 import type { ConformanceCaseId } from "../case-id";
+import { capabilityCases } from "../cases/capabilities";
+import { convergenceCases } from "../cases/convergence";
+import { cursorCases } from "../cases/cursor";
+import { deletionSafetyCases } from "../cases/deletion-safety";
+import { diagnosticsCases } from "../cases/diagnostics";
+import { hostileContentCases } from "../cases/hostile-content";
+import { injectionCases } from "../cases/injection";
+import { isolationCases } from "../cases/isolation";
+import { lockupCases } from "../cases/lockups";
+import { provenanceCases } from "../cases/provenance";
+import { windowCases } from "../cases/window";
+import { writeCases } from "../cases/writes";
 import type { SkippedCase } from "../report";
 import type { ConformanceCase } from "./case";
 
@@ -8,18 +20,53 @@ interface CaseSelection<Provider extends ProviderId = ProviderId> {
   readonly skipped: readonly SkippedCase[];
 }
 
+const allCases = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+): readonly ConformanceCase<Provider>[] => [
+  ...deletionSafetyCases(supports),
+  ...isolationCases(supports),
+  ...cursorCases(supports),
+  ...writeCases(supports),
+  ...provenanceCases(supports),
+  ...windowCases(supports),
+  ...capabilityCases(supports),
+  ...diagnosticsCases(supports),
+  ...convergenceCases(supports),
+  ...hostileContentCases(supports),
+  ...injectionCases(supports),
+  ...lockupCases(supports),
+];
+
+const skippedFrom = <Provider extends ProviderId>(
+  records: readonly ConformanceCase<Provider>[],
+): readonly SkippedCase[] =>
+  records.flatMap((record) => {
+    if (record.gate.kind !== "skip") {
+      return [];
+    }
+    return [{ id: record.id, capability: record.gate.capability, reason: record.gate.reason }];
+  });
+
 const selectConformanceCases = <Provider extends ProviderId>(
   supports: Capabilities<Provider>,
 ): CaseSelection<Provider> => {
-  throw new Error(`unimplemented: selectConformanceCases(${supports.provider})`);
+  const records = allCases(supports);
+  return {
+    selected: records.filter((record) => record.gate.kind !== "skip"),
+    skipped: skippedFrom(records),
+  };
 };
 
 const conformanceCaseOf = <Provider extends ProviderId>(
   id: ConformanceCaseId,
   supports: Capabilities<Provider>,
 ): ConformanceCase<Provider> => {
-  throw new Error(`unimplemented: conformanceCaseOf(${id}, ${supports.provider})`);
+  const found = allCases(supports).find((record) => record.id === id);
+  if (!found) {
+    throw new Error(`the conformance suite generates no case named "${id}"`);
+  }
+  return found;
 };
 
-export { conformanceCaseOf, selectConformanceCases };
+export { allCases, conformanceCaseOf, selectConformanceCases };
 export type { CaseSelection };

--- a/packages/sync-kit/conformance/src/registry/suite.ts
+++ b/packages/sync-kit/conformance/src/registry/suite.ts
@@ -1,0 +1,25 @@
+import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { ConformanceCaseId } from "../case-id";
+import type { SkippedCase } from "../report";
+import type { ConformanceCase } from "./case";
+
+interface CaseSelection<Provider extends ProviderId = ProviderId> {
+  readonly selected: readonly ConformanceCase<Provider>[];
+  readonly skipped: readonly SkippedCase[];
+}
+
+const selectConformanceCases = <Provider extends ProviderId>(
+  supports: Capabilities<Provider>,
+): CaseSelection<Provider> => {
+  throw new Error(`unimplemented: selectConformanceCases(${supports.provider})`);
+};
+
+const conformanceCaseOf = <Provider extends ProviderId>(
+  id: ConformanceCaseId,
+  supports: Capabilities<Provider>,
+): ConformanceCase<Provider> => {
+  throw new Error(`unimplemented: conformanceCaseOf(${id}, ${supports.provider})`);
+};
+
+export { conformanceCaseOf, selectConformanceCases };
+export type { CaseSelection };

--- a/packages/sync-kit/conformance/src/report.ts
+++ b/packages/sync-kit/conformance/src/report.ts
@@ -1,0 +1,28 @@
+import type { Capabilities } from "@keeper.sh/sync-protocol";
+import type { ConformanceCaseId, LedgerEntryId } from "./case-id";
+
+interface SelectedCase {
+  readonly id: ConformanceCaseId;
+  readonly title: string;
+  readonly ledger: LedgerEntryId;
+  readonly branch: string | null;
+}
+
+interface SkippedCase {
+  readonly id: ConformanceCaseId;
+  readonly capability: keyof Capabilities;
+  readonly reason: string;
+}
+
+interface ConformanceReport {
+  readonly name: string;
+  readonly selected: readonly SelectedCase[];
+  readonly skipped: readonly SkippedCase[];
+  readonly ungated: readonly ConformanceCaseId[];
+  readonly notAttempted: readonly ConformanceCaseId[];
+}
+
+const ungatedCaseIds: readonly ConformanceCaseId[] = [];
+
+export { ungatedCaseIds };
+export type { ConformanceReport, SelectedCase, SkippedCase };

--- a/packages/sync-kit/conformance/src/report.ts
+++ b/packages/sync-kit/conformance/src/report.ts
@@ -1,4 +1,3 @@
-import type { Capabilities } from "@keeper.sh/sync-protocol";
 import type { ConformanceCaseId, LedgerEntryId } from "./case-id";
 import { ungatedCaseIdsOf } from "./registry/gates";
 
@@ -9,21 +8,13 @@ interface SelectedCase {
   readonly branch: string | null;
 }
 
-interface SkippedCase {
-  readonly id: ConformanceCaseId;
-  readonly capability: keyof Capabilities;
-  readonly reason: string;
-}
-
 interface ConformanceReport {
   readonly name: string;
   readonly selected: readonly SelectedCase[];
-  readonly skipped: readonly SkippedCase[];
   readonly ungated: readonly ConformanceCaseId[];
-  readonly notAttempted: readonly ConformanceCaseId[];
 }
 
 const ungatedCaseIds: readonly ConformanceCaseId[] = ungatedCaseIdsOf();
 
 export { ungatedCaseIds };
-export type { ConformanceReport, SelectedCase, SkippedCase };
+export type { ConformanceReport, SelectedCase };

--- a/packages/sync-kit/conformance/src/report.ts
+++ b/packages/sync-kit/conformance/src/report.ts
@@ -1,5 +1,6 @@
 import type { Capabilities } from "@keeper.sh/sync-protocol";
 import type { ConformanceCaseId, LedgerEntryId } from "./case-id";
+import { ungatedCaseIdsOf } from "./registry/gates";
 
 interface SelectedCase {
   readonly id: ConformanceCaseId;
@@ -22,7 +23,7 @@ interface ConformanceReport {
   readonly notAttempted: readonly ConformanceCaseId[];
 }
 
-const ungatedCaseIds: readonly ConformanceCaseId[] = [];
+const ungatedCaseIds: readonly ConformanceCaseId[] = ungatedCaseIdsOf();
 
 export { ungatedCaseIds };
 export type { ConformanceReport, SelectedCase, SkippedCase };

--- a/packages/sync-kit/conformance/src/run-conformance.ts
+++ b/packages/sync-kit/conformance/src/run-conformance.ts
@@ -1,7 +1,12 @@
-import type { ProviderId } from "@keeper.sh/sync-protocol";
+import type { Instant, ProviderId } from "@keeper.sh/sync-protocol";
+import { describe, it } from "vitest";
 import type { ConformanceCaseId, LedgerEntryId } from "./case-id";
+import { createConformanceEnvironment } from "./environment";
 import type { RunConformanceOptions } from "./options";
 import type { ConformanceReport } from "./report";
+import { ungatedCaseIds } from "./report";
+import { branchNameOf } from "./registry/gates";
+import { selectConformanceCases } from "./registry/suite";
 
 interface PlannedCase {
   readonly id: ConformanceCaseId;
@@ -16,16 +21,71 @@ interface ConformanceRunPlan {
   readonly cases: readonly PlannedCase[];
 }
 
+const suiteStart: Instant = { kind: "instant", value: "2026-03-11T00:00:00.000Z" };
+
+const conformanceHash = (input: string): string => {
+  let accumulated = 0;
+  for (const character of input) {
+    accumulated = (accumulated * 31 + (character.codePointAt(0) ?? 0)) % 2_147_483_647;
+  }
+  return accumulated.toString(16).padStart(8, "0");
+};
+
 const planConformanceRun = <Provider extends ProviderId>(
   options: RunConformanceOptions<Provider>,
 ): ConformanceRunPlan => {
-  throw new Error(`unimplemented: planConformanceRun(${options.name})`);
+  const selection = selectConformanceCases(options.supports);
+  const cases = selection.selected.map((record) => ({
+    id: record.id,
+    title: record.title,
+    ledger: record.ledger,
+    branch: branchNameOf(record.gate),
+    execute: async (): Promise<void> => {
+      const environment = createConformanceEnvironment({
+        start: suiteStart,
+        installation: { kind: "installationId", value: `conformance-${options.name}` },
+        hash: conformanceHash,
+      });
+      const provider = await options.create(environment);
+      try {
+        await record.run({
+          provider,
+          environment,
+          supports: options.supports,
+          withinWindow: options.withinWindow,
+        });
+      } finally {
+        await provider.dispose();
+      }
+    },
+  }));
+  return {
+    report: {
+      name: options.name,
+      selected: cases.map((planned) => ({
+        id: planned.id,
+        title: planned.title,
+        ledger: planned.ledger,
+        branch: planned.branch,
+      })),
+      skipped: selection.skipped,
+      ungated: ungatedCaseIds,
+      notAttempted: [],
+    },
+    cases,
+  };
 };
 
 const runConformance = <Provider extends ProviderId>(
   options: RunConformanceOptions<Provider>,
 ): ConformanceReport => {
-  throw new Error(`unimplemented: runConformance(${options.name})`);
+  const plan = planConformanceRun(options);
+  describe(`conformance: ${options.name}`, () => {
+    for (const planned of plan.cases) {
+      it(planned.title, () => planned.execute());
+    }
+  });
+  return plan.report;
 };
 
 export { planConformanceRun, runConformance };

--- a/packages/sync-kit/conformance/src/run-conformance.ts
+++ b/packages/sync-kit/conformance/src/run-conformance.ts
@@ -1,0 +1,32 @@
+import type { ProviderId } from "@keeper.sh/sync-protocol";
+import type { ConformanceCaseId, LedgerEntryId } from "./case-id";
+import type { RunConformanceOptions } from "./options";
+import type { ConformanceReport } from "./report";
+
+interface PlannedCase {
+  readonly id: ConformanceCaseId;
+  readonly title: string;
+  readonly ledger: LedgerEntryId;
+  readonly branch: string | null;
+  readonly execute: () => Promise<void>;
+}
+
+interface ConformanceRunPlan {
+  readonly report: ConformanceReport;
+  readonly cases: readonly PlannedCase[];
+}
+
+const planConformanceRun = <Provider extends ProviderId>(
+  options: RunConformanceOptions<Provider>,
+): ConformanceRunPlan => {
+  throw new Error(`unimplemented: planConformanceRun(${options.name})`);
+};
+
+const runConformance = <Provider extends ProviderId>(
+  options: RunConformanceOptions<Provider>,
+): ConformanceReport => {
+  throw new Error(`unimplemented: runConformance(${options.name})`);
+};
+
+export { planConformanceRun, runConformance };
+export type { ConformanceRunPlan, PlannedCase };

--- a/packages/sync-kit/conformance/src/run-conformance.ts
+++ b/packages/sync-kit/conformance/src/run-conformance.ts
@@ -1,8 +1,7 @@
 import type { Instant, ProviderId } from "@keeper.sh/sync-protocol";
-import { describe, it } from "vitest";
 import type { ConformanceCaseId, LedgerEntryId } from "./case-id";
 import { createConformanceEnvironment } from "./environment";
-import type { RunConformanceOptions } from "./options";
+import type { RunConformanceOptions, SuiteRunner } from "./options";
 import type { ConformanceReport } from "./report";
 import { ungatedCaseIds } from "./report";
 import { branchNameOf } from "./registry/gates";
@@ -23,13 +22,8 @@ interface ConformanceRunPlan {
 
 const suiteStart: Instant = { kind: "instant", value: "2026-03-11T00:00:00.000Z" };
 
-const conformanceHash = (input: string): string => {
-  let accumulated = 0;
-  for (const character of input) {
-    accumulated = (accumulated * 31 + (character.codePointAt(0) ?? 0)) % 2_147_483_647;
-  }
-  return accumulated.toString(16).padStart(8, "0");
-};
+const conformanceHash = (input: string): string =>
+  new Bun.CryptoHasher("sha256").update(input).digest("hex");
 
 const planConformanceRun = <Provider extends ProviderId>(
   options: RunConformanceOptions<Provider>,
@@ -44,7 +38,7 @@ const planConformanceRun = <Provider extends ProviderId>(
       const environment = createConformanceEnvironment({
         start: suiteStart,
         installation: { kind: "installationId", value: `conformance-${options.name}` },
-        hash: conformanceHash,
+        hash: options.hash ?? conformanceHash,
       });
       const provider = await options.create(environment);
       try {
@@ -68,25 +62,24 @@ const planConformanceRun = <Provider extends ProviderId>(
         ledger: planned.ledger,
         branch: planned.branch,
       })),
-      skipped: selection.skipped,
       ungated: ungatedCaseIds,
-      notAttempted: [],
     },
     cases,
   };
 };
 
 const runConformance = <Provider extends ProviderId>(
+  runner: SuiteRunner,
   options: RunConformanceOptions<Provider>,
 ): ConformanceReport => {
   const plan = planConformanceRun(options);
-  describe(`conformance: ${options.name}`, () => {
+  runner.describe(`conformance: ${options.name}`, () => {
     for (const planned of plan.cases) {
-      it(planned.title, () => planned.execute());
+      runner.it(planned.title, () => planned.execute());
     }
   });
   return plan.report;
 };
 
-export { planConformanceRun, runConformance };
+export { conformanceHash, planConformanceRun, runConformance, suiteStart };
 export type { ConformanceRunPlan, PlannedCase };

--- a/packages/sync-kit/conformance/src/single-flight.ts
+++ b/packages/sync-kit/conformance/src/single-flight.ts
@@ -1,0 +1,36 @@
+interface SingleFlightOptions<Value> {
+  readonly retain: (value: Value) => boolean;
+}
+
+interface SingleFlight<Value> {
+  readonly run: (key: string, body: () => Promise<Value>) => Promise<Value>;
+}
+
+const createSingleFlight = <Value>(options: SingleFlightOptions<Value>): SingleFlight<Value> => {
+  const flights = new Map<string, Promise<Value>>();
+
+  const release = (key: string, started: Promise<Value>, settled: Value): Value => {
+    if (options.retain(settled)) {
+      return settled;
+    }
+    if (flights.get(key) === started) {
+      flights.delete(key);
+    }
+    return settled;
+  };
+
+  const run = (key: string, body: () => Promise<Value>): Promise<Value> => {
+    const joined = flights.get(key);
+    if (joined) {
+      return joined;
+    }
+    const started: Promise<Value> = body().then((settled) => release(key, started, settled));
+    flights.set(key, started);
+    return started;
+  };
+
+  return { run };
+};
+
+export { createSingleFlight };
+export type { SingleFlight, SingleFlightOptions };

--- a/packages/sync-kit/conformance/src/single-flight.ts
+++ b/packages/sync-kit/conformance/src/single-flight.ts
@@ -4,19 +4,31 @@ interface SingleFlightOptions<Value> {
 
 interface SingleFlight<Value> {
   readonly run: (key: string, body: () => Promise<Value>) => Promise<Value>;
+  readonly abandon: (key: string) => void;
+  readonly inFlightKeys: () => number;
 }
 
 const createSingleFlight = <Value>(options: SingleFlightOptions<Value>): SingleFlight<Value> => {
   const flights = new Map<string, Promise<Value>>();
 
+  const forget = (key: string, started: Promise<Value>): void => {
+    if (flights.get(key) !== started) {
+      return;
+    }
+    flights.delete(key);
+  };
+
   const release = (key: string, started: Promise<Value>, settled: Value): Value => {
     if (options.retain(settled)) {
       return settled;
     }
-    if (flights.get(key) === started) {
-      flights.delete(key);
-    }
+    forget(key, started);
     return settled;
+  };
+
+  const rethrow = (key: string, started: Promise<Value>, error: unknown): never => {
+    forget(key, started);
+    throw error;
   };
 
   const run = (key: string, body: () => Promise<Value>): Promise<Value> => {
@@ -24,12 +36,19 @@ const createSingleFlight = <Value>(options: SingleFlightOptions<Value>): SingleF
     if (joined) {
       return joined;
     }
-    const started: Promise<Value> = body().then((settled) => release(key, started, settled));
+    const started: Promise<Value> = body().then(
+      (settled) => release(key, started, settled),
+      (error: unknown) => rethrow(key, started, error),
+    );
     flights.set(key, started);
     return started;
   };
 
-  return { run };
+  const abandon = (key: string): void => {
+    flights.delete(key);
+  };
+
+  return { run, abandon, inFlightKeys: () => flights.size };
 };
 
 export { createSingleFlight };

--- a/packages/sync-kit/conformance/src/transport.ts
+++ b/packages/sync-kit/conformance/src/transport.ts
@@ -47,26 +47,35 @@ const remainingBehaviour = (behaviour: TransportBehaviour): TransportBehaviour =
   return { kind: "pass" };
 };
 
+interface TransportStubState {
+  behaviour: TransportBehaviour;
+  calls: number;
+  inFlight: number;
+  peak: number;
+}
+
 const createTransportStub = (): TransportStub => {
-  let behaviour: TransportBehaviour = { kind: "pass" };
-  let calls = 0;
-  let inFlight = 0;
-  let peak = 0;
+  const state: TransportStubState = {
+    behaviour: { kind: "pass" },
+    calls: 0,
+    inFlight: 0,
+    peak: 0,
+  };
 
   const track = async <Value>(execute: () => Promise<Value>): Promise<Value> => {
-    inFlight += 1;
-    peak = Math.max(peak, inFlight);
+    state.inFlight += 1;
+    state.peak = Math.max(state.peak, state.inFlight);
     try {
       return await execute();
     } finally {
-      inFlight -= 1;
+      state.inFlight -= 1;
     }
   };
 
   const run = <Value>(operation: OperationName, execute: () => Promise<Value>): Promise<Value> => {
-    calls += 1;
-    const current = behaviour;
-    behaviour = remainingBehaviour(current);
+    state.calls += 1;
+    const current = state.behaviour;
+    state.behaviour = remainingBehaviour(current);
     switch (current.kind) {
       case "pass": {
         return track(execute);
@@ -91,16 +100,16 @@ const createTransportStub = (): TransportStub => {
 
   return {
     run,
-    callCount: () => calls,
-    inFlightPeak: () => peak,
+    callCount: () => state.calls,
+    inFlightPeak: () => state.peak,
     stall: () => {
-      behaviour = { kind: "stall" };
+      state.behaviour = { kind: "stall" };
     },
     resume: () => {
-      behaviour = { kind: "pass" };
+      state.behaviour = { kind: "pass" };
     },
     answerWith: (next: TransportBehaviour) => {
-      behaviour = next;
+      state.behaviour = next;
     },
   };
 };

--- a/packages/sync-kit/conformance/src/transport.ts
+++ b/packages/sync-kit/conformance/src/transport.ts
@@ -1,0 +1,97 @@
+import type { OperationName, ProviderFailure } from "@keeper.sh/sync-protocol";
+import { assertNever } from "@keeper.sh/sync-protocol";
+import type { TransportBehaviour, TransportStub } from "./options";
+
+class TransportRejection extends Error {
+  readonly failure: ProviderFailure;
+
+  constructor(failure: ProviderFailure) {
+    super(`the injected transport answered with "${failure.kind}"`);
+    this.name = "TransportRejection";
+    this.failure = failure;
+  }
+}
+
+class TransportThrew extends Error {
+  constructor(operation: OperationName) {
+    super(`the injected transport threw out of "${operation}"`);
+    this.name = "TransportThrew";
+  }
+}
+
+const remainingBehaviour = (behaviour: TransportBehaviour): TransportBehaviour => {
+  if (behaviour.kind === "reject" && behaviour.times > 1) {
+    return { ...behaviour, times: behaviour.times - 1 };
+  }
+  if (behaviour.kind === "throw" && behaviour.times > 1) {
+    return { ...behaviour, times: behaviour.times - 1 };
+  }
+  if (behaviour.kind === "stall") {
+    return behaviour;
+  }
+  return { kind: "pass" };
+};
+
+const createTransportStub = (): TransportStub => {
+  let behaviour: TransportBehaviour = { kind: "pass" };
+  let calls = 0;
+  let inFlight = 0;
+  let peak = 0;
+
+  const track = async <Value>(execute: () => Promise<Value>): Promise<Value> => {
+    inFlight += 1;
+    peak = Math.max(peak, inFlight);
+    try {
+      return await execute();
+    } finally {
+      inFlight -= 1;
+    }
+  };
+
+  const run = <Value>(operation: OperationName, execute: () => Promise<Value>): Promise<Value> => {
+    calls += 1;
+    const current = behaviour;
+    behaviour = remainingBehaviour(current);
+    switch (current.kind) {
+      case "pass": {
+        return track(execute);
+      }
+      case "stall": {
+        return Promise.withResolvers<Value>().promise;
+      }
+      case "reject": {
+        return Promise.reject(new TransportRejection(current.failure));
+      }
+      case "throw": {
+        throw new TransportThrew(operation);
+      }
+      default: {
+        return assertNever(current);
+      }
+    }
+  };
+
+  return {
+    run,
+    callCount: () => calls,
+    inFlightPeak: () => peak,
+    stall: () => {
+      behaviour = { kind: "stall" };
+    },
+    resume: () => {
+      behaviour = { kind: "pass" };
+    },
+    answerWith: (next: TransportBehaviour) => {
+      behaviour = next;
+    },
+  };
+};
+
+const failureOfTransportError = (error: unknown): ProviderFailure => {
+  if (error instanceof TransportRejection) {
+    return error.failure;
+  }
+  return { kind: "transport", status: null, disposition: "permanent" };
+};
+
+export { createTransportStub, failureOfTransportError, TransportRejection, TransportThrew };

--- a/packages/sync-kit/conformance/src/transport.ts
+++ b/packages/sync-kit/conformance/src/transport.ts
@@ -1,4 +1,4 @@
-import type { OperationName, ProviderFailure } from "@keeper.sh/sync-protocol";
+import type { Instant, OperationName, ProviderFailure } from "@keeper.sh/sync-protocol";
 import { assertNever } from "@keeper.sh/sync-protocol";
 import type { TransportBehaviour, TransportStub } from "./options";
 
@@ -9,6 +9,18 @@ class TransportRejection extends Error {
     super(`the injected transport answered with "${failure.kind}"`);
     this.name = "TransportRejection";
     this.failure = failure;
+  }
+}
+
+class TransportStatus extends Error {
+  readonly status: number;
+  readonly retryAfter: Instant | null;
+
+  constructor(status: number, retryAfter: Instant | null) {
+    super(`the injected transport answered HTTP ${status}`);
+    this.name = "TransportStatus";
+    this.status = status;
+    this.retryAfter = retryAfter;
   }
 }
 
@@ -24,6 +36,9 @@ const remainingBehaviour = (behaviour: TransportBehaviour): TransportBehaviour =
     return { ...behaviour, times: behaviour.times - 1 };
   }
   if (behaviour.kind === "throw" && behaviour.times > 1) {
+    return { ...behaviour, times: behaviour.times - 1 };
+  }
+  if (behaviour.kind === "status" && behaviour.times > 1) {
     return { ...behaviour, times: behaviour.times - 1 };
   }
   if (behaviour.kind === "stall") {
@@ -62,6 +77,9 @@ const createTransportStub = (): TransportStub => {
       case "reject": {
         return Promise.reject(new TransportRejection(current.failure));
       }
+      case "status": {
+        return Promise.reject(new TransportStatus(current.status, current.retryAfter));
+      }
       case "throw": {
         throw new TransportThrew(operation);
       }
@@ -94,4 +112,10 @@ const failureOfTransportError = (error: unknown): ProviderFailure => {
   return { kind: "transport", status: null, disposition: "permanent" };
 };
 
-export { createTransportStub, failureOfTransportError, TransportRejection, TransportThrew };
+export {
+  createTransportStub,
+  failureOfTransportError,
+  TransportRejection,
+  TransportStatus,
+  TransportThrew,
+};

--- a/packages/sync-kit/conformance/src/violation.ts
+++ b/packages/sync-kit/conformance/src/violation.ts
@@ -1,0 +1,22 @@
+import type { ConformanceCaseId, LedgerEntryId } from "./case-id";
+
+interface ViolationDetail {
+  readonly case: ConformanceCaseId;
+  readonly ledger: LedgerEntryId;
+  readonly message: string;
+}
+
+class ConformanceViolation extends Error {
+  readonly case: ConformanceCaseId;
+  readonly ledger: LedgerEntryId;
+
+  constructor(detail: ViolationDetail) {
+    super(`${detail.case} (${detail.ledger}): ${detail.message}`);
+    this.name = "ConformanceViolation";
+    this.case = detail.case;
+    this.ledger = detail.ledger;
+  }
+}
+
+export { ConformanceViolation };
+export type { ViolationDetail };

--- a/packages/sync-kit/conformance/src/violation.ts
+++ b/packages/sync-kit/conformance/src/violation.ts
@@ -1,4 +1,5 @@
 import type { ConformanceCaseId, LedgerEntryId } from "./case-id";
+import { ledgerEntryOf } from "./case-id";
 
 interface ViolationDetail {
   readonly case: ConformanceCaseId;
@@ -18,5 +19,8 @@ class ConformanceViolation extends Error {
   }
 }
 
-export { ConformanceViolation };
+const violated = (id: ConformanceCaseId, message: string): ConformanceViolation =>
+  new ConformanceViolation({ case: id, ledger: ledgerEntryOf(id), message });
+
+export { ConformanceViolation, violated };
 export type { ViolationDetail };

--- a/packages/sync-kit/conformance/tests/capabilities.test.ts
+++ b/packages/sync-kit/conformance/tests/capabilities.test.ts
@@ -1,9 +1,13 @@
-import type { RemoteEvent } from "@keeper.sh/sync-protocol";
+import type { Capabilities, RemoteEvent } from "@keeper.sh/sync-protocol";
 import { describe, expect, test } from "vitest";
+import { allDayAs } from "../src/cases/capabilities";
 import { referenceCapabilities } from "../src/reference/capabilities";
 import { conformanceCaseIds } from "../src/case-id";
+import type { CaseGate } from "../src/registry/case";
+import { branchNameOf } from "../src/registry/gates";
 import { ungatedCaseIds } from "../src/report";
 import { selectConformanceCases } from "../src/registry/suite";
+import type { CaseSelection } from "../src/registry/suite";
 import { failureOf, listChanges, okValue, write } from "./support/drive";
 import { referenceHarness, runReferenceCase } from "./support/harness";
 import { createIntent, occurrence, scopeOver, spanning, timedAt } from "./support/protocol";
@@ -31,6 +35,25 @@ const zoneIdsOf = (events: readonly RemoteEvent[]): string[] =>
     return [time.zone.value];
   });
 
+const refusesEverything: Capabilities<"reference"> = {
+  ...referenceCapabilities,
+  delta: { kind: "none" },
+  deletionAuthority: "explicitRemovalsOnly",
+  removalsAreAmbiguous: true,
+  provenanceChannel: "none",
+  recurrenceWrite: "none",
+  echoesWrites: false,
+  allDay: "utcMidnightPair",
+  representableRange: { ...referenceCapabilities.representableRange, zeroDuration: "reject" },
+};
+
+const refusingCapabilities: readonly [string, Capabilities<"reference">][] = [
+  ["the reference's own capabilities", referenceCapabilities],
+  ["an adapter that refuses everything it can", refusesEverything],
+];
+
+const ungatedGate: CaseGate = { kind: "ungated" };
+
 const isAcceptedByIntl = (zone: string): boolean => {
   try {
     const formatter = new Intl.DateTimeFormat("en-US", { timeZone: zone });
@@ -55,23 +78,25 @@ describe("a declared refusal must actually refuse", () => {
     expect(ungatedCaseIds).toContain("CONF-O24");
   });
 
-  test("CONF-O29: every skipped case names the capability that skipped it", () => {
-    const selection = selectConformanceCases(referenceCapabilities);
+  test.each(refusingCapabilities)(
+    "CONF-O29: %s selects a branch and still runs every declared case",
+    (_name, supports) => {
+      const selection = selectConformanceCases(supports);
+      const covered = selection.selected.map((record) => record.id).toSorted();
 
-    expect(selection.skipped.filter((entry) => entry.reason.length === 0)).toEqual([]);
-    expect(
-      selection.skipped.filter((entry) => !conformanceCaseIds.includes(entry.id)),
-    ).toEqual([]);
-  });
+      expect(covered).toEqual([...conformanceCaseIds].toSorted());
+    },
+  );
 
-  test("CONF-O29: selection covers every declared case id exactly once", () => {
-    const selection = selectConformanceCases(referenceCapabilities);
-    const covered = [
-      ...selection.selected.map((record) => record.id),
-      ...selection.skipped.map((entry) => entry.id),
-    ].toSorted();
+  test("CONF-O29: a refusing capability takes a different branch, never no branch", () => {
+    const declining = selectConformanceCases(refusesEverything);
+    const accepting = selectConformanceCases(referenceCapabilities);
+    const branchOf = (selection: CaseSelection<"reference">, id: string): string | null =>
+      branchNameOf(selection.selected.find((record) => record.id === id)?.gate ?? ungatedGate);
 
-    expect(covered).toEqual([...conformanceCaseIds].toSorted());
+    expect(branchOf(declining, "CONF-O11")).toBe("noDelta");
+    expect(branchOf(accepting, "CONF-O11")).toBe("windowBoundToCursor");
+    expect(branchOf(declining, "CONF-O28")).toBe("reject");
   });
 
   test("CONF-O35: an unrepresentable construct is refused with its exact constraint", async () => {
@@ -135,6 +160,57 @@ describe("a declared refusal must actually refuse", () => {
 
     expect(failureOf(result).kind).toBe("unrepresentable");
     await harness.dispose();
+  });
+
+  test("CONF-O45: an all-day event round-trips in the representation the adapter declared", async () => {
+    const harness = await referenceHarness();
+    const submitted = allDayAs("all-day", harness.supports.allDay);
+
+    await write(harness.provider, harness.environment, createIntent("all-day", submitted));
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+    const mirrored = (listing.events ?? []).find((event) => event.uid.value === "all-day");
+
+    expect(harness.supports.allDay).toBe("dateOnly");
+    expect(mirrored?.content.time?.kind).toBe("allDay");
+    await harness.dispose();
+  });
+
+  test("CONF-O46: a declared throttle status is classified as rateLimited, an undeclared one is not", async () => {
+    const harness = await referenceHarness();
+    harness.environment.transport.answerWith({
+      kind: "status",
+      status: 429,
+      retryAfter: { kind: "instant", value: "2099-01-01T00:00:00.000Z" },
+      times: Number.MAX_SAFE_INTEGER,
+    });
+    const throttled = await listChanges(harness.provider, harness.environment, scope, null, {
+      maxAttempts: 1,
+    });
+    harness.environment.transport.answerWith({
+      kind: "status",
+      status: 599,
+      retryAfter: null,
+      times: Number.MAX_SAFE_INTEGER,
+    });
+    const rejected = await listChanges(harness.provider, harness.environment, scope, null, {
+      maxAttempts: 1,
+    });
+
+    expect(failureOf(throttled)).toEqual({
+      kind: "rateLimited",
+      retryAfter: { kind: "instant", value: "2099-01-01T00:00:00.000Z" },
+      scope: "perUser",
+    });
+    expect(failureOf(rejected).kind).toBe("transport");
+    await harness.dispose();
+  });
+
+  test("CONF-O45: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O45")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O46: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O46")).resolves.toBeUndefined();
   });
 
   test("CONF-O29: the generated case passes for the reference provider", async () => {

--- a/packages/sync-kit/conformance/tests/capabilities.test.ts
+++ b/packages/sync-kit/conformance/tests/capabilities.test.ts
@@ -1,0 +1,151 @@
+import type { RemoteEvent } from "@keeper.sh/sync-protocol";
+import { describe, expect, test } from "vitest";
+import { referenceCapabilities } from "../src/reference/capabilities";
+import { conformanceCaseIds } from "../src/case-id";
+import { ungatedCaseIds } from "../src/report";
+import { selectConformanceCases } from "../src/registry/suite";
+import { failureOf, listChanges, okValue, write } from "./support/drive";
+import { referenceHarness, runReferenceCase } from "./support/harness";
+import { createIntent, occurrence, scopeOver, spanning, timedAt } from "./support/protocol";
+
+const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
+const scope = scopeOver(march);
+
+const inverted = occurrence(
+  "Inverted range",
+  timedAt("2026-03-02T10:00:00.000Z", "2026-03-02T09:00:00.000Z"),
+);
+
+const zoneIdsOf = (events: readonly RemoteEvent[]): string[] =>
+  events.flatMap((event) => {
+    const { time } = event.content;
+    if (!time) {
+      return [];
+    }
+    if (time.kind === "allDay") {
+      return [];
+    }
+    if (time.zone === null) {
+      return [];
+    }
+    return [time.zone.value];
+  });
+
+const isAcceptedByIntl = (zone: string): boolean => {
+  try {
+    const formatter = new Intl.DateTimeFormat("en-US", { timeZone: zone });
+    return formatter.resolvedOptions().timeZone.length > 0;
+  } catch {
+    return false;
+  }
+};
+
+describe("a declared refusal must actually refuse", () => {
+  test("CONF-O29: the ungated case list is non-empty and no capability can remove it", () => {
+    const selection = selectConformanceCases(referenceCapabilities);
+    const selectedIds = new Set(selection.selected.map((record) => record.id));
+
+    expect(ungatedCaseIds.length).toBeGreaterThan(0);
+    expect(ungatedCaseIds.filter((id) => !selectedIds.has(id))).toEqual([]);
+  });
+
+  test("CONF-O29: the flagship deletion-safety guarantees are among the ungated cases", () => {
+    expect(ungatedCaseIds).toContain("CONF-O1");
+    expect(ungatedCaseIds).toContain("CONF-O2");
+    expect(ungatedCaseIds).toContain("CONF-O24");
+  });
+
+  test("CONF-O29: every skipped case names the capability that skipped it", () => {
+    const selection = selectConformanceCases(referenceCapabilities);
+
+    expect(selection.skipped.filter((entry) => entry.reason.length === 0)).toEqual([]);
+    expect(
+      selection.skipped.filter((entry) => !conformanceCaseIds.includes(entry.id)),
+    ).toEqual([]);
+  });
+
+  test("CONF-O29: selection covers every declared case id exactly once", () => {
+    const selection = selectConformanceCases(referenceCapabilities);
+    const covered = [
+      ...selection.selected.map((record) => record.id),
+      ...selection.skipped.map((entry) => entry.id),
+    ].toSorted();
+
+    expect(covered).toEqual([...conformanceCaseIds].toSorted());
+  });
+
+  test("CONF-O35: an unrepresentable construct is refused with its exact constraint", async () => {
+    const harness = await referenceHarness();
+
+    const result = await write(
+      harness.provider,
+      harness.environment,
+      createIntent("inverted", inverted),
+    );
+
+    expect(failureOf(result).kind).toBe("unrepresentable");
+    await harness.dispose();
+  });
+
+  test("CONF-O35: an unrepresentable construct is never clamped into a representable one", async () => {
+    const harness = await referenceHarness();
+
+    await write(harness.provider, harness.environment, createIntent("inverted", inverted));
+    const inspection = await harness.provider.inspect();
+
+    expect(inspection.objects).toEqual([]);
+    expect(harness.supports.representableRange.invertedRange).toBe("reject");
+    await harness.dispose();
+  });
+
+  test("CONF-O43: every zone identifier an adapter returns is accepted by Intl", async () => {
+    const harness = await referenceHarness();
+    await write(
+      harness.provider,
+      harness.environment,
+      createIntent(
+        "zoned",
+        occurrence("Zoned", timedAt("2026-03-02T09:00:00.000Z", "2026-03-02T10:00:00.000Z")),
+      ),
+    );
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+    const rejected = zoneIdsOf(listing.events ?? []).filter((zone) => !isAcceptedByIntl(zone));
+
+    expect(rejected).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-O43: a Windows zone identifier is refused with constraint zoneIdentifier", async () => {
+    const harness = await referenceHarness();
+    const windowsZoned = {
+      ...occurrence("Windows zoned", {
+        kind: "timed" as const,
+        start: { kind: "instant" as const, value: "2026-03-02T09:00:00.000Z" },
+        end: { kind: "instant" as const, value: "2026-03-02T10:00:00.000Z" },
+        zone: { kind: "zoneId" as const, value: "Pacific Standard Time" },
+      }),
+    };
+
+    const result = await write(
+      harness.provider,
+      harness.environment,
+      createIntent("windows-zoned", windowsZoned),
+    );
+
+    expect(failureOf(result).kind).toBe("unrepresentable");
+    await harness.dispose();
+  });
+
+  test("CONF-O29: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O29")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O35: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O35")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O43: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O43")).resolves.toBeUndefined();
+  });
+});

--- a/packages/sync-kit/conformance/tests/clock.test.ts
+++ b/packages/sync-kit/conformance/tests/clock.test.ts
@@ -1,0 +1,56 @@
+import { getEventListeners } from "node:events";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { createTestClock } from "../src/clock";
+import { suiteStart } from "./support/harness";
+
+const abortListenersOn = (signal: AbortSignal): number => getEventListeners(signal, "abort").length;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("the injected clock is drivable and leaves nothing behind", () => {
+  test("CONF-I51: a sleep is armed through setTimeout and resolved by advancing fake time", async () => {
+    const clock = createTestClock({ start: suiteStart });
+    const { signal } = new AbortController();
+
+    const sleeping = clock.sleep(1000, signal);
+    expect(clock.pendingTimers()).toBe(1);
+    await vi.advanceTimersByTimeAsync(1000);
+    await sleeping;
+
+    expect(clock.pendingTimers()).toBe(0);
+    expect(Date.parse(clock.now().value) - Date.parse(suiteStart.value)).toBe(1000);
+  });
+
+  test("CONF-I21: sleeping repeatedly on one signal does not accumulate abort listeners", async () => {
+    const clock = createTestClock({ start: suiteStart });
+    const caller = new AbortController();
+
+    for (const _attempt of [1, 2, 3, 4, 5]) {
+      const sleeping = clock.sleep(10, caller.signal);
+      await vi.advanceTimersByTimeAsync(10);
+      await sleeping;
+    }
+
+    expect(abortListenersOn(caller.signal)).toBe(0);
+    expect(clock.pendingTimers()).toBe(0);
+  });
+
+  test("CONF-I21: an aborted sleep rejects, clears its timer and removes its listener", async () => {
+    const clock = createTestClock({ start: suiteStart });
+    const caller = new AbortController();
+
+    const sleeping = clock.sleep(10_000, caller.signal);
+    expect(clock.pendingTimers()).toBe(1);
+    caller.abort();
+
+    await expect(sleeping).rejects.toThrow("aborted");
+    expect(clock.pendingTimers()).toBe(0);
+    expect(abortListenersOn(caller.signal)).toBe(0);
+  });
+});

--- a/packages/sync-kit/conformance/tests/convergence.test.ts
+++ b/packages/sync-kit/conformance/tests/convergence.test.ts
@@ -10,6 +10,7 @@ import {
   spanning,
   summarise,
   timedAt,
+  seedOf,
 } from "./support/protocol";
 
 const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
@@ -34,8 +35,8 @@ describe("identical input is zero work", () => {
   test("CONF-O8: the same colliding pair produces the same winner in either feed order", async () => {
     const forward = await referenceHarness();
     const backward = await referenceHarness();
-    await forward.provider.seed({ events: [early, late], corruptKnownRows: [] });
-    await backward.provider.seed({ events: [late, early], corruptKnownRows: [] });
+    await forward.provider.seed(seedOf([early, late], []));
+    await backward.provider.seed(seedOf([late, early], []));
 
     const first = okValue(await listChanges(forward.provider, forward.environment, scope));
     const second = okValue(await listChanges(backward.provider, backward.environment, scope));
@@ -49,7 +50,7 @@ describe("identical input is zero work", () => {
 
   test("CONF-O9: a second identical poll writes nothing at all", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [early], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([early], []));
     await listChanges(harness.provider, harness.environment, scope);
     const afterFirst = await harness.provider.inspect();
 
@@ -104,7 +105,7 @@ describe("identical input is zero work", () => {
 
   test("CONF-O22: one identity repeated in a listing is one entry, last observation wins", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [early, late, early], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([early, late, early], []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
     const collided = (listing.events ?? []).filter((event) => event.uid.value === "collider");
@@ -116,8 +117,8 @@ describe("identical input is zero work", () => {
   test("CONF-O22: reversing the repeats picks the same winner", async () => {
     const forward = await referenceHarness();
     const backward = await referenceHarness();
-    await forward.provider.seed({ events: [early, late], corruptKnownRows: [] });
-    await backward.provider.seed({ events: [late, early], corruptKnownRows: [] });
+    await forward.provider.seed(seedOf([early, late], []));
+    await backward.provider.seed(seedOf([late, early], []));
 
     const first = okValue(await listChanges(forward.provider, forward.environment, scope));
     const second = okValue(await listChanges(backward.provider, backward.environment, scope));
@@ -131,7 +132,7 @@ describe("identical input is zero work", () => {
 
   test("CONF-O9: a failed poll is still not a write", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [early], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([early], []));
     harness.environment.transport.answerWith({
       kind: "reject",
       failure: { kind: "transport", status: 500, disposition: "permanent" },

--- a/packages/sync-kit/conformance/tests/convergence.test.ts
+++ b/packages/sync-kit/conformance/tests/convergence.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from "vitest";
+import { canonicalise, sortedKeys } from "../src/canonical";
+import { failureOf, listChanges, okValue, write } from "./support/drive";
+import { referenceHarness, runReferenceCase } from "./support/harness";
+import {
+  createIntent,
+  foreignEvent,
+  occurrence,
+  scopeOver,
+  spanning,
+  summarise,
+  timedAt,
+} from "./support/protocol";
+
+const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
+const scope = scopeOver(march);
+
+const early = foreignEvent({
+  uid: "collider",
+  title: "Older",
+  start: "2026-03-02T09:00:00.000Z",
+  end: "2026-03-02T10:00:00.000Z",
+  revision: 1,
+});
+const late = foreignEvent({
+  uid: "collider",
+  title: "Newer",
+  start: "2026-03-02T11:00:00.000Z",
+  end: "2026-03-02T12:00:00.000Z",
+  revision: 2,
+});
+
+describe("identical input is zero work", () => {
+  test("CONF-O8: the same colliding pair produces the same winner in either feed order", async () => {
+    const forward = await referenceHarness();
+    const backward = await referenceHarness();
+    await forward.provider.seed({ events: [early, late], corruptKnownRows: [] });
+    await backward.provider.seed({ events: [late, early], corruptKnownRows: [] });
+
+    const first = okValue(await listChanges(forward.provider, forward.environment, scope));
+    const second = okValue(await listChanges(backward.provider, backward.environment, scope));
+
+    expect(canonicalise(summarise(first.events ?? []))).toBe(
+      canonicalise(summarise(second.events ?? [])),
+    );
+    await forward.dispose();
+    await backward.dispose();
+  });
+
+  test("CONF-O9: a second identical poll writes nothing at all", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [early], corruptKnownRows: [] });
+    await listChanges(harness.provider, harness.environment, scope);
+    const afterFirst = await harness.provider.inspect();
+
+    await listChanges(harness.provider, harness.environment, scope);
+    const afterSecond = await harness.provider.inspect();
+
+    expect(afterSecond.writeLog).toEqual(afterFirst.writeLog);
+    expect(afterSecond.writeLog).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-O20: a provider's own lossless rewrite does not read as drift", async () => {
+    const harness = await referenceHarness();
+    const submitted = occurrence(
+      "Trailing space \r\nand a CRLF",
+      timedAt("2026-03-02T09:00:00.500Z", "2026-03-02T10:00:00.500Z"),
+    );
+    const created = okValue(
+      await write(harness.provider, harness.environment, createIntent("rewritten", submitted)),
+    );
+
+    await listChanges(harness.provider, harness.environment, scope);
+    const afterFirst = await harness.provider.inspect();
+    await listChanges(harness.provider, harness.environment, scope);
+    const afterSecond = await harness.provider.inspect();
+
+    expect(created.kind).toBe("created");
+    expect(afterSecond.writeLog).toEqual(afterFirst.writeLog);
+    await harness.dispose();
+  });
+
+  test("CONF-O21: permuted key order canonicalises to one identity", () => {
+    const straight = canonicalise({ alpha: 1, bravo: 2, charlie: 3 });
+    const permuted = canonicalise({ charlie: 3, alpha: 1, bravo: 2 });
+
+    expect(straight).toBe(permuted);
+  });
+
+  test("CONF-O21: keys are sorted by UTF-16 code unit, not by localeCompare", () => {
+    const keys = ["Z", "a", "ä", "Á", "\u{1F600}", "Ａ"];
+
+    expect(sortedKeys(keys)).toEqual(keys.toSorted());
+    expect(sortedKeys(keys)).not.toEqual(keys.toSorted((one, two) => one.localeCompare(two)));
+  });
+
+  test("CONF-O21: an absent value spelled null and an absent value omitted are one identity", () => {
+    const spelled = canonicalise({ description: null, title: "Alpha" });
+    const alsoSpelled = canonicalise({ title: "Alpha", description: null });
+
+    expect(spelled).toBe(alsoSpelled);
+  });
+
+  test("CONF-O22: one identity repeated in a listing is one entry, last observation wins", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [early, late, early], corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+    const collided = (listing.events ?? []).filter((event) => event.uid.value === "collider");
+
+    expect(collided).toHaveLength(1);
+    await harness.dispose();
+  });
+
+  test("CONF-O22: reversing the repeats picks the same winner", async () => {
+    const forward = await referenceHarness();
+    const backward = await referenceHarness();
+    await forward.provider.seed({ events: [early, late], corruptKnownRows: [] });
+    await backward.provider.seed({ events: [late, early], corruptKnownRows: [] });
+
+    const first = okValue(await listChanges(forward.provider, forward.environment, scope));
+    const second = okValue(await listChanges(backward.provider, backward.environment, scope));
+
+    expect((first.events ?? []).map((event) => event.revision)).toEqual(
+      (second.events ?? []).map((event) => event.revision),
+    );
+    await forward.dispose();
+    await backward.dispose();
+  });
+
+  test("CONF-O9: a failed poll is still not a write", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [early], corruptKnownRows: [] });
+    harness.environment.transport.answerWith({
+      kind: "reject",
+      failure: { kind: "transport", status: 500, disposition: "permanent" },
+      times: Number.MAX_SAFE_INTEGER,
+    });
+
+    const result = await listChanges(harness.provider, harness.environment, scope);
+    const inspection = await harness.provider.inspect();
+
+    expect(failureOf(result).kind).toBe("transport");
+    expect(inspection.writeLog).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-O8: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O8")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O9: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O9")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O20: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O20")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O21: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O21")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O22: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O22")).resolves.toBeUndefined();
+  });
+});

--- a/packages/sync-kit/conformance/tests/cursor.test.ts
+++ b/packages/sync-kit/conformance/tests/cursor.test.ts
@@ -1,0 +1,207 @@
+import type { ChangeListing, ListingScope, SyncCursor } from "@keeper.sh/sync-protocol";
+import { describe, expect, test } from "vitest";
+import { expiringCursorAfter, truncatingAfter } from "../src/fixtures";
+import { failureOf, listChanges, listingKindOf, okValue } from "./support/drive";
+import { referenceHarness, runReferenceCase } from "./support/harness";
+import { foreignEvent, scopeOver, spanning } from "./support/protocol";
+
+const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
+const quarter = spanning("2026-01-01T00:00:00.000Z", "2026-07-01T00:00:00.000Z");
+const scope = scopeOver(march);
+const widerScope = scopeOver(quarter);
+
+const events = [
+  foreignEvent({
+    uid: "alpha",
+    title: "Alpha",
+    start: "2026-03-02T09:00:00.000Z",
+    end: "2026-03-02T10:00:00.000Z",
+  }),
+  foreignEvent({
+    uid: "bravo",
+    title: "Bravo",
+    start: "2026-03-03T09:00:00.000Z",
+    end: "2026-03-03T10:00:00.000Z",
+  }),
+  foreignEvent({
+    uid: "charlie",
+    title: "Charlie",
+    start: "2026-03-04T09:00:00.000Z",
+    end: "2026-03-04T10:00:00.000Z",
+  }),
+];
+
+const cursorOf = (listing: ChangeListing): SyncCursor | null => listing.cursor ?? null;
+
+const cursorValueOf = (listing: ChangeListing): string => {
+  const cursor = cursorOf(listing);
+  if (cursor === null) {
+    return "no-cursor";
+  }
+  return cursor.value;
+};
+
+const scopeOfCursor = (listing: ChangeListing): ListingScope => {
+  const cursor = cursorOf(listing);
+  if (cursor === null) {
+    return listing.scope;
+  }
+  return cursor.scope;
+};
+
+describe("a cursor is opaque, scoped, and never advanced past unapplied work", () => {
+  test("CONF-O10: an expired cursor mid-pagination yields cursorLost and no tombstones", async () => {
+    const harness = await referenceHarness(expiringCursorAfter(1));
+    await harness.provider.seed({ events, corruptKnownRows: [] });
+    const first = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    const second = await listChanges(
+      harness.provider,
+      harness.environment,
+      scope,
+      cursorOf(first),
+    );
+
+    expect(listingKindOf(second)).toBe("cursorLost");
+    expect(okValue(second).removals).toBeUndefined();
+    expect(okValue(second).events).toBeUndefined();
+    await harness.dispose();
+  });
+
+  test("CONF-O10: cursorLost is never expressed as an empty delta", async () => {
+    const harness = await referenceHarness(expiringCursorAfter(1));
+    await harness.provider.seed({ events, corruptKnownRows: [] });
+    const first = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    const second = okValue(
+      await listChanges(harness.provider, harness.environment, scope, cursorOf(first)),
+    );
+
+    expect(second.kind).not.toBe("delta");
+    expect(second.cursor).toBeUndefined();
+    await harness.dispose();
+  });
+
+  test("CONF-O11: a cursor minted under a narrow window is refused when the window widens", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events, corruptKnownRows: [] });
+    const narrow = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    const widened = await listChanges(
+      harness.provider,
+      harness.environment,
+      widerScope,
+      cursorOf(narrow),
+    );
+
+    expect(["cursorLost", "failure:cursorInvalid"]).toContain(listingKindOf(widened));
+    expect(harness.supports.delta).toEqual({ kind: "tokenized", windowBoundToCursor: true });
+    await harness.dispose();
+  });
+
+  test("CONF-O24: a truncated read never returns a sync cursor", async () => {
+    const harness = await referenceHarness(truncatingAfter(1));
+    await harness.provider.seed({ events, corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(cursorValueOf(listing)).toBe("no-cursor");
+    await harness.dispose();
+  });
+
+  test("CONF-O24: an aborted run never returns a sync cursor", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events, corruptKnownRows: [] });
+    const caller = new AbortController();
+    caller.abort();
+
+    const result = await listChanges(harness.provider, harness.environment, scope, null, {
+      signal: caller.signal,
+    });
+
+    expect(failureOf(result).kind).toBe("notAttempted");
+    await harness.dispose();
+  });
+
+  test("CONF-O24: a transport failure never returns a sync cursor", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events, corruptKnownRows: [] });
+    harness.environment.transport.answerWith({
+      kind: "reject",
+      failure: { kind: "transport", status: 500, disposition: "permanent" },
+      times: Number.MAX_SAFE_INTEGER,
+    });
+
+    const result = await listChanges(harness.provider, harness.environment, scope);
+
+    expect(failureOf(result).kind).toBe("transport");
+    await harness.dispose();
+  });
+
+  test("CONF-O37: a quiet calendar still advances its cursor while writing nothing", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events, corruptKnownRows: [] });
+    const first = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    const second = okValue(
+      await listChanges(harness.provider, harness.environment, scope, cursorOf(first)),
+    );
+    const inspection = await harness.provider.inspect();
+
+    expect(cursorValueOf(second)).not.toBe(cursorValueOf(first));
+    expect(cursorValueOf(second)).not.toBe("no-cursor");
+    expect(inspection.writeLog).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-O38: a sparse delta item never blanks the fields it omits", async () => {
+    await expect(runReferenceCase("CONF-O38")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O40: a cursor whose bytes were mutated yields cursorLost, never a throw", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events, corruptKnownRows: [] });
+    const first = okValue(await listChanges(harness.provider, harness.environment, scope));
+    const mutated = {
+      kind: "syncCursor" as const,
+      value: `${cursorValueOf(first)}-tampered`,
+      scope: scopeOfCursor(first),
+    };
+
+    const replayed = await listChanges(harness.provider, harness.environment, scope, mutated);
+
+    expect(["cursorLost", "failure:cursorInvalid"]).toContain(listingKindOf(replayed));
+    await harness.dispose();
+  });
+
+  test("CONF-O40: the suite never parses the cursor it was handed", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events, corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(typeof cursorValueOf(listing)).toBe("string");
+    expect(cursorValueOf(listing)).not.toContain("2026-03-01");
+    await harness.dispose();
+  });
+
+  test("CONF-O10: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O10", expiringCursorAfter(1))).resolves.toBeUndefined();
+  });
+
+  test("CONF-O11: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O11")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O24: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O24", truncatingAfter(1))).resolves.toBeUndefined();
+  });
+
+  test("CONF-O37: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O37")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O40: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O40")).resolves.toBeUndefined();
+  });
+});

--- a/packages/sync-kit/conformance/tests/cursor.test.ts
+++ b/packages/sync-kit/conformance/tests/cursor.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest";
 import { expiringCursorAfter, truncatingAfter } from "../src/fixtures";
 import { failureOf, listChanges, listingKindOf, okValue } from "./support/drive";
 import { referenceHarness, runReferenceCase } from "./support/harness";
-import { foreignEvent, scopeOver, spanning } from "./support/protocol";
+import { foreignEvent, scopeOver, seedOf, spanning } from "./support/protocol";
 
 const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
 const quarter = spanning("2026-01-01T00:00:00.000Z", "2026-07-01T00:00:00.000Z");
@@ -52,7 +52,7 @@ const scopeOfCursor = (listing: ChangeListing): ListingScope => {
 describe("a cursor is opaque, scoped, and never advanced past unapplied work", () => {
   test("CONF-O10: an expired cursor mid-pagination yields cursorLost and no tombstones", async () => {
     const harness = await referenceHarness(expiringCursorAfter(1));
-    await harness.provider.seed({ events, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(events, []));
     const first = okValue(await listChanges(harness.provider, harness.environment, scope));
 
     const second = await listChanges(
@@ -70,7 +70,7 @@ describe("a cursor is opaque, scoped, and never advanced past unapplied work", (
 
   test("CONF-O10: cursorLost is never expressed as an empty delta", async () => {
     const harness = await referenceHarness(expiringCursorAfter(1));
-    await harness.provider.seed({ events, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(events, []));
     const first = okValue(await listChanges(harness.provider, harness.environment, scope));
 
     const second = okValue(
@@ -84,7 +84,7 @@ describe("a cursor is opaque, scoped, and never advanced past unapplied work", (
 
   test("CONF-O11: a cursor minted under a narrow window is refused when the window widens", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(events, []));
     const narrow = okValue(await listChanges(harness.provider, harness.environment, scope));
 
     const widened = await listChanges(
@@ -101,7 +101,7 @@ describe("a cursor is opaque, scoped, and never advanced past unapplied work", (
 
   test("CONF-O24: a truncated read never returns a sync cursor", async () => {
     const harness = await referenceHarness(truncatingAfter(1));
-    await harness.provider.seed({ events, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(events, []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 
@@ -111,7 +111,7 @@ describe("a cursor is opaque, scoped, and never advanced past unapplied work", (
 
   test("CONF-O24: an aborted run never returns a sync cursor", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(events, []));
     const caller = new AbortController();
     caller.abort();
 
@@ -125,7 +125,7 @@ describe("a cursor is opaque, scoped, and never advanced past unapplied work", (
 
   test("CONF-O24: a transport failure never returns a sync cursor", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(events, []));
     harness.environment.transport.answerWith({
       kind: "reject",
       failure: { kind: "transport", status: 500, disposition: "permanent" },
@@ -140,7 +140,7 @@ describe("a cursor is opaque, scoped, and never advanced past unapplied work", (
 
   test("CONF-O37: a quiet calendar still advances its cursor while writing nothing", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(events, []));
     const first = okValue(await listChanges(harness.provider, harness.environment, scope));
 
     const second = okValue(
@@ -160,7 +160,7 @@ describe("a cursor is opaque, scoped, and never advanced past unapplied work", (
 
   test("CONF-O40: a cursor whose bytes were mutated yields cursorLost, never a throw", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(events, []));
     const first = okValue(await listChanges(harness.provider, harness.environment, scope));
     const mutated = {
       kind: "syncCursor" as const,
@@ -176,7 +176,7 @@ describe("a cursor is opaque, scoped, and never advanced past unapplied work", (
 
   test("CONF-O40: the suite never parses the cursor it was handed", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(events, []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 

--- a/packages/sync-kit/conformance/tests/deletion-safety.test.ts
+++ b/packages/sync-kit/conformance/tests/deletion-safety.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from "vitest";
+import { assertNoRemovalDerivable, derivableRemovals } from "../src/assertions/no-removal";
+import { truncatingAfter } from "../src/fixtures";
+import { referenceCalendar } from "../src/reference/provider";
+import { ConformanceViolation } from "../src/violation";
+import { failureOf, listChanges, listingKindOf, okValue } from "./support/drive";
+import { referenceHarness, runReferenceCase } from "./support/harness";
+import { foreignEvent, instant, scopeOver, spanning } from "./support/protocol";
+
+const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
+const scope = scopeOver(march);
+
+const alpha = foreignEvent({
+  uid: "alpha",
+  title: "Alpha",
+  start: "2026-03-02T09:00:00.000Z",
+  end: "2026-03-02T10:00:00.000Z",
+});
+const bravo = foreignEvent({
+  uid: "bravo",
+  title: "Bravo",
+  start: "2026-03-03T09:00:00.000Z",
+  end: "2026-03-03T10:00:00.000Z",
+});
+const charlie = foreignEvent({
+  uid: "charlie",
+  title: "Charlie",
+  start: "2026-03-04T09:00:00.000Z",
+  end: "2026-03-04T10:00:00.000Z",
+});
+
+const threeEvents = [alpha, bravo, charlie];
+
+const knownFromSeed = () => ({
+  calendar: referenceCalendar,
+  ids: new Map(threeEvents.map((event) => [event.uid.value, event.id])),
+});
+
+describe("a short read is never a deletion", () => {
+  test("CONF-O1: a page truncated to one of three events never yields a snapshot", async () => {
+    const harness = await referenceHarness(truncatingAfter(1));
+    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+
+    const result = await listChanges(harness.provider, harness.environment, scope);
+
+    expect(listingKindOf(result)).not.toBe("snapshot");
+    expect(listingKindOf(result)).not.toBe("delta");
+    await harness.dispose();
+  });
+
+  test("CONF-O1: a truncated page derives no removal even though two seeded events are missing", async () => {
+    const harness = await referenceHarness(truncatingAfter(1));
+    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(() => assertNoRemovalDerivable(listing)).not.toThrow();
+    expect(
+      derivableRemovals({ listing, known: knownFromSeed(), withinWindow: () => true }),
+    ).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-O1: a truncated page returns a continuation and structurally cannot carry a cursor", async () => {
+    const harness = await referenceHarness(truncatingAfter(1));
+    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(listing.kind).toBe("partial");
+    expect(listing.cursor).toBeUndefined();
+    expect(listing.coverage).toBeUndefined();
+    expect(listing.removals).toBeUndefined();
+    await harness.dispose();
+  });
+
+  test("CONF-O1: the case itself passes for the reference provider under truncation", async () => {
+    await expect(runReferenceCase("CONF-O1", truncatingAfter(1))).resolves.toBeUndefined();
+  });
+
+  test("CONF-O2: a transport failure and an empty calendar are two distinguishable outputs", async () => {
+    const failing = await referenceHarness();
+    await failing.provider.seed({ events: [], corruptKnownRows: [] });
+    failing.environment.transport.answerWith({
+      kind: "reject",
+      failure: { kind: "transport", status: 503, disposition: "transient" },
+      times: 8,
+    });
+    const failed = await listChanges(failing.provider, failing.environment, scope);
+
+    const empty = await referenceHarness();
+    await empty.provider.seed({ events: [], corruptKnownRows: [] });
+    const emptied = await listChanges(empty.provider, empty.environment, scope);
+
+    expect(failureOf(failed).kind).toBe("transport");
+    expect(okValue(emptied).kind).toBe("snapshot");
+    expect(failed).not.toEqual(emptied);
+    await failing.dispose();
+    await empty.dispose();
+  });
+
+  test("CONF-O2: a genuinely empty calendar still proves its coverage", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [], corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(listing.coverage).toEqual({ covered: march, calendar: referenceCalendar });
+    expect(listing.events).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-O3: the reference declares snapshotAbsence, so absence inside coverage is a removal", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [alpha], corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(harness.supports.deletionAuthority).toBe("snapshotAbsence");
+    expect(
+      derivableRemovals({ listing, known: knownFromSeed(), withinWindow: () => true }),
+    ).toEqual(["bravo", "charlie"]);
+    await harness.dispose();
+  });
+
+  test("CONF-O3: the case rejects an adapter that deletes an unnamed identity under explicitRemovalsOnly", async () => {
+    await expect(runReferenceCase("CONF-O3")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O4: proven coverage is the narrower window, never the requested one", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+    const wider = scopeOver(spanning("2020-01-01T00:00:00.000Z", "2030-01-01T00:00:00.000Z"));
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, wider));
+
+    expect(listing.coverage?.covered).not.toEqual(wider.window);
+    expect(listing.coverage?.calendar).toEqual(wider.calendar);
+    await harness.dispose();
+  });
+
+  test("CONF-O4: nothing in the requested-but-uncovered band is derivable as a removal", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+    const wider = scopeOver(spanning("2020-01-01T00:00:00.000Z", "2030-01-01T00:00:00.000Z"));
+    const listing = okValue(await listChanges(harness.provider, harness.environment, wider));
+
+    const removed = derivableRemovals({
+      listing,
+      known: {
+        calendar: referenceCalendar,
+        ids: new Map([["ancient", { kind: "remoteEventId", value: "id-ancient" }]]),
+      },
+      withinWindow: () => true,
+    });
+
+    expect(removed).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-O5: a withheld event is reported as present and never becomes a removal", async () => {
+    const harness = await referenceHarness();
+    const unrepresentable = foreignEvent({
+      uid: "inverted",
+      title: "Inverted",
+      start: "2026-03-05T10:00:00.000Z",
+      end: "2026-03-05T09:00:00.000Z",
+    });
+    await harness.provider.seed({ events: [unrepresentable], corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(listing.withheld?.map((entry) => entry.reason)).toEqual(["unrepresentableTime"]);
+    expect(
+      derivableRemovals({
+        listing,
+        known: {
+          calendar: referenceCalendar,
+          ids: new Map([["inverted", unrepresentable.id]]),
+        },
+        withinWindow: () => true,
+      }),
+    ).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-O12: a corrupt known row demands a resync and emits zero removals", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: threeEvents, corruptKnownRows: ["bravo"] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(listing.kind).toBe("cursorLost");
+    expect(listing.removals).toBeUndefined();
+    await harness.dispose();
+  });
+
+  test("CONF-O13: an ambiguous removal is excluded from removals rather than deleted", async () => {
+    await expect(runReferenceCase("CONF-O13")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O33: a withheld identity keeps its mirror on the destination side", async () => {
+    await expect(runReferenceCase("CONF-O33")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O34: cancelled, unnamed and outOfScope are three different verdicts", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    const removals = listing.removals ?? [];
+
+    expect(removals.filter((removal) => removal.kind === "outOfScope")).toEqual([]);
+    expect(
+      derivableRemovals({ listing, known: knownFromSeed(), withinWindow: () => true }),
+    ).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-O41: a truncated page's resumable token is a Continuation, never a SyncCursor", async () => {
+    const harness = await referenceHarness(truncatingAfter(2));
+    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(listing.continuation?.kind).toBe("continuation");
+    expect(listing.cursor).toBeUndefined();
+    await harness.dispose();
+  });
+
+  test("CONF-O41: resuming from the continuation eventually proves coverage without ever deleting", async () => {
+    const harness = await referenceHarness(truncatingAfter(2));
+    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+    const first = okValue(await listChanges(harness.provider, harness.environment, scope));
+    const resume = first.continuation ?? null;
+
+    const second = okValue(await listChanges(harness.provider, harness.environment, scope, resume));
+
+    expect(first.kind).toBe("partial");
+    expect(second.kind).toBe("snapshot");
+    expect(() => assertNoRemovalDerivable(first)).not.toThrow();
+    await harness.dispose();
+  });
+
+  test("CONF-O1: assertNoRemovalDerivable throws a typed ConformanceViolation on a snapshot short read", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [alpha], corruptKnownRows: [] });
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(() => assertNoRemovalDerivable(listing)).toThrow(ConformanceViolation);
+    await harness.dispose();
+  });
+
+  test("CONF-O4: a coverage window proved for a different calendar is refused", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(listing.coverage?.calendar.calendar.value).toBe(
+      referenceCalendar.calendar.value,
+    );
+    expect(listing.coverage?.covered.start).toEqual(instant(march.start.value));
+    await harness.dispose();
+  });
+});

--- a/packages/sync-kit/conformance/tests/deletion-safety.test.ts
+++ b/packages/sync-kit/conformance/tests/deletion-safety.test.ts
@@ -5,7 +5,16 @@ import { referenceCalendar } from "../src/reference/provider";
 import { ConformanceViolation } from "../src/violation";
 import { failureOf, listChanges, listingKindOf, okValue } from "./support/drive";
 import { referenceHarness, runReferenceCase } from "./support/harness";
-import { foreignEvent, instant, scopeOver, spanning } from "./support/protocol";
+import {
+  foreignEvent,
+  instant,
+  knownFrom,
+  knownNamed,
+  scopeOver,
+  seedOf,
+  spanning,
+  timedAt,
+} from "./support/protocol";
 
 const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
 const scope = scopeOver(march);
@@ -31,15 +40,12 @@ const charlie = foreignEvent({
 
 const threeEvents = [alpha, bravo, charlie];
 
-const knownFromSeed = () => ({
-  calendar: referenceCalendar,
-  ids: new Map(threeEvents.map((event) => [event.uid.value, event.id])),
-});
+const knownFromSeed = () => knownFrom(threeEvents);
 
 describe("a short read is never a deletion", () => {
   test("CONF-O1: a page truncated to one of three events never yields a snapshot", async () => {
     const harness = await referenceHarness(truncatingAfter(1));
-    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(threeEvents, []));
 
     const result = await listChanges(harness.provider, harness.environment, scope);
 
@@ -50,7 +56,7 @@ describe("a short read is never a deletion", () => {
 
   test("CONF-O1: a truncated page derives no removal even though two seeded events are missing", async () => {
     const harness = await referenceHarness(truncatingAfter(1));
-    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(threeEvents, []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 
@@ -63,7 +69,7 @@ describe("a short read is never a deletion", () => {
 
   test("CONF-O1: a truncated page returns a continuation and structurally cannot carry a cursor", async () => {
     const harness = await referenceHarness(truncatingAfter(1));
-    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(threeEvents, []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 
@@ -80,7 +86,7 @@ describe("a short read is never a deletion", () => {
 
   test("CONF-O2: a transport failure and an empty calendar are two distinguishable outputs", async () => {
     const failing = await referenceHarness();
-    await failing.provider.seed({ events: [], corruptKnownRows: [] });
+    await failing.provider.seed(seedOf([], []));
     failing.environment.transport.answerWith({
       kind: "reject",
       failure: { kind: "transport", status: 503, disposition: "transient" },
@@ -89,7 +95,7 @@ describe("a short read is never a deletion", () => {
     const failed = await listChanges(failing.provider, failing.environment, scope);
 
     const empty = await referenceHarness();
-    await empty.provider.seed({ events: [], corruptKnownRows: [] });
+    await empty.provider.seed(seedOf([], []));
     const emptied = await listChanges(empty.provider, empty.environment, scope);
 
     expect(failureOf(failed).kind).toBe("transport");
@@ -101,7 +107,7 @@ describe("a short read is never a deletion", () => {
 
   test("CONF-O2: a genuinely empty calendar still proves its coverage", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([], []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 
@@ -112,7 +118,7 @@ describe("a short read is never a deletion", () => {
 
   test("CONF-O3: the reference declares snapshotAbsence, so absence inside coverage is a removal", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [alpha], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([alpha], []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 
@@ -129,7 +135,7 @@ describe("a short read is never a deletion", () => {
 
   test("CONF-O4: proven coverage is the narrower window, never the requested one", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(threeEvents, []));
     const wider = scopeOver(spanning("2020-01-01T00:00:00.000Z", "2030-01-01T00:00:00.000Z"));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, wider));
@@ -141,16 +147,13 @@ describe("a short read is never a deletion", () => {
 
   test("CONF-O4: nothing in the requested-but-uncovered band is derivable as a removal", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(threeEvents, []));
     const wider = scopeOver(spanning("2020-01-01T00:00:00.000Z", "2030-01-01T00:00:00.000Z"));
     const listing = okValue(await listChanges(harness.provider, harness.environment, wider));
 
     const removed = derivableRemovals({
       listing,
-      known: {
-        calendar: referenceCalendar,
-        ids: new Map([["ancient", { kind: "remoteEventId", value: "id-ancient" }]]),
-      },
+      known: knownNamed("ancient", timedAt("2026-03-02T09:00:00.000Z", "2026-03-02T10:00:00.000Z")),
       withinWindow: () => true,
     });
 
@@ -166,7 +169,7 @@ describe("a short read is never a deletion", () => {
       start: "2026-03-05T10:00:00.000Z",
       end: "2026-03-05T09:00:00.000Z",
     });
-    await harness.provider.seed({ events: [unrepresentable], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([unrepresentable], []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 
@@ -174,10 +177,7 @@ describe("a short read is never a deletion", () => {
     expect(
       derivableRemovals({
         listing,
-        known: {
-          calendar: referenceCalendar,
-          ids: new Map([["inverted", unrepresentable.id]]),
-        },
+        known: knownFrom([unrepresentable]),
         withinWindow: () => true,
       }),
     ).toEqual([]);
@@ -186,7 +186,7 @@ describe("a short read is never a deletion", () => {
 
   test("CONF-O12: a corrupt known row demands a resync and emits zero removals", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: threeEvents, corruptKnownRows: ["bravo"] });
+    await harness.provider.seed(seedOf(threeEvents, ["bravo"]));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 
@@ -205,7 +205,7 @@ describe("a short read is never a deletion", () => {
 
   test("CONF-O34: cancelled, unnamed and outOfScope are three different verdicts", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(threeEvents, []));
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 
     const removals = listing.removals ?? [];
@@ -219,7 +219,7 @@ describe("a short read is never a deletion", () => {
 
   test("CONF-O41: a truncated page's resumable token is a Continuation, never a SyncCursor", async () => {
     const harness = await referenceHarness(truncatingAfter(2));
-    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(threeEvents, []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 
@@ -230,7 +230,7 @@ describe("a short read is never a deletion", () => {
 
   test("CONF-O41: resuming from the continuation eventually proves coverage without ever deleting", async () => {
     const harness = await referenceHarness(truncatingAfter(2));
-    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(threeEvents, []));
     const first = okValue(await listChanges(harness.provider, harness.environment, scope));
     const resume = first.continuation ?? null;
 
@@ -244,7 +244,7 @@ describe("a short read is never a deletion", () => {
 
   test("CONF-O1: assertNoRemovalDerivable throws a typed ConformanceViolation on a snapshot short read", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [alpha], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([alpha], []));
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 
     expect(() => assertNoRemovalDerivable(listing)).toThrow(ConformanceViolation);
@@ -253,7 +253,7 @@ describe("a short read is never a deletion", () => {
 
   test("CONF-O4: a coverage window proved for a different calendar is refused", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: threeEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(threeEvents, []));
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 
     expect(listing.coverage?.calendar.calendar.value).toBe(

--- a/packages/sync-kit/conformance/tests/diagnostics.test.ts
+++ b/packages/sync-kit/conformance/tests/diagnostics.test.ts
@@ -1,0 +1,183 @@
+import type { BoundedSample, ListingDiagnostics } from "@keeper.sh/sync-protocol";
+import { describe, expect, test } from "vitest";
+import { assertNoContentInDiagnostics } from "../src/assertions/listing";
+import { conformanceLimits } from "../src/limits";
+import { listChanges, okValue, write } from "./support/drive";
+import { referenceHarness, runReferenceCase } from "./support/harness";
+import {
+  createIntent,
+  foreignEvent,
+  occurrence,
+  scopeOver,
+  spanning,
+  timedAt,
+} from "./support/protocol";
+
+const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
+const scope = scopeOver(march);
+
+const secretTitle = "Board comp review with Alex";
+const secretLocation = "Room 12, 4th floor";
+const secretDescription = "salary bands attached";
+
+const secretiveEvent = {
+  ...occurrence(secretTitle, timedAt("2026-03-02T09:00:00.000Z", "2026-03-02T10:00:00.000Z")),
+  description: secretDescription,
+  location: secretLocation,
+};
+
+const benign = foreignEvent({
+  uid: "benign",
+  title: "Benign",
+  start: "2026-03-03T09:00:00.000Z",
+  end: "2026-03-03T10:00:00.000Z",
+});
+
+const manyWithheld = [...Array.from({ length: 2000 }).keys()].map((index) =>
+  foreignEvent({
+    uid: `withheld-${index}`,
+    title: `Withheld ${index}`,
+    start: "2026-03-04T10:00:00.000Z",
+    end: "2026-03-04T09:00:00.000Z",
+  }),
+);
+
+const samplesOf = (diagnostics: ListingDiagnostics): readonly BoundedSample[] => [
+  diagnostics.withheld,
+  diagnostics.selfAuthored,
+  diagnostics.unrepresentable,
+];
+
+const utf16LengthOf = (sample: BoundedSample): number =>
+  sample.sample.reduce((total, entry) => total + entry.length, 0);
+
+describe("diagnostics are bounded, exact, and carry no content", () => {
+  test("CONF-O19: no event title, description or location ever appears in diagnostics", async () => {
+    const harness = await referenceHarness();
+    await write(
+      harness.provider,
+      harness.environment,
+      createIntent("secretive", secretiveEvent),
+    );
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(() =>
+      assertNoContentInDiagnostics(listing, [secretTitle, secretDescription, secretLocation]),
+    ).not.toThrow();
+    await harness.dispose();
+  });
+
+  test("CONF-O19: the leak scan actually fires when content is present", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [benign], corruptKnownRows: [] });
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(() => assertNoContentInDiagnostics(listing, ["benign"])).toThrow();
+    await harness.dispose();
+  });
+
+  test("CONF-O30: a clean listing reports all-zero totals", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [benign], corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(samplesOf(listing.diagnostics).map((sample) => sample.total)).toEqual([0, 0, 0]);
+    await harness.dispose();
+  });
+
+  test("CONF-O30: self-authored and unrepresentable are counted separately", async () => {
+    const harness = await referenceHarness();
+    const unrepresentable = foreignEvent({
+      uid: "inverted",
+      title: "Inverted",
+      start: "2026-03-05T10:00:00.000Z",
+      end: "2026-03-05T09:00:00.000Z",
+    });
+    await harness.provider.seed({ events: [unrepresentable], corruptKnownRows: [] });
+    await write(harness.provider, harness.environment, createIntent("ours", secretiveEvent));
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(listing.diagnostics.selfAuthored.total).toBe(1);
+    expect(listing.diagnostics.unrepresentable.total).toBe(1);
+    await harness.dispose();
+  });
+
+  test("CONF-O30: two identical polls produce identical diagnostics including sample order", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: manyWithheld.slice(0, 5), corruptKnownRows: [] });
+
+    const first = okValue(await listChanges(harness.provider, harness.environment, scope));
+    const second = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(second.diagnostics).toEqual(first.diagnostics);
+    await harness.dispose();
+  });
+
+  test("CONF-O31: the sample is bounded by entry count while the total stays exact", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: manyWithheld, corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(listing.diagnostics.withheld.total).toBe(manyWithheld.length);
+    expect(listing.diagnostics.withheld.sample.length).toBeLessThanOrEqual(
+      conformanceLimits.diagnosticSampleEntries,
+    );
+    await harness.dispose();
+  });
+
+  test("CONF-O31: the sample is bounded by total UTF-16 length, not only entry count", async () => {
+    const harness = await referenceHarness();
+    const pathological = foreignEvent({
+      uid: "x".repeat(50_000),
+      title: "Pathological identifier",
+      start: "2026-03-06T10:00:00.000Z",
+      end: "2026-03-06T09:00:00.000Z",
+    });
+    await harness.provider.seed({ events: [pathological], corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(utf16LengthOf(listing.diagnostics.withheld)).toBeLessThanOrEqual(
+      conformanceLimits.diagnosticSampleUtf16Length,
+    );
+    await harness.dispose();
+  });
+
+  test("CONF-O32: a discard with neither uid nor start is still reported as missingIdentity", async () => {
+    await expect(runReferenceCase("CONF-O32")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O42: a failed run leaks no diagnostics into the run that follows it", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [benign], corruptKnownRows: [] });
+    harness.environment.transport.answerWith({
+      kind: "reject",
+      failure: { kind: "transport", status: 500, disposition: "permanent" },
+      times: 8,
+    });
+    await listChanges(harness.provider, harness.environment, scope);
+
+    harness.environment.transport.answerWith({ kind: "pass" });
+    const recovered = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(recovered.diagnostics.pagesFetched).toBeGreaterThan(0);
+    expect(samplesOf(recovered.diagnostics).map((sample) => sample.total)).toEqual([0, 0, 0]);
+    await harness.dispose();
+  });
+
+  test("CONF-O30: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O30")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O31: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O31")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O42: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O42")).resolves.toBeUndefined();
+  });
+});

--- a/packages/sync-kit/conformance/tests/diagnostics.test.ts
+++ b/packages/sync-kit/conformance/tests/diagnostics.test.ts
@@ -11,6 +11,7 @@ import {
   scopeOver,
   spanning,
   timedAt,
+  seedOf,
 } from "./support/protocol";
 
 const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
@@ -70,7 +71,7 @@ describe("diagnostics are bounded, exact, and carry no content", () => {
 
   test("CONF-O19: the leak scan actually fires when content is present", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [benign], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([benign], []));
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 
     expect(() => assertNoContentInDiagnostics(listing, ["benign"])).toThrow();
@@ -79,7 +80,7 @@ describe("diagnostics are bounded, exact, and carry no content", () => {
 
   test("CONF-O30: a clean listing reports all-zero totals", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [benign], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([benign], []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 
@@ -95,7 +96,7 @@ describe("diagnostics are bounded, exact, and carry no content", () => {
       start: "2026-03-05T10:00:00.000Z",
       end: "2026-03-05T09:00:00.000Z",
     });
-    await harness.provider.seed({ events: [unrepresentable], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([unrepresentable], []));
     await write(harness.provider, harness.environment, createIntent("ours", secretiveEvent));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
@@ -107,7 +108,7 @@ describe("diagnostics are bounded, exact, and carry no content", () => {
 
   test("CONF-O30: two identical polls produce identical diagnostics including sample order", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: manyWithheld.slice(0, 5), corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(manyWithheld.slice(0, 5), []));
 
     const first = okValue(await listChanges(harness.provider, harness.environment, scope));
     const second = okValue(await listChanges(harness.provider, harness.environment, scope));
@@ -118,7 +119,7 @@ describe("diagnostics are bounded, exact, and carry no content", () => {
 
   test("CONF-O31: the sample is bounded by entry count while the total stays exact", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: manyWithheld, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(manyWithheld, []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 
@@ -137,7 +138,7 @@ describe("diagnostics are bounded, exact, and carry no content", () => {
       start: "2026-03-06T10:00:00.000Z",
       end: "2026-03-06T09:00:00.000Z",
     });
-    await harness.provider.seed({ events: [pathological], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([pathological], []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 
@@ -153,7 +154,7 @@ describe("diagnostics are bounded, exact, and carry no content", () => {
 
   test("CONF-O42: a failed run leaks no diagnostics into the run that follows it", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [benign], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([benign], []));
     harness.environment.transport.answerWith({
       kind: "reject",
       failure: { kind: "transport", status: 500, disposition: "permanent" },

--- a/packages/sync-kit/conformance/tests/harness/per-case-isolation.test.ts
+++ b/packages/sync-kit/conformance/tests/harness/per-case-isolation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { conformanceCaseIds } from "../../src/case-id";
 import { planConformanceRun } from "../../src/run-conformance";
 import type { ConformanceEnvironment, ProviderUnderTest } from "../../src/options";
 import { referenceCapabilities } from "../../src/reference/capabilities";
@@ -78,15 +79,15 @@ describe("a provider instance never outlives its case", () => {
     );
   });
 
-  test("CONF-I77: skipping is visible in the report rather than silent", () => {
+  test("CONF-I77: no capability value removes a case from the report", () => {
     const counting = countingCreate();
 
     const plan = planWith(counting);
-    const overlap = plan.report.skipped.filter((entry) =>
-      plan.report.selected.some((selected) => selected.id === entry.id),
+    const missing = conformanceCaseIds.filter(
+      (id) => !plan.report.selected.some((selected) => selected.id === id),
     );
 
-    expect(overlap).toEqual([]);
+    expect(missing).toEqual([]);
     expect(plan.report.ungated.length).toBeGreaterThan(0);
   });
 });

--- a/packages/sync-kit/conformance/tests/harness/per-case-isolation.test.ts
+++ b/packages/sync-kit/conformance/tests/harness/per-case-isolation.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "vitest";
+import { planConformanceRun } from "../../src/run-conformance";
+import type { ConformanceEnvironment, ProviderUnderTest } from "../../src/options";
+import { referenceCapabilities } from "../../src/reference/capabilities";
+import { createReferenceProvider } from "../../src/reference/provider";
+import { isInsideWindow } from "../support/protocol";
+
+interface CountingCreate {
+  readonly create: (environment: ConformanceEnvironment) => Promise<ProviderUnderTest<"reference">>;
+  readonly creations: () => number;
+  readonly disposals: () => number;
+}
+
+const countingCreate = (): CountingCreate => {
+  let creations = 0;
+  let disposals = 0;
+  return {
+    create: async (environment) => {
+      creations += 1;
+      const provider = await createReferenceProvider(environment);
+      return {
+        ...provider,
+        dispose: async () => {
+          disposals += 1;
+          await provider.dispose();
+        },
+      };
+    },
+    creations: () => creations,
+    disposals: () => disposals,
+  };
+};
+
+const planWith = (counting: CountingCreate) =>
+  planConformanceRun({
+    name: "reference",
+    supports: referenceCapabilities,
+    create: counting.create,
+    withinWindow: isInsideWindow,
+  });
+
+describe("a provider instance never outlives its case", () => {
+  test("CONF-I57: planning the run creates no provider at all", () => {
+    const counting = countingCreate();
+
+    const plan = planWith(counting);
+
+    expect(plan.cases.length).toBeGreaterThan(0);
+    expect(counting.creations()).toBe(0);
+  });
+
+  test("CONF-I57: create runs once per case, not once per suite", async () => {
+    const counting = countingCreate();
+    const plan = planWith(counting);
+
+    await plan.cases[0]?.execute();
+    await plan.cases[1]?.execute();
+
+    expect(counting.creations()).toBe(2);
+  });
+
+  test("CONF-I57: a case disposes its provider even when the case fails", async () => {
+    const counting = countingCreate();
+    const plan = planWith(counting);
+
+    await Promise.allSettled(plan.cases.slice(0, 3).map((entry) => entry.execute()));
+
+    expect(counting.disposals()).toBe(counting.creations());
+  });
+
+  test("CONF-I57: the report names every case the plan will execute", () => {
+    const counting = countingCreate();
+
+    const plan = planWith(counting);
+
+    expect(plan.report.selected.map((entry) => entry.id)).toEqual(
+      plan.cases.map((entry) => entry.id),
+    );
+  });
+
+  test("CONF-I77: skipping is visible in the report rather than silent", () => {
+    const counting = countingCreate();
+
+    const plan = planWith(counting);
+    const overlap = plan.report.skipped.filter((entry) =>
+      plan.report.selected.some((selected) => selected.id === entry.id),
+    );
+
+    expect(overlap).toEqual([]);
+    expect(plan.report.ungated.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/sync-kit/conformance/tests/hostile-content.test.ts
+++ b/packages/sync-kit/conformance/tests/hostile-content.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "vitest";
+import { failureOf, listChanges, listingKindOf, okValue } from "./support/drive";
+import { referenceHarness, runReferenceCase } from "./support/harness";
+import { foreignEvent, scopeOver, spanning } from "./support/protocol";
+
+const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
+const scope = scopeOver(march);
+
+const benign = foreignEvent({
+  uid: "benign",
+  title: "Weekly sync",
+  start: "2026-03-02T09:00:00.000Z",
+  end: "2026-03-02T10:00:00.000Z",
+});
+
+const hostileTitles = [
+  "rate limit exceeded",
+  "410 Gone",
+  "Precondition Failed",
+  "HTTP 429 Too Many Requests",
+  "fullSyncRequired",
+  "\u0000 NUL byte",
+];
+
+const hostileEvents = hostileTitles.map((title, index) =>
+  foreignEvent({
+    uid: `hostile-${index}`,
+    title,
+    start: "2026-03-02T09:00:00.000Z",
+    end: "2026-03-02T10:00:00.000Z",
+  }),
+);
+
+describe("event content cannot change how a failure is classified", () => {
+  test("CONF-O23: hostile titles do not turn a healthy listing into a failure", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: hostileEvents, corruptKnownRows: [] });
+
+    const result = await listChanges(harness.provider, harness.environment, scope);
+
+    expect(listingKindOf(result)).toBe("snapshot");
+    expect(okValue(result).events).toHaveLength(hostileEvents.length);
+    await harness.dispose();
+  });
+
+  test("CONF-O23: the identity of a hostile event matches the identity of a benign one", async () => {
+    const hostile = await referenceHarness();
+    const calm = await referenceHarness();
+    await hostile.provider.seed({ events: [hostileEvents[0] ?? benign], corruptKnownRows: [] });
+    await calm.provider.seed({ events: [benign], corruptKnownRows: [] });
+
+    const first = okValue(await listChanges(hostile.provider, hostile.environment, scope));
+    const second = okValue(await listChanges(calm.provider, calm.environment, scope));
+
+    expect((first.events ?? []).map((event) => event.uid.value)).toHaveLength(
+      (second.events ?? []).length,
+    );
+    expect(first.kind).toBe(second.kind);
+    expect(first.diagnostics).toEqual(second.diagnostics);
+    await hostile.dispose();
+    await calm.dispose();
+  });
+
+  test("CONF-O23: a real rate limit is still classified as rateLimited whatever the content says", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: hostileEvents, corruptKnownRows: [] });
+    harness.environment.transport.answerWith({
+      kind: "reject",
+      failure: { kind: "rateLimited", retryAfter: null, scope: "perUser" },
+      times: Number.MAX_SAFE_INTEGER,
+    });
+
+    const result = await listChanges(harness.provider, harness.environment, scope, null, {
+      maxAttempts: 1,
+    });
+
+    expect(failureOf(result).kind).toBe("rateLimited");
+    await harness.dispose();
+  });
+
+  test("CONF-O23: a NUL byte in a title does not split or truncate the identity key", async () => {
+    const harness = await referenceHarness();
+    const nulled = foreignEvent({
+      uid: "with\u0000nul",
+      title: "Contains a NUL",
+      start: "2026-03-02T09:00:00.000Z",
+      end: "2026-03-02T10:00:00.000Z",
+    });
+    await harness.provider.seed({ events: [nulled, benign], corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+    const uids = (listing.events ?? []).map((event) => event.uid.value);
+
+    expect(uids).toHaveLength(2);
+    expect(new Set(uids).size).toBe(2);
+    await harness.dispose();
+  });
+
+  test("CONF-O23: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O23")).resolves.toBeUndefined();
+  });
+});

--- a/packages/sync-kit/conformance/tests/hostile-content.test.ts
+++ b/packages/sync-kit/conformance/tests/hostile-content.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { failureOf, listChanges, listingKindOf, okValue } from "./support/drive";
 import { referenceHarness, runReferenceCase } from "./support/harness";
-import { foreignEvent, scopeOver, spanning } from "./support/protocol";
+import { foreignEvent, scopeOver, seedOf, spanning } from "./support/protocol";
 
 const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
 const scope = scopeOver(march);
@@ -34,7 +34,7 @@ const hostileEvents = hostileTitles.map((title, index) =>
 describe("event content cannot change how a failure is classified", () => {
   test("CONF-O23: hostile titles do not turn a healthy listing into a failure", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: hostileEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(hostileEvents, []));
 
     const result = await listChanges(harness.provider, harness.environment, scope);
 
@@ -46,8 +46,8 @@ describe("event content cannot change how a failure is classified", () => {
   test("CONF-O23: the identity of a hostile event matches the identity of a benign one", async () => {
     const hostile = await referenceHarness();
     const calm = await referenceHarness();
-    await hostile.provider.seed({ events: [hostileEvents[0] ?? benign], corruptKnownRows: [] });
-    await calm.provider.seed({ events: [benign], corruptKnownRows: [] });
+    await hostile.provider.seed(seedOf([hostileEvents[0] ?? benign], []));
+    await calm.provider.seed(seedOf([benign], []));
 
     const first = okValue(await listChanges(hostile.provider, hostile.environment, scope));
     const second = okValue(await listChanges(calm.provider, calm.environment, scope));
@@ -63,7 +63,7 @@ describe("event content cannot change how a failure is classified", () => {
 
   test("CONF-O23: a real rate limit is still classified as rateLimited whatever the content says", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: hostileEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(hostileEvents, []));
     harness.environment.transport.answerWith({
       kind: "reject",
       failure: { kind: "rateLimited", retryAfter: null, scope: "perUser" },
@@ -86,7 +86,7 @@ describe("event content cannot change how a failure is classified", () => {
       start: "2026-03-02T09:00:00.000Z",
       end: "2026-03-02T10:00:00.000Z",
     });
-    await harness.provider.seed({ events: [nulled, benign], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([nulled, benign], []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
     const uids = (listing.events ?? []).map((event) => event.uid.value);

--- a/packages/sync-kit/conformance/tests/hygiene/ledger-citations.test.ts
+++ b/packages/sync-kit/conformance/tests/hygiene/ledger-citations.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { beforeAll, describe, expect, test } from "vitest";
 import { caseIdsCitedBy, conformanceCaseIds, ledgerEntryOf } from "../../src/case-id";
 import type { ConformanceCaseId, LedgerEntryId } from "../../src/case-id";
 import { packageRoot, readSource, sourceFiles } from "../support/sources";
@@ -17,10 +17,13 @@ const conformanceSectionOf = (ledger: string): string =>
 const isCaseId = (value: string): value is ConformanceCaseId =>
   conformanceCaseIds.some((id) => id === value);
 
-const plannedCaseParagraphsIn = (body: string): readonly string[] =>
+const provingMarker = "**Proved by.**";
+
+const provingClaimsIn = (body: string): readonly string[] =>
   body
     .split(/\n\n+/)
-    .filter((paragraph) => paragraph.includes("**Planned case.**"));
+    .filter((paragraph) => paragraph.includes(provingMarker))
+    .map((paragraph) => paragraph.slice(paragraph.indexOf(provingMarker)));
 
 const citationsIn = (section: string): readonly Citation[] => {
   const entries = section.split(/^### (CONF-I\d+)\./gm);
@@ -31,7 +34,7 @@ const citationsIn = (section: string): readonly Citation[] => {
     if (!entry || !body) {
       continue;
     }
-    for (const paragraph of plannedCaseParagraphsIn(body)) {
+    for (const paragraph of provingClaimsIn(body)) {
       const files = [
         ...paragraph.matchAll(/`conformance\/(tests\/[^`\s]+\.test\.ts)`/g),
       ].flatMap((match) => {
@@ -73,9 +76,13 @@ const titlesIn = (text: string): readonly string[] =>
     return [title];
   });
 
-const citations = citationsIn(conformanceSectionOf(await ledgerText()));
+let citations: readonly Citation[] = [];
 
 describe("the ledger can be walked against the suite", () => {
+  beforeAll(async () => {
+    citations = citationsIn(conformanceSectionOf(await ledgerText()));
+  });
+
   test("CONF-I59: every cited test file exists and every case resolves to a real ledger entry", async () => {
     const section = conformanceSectionOf(await ledgerText());
     const files = new Set(await sourceFiles("tests"));

--- a/packages/sync-kit/conformance/tests/hygiene/ledger-citations.test.ts
+++ b/packages/sync-kit/conformance/tests/hygiene/ledger-citations.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "vitest";
+import { caseIdsCitedBy, conformanceCaseIds, ledgerEntryOf } from "../../src/case-id";
+import type { ConformanceCaseId, LedgerEntryId } from "../../src/case-id";
+import { packageRoot, readSource, sourceFiles } from "../support/sources";
+
+interface Citation {
+  readonly entry: LedgerEntryId;
+  readonly case: ConformanceCaseId;
+  readonly file: string;
+}
+
+const ledgerText = (): Promise<string> => Bun.file(`${packageRoot}../LEARNINGS.md`).text();
+
+const conformanceSectionOf = (ledger: string): string =>
+  ledger.slice(ledger.indexOf("# sync-conformance learnings ledger"));
+
+const isCaseId = (value: string): value is ConformanceCaseId =>
+  conformanceCaseIds.some((id) => id === value);
+
+const plannedCaseParagraphsIn = (body: string): readonly string[] =>
+  body
+    .split(/\n\n+/)
+    .filter((paragraph) => paragraph.includes("**Planned case.**"));
+
+const citationsIn = (section: string): readonly Citation[] => {
+  const entries = section.split(/^### (CONF-I\d+)\./gm);
+  const found: Citation[] = [];
+  for (let index = 1; index < entries.length; index += 2) {
+    const entry = entries.at(index);
+    const body = entries.at(index + 1);
+    if (!entry || !body) {
+      continue;
+    }
+    for (const paragraph of plannedCaseParagraphsIn(body)) {
+      const files = [
+        ...paragraph.matchAll(/`conformance\/(tests\/[^`\s]+\.test\.ts)`/g),
+      ].flatMap((match) => {
+        const file = match.at(1);
+        if (!file) {
+          return [];
+        }
+        return [file];
+      });
+      const cases = [...paragraph.matchAll(/`(CONF-[OL]\d+)`/g)].flatMap((match) => {
+        const caseId = match.at(1);
+        if (!caseId || !isCaseId(caseId)) {
+          return [];
+        }
+        return [caseId];
+      });
+      for (const [position, caseId] of cases.entries()) {
+        const file = files.at(position) ?? files.at(0);
+        if (!file) {
+          continue;
+        }
+        found.push({
+          entry: `CONF-I${Number(entry.slice("CONF-I".length))}`,
+          case: caseId,
+          file,
+        });
+      }
+    }
+  }
+  return found;
+};
+
+const titlesIn = (text: string): readonly string[] =>
+  [...text.matchAll(/test\(\s*(["'`])((?:\\.|(?!\1)[^\\])*)\1/g)].flatMap((match) => {
+    const title = match.at(2);
+    if (!title) {
+      return [];
+    }
+    return [title];
+  });
+
+const citations = citationsIn(conformanceSectionOf(await ledgerText()));
+
+describe("the ledger can be walked against the suite", () => {
+  test("CONF-I59: every cited test file exists and every case resolves to a real ledger entry", async () => {
+    const section = conformanceSectionOf(await ledgerText());
+    const files = new Set(await sourceFiles("tests"));
+    const missing = citations.filter((citation) => !files.has(citation.file));
+    const unresolved = conformanceCaseIds.filter(
+      (id) => !section.includes(`### ${ledgerEntryOf(id)}.`),
+    );
+
+    expect(missing.map((citation) => citation.file)).toEqual([]);
+    expect(unresolved).toEqual([]);
+    expect(citations.length).toBeGreaterThan(40);
+  });
+
+  test("CONF-I59: every cited case id appears verbatim in a test title in the file that cites it", async () => {
+    const broken: string[] = [];
+    const titlesOf = new Map<string, readonly string[]>();
+    for (const citation of citations) {
+      const cached = titlesOf.get(citation.file);
+      const titles = cached ?? titlesIn(await readSource(citation.file));
+      titlesOf.set(citation.file, titles);
+      if (!titles.some((title) => title.startsWith(`${citation.case}:`))) {
+        broken.push(`${citation.file} :: ${citation.case}`);
+      }
+    }
+
+    expect(broken).toEqual([]);
+    expect(citations.map((citation) => ledgerEntryOf(citation.case))).toEqual(
+      citations.map((citation) => citation.entry),
+    );
+  });
+
+  test("CONF-I59: every declared case id is cited by the ledger entry case-id.ts names", () => {
+    const cited = new Set(citations.map((citation) => citation.case));
+    const uncited = conformanceCaseIds.filter((id) => !cited.has(id));
+    const misattributed = conformanceCaseIds.filter(
+      (id) =>
+        !citations.some(
+          (citation) => citation.case === id && citation.entry === ledgerEntryOf(id),
+        ),
+    );
+
+    expect(uncited).toEqual([]);
+    expect(misattributed).toEqual([]);
+  });
+
+  test("CONF-I59: the case-id cross-reference agrees with the ledger it claims to index", () => {
+    const disagreements = citations.filter(
+      (citation) => ledgerEntryOf(citation.case) !== citation.entry,
+    );
+
+    expect(disagreements.map((citation) => citation.case)).toEqual([]);
+  });
+
+  test("CONF-I59: the reverse lookup returns every case an entry cites", () => {
+    const alpha = citations.at(0);
+    const expected = citations
+      .filter((citation) => citation.entry === alpha?.entry)
+      .map((citation) => citation.case);
+
+    expect(caseIdsCitedBy(alpha?.entry ?? "CONF-I1")).toEqual(expected);
+  });
+});

--- a/packages/sync-kit/conformance/tests/hygiene/no-bun-sleep.test.ts
+++ b/packages/sync-kit/conformance/tests/hygiene/no-bun-sleep.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { createTestClock } from "../../src/clock";
+import { filesMatching, sourceFiles } from "../support/sources";
+import { suiteStart } from "../support/harness";
+
+const unfakeablePrimitive = ["Bun", "sleep"].join(".");
+
+describe("timing primitives fake timers cannot patch", () => {
+  test("CONF-I51: no file under src reaches for the unfakeable sleep primitive", async () => {
+    const offenders = await filesMatching("src", unfakeablePrimitive);
+    const files = await sourceFiles("src");
+
+    expect(offenders).toEqual([]);
+    expect(files.length).toBeGreaterThan(20);
+    expect(() => createTestClock({ start: suiteStart })).not.toThrow();
+  });
+
+  test("CONF-I51: no file under tests reaches for the unfakeable sleep primitive", async () => {
+    const offenders = await filesMatching("tests", unfakeablePrimitive);
+    const files = await sourceFiles("tests");
+
+    expect(offenders).toEqual([]);
+    expect(files.length).toBeGreaterThan(15);
+    expect(() => createTestClock({ start: suiteStart })).not.toThrow();
+  });
+
+  test("CONF-I51: the injected clock schedules through setTimeout so fake timers can drive it", () => {
+    const clock = createTestClock({ start: suiteStart });
+
+    expect(clock.pendingTimers()).toBe(0);
+    expect(clock.now()).toEqual(suiteStart);
+  });
+});

--- a/packages/sync-kit/conformance/tests/hygiene/no-bun-sleep.test.ts
+++ b/packages/sync-kit/conformance/tests/hygiene/no-bun-sleep.test.ts
@@ -1,33 +1,39 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { createTestClock } from "../../src/clock";
 import { filesMatching, sourceFiles } from "../support/sources";
 import { suiteStart } from "../support/harness";
 
-const unfakeablePrimitive = ["Bun", "sleep"].join(".");
+const unfakeablePrimitiveThisFileMustNotSpellOutItself = ["Bun", "sleep"].join(".");
 
 describe("timing primitives fake timers cannot patch", () => {
   test("CONF-I51: no file under src reaches for the unfakeable sleep primitive", async () => {
-    const offenders = await filesMatching("src", unfakeablePrimitive);
+    const offenders = await filesMatching("src", unfakeablePrimitiveThisFileMustNotSpellOutItself);
     const files = await sourceFiles("src");
 
     expect(offenders).toEqual([]);
     expect(files.length).toBeGreaterThan(20);
-    expect(() => createTestClock({ start: suiteStart })).not.toThrow();
   });
 
   test("CONF-I51: no file under tests reaches for the unfakeable sleep primitive", async () => {
-    const offenders = await filesMatching("tests", unfakeablePrimitive);
+    const offenders = await filesMatching("tests", unfakeablePrimitiveThisFileMustNotSpellOutItself);
     const files = await sourceFiles("tests");
 
     expect(offenders).toEqual([]);
     expect(files.length).toBeGreaterThan(15);
-    expect(() => createTestClock({ start: suiteStart })).not.toThrow();
   });
 
-  test("CONF-I51: the injected clock schedules through setTimeout so fake timers can drive it", () => {
+  test("CONF-I51: the injected clock schedules through setTimeout so fake timers can drive it", async () => {
+    vi.useFakeTimers();
     const clock = createTestClock({ start: suiteStart });
 
+    const sleeping = clock.sleep(500, new AbortController().signal);
+    const armed = clock.pendingTimers();
+    await vi.advanceTimersByTimeAsync(500);
+    await sleeping;
+
+    expect(armed).toBe(1);
     expect(clock.pendingTimers()).toBe(0);
-    expect(clock.now()).toEqual(suiteStart);
+    expect(Date.parse(clock.now().value) - Date.parse(suiteStart.value)).toBe(500);
+    vi.useRealTimers();
   });
 });

--- a/packages/sync-kit/conformance/tests/hygiene/no-reassignment.test.ts
+++ b/packages/sync-kit/conformance/tests/hygiene/no-reassignment.test.ts
@@ -1,0 +1,45 @@
+import { Glob } from "bun";
+import { describe, expect, test } from "vitest";
+
+const packageRoot = new URL("../../", import.meta.url).pathname;
+
+/*
+ * A rebindable name is state a reader has to simulate. Both forms are checked: a `let` in
+ * statement position, and a `let` in a classic for-loop header. Anchoring to the start of a
+ * line keeps prose in a comment from reading as a declaration.
+ */
+const statementBinding = /^\s*let\s+[A-Za-z_$]/;
+const loopBinding = /\(\s*let\s+[A-Za-z_$]/;
+
+const sourceFiles = async (directory: string): Promise<readonly string[]> => {
+  const glob = new Glob("**/*.ts");
+  const found: string[] = [];
+  for await (const relative of glob.scan({ cwd: `${packageRoot}${directory}` })) {
+    found.push(relative);
+  }
+  return found;
+};
+
+const offendersIn = async (directory: string): Promise<readonly string[]> => {
+  const files = await sourceFiles(directory);
+  const offenders: string[] = [];
+  for (const relative of files) {
+    const text = await Bun.file(`${packageRoot}${directory}/${relative}`).text();
+    for (const [index, line] of text.split("\n").entries()) {
+      if (statementBinding.test(line) || loopBinding.test(line)) {
+        offenders.push(`${directory}/${relative}:${String(index + 1)}`);
+      }
+    }
+  }
+  return offenders;
+};
+
+describe("rebindable names", () => {
+  test("CONF-H50: no file under src declares a let", async () => {
+    const files = await sourceFiles("src");
+    const offenders = await offendersIn("src");
+
+    expect(offenders).toEqual([]);
+    expect(files.length).toBeGreaterThan(25);
+  });
+});

--- a/packages/sync-kit/conformance/tests/hygiene/no-unpatchable-timers.test.ts
+++ b/packages/sync-kit/conformance/tests/hygiene/no-unpatchable-timers.test.ts
@@ -3,30 +3,27 @@ import { createTestClock } from "../../src/clock";
 import { filesMatching } from "../support/sources";
 import { suiteStart } from "../support/harness";
 
-const abortTimeout = ["AbortSignal", "timeout"].join(".");
-const timersPromises = ["node", "timers/promises"].join(":");
+const abortTimeoutThisFileMustNotSpellOutItself = ["AbortSignal", "timeout"].join(".");
+const timersModuleThisFileMustNotSpellOutItself = ["node", "timers/promises"].join(":");
 
 describe("deadlines are built only from primitives fake timers patch", () => {
   test("CONF-I52: no file under src uses the unpatchable AbortSignal timeout", async () => {
-    const offenders = await filesMatching("src", abortTimeout);
+    const offenders = await filesMatching("src", abortTimeoutThisFileMustNotSpellOutItself);
 
     expect(offenders).toEqual([]);
-    expect(() => createTestClock({ start: suiteStart })).not.toThrow();
   });
 
   test("CONF-I52: no file under tests uses the unpatchable AbortSignal timeout", async () => {
-    const offenders = await filesMatching("tests", abortTimeout);
+    const offenders = await filesMatching("tests", abortTimeoutThisFileMustNotSpellOutItself);
 
     expect(offenders).toEqual([]);
-    expect(() => createTestClock({ start: suiteStart })).not.toThrow();
   });
 
   test("CONF-I52: nothing imports the node timers/promises module", async () => {
-    const inSource = await filesMatching("src", timersPromises);
-    const inTests = await filesMatching("tests", timersPromises);
+    const inSource = await filesMatching("src", timersModuleThisFileMustNotSpellOutItself);
+    const inTests = await filesMatching("tests", timersModuleThisFileMustNotSpellOutItself);
 
     expect([...inSource, ...inTests]).toEqual([]);
-    expect(() => createTestClock({ start: suiteStart })).not.toThrow();
   });
 
   test("CONF-I52: the clock owns its own AbortController rather than borrowing one", async () => {

--- a/packages/sync-kit/conformance/tests/hygiene/no-unpatchable-timers.test.ts
+++ b/packages/sync-kit/conformance/tests/hygiene/no-unpatchable-timers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import { createTestClock } from "../../src/clock";
+import { filesMatching } from "../support/sources";
+import { suiteStart } from "../support/harness";
+
+const abortTimeout = ["AbortSignal", "timeout"].join(".");
+const timersPromises = ["node", "timers/promises"].join(":");
+
+describe("deadlines are built only from primitives fake timers patch", () => {
+  test("CONF-I52: no file under src uses the unpatchable AbortSignal timeout", async () => {
+    const offenders = await filesMatching("src", abortTimeout);
+
+    expect(offenders).toEqual([]);
+    expect(() => createTestClock({ start: suiteStart })).not.toThrow();
+  });
+
+  test("CONF-I52: no file under tests uses the unpatchable AbortSignal timeout", async () => {
+    const offenders = await filesMatching("tests", abortTimeout);
+
+    expect(offenders).toEqual([]);
+    expect(() => createTestClock({ start: suiteStart })).not.toThrow();
+  });
+
+  test("CONF-I52: nothing imports the node timers/promises module", async () => {
+    const inSource = await filesMatching("src", timersPromises);
+    const inTests = await filesMatching("tests", timersPromises);
+
+    expect([...inSource, ...inTests]).toEqual([]);
+    expect(() => createTestClock({ start: suiteStart })).not.toThrow();
+  });
+
+  test("CONF-I52: the clock owns its own AbortController rather than borrowing one", async () => {
+    const clock = createTestClock({ start: suiteStart });
+    const caller = new AbortController();
+    caller.abort();
+
+    await expect(clock.sleep(1000, caller.signal)).rejects.toThrow();
+    expect(clock.pendingTimers()).toBe(0);
+  });
+});

--- a/packages/sync-kit/conformance/tests/hygiene/no-wall-clock.test.ts
+++ b/packages/sync-kit/conformance/tests/hygiene/no-wall-clock.test.ts
@@ -3,24 +3,24 @@ import { createTestClock } from "../../src/clock";
 import { filesMatching } from "../support/sources";
 import { suiteStart } from "../support/harness";
 
-const wallClockReadings = [
-  ["Date", "now()"].join("."),
-  ["performance", "now()"].join("."),
+const spelledInPieces = (pieces: readonly string[]): string => pieces.join(".");
+
+const readingsThisFileMustNotSpellOutItself = [
+  spelledInPieces(["Date", "now()"]),
+  spelledInPieces(["performance", "now()"]),
 ];
 
 describe("a deadline is asserted on the fake clock, never on the CI agent", () => {
-  test.each(wallClockReadings)("CONF-I53: no file under src reads %s", async (reading) => {
+  test.each(readingsThisFileMustNotSpellOutItself)("CONF-I53: no file under src reads %s", async (reading) => {
     const offenders = await filesMatching("src", reading);
 
     expect(offenders).toEqual([]);
-    expect(() => createTestClock({ start: suiteStart })).not.toThrow();
   });
 
-  test.each(wallClockReadings)("CONF-I53: no test file reads %s", async (reading) => {
+  test.each(readingsThisFileMustNotSpellOutItself)("CONF-I53: no test file reads %s", async (reading) => {
     const offenders = await filesMatching("tests", reading);
 
     expect(offenders).toEqual([]);
-    expect(() => createTestClock({ start: suiteStart })).not.toThrow();
   });
 
   test("CONF-I53: advancing the injected clock moves its own now, not the machine's", async () => {

--- a/packages/sync-kit/conformance/tests/hygiene/no-wall-clock.test.ts
+++ b/packages/sync-kit/conformance/tests/hygiene/no-wall-clock.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+import { createTestClock } from "../../src/clock";
+import { filesMatching } from "../support/sources";
+import { suiteStart } from "../support/harness";
+
+const wallClockReadings = [
+  ["Date", "now()"].join("."),
+  ["performance", "now()"].join("."),
+];
+
+describe("a deadline is asserted on the fake clock, never on the CI agent", () => {
+  test.each(wallClockReadings)("CONF-I53: no file under src reads %s", async (reading) => {
+    const offenders = await filesMatching("src", reading);
+
+    expect(offenders).toEqual([]);
+    expect(() => createTestClock({ start: suiteStart })).not.toThrow();
+  });
+
+  test.each(wallClockReadings)("CONF-I53: no test file reads %s", async (reading) => {
+    const offenders = await filesMatching("tests", reading);
+
+    expect(offenders).toEqual([]);
+    expect(() => createTestClock({ start: suiteStart })).not.toThrow();
+  });
+
+  test("CONF-I53: advancing the injected clock moves its own now, not the machine's", async () => {
+    const clock = createTestClock({ start: suiteStart });
+    const before = clock.now();
+
+    await clock.advance(5000);
+
+    expect(clock.now()).not.toEqual(before);
+    expect(Date.parse(clock.now().value) - Date.parse(before.value)).toBe(5000);
+  });
+});

--- a/packages/sync-kit/conformance/tests/injection.test.ts
+++ b/packages/sync-kit/conformance/tests/injection.test.ts
@@ -4,7 +4,7 @@ import { selectConformanceCases } from "../src/registry/suite";
 import { referenceCapabilities } from "../src/reference/capabilities";
 import { listChanges } from "./support/drive";
 import { referenceHarness, runReferenceCase } from "./support/harness";
-import { foreignEvent, scopeOver, spanning } from "./support/protocol";
+import { foreignEvent, scopeOver, seedOf, spanning } from "./support/protocol";
 
 const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
 const scope = scopeOver(march);
@@ -23,7 +23,7 @@ const lockupCaseIds = new Set(conformanceCaseIds.filter((id) => id.startsWith("C
 describe("the injected seams were actually used", () => {
   test("CONF-L13: a nominal operation goes through the injected transport", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seeded, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seeded, []));
 
     await listChanges(harness.provider, harness.environment, scope);
 
@@ -33,7 +33,7 @@ describe("the injected seams were actually used", () => {
 
   test("CONF-L13: a nominal operation reads the injected clock", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seeded, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seeded, []));
     const before = harness.environment.clock.nowCount();
 
     await listChanges(harness.provider, harness.environment, scope);
@@ -53,7 +53,7 @@ describe("the injected seams were actually used", () => {
 
   test("CONF-L13: an adapter that ignores the injected seams fails the case", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seeded, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seeded, []));
     const untouched = harness.environment.transport.callCount();
 
     expect(untouched).toBe(0);

--- a/packages/sync-kit/conformance/tests/injection.test.ts
+++ b/packages/sync-kit/conformance/tests/injection.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+import { conformanceCaseIds } from "../src/case-id";
+import { selectConformanceCases } from "../src/registry/suite";
+import { referenceCapabilities } from "../src/reference/capabilities";
+import { listChanges } from "./support/drive";
+import { referenceHarness, runReferenceCase } from "./support/harness";
+import { foreignEvent, scopeOver, spanning } from "./support/protocol";
+
+const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
+const scope = scopeOver(march);
+
+const seeded = [
+  foreignEvent({
+    uid: "alpha",
+    title: "Alpha",
+    start: "2026-03-02T09:00:00.000Z",
+    end: "2026-03-02T10:00:00.000Z",
+  }),
+];
+
+const lockupCaseIds = new Set(conformanceCaseIds.filter((id) => id.startsWith("CONF-L")));
+
+describe("the injected seams were actually used", () => {
+  test("CONF-L13: a nominal operation goes through the injected transport", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seeded, corruptKnownRows: [] });
+
+    await listChanges(harness.provider, harness.environment, scope);
+
+    expect(harness.environment.transport.callCount()).toBeGreaterThan(0);
+    await harness.dispose();
+  });
+
+  test("CONF-L13: a nominal operation reads the injected clock", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seeded, corruptKnownRows: [] });
+    const before = harness.environment.clock.nowCount();
+
+    await listChanges(harness.provider, harness.environment, scope);
+
+    expect(harness.environment.clock.nowCount()).toBeGreaterThan(before);
+    await harness.dispose();
+  });
+
+  test("CONF-L13: the anti-vacuity case runs before every other lockup case", () => {
+    const selection = selectConformanceCases(referenceCapabilities);
+    const lockups = selection.selected
+      .map((record) => record.id)
+      .filter((id) => lockupCaseIds.has(id));
+
+    expect(lockups.at(0)).toBe("CONF-L13");
+  });
+
+  test("CONF-L13: an adapter that ignores the injected seams fails the case", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seeded, corruptKnownRows: [] });
+    const untouched = harness.environment.transport.callCount();
+
+    expect(untouched).toBe(0);
+    await expect(runReferenceCase("CONF-L13")).resolves.toBeUndefined();
+    await harness.dispose();
+  });
+});

--- a/packages/sync-kit/conformance/tests/isolation.test.ts
+++ b/packages/sync-kit/conformance/tests/isolation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+import { listChanges, listingKindOf, okValue } from "./support/drive";
+import { referenceHarness, runReferenceCase } from "./support/harness";
+import { foreignEvent, scopeOver, spanning } from "./support/protocol";
+
+const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
+const scope = scopeOver(march);
+
+const usable = foreignEvent({
+  uid: "usable",
+  title: "Usable",
+  start: "2026-03-02T09:00:00.000Z",
+  end: "2026-03-02T10:00:00.000Z",
+});
+const unusable = foreignEvent({
+  uid: "unusable",
+  title: "Unusable",
+  start: "2026-03-03T10:00:00.000Z",
+  end: "2026-03-03T09:00:00.000Z",
+});
+const doomed = foreignEvent({
+  uid: "doomed",
+  title: "Doomed",
+  start: "2026-03-04T09:00:00.000Z",
+  end: "2026-03-04T10:00:00.000Z",
+});
+
+describe("one bad event does not stall the feed", () => {
+  test("CONF-O6: a listing carrying one unusable item still returns the other items", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [usable, unusable], corruptKnownRows: [] });
+
+    const result = await listChanges(harness.provider, harness.environment, scope);
+
+    expect(listingKindOf(result)).toBe("snapshot");
+    expect((okValue(result).events ?? []).map((event) => event.uid.value)).toContain("usable");
+    await harness.dispose();
+  });
+
+  test("CONF-O6: a real deletion in the same payload as an unusable item still applies", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [usable, unusable, doomed], corruptKnownRows: [] });
+    await listChanges(harness.provider, harness.environment, scope);
+
+    await harness.provider.seed({ events: [usable, unusable], corruptKnownRows: [] });
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+    const removed = (listing.removals ?? []).flatMap((removal) => {
+      if (removal.kind === "outOfScope") {
+        return [];
+      }
+      return [removal.uid.value];
+    });
+
+    expect(removed).toContain("doomed");
+    await harness.dispose();
+  });
+
+  test("CONF-O6: a second identical poll of a malformed feed is byte-identical", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [usable, unusable], corruptKnownRows: [] });
+
+    const first = okValue(await listChanges(harness.provider, harness.environment, scope));
+    const second = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(second.withheld).toEqual(first.withheld);
+    expect(second.diagnostics).toEqual(first.diagnostics);
+    await harness.dispose();
+  });
+
+  test("CONF-O6: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O6")).resolves.toBeUndefined();
+  });
+});

--- a/packages/sync-kit/conformance/tests/isolation.test.ts
+++ b/packages/sync-kit/conformance/tests/isolation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { listChanges, listingKindOf, okValue } from "./support/drive";
 import { referenceHarness, runReferenceCase } from "./support/harness";
-import { foreignEvent, scopeOver, spanning } from "./support/protocol";
+import { foreignEvent, scopeOver, seedOf, spanning } from "./support/protocol";
 
 const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
 const scope = scopeOver(march);
@@ -28,7 +28,7 @@ const doomed = foreignEvent({
 describe("one bad event does not stall the feed", () => {
   test("CONF-O6: a listing carrying one unusable item still returns the other items", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [usable, unusable], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([usable, unusable], []));
 
     const result = await listChanges(harness.provider, harness.environment, scope);
 
@@ -39,10 +39,10 @@ describe("one bad event does not stall the feed", () => {
 
   test("CONF-O6: a real deletion in the same payload as an unusable item still applies", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [usable, unusable, doomed], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([usable, unusable, doomed], []));
     await listChanges(harness.provider, harness.environment, scope);
 
-    await harness.provider.seed({ events: [usable, unusable], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([usable, unusable], []));
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
     const removed = (listing.removals ?? []).flatMap((removal) => {
       if (removal.kind === "outOfScope") {
@@ -57,7 +57,7 @@ describe("one bad event does not stall the feed", () => {
 
   test("CONF-O6: a second identical poll of a malformed feed is byte-identical", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [usable, unusable], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([usable, unusable], []));
 
     const first = okValue(await listChanges(harness.provider, harness.environment, scope));
     const second = okValue(await listChanges(harness.provider, harness.environment, scope));

--- a/packages/sync-kit/conformance/tests/lockups.test.ts
+++ b/packages/sync-kit/conformance/tests/lockups.test.ts
@@ -4,7 +4,7 @@ import { stallingOn } from "../src/fixtures";
 import { conformanceLimits } from "../src/limits";
 import { failureOf, listChanges, okValue } from "./support/drive";
 import { referenceHarness, runReferenceCase } from "./support/harness";
-import { foreignEvent, scopeOver, spanning } from "./support/protocol";
+import { foreignEvent, scopeOver, seedOf, spanning } from "./support/protocol";
 
 const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
 const april = spanning("2026-04-01T00:00:00.000Z", "2026-05-01T00:00:00.000Z");
@@ -49,7 +49,7 @@ afterEach(() => {
 describe("nothing in this package can wedge", () => {
   test("CONF-L1: a retry path stops at the declared attempt ceiling", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
     harness.environment.transport.answerWith({
       kind: "reject",
       failure: {
@@ -75,7 +75,7 @@ describe("nothing in this package can wedge", () => {
     const tight = await referenceHarness();
     const loose = await referenceHarness();
     for (const harness of [tight, loose]) {
-      await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+      await harness.provider.seed(seedOf(seedEvents, []));
       harness.environment.transport.answerWith({
         kind: "reject",
         failure: { kind: "rateLimited", retryAfter: null, scope: "perUser" },
@@ -102,7 +102,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L1: a provider-supplied retry delay is capped by the budget, not obeyed", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
     harness.environment.transport.answerWith({
       kind: "reject",
       failure: {
@@ -128,7 +128,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L2: a permanently pending transport settles as a typed failure at the deadline", async () => {
     const harness = await referenceHarness(stallingOn(() => true));
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
 
     const pending = listChanges(harness.provider, harness.environment, scope, null, {
       deadlineMs: conformanceLimits.deadlineMs,
@@ -141,7 +141,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L2: reaching the deadline leaves no timer behind", async () => {
     const harness = await referenceHarness(stallingOn(() => true));
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
 
     const pending = listChanges(harness.provider, harness.environment, scope, null, {
       deadlineMs: conformanceLimits.deadlineMs,
@@ -156,7 +156,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L3: an abort mid-flight is reported as aborted, never as a provider timeout", async () => {
     const harness = await referenceHarness(stallingOn(() => true));
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
     const caller = new AbortController();
 
     const pending = listChanges(harness.provider, harness.environment, scope, null, {
@@ -174,8 +174,8 @@ describe("nothing in this package can wedge", () => {
   test("CONF-L3: an abort and a deadline produce different outcomes", async () => {
     const aborted = await referenceHarness(stallingOn(() => true));
     const expired = await referenceHarness(stallingOn(() => true));
-    await aborted.provider.seed({ events: seedEvents, corruptKnownRows: [] });
-    await expired.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await aborted.provider.seed(seedOf(seedEvents, []));
+    await expired.provider.seed(seedOf(seedEvents, []));
     const caller = new AbortController();
 
     const abortedRun = listChanges(aborted.provider, aborted.environment, scope, null, {
@@ -198,7 +198,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L4: a single-flight leader's rejection reaches every follower", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
     harness.environment.transport.answerWith({ kind: "throw", times: 1 });
 
     const followers = Array.from({ length: 5 }, () =>
@@ -214,7 +214,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L4: a caller arriving after the rejection starts a fresh attempt", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
     harness.environment.transport.answerWith({ kind: "throw", times: 1 });
     const first = listChanges(harness.provider, harness.environment, scope);
     await vi.advanceTimersByTimeAsync(1000);
@@ -232,7 +232,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L5: coalesced callers each receive their own diagnostics object", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
 
     const leading = listChanges(harness.provider, harness.environment, scope);
     const following = listChanges(harness.provider, harness.environment, scope);
@@ -247,7 +247,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L6: overlapping key sets acquired in opposite orders both settle", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
 
     const forward = Promise.all([
       listChanges(harness.provider, harness.environment, scope),
@@ -266,7 +266,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L7: a lease taken by a synchronously throwing body is released", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
     harness.environment.transport.answerWith({ kind: "throw", times: 1 });
     const thrown = listChanges(harness.provider, harness.environment, scope);
     await vi.advanceTimersByTimeAsync(1000);
@@ -284,7 +284,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L7: a lease taken by a rejecting body is released", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
     harness.environment.transport.answerWith({
       kind: "reject",
       failure: { kind: "transport", status: 500, disposition: "permanent" },
@@ -306,7 +306,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L8: no timer survives a completed operation", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
 
     const listing = listChanges(harness.provider, harness.environment, scope);
     await vi.advanceTimersByTimeAsync(1000);
@@ -320,7 +320,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L8: no timer survives a failed operation", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
     harness.environment.transport.answerWith({ kind: "throw", times: 1 });
 
     const listing = listChanges(harness.provider, harness.environment, scope);
@@ -335,7 +335,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L9: an aborted waiter does not strand the waiters behind it", async () => {
     const harness = await referenceHarness(stallingOn(() => true));
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
     const cancelled = new AbortController();
 
     const first = listChanges(harness.provider, harness.environment, scope, null, {
@@ -365,7 +365,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L10: an aborted queued task does not leak its concurrency permit", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
     const cancelled = new AbortController();
 
     const indices = [...Array.from({ length: conformanceLimits.fanOutTasks }).keys()];
@@ -388,7 +388,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L11: a fan-out returns one result per task even when one stalls forever", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
 
     const tasks = Array.from({ length: conformanceLimits.fanOutTasks }, () =>
       listChanges(harness.provider, harness.environment, scope, null, {
@@ -406,7 +406,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L11: a fan-out never exceeds the declared concurrency", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
 
     const tasks = Array.from({ length: conformanceLimits.fanOutTasks }, () =>
       listChanges(harness.provider, harness.environment, scope),
@@ -422,7 +422,7 @@ describe("nothing in this package can wedge", () => {
 
   test("CONF-L12: an unattempted run is neither a success nor a failure", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seedEvents, []));
     const caller = new AbortController();
     caller.abort();
 
@@ -435,27 +435,17 @@ describe("nothing in this package can wedge", () => {
     await harness.dispose();
   });
 
-  test("CONF-L1: the generated case passes for the reference provider", async () => {
-    await expect(runReferenceCase("CONF-L1")).resolves.toBeUndefined();
+});
+
+describe("the generated lockup cases drive real timers, as an adapter's own suite will", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
   });
 
-  test("CONF-L2: the generated case passes for the reference provider", async () => {
-    await expect(runReferenceCase("CONF-L2")).resolves.toBeUndefined();
-  });
-
-  test("CONF-L4: the generated case passes for the reference provider", async () => {
-    await expect(runReferenceCase("CONF-L4")).resolves.toBeUndefined();
-  });
-
-  test("CONF-L7: the generated case passes for the reference provider", async () => {
-    await expect(runReferenceCase("CONF-L7")).resolves.toBeUndefined();
-  });
-
-  test("CONF-L11: the generated case passes for the reference provider", async () => {
-    await expect(runReferenceCase("CONF-L11")).resolves.toBeUndefined();
-  });
-
-  test("CONF-L12: the generated case passes for the reference provider", async () => {
-    await expect(runReferenceCase("CONF-L12")).resolves.toBeUndefined();
-  });
+  test.each(["CONF-L1", "CONF-L2", "CONF-L3", "CONF-L4", "CONF-L7", "CONF-L11", "CONF-L12"] as const)(
+    "%s: the generated case passes for the reference provider",
+    async (id) => {
+      await expect(runReferenceCase(id)).resolves.toBeUndefined();
+    },
+  );
 });

--- a/packages/sync-kit/conformance/tests/lockups.test.ts
+++ b/packages/sync-kit/conformance/tests/lockups.test.ts
@@ -1,0 +1,461 @@
+import type { ProviderFailure, Result, ChangeListing } from "@keeper.sh/sync-protocol";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { stallingOn } from "../src/fixtures";
+import { conformanceLimits } from "../src/limits";
+import { failureOf, listChanges, okValue } from "./support/drive";
+import { referenceHarness, runReferenceCase } from "./support/harness";
+import { foreignEvent, scopeOver, spanning } from "./support/protocol";
+
+const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
+const april = spanning("2026-04-01T00:00:00.000Z", "2026-05-01T00:00:00.000Z");
+const scope = scopeOver(march);
+const otherScope = scopeOver(april);
+
+const seedEvents = [
+  foreignEvent({
+    uid: "alpha",
+    title: "Alpha",
+    start: "2026-03-02T09:00:00.000Z",
+    end: "2026-03-02T10:00:00.000Z",
+  }),
+];
+
+const failureKindsOf = (results: readonly PromiseSettledResult<Result<ChangeListing>>[]): string[] =>
+  results.map((settled) => {
+    if (settled.status === "rejected") {
+      return "rejected";
+    }
+    if (settled.value.ok) {
+      return "ok";
+    }
+    return settled.value.failure.kind;
+  });
+
+const notAttemptedReasonOf = (failure: ProviderFailure): string => {
+  if (failure.kind === "notAttempted") {
+    return failure.reason;
+  }
+  return `not-a-notAttempted:${failure.kind}`;
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("nothing in this package can wedge", () => {
+  test("CONF-L1: a retry path stops at the declared attempt ceiling", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    harness.environment.transport.answerWith({
+      kind: "reject",
+      failure: {
+        kind: "rateLimited",
+        retryAfter: { kind: "instant", value: "2099-01-01T00:00:00.000Z" },
+        scope: "perUser",
+      },
+      times: Number.MAX_SAFE_INTEGER,
+    });
+
+    const pending = listChanges(harness.provider, harness.environment, scope, null, {
+      maxAttempts: 3,
+      retryDelayCeilingMs: 1000,
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(failureOf(await pending).kind).toBe("rateLimited");
+    expect(harness.environment.transport.callCount()).toBe(3);
+    await harness.dispose();
+  });
+
+  test("CONF-L1: the ceiling that stopped it is the one that was named", async () => {
+    const tight = await referenceHarness();
+    const loose = await referenceHarness();
+    for (const harness of [tight, loose]) {
+      await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+      harness.environment.transport.answerWith({
+        kind: "reject",
+        failure: { kind: "rateLimited", retryAfter: null, scope: "perUser" },
+        times: Number.MAX_SAFE_INTEGER,
+      });
+    }
+
+    const tightRun = listChanges(tight.provider, tight.environment, scope, null, {
+      maxAttempts: 2,
+      retryDelayCeilingMs: 500,
+    });
+    const looseRun = listChanges(loose.provider, loose.environment, scope, null, {
+      maxAttempts: 5,
+      retryDelayCeilingMs: 500,
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+    await Promise.allSettled([tightRun, looseRun]);
+
+    expect(tight.environment.transport.callCount()).toBe(2);
+    expect(loose.environment.transport.callCount()).toBe(5);
+    await tight.dispose();
+    await loose.dispose();
+  });
+
+  test("CONF-L1: a provider-supplied retry delay is capped by the budget, not obeyed", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    harness.environment.transport.answerWith({
+      kind: "reject",
+      failure: {
+        kind: "rateLimited",
+        retryAfter: { kind: "instant", value: "2099-01-01T00:00:00.000Z" },
+        scope: "perUser",
+      },
+      times: Number.MAX_SAFE_INTEGER,
+    });
+    const startedAt = Date.parse(harness.environment.clock.now().value);
+
+    const pending = listChanges(harness.provider, harness.environment, scope, null, {
+      maxAttempts: 3,
+      retryDelayCeilingMs: 1000,
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+    await pending;
+    const elapsedOnTheFakeClock = Date.parse(harness.environment.clock.now().value) - startedAt;
+
+    expect(elapsedOnTheFakeClock).toBeLessThanOrEqual(3 * 1000);
+    await harness.dispose();
+  });
+
+  test("CONF-L2: a permanently pending transport settles as a typed failure at the deadline", async () => {
+    const harness = await referenceHarness(stallingOn(() => true));
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+
+    const pending = listChanges(harness.provider, harness.environment, scope, null, {
+      deadlineMs: conformanceLimits.deadlineMs,
+    });
+    await vi.advanceTimersByTimeAsync(conformanceLimits.deadlineMs + 1000);
+
+    expect(notAttemptedReasonOf(failureOf(await pending))).toBe("budgetExhausted");
+    await harness.dispose();
+  });
+
+  test("CONF-L2: reaching the deadline leaves no timer behind", async () => {
+    const harness = await referenceHarness(stallingOn(() => true));
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+
+    const pending = listChanges(harness.provider, harness.environment, scope, null, {
+      deadlineMs: conformanceLimits.deadlineMs,
+    });
+    await vi.advanceTimersByTimeAsync(conformanceLimits.deadlineMs + 1000);
+    await pending;
+
+    expect(harness.environment.clock.pendingTimers()).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+    await harness.dispose();
+  });
+
+  test("CONF-L3: an abort mid-flight is reported as aborted, never as a provider timeout", async () => {
+    const harness = await referenceHarness(stallingOn(() => true));
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    const caller = new AbortController();
+
+    const pending = listChanges(harness.provider, harness.environment, scope, null, {
+      signal: caller.signal,
+      deadlineMs: conformanceLimits.deadlineMs,
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    caller.abort();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(notAttemptedReasonOf(failureOf(await pending))).toBe("aborted");
+    await harness.dispose();
+  });
+
+  test("CONF-L3: an abort and a deadline produce different outcomes", async () => {
+    const aborted = await referenceHarness(stallingOn(() => true));
+    const expired = await referenceHarness(stallingOn(() => true));
+    await aborted.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    await expired.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    const caller = new AbortController();
+
+    const abortedRun = listChanges(aborted.provider, aborted.environment, scope, null, {
+      signal: caller.signal,
+      deadlineMs: conformanceLimits.deadlineMs,
+    });
+    const expiredRun = listChanges(expired.provider, expired.environment, scope, null, {
+      deadlineMs: conformanceLimits.deadlineMs,
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    caller.abort();
+    await vi.advanceTimersByTimeAsync(conformanceLimits.deadlineMs + 1000);
+
+    expect(notAttemptedReasonOf(failureOf(await abortedRun))).not.toBe(
+      notAttemptedReasonOf(failureOf(await expiredRun)),
+    );
+    await aborted.dispose();
+    await expired.dispose();
+  });
+
+  test("CONF-L4: a single-flight leader's rejection reaches every follower", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    harness.environment.transport.answerWith({ kind: "throw", times: 1 });
+
+    const followers = Array.from({ length: 5 }, () =>
+      listChanges(harness.provider, harness.environment, scope),
+    );
+    await vi.advanceTimersByTimeAsync(1000);
+    const settled = await Promise.allSettled(followers);
+
+    expect(settled).toHaveLength(5);
+    expect(failureKindsOf(settled).filter((kind) => kind === "ok")).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-L4: a caller arriving after the rejection starts a fresh attempt", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    harness.environment.transport.answerWith({ kind: "throw", times: 1 });
+    const first = listChanges(harness.provider, harness.environment, scope);
+    await vi.advanceTimersByTimeAsync(1000);
+    await Promise.allSettled([first]);
+    const callsAfterTheFailure = harness.environment.transport.callCount();
+
+    harness.environment.transport.answerWith({ kind: "pass" });
+    const second = listChanges(harness.provider, harness.environment, scope);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(okValue(await second).kind).toBe("snapshot");
+    expect(harness.environment.transport.callCount()).toBeGreaterThan(callsAfterTheFailure);
+    await harness.dispose();
+  });
+
+  test("CONF-L5: coalesced callers each receive their own diagnostics object", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+
+    const leading = listChanges(harness.provider, harness.environment, scope);
+    const following = listChanges(harness.provider, harness.environment, scope);
+    await vi.advanceTimersByTimeAsync(1000);
+    const first = okValue(await leading);
+    const second = okValue(await following);
+
+    expect(first.diagnostics).not.toBe(second.diagnostics);
+    expect(first.diagnostics).toEqual(second.diagnostics);
+    await harness.dispose();
+  });
+
+  test("CONF-L6: overlapping key sets acquired in opposite orders both settle", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+
+    const forward = Promise.all([
+      listChanges(harness.provider, harness.environment, scope),
+      listChanges(harness.provider, harness.environment, otherScope),
+    ]);
+    const backward = Promise.all([
+      listChanges(harness.provider, harness.environment, otherScope),
+      listChanges(harness.provider, harness.environment, scope),
+    ]);
+    await vi.advanceTimersByTimeAsync(conformanceLimits.deadlineMs);
+    const settled = await Promise.allSettled([forward, backward]);
+
+    expect(settled.map((entry) => entry.status)).toEqual(["fulfilled", "fulfilled"]);
+    await harness.dispose();
+  });
+
+  test("CONF-L7: a lease taken by a synchronously throwing body is released", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    harness.environment.transport.answerWith({ kind: "throw", times: 1 });
+    const thrown = listChanges(harness.provider, harness.environment, scope);
+    await vi.advanceTimersByTimeAsync(1000);
+    await Promise.allSettled([thrown]);
+
+    harness.environment.transport.answerWith({ kind: "pass" });
+    const afterwards = listChanges(harness.provider, harness.environment, scope, null, {
+      deadlineMs: conformanceLimits.deadlineMs,
+    });
+    await vi.advanceTimersByTimeAsync(conformanceLimits.deadlineMs);
+
+    expect(okValue(await afterwards).kind).toBe("snapshot");
+    await harness.dispose();
+  });
+
+  test("CONF-L7: a lease taken by a rejecting body is released", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    harness.environment.transport.answerWith({
+      kind: "reject",
+      failure: { kind: "transport", status: 500, disposition: "permanent" },
+      times: 1,
+    });
+    const rejected = listChanges(harness.provider, harness.environment, scope);
+    await vi.advanceTimersByTimeAsync(1000);
+    await Promise.allSettled([rejected]);
+
+    harness.environment.transport.answerWith({ kind: "pass" });
+    const afterwards = listChanges(harness.provider, harness.environment, scope, null, {
+      deadlineMs: conformanceLimits.deadlineMs,
+    });
+    await vi.advanceTimersByTimeAsync(conformanceLimits.deadlineMs);
+
+    expect(okValue(await afterwards).kind).toBe("snapshot");
+    await harness.dispose();
+  });
+
+  test("CONF-L8: no timer survives a completed operation", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+
+    const listing = listChanges(harness.provider, harness.environment, scope);
+    await vi.advanceTimersByTimeAsync(1000);
+    await listing;
+    await vi.advanceTimersByTimeAsync(conformanceLimits.deadlineMs * 4);
+
+    expect(harness.environment.clock.pendingTimers()).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+    await harness.dispose();
+  });
+
+  test("CONF-L8: no timer survives a failed operation", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    harness.environment.transport.answerWith({ kind: "throw", times: 1 });
+
+    const listing = listChanges(harness.provider, harness.environment, scope);
+    await vi.advanceTimersByTimeAsync(1000);
+    await Promise.allSettled([listing]);
+    await vi.advanceTimersByTimeAsync(conformanceLimits.deadlineMs * 4);
+
+    expect(harness.environment.clock.pendingTimers()).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+    await harness.dispose();
+  });
+
+  test("CONF-L9: an aborted waiter does not strand the waiters behind it", async () => {
+    const harness = await referenceHarness(stallingOn(() => true));
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    const cancelled = new AbortController();
+
+    const first = listChanges(harness.provider, harness.environment, scope, null, {
+      deadlineMs: conformanceLimits.deadlineMs,
+    });
+    const second = listChanges(harness.provider, harness.environment, scope, null, {
+      signal: cancelled.signal,
+      deadlineMs: conformanceLimits.deadlineMs,
+    });
+    const third = listChanges(harness.provider, harness.environment, scope, null, {
+      deadlineMs: conformanceLimits.deadlineMs,
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    cancelled.abort();
+    await vi.advanceTimersByTimeAsync(conformanceLimits.deadlineMs + 1000);
+    const settled = await Promise.allSettled([first, second, third]);
+
+    expect(settled.map((entry) => entry.status)).toEqual([
+      "fulfilled",
+      "fulfilled",
+      "fulfilled",
+    ]);
+    expect(notAttemptedReasonOf(failureOf(await first))).not.toBe("aborted");
+    expect(notAttemptedReasonOf(failureOf(await third))).not.toBe("aborted");
+    await harness.dispose();
+  });
+
+  test("CONF-L10: an aborted queued task does not leak its concurrency permit", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    const cancelled = new AbortController();
+
+    const indices = [...Array.from({ length: conformanceLimits.fanOutTasks }).keys()];
+    const queued = indices.map((index) => {
+      if (index === 1) {
+        return listChanges(harness.provider, harness.environment, scope, null, {
+          signal: cancelled.signal,
+        });
+      }
+      return listChanges(harness.provider, harness.environment, scope);
+    });
+    cancelled.abort();
+    await vi.advanceTimersByTimeAsync(conformanceLimits.deadlineMs);
+    const settled = await Promise.allSettled(queued);
+
+    expect(settled).toHaveLength(conformanceLimits.fanOutTasks);
+    expect(settled.filter((entry) => entry.status === "rejected")).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-L11: a fan-out returns one result per task even when one stalls forever", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+
+    const tasks = Array.from({ length: conformanceLimits.fanOutTasks }, () =>
+      listChanges(harness.provider, harness.environment, scope, null, {
+        deadlineMs: conformanceLimits.deadlineMs,
+      }),
+    );
+    harness.environment.transport.stall();
+    await vi.advanceTimersByTimeAsync(conformanceLimits.deadlineMs + 1000);
+    const settled = await Promise.allSettled(tasks);
+
+    expect(settled).toHaveLength(conformanceLimits.fanOutTasks);
+    expect(settled.filter((entry) => entry.status === "rejected")).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-L11: a fan-out never exceeds the declared concurrency", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+
+    const tasks = Array.from({ length: conformanceLimits.fanOutTasks }, () =>
+      listChanges(harness.provider, harness.environment, scope),
+    );
+    await vi.advanceTimersByTimeAsync(conformanceLimits.deadlineMs);
+    await Promise.allSettled(tasks);
+
+    expect(harness.environment.transport.inFlightPeak()).toBeLessThanOrEqual(
+      conformanceLimits.concurrency,
+    );
+    await harness.dispose();
+  });
+
+  test("CONF-L12: an unattempted run is neither a success nor a failure", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seedEvents, corruptKnownRows: [] });
+    const caller = new AbortController();
+    caller.abort();
+
+    const result = await listChanges(harness.provider, harness.environment, scope, null, {
+      signal: caller.signal,
+    });
+
+    expect(notAttemptedReasonOf(failureOf(result))).toBe("aborted");
+    expect(harness.environment.transport.callCount()).toBe(0);
+    await harness.dispose();
+  });
+
+  test("CONF-L1: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-L1")).resolves.toBeUndefined();
+  });
+
+  test("CONF-L2: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-L2")).resolves.toBeUndefined();
+  });
+
+  test("CONF-L4: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-L4")).resolves.toBeUndefined();
+  });
+
+  test("CONF-L7: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-L7")).resolves.toBeUndefined();
+  });
+
+  test("CONF-L11: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-L11")).resolves.toBeUndefined();
+  });
+
+  test("CONF-L12: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-L12")).resolves.toBeUndefined();
+  });
+});

--- a/packages/sync-kit/conformance/tests/provenance.test.ts
+++ b/packages/sync-kit/conformance/tests/provenance.test.ts
@@ -1,7 +1,6 @@
 import type { RemoteEvent } from "@keeper.sh/sync-protocol";
 import { describe, expect, test } from "vitest";
 import { derivableRemovals } from "../src/assertions/no-removal";
-import { referenceCalendar } from "../src/reference/provider";
 import { listChanges, okValue, write } from "./support/drive";
 import { referenceHarness, runReferenceCase } from "./support/harness";
 import {
@@ -13,6 +12,8 @@ import {
   spanning,
   summarise,
   timedAt,
+  knownFrom,
+  seedOf,
 } from "./support/protocol";
 
 const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
@@ -68,7 +69,7 @@ describe("we never echo our own writes and never touch a stranger's event", () =
 
   test("CONF-O17: a foreign canary survives every reconciliation the suite generates", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [canary], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([canary], []));
     const before = await harness.provider.inspect();
 
     await write(harness.provider, harness.environment, createIntent("mirrored", mirrored));
@@ -85,12 +86,12 @@ describe("we never echo our own writes and never touch a stranger's event", () =
 
   test("CONF-O17: no removal is ever derivable for a foreign event", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [canary], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([canary], []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
     const removable = derivableRemovals({
       listing,
-      known: { calendar: referenceCalendar, ids: new Map([["canary", canary.id]]) },
+      known: knownFrom([canary]),
       withinWindow: () => true,
     });
 

--- a/packages/sync-kit/conformance/tests/provenance.test.ts
+++ b/packages/sync-kit/conformance/tests/provenance.test.ts
@@ -1,0 +1,108 @@
+import type { RemoteEvent } from "@keeper.sh/sync-protocol";
+import { describe, expect, test } from "vitest";
+import { derivableRemovals } from "../src/assertions/no-removal";
+import { referenceCalendar } from "../src/reference/provider";
+import { listChanges, okValue, write } from "./support/drive";
+import { referenceHarness, runReferenceCase } from "./support/harness";
+import {
+  createIntent,
+  foreignEvent,
+  installation,
+  occurrence,
+  scopeOver,
+  spanning,
+  summarise,
+  timedAt,
+} from "./support/protocol";
+
+const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
+const scope = scopeOver(march);
+
+const canary = foreignEvent({
+  uid: "canary",
+  title: "Someone else's event",
+  start: "2026-03-06T09:00:00.000Z",
+  end: "2026-03-06T10:00:00.000Z",
+});
+
+const mirrored = occurrence(
+  "Mirrored meeting",
+  timedAt("2026-03-07T09:00:00.000Z", "2026-03-07T10:00:00.000Z"),
+);
+
+const provenanceKindsOf = (events: readonly RemoteEvent[]): string[] =>
+  events.map((event) => event.provenance.kind);
+
+const installationOf = (event: RemoteEvent): string => {
+  if (event.provenance.kind === "ours") {
+    return event.provenance.installation.value;
+  }
+  return `not-ours:${event.provenance.kind}`;
+};
+
+describe("we never echo our own writes and never touch a stranger's event", () => {
+  test("CONF-O16: an event we wrote comes back as ours with our installation id", async () => {
+    const harness = await referenceHarness();
+    await write(harness.provider, harness.environment, createIntent("mirrored", mirrored));
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+    const ours = (listing.events ?? []).filter((event) => event.provenance.kind === "ours");
+
+    expect(ours).toHaveLength(1);
+    expect(ours.map((event) => installationOf(event))).toEqual([installation.value]);
+    await harness.dispose();
+  });
+
+  test("CONF-O16: the round trip goes through the adapter, not through our own record of the write", async () => {
+    const harness = await referenceHarness();
+    const created = okValue(
+      await write(harness.provider, harness.environment, createIntent("mirrored", mirrored)),
+    );
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(created.kind).toBe("created");
+    expect(provenanceKindsOf(listing.events ?? [])).toEqual(["ours"]);
+    await harness.dispose();
+  });
+
+  test("CONF-O17: a foreign canary survives every reconciliation the suite generates", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [canary], corruptKnownRows: [] });
+    const before = await harness.provider.inspect();
+
+    await write(harness.provider, harness.environment, createIntent("mirrored", mirrored));
+    await listChanges(harness.provider, harness.environment, scope);
+    const after = await harness.provider.inspect();
+
+    const survivorsBefore = before.objects.filter((event) => event.uid.value === "canary");
+    const survivorsAfter = after.objects.filter((event) => event.uid.value === "canary");
+
+    expect(summarise(survivorsAfter)).toEqual(summarise(survivorsBefore));
+    expect(survivorsAfter).toHaveLength(1);
+    await harness.dispose();
+  });
+
+  test("CONF-O17: no removal is ever derivable for a foreign event", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [canary], corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+    const removable = derivableRemovals({
+      listing,
+      known: { calendar: referenceCalendar, ids: new Map([["canary", canary.id]]) },
+      withinWindow: () => true,
+    });
+
+    expect(removable).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-O16: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O16")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O17: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O17")).resolves.toBeUndefined();
+  });
+});

--- a/packages/sync-kit/conformance/tests/reference/fixed-point.test.ts
+++ b/packages/sync-kit/conformance/tests/reference/fixed-point.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "vitest";
+import {
+  conflictingOn,
+  expiringCursorAfter,
+  stallingOn,
+  truncatingAfter,
+  undecorated,
+} from "../../src/fixtures";
+import type { ProviderDecorator } from "../../src/fixtures";
+import { referenceCapabilities } from "../../src/reference/capabilities";
+import { selectConformanceCases } from "../../src/registry/suite";
+import { listChanges, okValue, write } from "../support/drive";
+import { referenceHarness, runCaseAgainst } from "../support/harness";
+import {
+  createIntent,
+  foreignEvent,
+  occurrence,
+  scopeOver,
+  spanning,
+  timedAt,
+} from "../support/protocol";
+
+const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
+const scope = scopeOver(march);
+
+const seeded = [
+  foreignEvent({
+    uid: "alpha",
+    title: "Alpha",
+    start: "2026-03-02T09:00:00.000Z",
+    end: "2026-03-02T10:00:00.000Z",
+  }),
+  foreignEvent({
+    uid: "bravo",
+    title: "Bravo",
+    start: "2026-03-03T09:00:00.000Z",
+    end: "2026-03-03T10:00:00.000Z",
+  }),
+];
+
+const mirrored = occurrence(
+  "Mirrored",
+  timedAt("2026-03-04T09:00:00.000Z", "2026-03-04T10:00:00.000Z"),
+);
+
+const decorators: readonly [string, () => ProviderDecorator][] = [
+  ["bare", () => undecorated],
+  ["truncatingAfter(1)", () => truncatingAfter(1)],
+  ["expiringCursorAfter(1)", () => expiringCursorAfter(1)],
+  ["conflictingOn(create)", () => conflictingOn((intent) => intent.kind === "create")],
+  ["stallingOn(write)", () => stallingOn((operation) => operation === "write")],
+];
+
+describe("the reference provider is adversarial about its own success", () => {
+  test("CONF-I55: list, apply, list, apply reaches a fixed point with zero further writes", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seeded, corruptKnownRows: [] });
+
+    await listChanges(harness.provider, harness.environment, scope);
+    await write(harness.provider, harness.environment, createIntent("mirrored", mirrored));
+    const afterApply = await harness.provider.inspect();
+    await listChanges(harness.provider, harness.environment, scope);
+    await listChanges(harness.provider, harness.environment, scope);
+    const afterConvergence = await harness.provider.inspect();
+
+    expect(afterConvergence.writeLog).toEqual(afterApply.writeLog);
+    await harness.dispose();
+  });
+
+  test("CONF-I55: the reference passes every selected case when run bare", async () => {
+    const harness = await referenceHarness();
+    const selection = selectConformanceCases(referenceCapabilities);
+    const failures: string[] = [];
+
+    for (const record of selection.selected) {
+      const settled = await Promise.allSettled([
+        runCaseAgainst(record.id, harness.provider, harness.environment, harness.supports),
+      ]);
+      for (const outcome of settled) {
+        if (outcome.status === "rejected") {
+          failures.push(`${record.id}: ${String(outcome.reason)}`);
+        }
+      }
+    }
+
+    expect(failures).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-I55: a listing is byte-identical across two polls of unchanged input", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seeded, corruptKnownRows: [] });
+
+    const first = okValue(await listChanges(harness.provider, harness.environment, scope));
+    const second = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(second.events).toEqual(first.events);
+    expect(second.withheld).toEqual(first.withheld);
+    await harness.dispose();
+  });
+
+  test.each(decorators)(
+    "CONF-I55: the %s fixture does not break correct behaviour of a listing",
+    async (name, decorate) => {
+      const harness = await referenceHarness(decorate());
+      await harness.provider.seed({ events: seeded, corruptKnownRows: [] });
+
+      const result = await listChanges(harness.provider, harness.environment, scope);
+
+      expect(name.length).toBeGreaterThan(0);
+      expect(["snapshot", "delta", "partial", "cursorLost"]).toContain(
+        okValue(result).kind,
+      );
+      await harness.dispose();
+    },
+  );
+
+  test("CONF-I55: disposing the reference provider releases every timer it armed", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: seeded, corruptKnownRows: [] });
+    await listChanges(harness.provider, harness.environment, scope);
+
+    await harness.dispose();
+
+    expect(harness.environment.clock.pendingTimers()).toBe(0);
+  });
+});

--- a/packages/sync-kit/conformance/tests/reference/fixed-point.test.ts
+++ b/packages/sync-kit/conformance/tests/reference/fixed-point.test.ts
@@ -9,13 +9,14 @@ import {
 import type { ProviderDecorator } from "../../src/fixtures";
 import { referenceCapabilities } from "../../src/reference/capabilities";
 import { selectConformanceCases } from "../../src/registry/suite";
-import { listChanges, okValue, write } from "../support/drive";
+import { failureOf, listChanges, okValue, write } from "../support/drive";
 import { referenceHarness, runCaseAgainst } from "../support/harness";
 import {
   createIntent,
   foreignEvent,
   occurrence,
   scopeOver,
+  seedOf,
   spanning,
   timedAt,
 } from "../support/protocol";
@@ -43,18 +44,22 @@ const mirrored = occurrence(
   timedAt("2026-03-04T09:00:00.000Z", "2026-03-04T10:00:00.000Z"),
 );
 
-const decorators: readonly [string, () => ProviderDecorator][] = [
-  ["bare", () => undecorated],
-  ["truncatingAfter(1)", () => truncatingAfter(1)],
-  ["expiringCursorAfter(1)", () => expiringCursorAfter(1)],
-  ["conflictingOn(create)", () => conflictingOn((intent) => intent.kind === "create")],
-  ["stallingOn(write)", () => stallingOn((operation) => operation === "write")],
+const decorators: readonly [string, () => ProviderDecorator, string][] = [
+  ["bare", () => undecorated, "snapshot"],
+  ["truncatingAfter(1)", () => truncatingAfter(1), "partial"],
+  ["expiringCursorAfter(1)", () => expiringCursorAfter(1), "snapshot"],
+  [
+    "conflictingOn(create)",
+    () => conflictingOn((intent) => intent.kind === "create"),
+    "snapshot",
+  ],
+  ["stallingOn(write)", () => stallingOn((operation) => operation === "write"), "snapshot"],
 ];
 
 describe("the reference provider is adversarial about its own success", () => {
   test("CONF-I55: list, apply, list, apply reaches a fixed point with zero further writes", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seeded, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seeded));
 
     await listChanges(harness.provider, harness.environment, scope);
     await write(harness.provider, harness.environment, createIntent("mirrored", mirrored));
@@ -89,7 +94,7 @@ describe("the reference provider is adversarial about its own success", () => {
 
   test("CONF-I55: a listing is byte-identical across two polls of unchanged input", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seeded, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seeded));
 
     const first = okValue(await listChanges(harness.provider, harness.environment, scope));
     const second = okValue(await listChanges(harness.provider, harness.environment, scope));
@@ -100,24 +105,64 @@ describe("the reference provider is adversarial about its own success", () => {
   });
 
   test.each(decorators)(
-    "CONF-I55: the %s fixture does not break correct behaviour of a listing",
-    async (name, decorate) => {
+    "CONF-I55: the %s fixture answers a first listing as exactly the kind it promises",
+    async (_name, decorate, expected) => {
       const harness = await referenceHarness(decorate());
-      await harness.provider.seed({ events: seeded, corruptKnownRows: [] });
+      await harness.provider.seed(seedOf(seeded));
 
       const result = await listChanges(harness.provider, harness.environment, scope);
 
-      expect(name.length).toBeGreaterThan(0);
-      expect(["snapshot", "delta", "partial", "cursorLost"]).toContain(
-        okValue(result).kind,
-      );
+      expect(okValue(result).kind).toBe(expected);
       await harness.dispose();
     },
   );
 
+  test("CONF-I55: the expiringCursorAfter(1) fixture loses the cursor on the poll after the first", async () => {
+    const harness = await referenceHarness(expiringCursorAfter(1));
+    await harness.provider.seed(seedOf(seeded));
+
+    const first = okValue(await listChanges(harness.provider, harness.environment, scope));
+    const resumed = await listChanges(
+      harness.provider,
+      harness.environment,
+      scope,
+      first.cursor ?? null,
+    );
+
+    expect(okValue(resumed).kind).toBe("cursorLost");
+    await harness.dispose();
+  });
+
+  test("CONF-I55: the conflictingOn(create) fixture turns a create into a typed conflict", async () => {
+    const harness = await referenceHarness(conflictingOn((intent) => intent.kind === "create"));
+
+    const answered = await write(
+      harness.provider,
+      harness.environment,
+      createIntent("mirrored", mirrored),
+    );
+
+    expect(okValue(answered).kind).toBe("conflict");
+    await harness.dispose();
+  });
+
+  test("CONF-I55: the stallingOn(write) fixture settles a write at its deadline, never never", async () => {
+    const harness = await referenceHarness(stallingOn((operation) => operation === "write"));
+
+    const answered = await write(
+      harness.provider,
+      harness.environment,
+      createIntent("mirrored", mirrored),
+      { deadlineMs: 20 },
+    );
+
+    expect(failureOf(answered)).toEqual({ kind: "notAttempted", reason: "budgetExhausted" });
+    await harness.dispose();
+  });
+
   test("CONF-I55: disposing the reference provider releases every timer it armed", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: seeded, corruptKnownRows: [] });
+    await harness.provider.seed(seedOf(seeded));
     await listChanges(harness.provider, harness.environment, scope);
 
     await harness.dispose();

--- a/packages/sync-kit/conformance/tests/reference/negative-controls.test.ts
+++ b/packages/sync-kit/conformance/tests/reference/negative-controls.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import { conformanceCaseIds } from "../../src/case-id";
+import { runSuiteAgainstMutant } from "../support/harness";
+
+describe("every case ships a mutant that must fail exactly it", () => {
+  test.each(conformanceCaseIds)("%s: its own mutant fails that case", async (defect) => {
+    const outcome = await runSuiteAgainstMutant(defect);
+
+    expect(outcome.failed).toContain(defect);
+  });
+
+  test.each(conformanceCaseIds)("%s: its own mutant fails no other case", async (defect) => {
+    const outcome = await runSuiteAgainstMutant(defect);
+
+    expect(outcome.failed.filter((id) => id !== defect)).toEqual([]);
+  });
+
+  test("CONF-I55: an unmutated reference fails nothing at all", async () => {
+    const outcome = await runSuiteAgainstMutant("CONF-O1");
+
+    expect(outcome.failed.length).toBeGreaterThan(0);
+    expect(conformanceCaseIds.length).toBeGreaterThan(50);
+  });
+});

--- a/packages/sync-kit/conformance/tests/reference/negative-controls.test.ts
+++ b/packages/sync-kit/conformance/tests/reference/negative-controls.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { conformanceCaseIds } from "../../src/case-id";
-import { runSuiteAgainstMutant } from "../support/harness";
+import { runSuiteAgainstMutant, runSuiteAgainstUnmutatedReference } from "../support/harness";
 
 describe("every case ships a mutant that must fail exactly it", () => {
   test.each(conformanceCaseIds)("%s: its own mutant fails that case", async (defect) => {
@@ -16,9 +16,9 @@ describe("every case ships a mutant that must fail exactly it", () => {
   });
 
   test("CONF-I55: an unmutated reference fails nothing at all", async () => {
-    const outcome = await runSuiteAgainstMutant("CONF-O1");
+    const outcome = await runSuiteAgainstUnmutatedReference();
 
-    expect(outcome.failed.length).toBeGreaterThan(0);
+    expect(outcome.failed).toEqual([]);
     expect(conformanceCaseIds.length).toBeGreaterThan(50);
   });
 });

--- a/packages/sync-kit/conformance/tests/single-flight.test.ts
+++ b/packages/sync-kit/conformance/tests/single-flight.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest";
+import { createSingleFlight } from "../src/single-flight";
+
+const neverRetained = { retain: () => false };
+
+const settledLater = <Value>(): {
+  promise: Promise<Value>;
+  resolve: (value: Value) => void;
+  reject: (failure: unknown) => void;
+} => Promise.withResolvers<Value>();
+
+describe("a coalescing slot is never a place a key can die", () => {
+  test("CONF-L4: a rejecting body reaches every follower registered before it settled", async () => {
+    const flights = createSingleFlight<string>(neverRetained);
+    const leader = settledLater<string>();
+
+    const first = flights.run("key", () => leader.promise);
+    const second = flights.run("key", () => leader.promise);
+    leader.reject(new Error("the leader failed"));
+    const settled = await Promise.allSettled([first, second]);
+
+    expect(settled.map((entry) => entry.status)).toEqual(["rejected", "rejected"]);
+  });
+
+  test("CONF-L7: a rejecting body releases its key, so the next caller starts a fresh flight", async () => {
+    const flights = createSingleFlight<string>(neverRetained);
+    let bodies = 0;
+    const failing = (): Promise<string> => {
+      bodies += 1;
+      return Promise.reject(new Error("the leader failed"));
+    };
+
+    await Promise.allSettled([flights.run("key", failing)]);
+    const afterwards = await flights.run("key", () => Promise.resolve("healthy"));
+
+    expect(afterwards).toBe("healthy");
+    expect(bodies).toBe(1);
+    expect(flights.inFlightKeys()).toBe(0);
+  });
+
+  test("CONF-L2: an abandoned key is not joined by the caller that follows it", async () => {
+    const flights = createSingleFlight<string>(neverRetained);
+    const wedged = settledLater<string>();
+
+    const abandoned = flights.run("key", () => wedged.promise);
+    flights.abandon("key");
+    const afterwards = await flights.run("key", () => Promise.resolve("fresh"));
+
+    expect(afterwards).toBe("fresh");
+    expect(flights.inFlightKeys()).toBe(0);
+    wedged.resolve("the abandoned leader eventually answered");
+    await expect(abandoned).resolves.toBe("the abandoned leader eventually answered");
+  });
+
+  test("CONF-L6: two keys in flight at once do not evict each other", async () => {
+    const flights = createSingleFlight<string>(neverRetained);
+    const alpha = settledLater<string>();
+    const bravo = settledLater<string>();
+
+    const first = flights.run("alpha", () => alpha.promise);
+    const second = flights.run("bravo", () => bravo.promise);
+    expect(flights.inFlightKeys()).toBe(2);
+    alpha.resolve("alpha");
+    bravo.resolve("bravo");
+
+    expect(await Promise.all([first, second])).toEqual(["alpha", "bravo"]);
+    expect(flights.inFlightKeys()).toBe(0);
+  });
+});

--- a/packages/sync-kit/conformance/tests/support/drive.ts
+++ b/packages/sync-kit/conformance/tests/support/drive.ts
@@ -1,0 +1,70 @@
+import type {
+  ChangeListing,
+  Continuation,
+  ListingScope,
+  ProviderFailure,
+  ProviderId,
+  Result,
+  SyncCursor,
+  WriteIntent,
+  WriteOutcome,
+} from "@keeper.sh/sync-protocol";
+import type { ConformanceEnvironment, ProviderUnderTest } from "../../src/options";
+import { contextOf } from "./protocol";
+
+interface DriveOptions {
+  readonly signal?: AbortSignal;
+  readonly deadlineMs?: number;
+  readonly maxAttempts?: number;
+  readonly retryDelayCeilingMs?: number;
+}
+
+const contextFrom = (environment: ConformanceEnvironment, options: DriveOptions) =>
+  contextOf({
+    now: environment.clock.now,
+    signal: options.signal ?? new AbortController().signal,
+    deadlineMs: options.deadlineMs,
+    maxAttempts: options.maxAttempts,
+    retryDelayCeilingMs: options.retryDelayCeilingMs,
+  });
+
+const listChanges = <Provider extends ProviderId>(
+  provider: ProviderUnderTest<Provider>,
+  environment: ConformanceEnvironment,
+  scope: ListingScope,
+  resume: SyncCursor | Continuation | null = null,
+  options: DriveOptions = {},
+): Promise<Result<ChangeListing>> =>
+  provider.contract.provider.listChanges({ scope, resume }, contextFrom(environment, options));
+
+const write = <Provider extends ProviderId>(
+  provider: ProviderUnderTest<Provider>,
+  environment: ConformanceEnvironment,
+  intent: WriteIntent<Provider>,
+  options: DriveOptions = {},
+): Promise<Result<WriteOutcome>> =>
+  provider.contract.provider.write(intent, contextFrom(environment, options));
+
+const listingKindOf = (result: Result<ChangeListing>): string => {
+  if (result.ok) {
+    return result.value.kind;
+  }
+  return `failure:${result.failure.kind}`;
+};
+
+const okValue = <Value>(result: Result<Value>): Value => {
+  if (result.ok) {
+    return result.value;
+  }
+  throw new Error(`expected an ok Result, observed failure "${result.failure.kind}"`);
+};
+
+const failureOf = <Value>(result: Result<Value>): ProviderFailure => {
+  if (result.ok) {
+    throw new Error("expected a failed Result, observed ok");
+  }
+  return result.failure;
+};
+
+export { contextFrom, failureOf, listChanges, listingKindOf, okValue, write };
+export type { DriveOptions };

--- a/packages/sync-kit/conformance/tests/support/harness.ts
+++ b/packages/sync-kit/conformance/tests/support/harness.ts
@@ -1,0 +1,105 @@
+import type { Capabilities, ProviderId } from "@keeper.sh/sync-protocol";
+import type { ConformanceCaseId } from "../../src/case-id";
+import { createConformanceEnvironment } from "../../src/environment";
+import type { ProviderDecorator } from "../../src/fixtures";
+import { undecorated } from "../../src/fixtures";
+import type { ConformanceEnvironment, ProviderUnderTest } from "../../src/options";
+import { createMutantReferenceProvider } from "../../src/reference/mutants";
+import { referenceCapabilities } from "../../src/reference/capabilities";
+import { createReferenceProvider } from "../../src/reference/provider";
+import { conformanceCaseOf, selectConformanceCases } from "../../src/registry/suite";
+import { installation, instant, isInsideWindow } from "./protocol";
+
+const suiteStart = instant("2026-03-11T00:00:00.000Z");
+
+const countingHash = (input: string): string => `h${input.length}:${input.slice(0, 16)}`;
+
+const environmentFor = (): ConformanceEnvironment =>
+  createConformanceEnvironment({
+    start: suiteStart,
+    installation,
+    hash: countingHash,
+  });
+
+interface ReferenceHarness {
+  readonly environment: ConformanceEnvironment;
+  readonly provider: ProviderUnderTest<"reference">;
+  readonly supports: Capabilities<"reference">;
+  readonly dispose: () => Promise<void>;
+}
+
+const referenceHarness = async (
+  decorate: ProviderDecorator = undecorated,
+): Promise<ReferenceHarness> => {
+  const environment = environmentFor();
+  const provider = decorate(await createReferenceProvider(environment));
+  return {
+    environment,
+    provider,
+    supports: referenceCapabilities,
+    dispose: () => provider.dispose(),
+  };
+};
+
+const runCaseAgainst = async <Provider extends ProviderId>(
+  id: ConformanceCaseId,
+  provider: ProviderUnderTest<Provider>,
+  environment: ConformanceEnvironment,
+  supports: Capabilities<Provider>,
+): Promise<void> => {
+  const record = conformanceCaseOf(id, supports);
+  await record.run({ provider, environment, supports, withinWindow: isInsideWindow });
+};
+
+const runReferenceCase = async (
+  id: ConformanceCaseId,
+  decorate: ProviderDecorator = undecorated,
+): Promise<void> => {
+  const harness = await referenceHarness(decorate);
+  try {
+    await runCaseAgainst(id, harness.provider, harness.environment, harness.supports);
+  } finally {
+    await harness.dispose();
+  }
+};
+
+interface MutantOutcome {
+  readonly failed: readonly ConformanceCaseId[];
+}
+
+const runSuiteAgainstMutant = async (defect: ConformanceCaseId): Promise<MutantOutcome> => {
+  const environment = environmentFor();
+  const provider = await createMutantReferenceProvider(environment, defect);
+  const selection = selectConformanceCases(referenceCapabilities);
+  const failed: ConformanceCaseId[] = [];
+  try {
+    for (const record of selection.selected) {
+      const outcome = await record
+        .run({
+          provider,
+          environment,
+          supports: referenceCapabilities,
+          withinWindow: isInsideWindow,
+        })
+        .then(() => "passed")
+        .catch(() => "failed");
+      if (outcome === "failed") {
+        failed.push(record.id);
+      }
+    }
+  } finally {
+    await provider.dispose();
+  }
+  return { failed };
+};
+
+export {
+  countingHash,
+  environmentFor,
+  referenceHarness,
+  runCaseAgainst,
+  runReferenceCase,
+  runSuiteAgainstMutant,
+  suiteStart,
+};
+export type { MutantOutcome, ReferenceHarness };

--- a/packages/sync-kit/conformance/tests/support/harness.ts
+++ b/packages/sync-kit/conformance/tests/support/harness.ts
@@ -12,7 +12,10 @@ import { installation, instant, isInsideWindow } from "./protocol";
 
 const suiteStart = instant("2026-03-11T00:00:00.000Z");
 
-const countingHash = (input: string): string => `h${input.length}:${input.slice(0, 16)}`;
+const countingHash = (input: string): string =>
+  `h${input.length}:${new Bun.CryptoHasher("sha256").update(input).digest("hex").slice(0, 16)}`;
+
+const collidingHash = (input: string): string => `collides:${input.length}`;
 
 const environmentFor = (): ConformanceEnvironment =>
   createConformanceEnvironment({
@@ -67,9 +70,10 @@ interface MutantOutcome {
   readonly failed: readonly ConformanceCaseId[];
 }
 
-const runSuiteAgainstMutant = async (defect: ConformanceCaseId): Promise<MutantOutcome> => {
-  const environment = environmentFor();
-  const provider = await createMutantReferenceProvider(environment, defect);
+const runSuiteAgainst = async (
+  provider: ProviderUnderTest<"reference">,
+  environment: ConformanceEnvironment,
+): Promise<MutantOutcome> => {
   const selection = selectConformanceCases(referenceCapabilities);
   const failed: ConformanceCaseId[] = [];
   try {
@@ -93,13 +97,25 @@ const runSuiteAgainstMutant = async (defect: ConformanceCaseId): Promise<MutantO
   return { failed };
 };
 
+const runSuiteAgainstMutant = async (defect: ConformanceCaseId): Promise<MutantOutcome> => {
+  const environment = environmentFor();
+  return runSuiteAgainst(await createMutantReferenceProvider(environment, defect), environment);
+};
+
+const runSuiteAgainstUnmutatedReference = async (): Promise<MutantOutcome> => {
+  const environment = environmentFor();
+  return runSuiteAgainst(await createReferenceProvider(environment), environment);
+};
+
 export {
+  collidingHash,
   countingHash,
   environmentFor,
   referenceHarness,
   runCaseAgainst,
   runReferenceCase,
   runSuiteAgainstMutant,
+  runSuiteAgainstUnmutatedReference,
   suiteStart,
 };
 export type { MutantOutcome, ReferenceHarness };

--- a/packages/sync-kit/conformance/tests/support/protocol.ts
+++ b/packages/sync-kit/conformance/tests/support/protocol.ts
@@ -20,6 +20,8 @@ import type {
   WriteIntent,
 } from "@keeper.sh/sync-protocol";
 import type { CanonicalValue } from "../../src/canonical";
+import type { ProviderSeed } from "../../src/options";
+import type { KnownMirror } from "../../src/assertions/no-removal";
 import { referenceCalendar } from "../../src/reference/provider";
 
 const instant = (value: string): Instant => ({ kind: "instant", value });
@@ -185,9 +187,32 @@ const deleteIntent = (handle: string, version: string): WriteIntent<"reference">
   reason: "sourceDeleted",
 });
 
+const knownFrom = (events: readonly RemoteEvent[]): KnownMirror => ({
+  calendar: referenceCalendar,
+  entries: events.map((event) => ({ uid: event.uid.value, id: event.id, time: timeOf(event) })),
+});
+
+const knownNamed = (uid: string, time: EventTime): KnownMirror => ({
+  calendar: referenceCalendar,
+  entries: [{ uid, id: { kind: "remoteEventId", value: `id-${uid}` }, time }],
+});
+
+const seedOf = (
+  events: readonly RemoteEvent[],
+  corruptKnownRows: readonly string[] = [],
+): ProviderSeed => ({
+  events,
+  corruptKnownRows,
+  cancelled: [],
+  unattributableRemovals: [],
+});
+
 export {
   contextOf,
   createIntent,
+  knownFrom,
+  knownNamed,
+  seedOf,
   deleteIntent,
   normalized,
   updateIntent,

--- a/packages/sync-kit/conformance/tests/support/protocol.ts
+++ b/packages/sync-kit/conformance/tests/support/protocol.ts
@@ -1,0 +1,210 @@
+import type {
+  CalendarKey,
+  DescribedContent,
+  EditableContent,
+  EventTime,
+  ForeignEvent,
+  IndeterminateEvent,
+  InstallationId,
+  Instant,
+  ListingScope,
+  NormalizedContent,
+  OperationContext,
+  OwnEvent,
+  RemoteEvent,
+  RemoteEventFacts,
+  SingleOccurrenceContent,
+  TimeWindow,
+  WindowMembership,
+  WritableCalendar,
+  WriteIntent,
+} from "@keeper.sh/sync-protocol";
+import type { CanonicalValue } from "../../src/canonical";
+import { referenceCalendar } from "../../src/reference/provider";
+
+const instant = (value: string): Instant => ({ kind: "instant", value });
+
+const installation: InstallationId = { kind: "installationId", value: "keeper-conformance" };
+
+const foreignInstallation: InstallationId = { kind: "installationId", value: "someone-else" };
+
+const spanning = (start: string, end: string): TimeWindow => ({
+  start: instant(start),
+  end: instant(end),
+});
+
+const timedAt = (start: string, end: string): EventTime => ({
+  kind: "timed",
+  start: instant(start),
+  end: instant(end),
+  zone: { kind: "zoneId", value: "UTC" },
+});
+
+const describedAs = (title: string): DescribedContent => ({
+  title,
+  description: null,
+  location: null,
+  availability: "busy",
+  visibility: "default",
+});
+
+const occurrence = (title: string, time: EventTime): SingleOccurrenceContent => ({
+  ...describedAs(title),
+  recurrence: null,
+  time,
+});
+
+interface EventDraft {
+  readonly uid: string;
+  readonly title: string;
+  readonly start: string;
+  readonly end: string;
+  readonly revision?: number;
+  readonly calendar?: CalendarKey;
+}
+
+const factsOf = (draft: EventDraft): RemoteEventFacts => ({
+  id: { kind: "remoteEventId", value: `id-${draft.uid}` },
+  deleteHandle: { kind: "deleteHandle", value: `handle-${draft.uid}` },
+  uid: { kind: "eventUid", value: draft.uid },
+  calendar: draft.calendar ?? referenceCalendar,
+  revision: draft.revision ?? 1,
+  version: { kind: "remoteVersion", value: `v${draft.revision ?? 1}-${draft.uid}` },
+  content: occurrence(draft.title, timedAt(draft.start, draft.end)),
+  fingerprint: { kind: "fingerprint", value: `fp-${draft.uid}-${draft.revision ?? 1}` },
+});
+
+const foreignEvent = (draft: EventDraft): ForeignEvent => ({
+  ...factsOf(draft),
+  provenance: { kind: "foreign" },
+});
+
+const ownEvent = (draft: EventDraft): OwnEvent => ({
+  ...factsOf(draft),
+  provenance: { kind: "ours", installation },
+});
+
+const indeterminateEvent = (draft: EventDraft): IndeterminateEvent => ({
+  ...factsOf(draft),
+  provenance: { kind: "indeterminate" },
+});
+
+const writableCalendar: WritableCalendar = {
+  key: referenceCalendar,
+  access: "readWrite",
+};
+
+const scopeOver = (covered: TimeWindow): ListingScope => ({
+  calendar: referenceCalendar,
+  window: covered,
+  expandRecurrences: true,
+});
+
+interface ContextDraft {
+  readonly now: () => Instant;
+  readonly signal: AbortSignal;
+  readonly deadlineMs?: number;
+  readonly maxAttempts?: number;
+  readonly retryDelayCeilingMs?: number;
+}
+
+const contextOf = (draft: ContextDraft): OperationContext => ({
+  signal: draft.signal,
+  now: draft.now,
+  deadline: instant(
+    new Date(Date.parse(draft.now().value) + (draft.deadlineMs ?? 30_000)).toISOString(),
+  ),
+  retryBudget: {
+    maxAttempts: draft.maxAttempts ?? 4,
+    retryDelayCeilingMs: draft.retryDelayCeilingMs ?? 1000,
+  },
+});
+
+const isInsideWindow: WindowMembership = (bounds, time) => {
+  if (time.kind === "allDay") {
+    return time.startDate.value >= bounds.start.value && time.startDate.value < bounds.end.value;
+  }
+  return time.start.value < bounds.end.value && time.end.value > bounds.start.value;
+};
+
+const timeOf = (event: RemoteEvent): EventTime => {
+  const { time } = event.content;
+  if (!time) {
+    throw new Error(`expected a single-occurrence event, "${event.uid.value}" is recurring`);
+  }
+  return time;
+};
+
+const summarise = (events: readonly RemoteEvent[]): CanonicalValue =>
+  events.map((event) => ({
+    uid: event.uid.value,
+    revision: event.revision,
+    title: event.content.title,
+    provenance: event.provenance.kind,
+  }));
+
+const normalized = (
+  content: EditableContent,
+  fingerprint: string,
+): NormalizedContent<"reference"> => ({
+  kind: "normalized",
+  provider: "reference",
+  content,
+  fingerprint: { kind: "fingerprint", value: fingerprint },
+});
+
+const createIntent = (
+  key: string,
+  content: EditableContent,
+): WriteIntent<"reference"> => ({
+  kind: "create",
+  calendar: writableCalendar,
+  idempotencyKey: { kind: "idempotencyKey", value: key },
+  content: normalized(content, `fp-${key}`),
+  provenance: { kind: "ours", installation },
+  precondition: { kind: "absent" },
+});
+
+const updateIntent = (
+  target: string,
+  content: EditableContent,
+  version: string,
+): WriteIntent<"reference"> => ({
+  kind: "update",
+  calendar: writableCalendar,
+  target: { kind: "remoteEventId", value: target },
+  content: normalized(content, `fp-${target}`),
+  precondition: { kind: "matchesVersion", version: { kind: "remoteVersion", value: version } },
+});
+
+const deleteIntent = (handle: string, version: string): WriteIntent<"reference"> => ({
+  kind: "delete",
+  calendar: writableCalendar,
+  target: { kind: "deleteHandle", value: handle },
+  precondition: { kind: "matchesVersion", version: { kind: "remoteVersion", value: version } },
+  reason: "sourceDeleted",
+});
+
+export {
+  contextOf,
+  createIntent,
+  deleteIntent,
+  normalized,
+  updateIntent,
+  describedAs,
+  foreignEvent,
+  foreignInstallation,
+  indeterminateEvent,
+  installation,
+  instant,
+  isInsideWindow,
+  occurrence,
+  ownEvent,
+  scopeOver,
+  summarise,
+  timeOf,
+  timedAt,
+  spanning,
+  writableCalendar,
+};
+export type { ContextDraft, EventDraft };

--- a/packages/sync-kit/conformance/tests/support/sources.ts
+++ b/packages/sync-kit/conformance/tests/support/sources.ts
@@ -1,0 +1,29 @@
+import { Glob } from "bun";
+
+const packageRoot = new URL("../../", import.meta.url).pathname;
+
+const sourceFiles = async (directory: string): Promise<readonly string[]> => {
+  const glob = new Glob("**/*.ts");
+  const found: string[] = [];
+  for await (const relative of glob.scan({ cwd: `${packageRoot}${directory}` })) {
+    found.push(`${directory}/${relative}`);
+  }
+  return found.toSorted();
+};
+
+const readSource = (relative: string): Promise<string> =>
+  Bun.file(`${packageRoot}${relative}`).text();
+
+const filesMatching = async (directory: string, needle: string): Promise<readonly string[]> => {
+  const files = await sourceFiles(directory);
+  const matched: string[] = [];
+  for (const file of files) {
+    const text = await readSource(file);
+    if (text.includes(needle)) {
+      matched.push(file);
+    }
+  }
+  return matched;
+};
+
+export { filesMatching, packageRoot, readSource, sourceFiles };

--- a/packages/sync-kit/conformance/tests/window.test.ts
+++ b/packages/sync-kit/conformance/tests/window.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "vitest";
 import { derivableRemovals } from "../src/assertions/no-removal";
-import { referenceCalendar } from "../src/reference/provider";
 import { listChanges, okValue, write } from "./support/drive";
 import { referenceHarness, runReferenceCase } from "./support/harness";
 import {
@@ -12,6 +11,8 @@ import {
   spanning,
   timeOf,
   timedAt,
+  knownFrom,
+  seedOf,
 } from "./support/protocol";
 
 const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
@@ -45,12 +46,12 @@ const zeroDuration = foreignEvent({
 describe("one window predicate, agreeing at every boundary", () => {
   test("CONF-O27: the lower edge is admitted by the same predicate at listing and removal time", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [onTheLowerEdge], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([onTheLowerEdge], []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
     const removable = derivableRemovals({
       listing,
-      known: { calendar: referenceCalendar, ids: new Map([["lower-edge", onTheLowerEdge.id]]) },
+      known: knownFrom([onTheLowerEdge]),
       withinWindow: isInsideWindow,
     });
 
@@ -61,7 +62,7 @@ describe("one window predicate, agreeing at every boundary", () => {
 
   test("CONF-O27: the upper edge gets the same verdict from the predicate on both sides", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [onTheUpperEdge], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([onTheUpperEdge], []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
     const listed = (listing.events ?? []).some((event) => event.uid.value === "upper-edge");
@@ -73,7 +74,7 @@ describe("one window predicate, agreeing at every boundary", () => {
 
   test("CONF-O27: an inverted window admits nothing and removes nothing", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [onTheLowerEdge], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([onTheLowerEdge], []));
     const inverted = scopeOver(
       spanning("2026-04-01T00:00:00.000Z", "2026-03-01T00:00:00.000Z"),
     );
@@ -84,7 +85,7 @@ describe("one window predicate, agreeing at every boundary", () => {
     expect(
       derivableRemovals({
         listing,
-        known: { calendar: referenceCalendar, ids: new Map([["lower-edge", onTheLowerEdge.id]]) },
+        known: knownFrom([onTheLowerEdge]),
         withinWindow: isInsideWindow,
       }),
     ).toEqual([]);
@@ -93,14 +94,14 @@ describe("one window predicate, agreeing at every boundary", () => {
 
   test("CONF-O26: an event reported outside the requested window is returned and never removed", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [outsideTheWindow], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([outsideTheWindow], []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
 
     expect(
       derivableRemovals({
         listing,
-        known: { calendar: referenceCalendar, ids: new Map([["outside", outsideTheWindow.id]]) },
+        known: knownFrom([outsideTheWindow]),
         withinWindow: isInsideWindow,
       }),
     ).toEqual([]);
@@ -109,7 +110,7 @@ describe("one window predicate, agreeing at every boundary", () => {
 
   test("CONF-O26: two polls do not oscillate an out-of-window event between add and retire", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [outsideTheWindow], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([outsideTheWindow], []));
 
     await listChanges(harness.provider, harness.environment, scope);
     const afterFirst = await harness.provider.inspect();
@@ -122,7 +123,7 @@ describe("one window predicate, agreeing at every boundary", () => {
 
   test("CONF-O28: a zero-duration event is preserved at the source", async () => {
     const harness = await referenceHarness();
-    await harness.provider.seed({ events: [zeroDuration], corruptKnownRows: [] });
+    await harness.provider.seed(seedOf([zeroDuration], []));
 
     const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
     const found = (listing.events ?? []).filter((event) => event.uid.value === "degenerate");

--- a/packages/sync-kit/conformance/tests/window.test.ts
+++ b/packages/sync-kit/conformance/tests/window.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "vitest";
+import { derivableRemovals } from "../src/assertions/no-removal";
+import { referenceCalendar } from "../src/reference/provider";
+import { listChanges, okValue, write } from "./support/drive";
+import { referenceHarness, runReferenceCase } from "./support/harness";
+import {
+  createIntent,
+  foreignEvent,
+  isInsideWindow,
+  occurrence,
+  scopeOver,
+  spanning,
+  timeOf,
+  timedAt,
+} from "./support/protocol";
+
+const march = spanning("2026-03-01T00:00:00.000Z", "2026-04-01T00:00:00.000Z");
+const scope = scopeOver(march);
+
+const onTheLowerEdge = foreignEvent({
+  uid: "lower-edge",
+  title: "Lower edge",
+  start: "2026-03-01T00:00:00.000Z",
+  end: "2026-03-01T01:00:00.000Z",
+});
+const onTheUpperEdge = foreignEvent({
+  uid: "upper-edge",
+  title: "Upper edge",
+  start: "2026-03-31T23:00:00.000Z",
+  end: "2026-04-01T00:00:00.000Z",
+});
+const outsideTheWindow = foreignEvent({
+  uid: "outside",
+  title: "Outside",
+  start: "2026-05-02T09:00:00.000Z",
+  end: "2026-05-02T10:00:00.000Z",
+});
+const zeroDuration = foreignEvent({
+  uid: "degenerate",
+  title: "Zero duration",
+  start: "2026-03-10T09:00:00.000Z",
+  end: "2026-03-10T09:00:00.000Z",
+});
+
+describe("one window predicate, agreeing at every boundary", () => {
+  test("CONF-O27: the lower edge is admitted by the same predicate at listing and removal time", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [onTheLowerEdge], corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+    const removable = derivableRemovals({
+      listing,
+      known: { calendar: referenceCalendar, ids: new Map([["lower-edge", onTheLowerEdge.id]]) },
+      withinWindow: isInsideWindow,
+    });
+
+    expect((listing.events ?? []).map((event) => event.uid.value)).toEqual(["lower-edge"]);
+    expect(removable).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-O27: the upper edge gets the same verdict from the predicate on both sides", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [onTheUpperEdge], corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+    const listed = (listing.events ?? []).some((event) => event.uid.value === "upper-edge");
+    const admitted = isInsideWindow(march, timeOf(onTheUpperEdge));
+
+    expect(listed).toBe(admitted);
+    await harness.dispose();
+  });
+
+  test("CONF-O27: an inverted window admits nothing and removes nothing", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [onTheLowerEdge], corruptKnownRows: [] });
+    const inverted = scopeOver(
+      spanning("2026-04-01T00:00:00.000Z", "2026-03-01T00:00:00.000Z"),
+    );
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, inverted));
+
+    expect(listing.events ?? []).toEqual([]);
+    expect(
+      derivableRemovals({
+        listing,
+        known: { calendar: referenceCalendar, ids: new Map([["lower-edge", onTheLowerEdge.id]]) },
+        withinWindow: isInsideWindow,
+      }),
+    ).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-O26: an event reported outside the requested window is returned and never removed", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [outsideTheWindow], corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+
+    expect(
+      derivableRemovals({
+        listing,
+        known: { calendar: referenceCalendar, ids: new Map([["outside", outsideTheWindow.id]]) },
+        withinWindow: isInsideWindow,
+      }),
+    ).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-O26: two polls do not oscillate an out-of-window event between add and retire", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [outsideTheWindow], corruptKnownRows: [] });
+
+    await listChanges(harness.provider, harness.environment, scope);
+    const afterFirst = await harness.provider.inspect();
+    await listChanges(harness.provider, harness.environment, scope);
+    const afterSecond = await harness.provider.inspect();
+
+    expect(afterSecond.writeLog).toEqual(afterFirst.writeLog);
+    await harness.dispose();
+  });
+
+  test("CONF-O28: a zero-duration event is preserved at the source", async () => {
+    const harness = await referenceHarness();
+    await harness.provider.seed({ events: [zeroDuration], corruptKnownRows: [] });
+
+    const listing = okValue(await listChanges(harness.provider, harness.environment, scope));
+    const found = (listing.events ?? []).filter((event) => event.uid.value === "degenerate");
+
+    expect(found).toHaveLength(1);
+    expect(harness.supports.representableRange.zeroDuration).toBe("accept");
+    await harness.dispose();
+  });
+
+  test("CONF-O28: a widened mirror of a degenerate range does not read as changed", async () => {
+    const harness = await referenceHarness();
+    const degenerate = occurrence(
+      "Zero duration",
+      timedAt("2026-03-10T09:00:00.000Z", "2026-03-10T09:00:00.000Z"),
+    );
+    await write(harness.provider, harness.environment, createIntent("degenerate", degenerate));
+
+    await listChanges(harness.provider, harness.environment, scope);
+    const afterFirst = await harness.provider.inspect();
+    await listChanges(harness.provider, harness.environment, scope);
+    const afterSecond = await harness.provider.inspect();
+
+    expect(afterSecond.writeLog).toEqual(afterFirst.writeLog);
+    await harness.dispose();
+  });
+
+  test("CONF-O26: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O26")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O27: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O27")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O28: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O28")).resolves.toBeUndefined();
+  });
+});

--- a/packages/sync-kit/conformance/tests/writes.test.ts
+++ b/packages/sync-kit/conformance/tests/writes.test.ts
@@ -2,7 +2,7 @@ import type { WriteIntent, WriteOutcome } from "@keeper.sh/sync-protocol";
 import { describe, expect, test } from "vitest";
 import {
   assertConflictNotOverwrite,
-  assertNoDeleteThenCreate,
+  assertNoUnplannedRecreation,
   assertNoUnconditionalWrite,
 } from "../src/assertions/outcome";
 import { conflictingOn } from "../src/fixtures";
@@ -76,7 +76,7 @@ describe("a write can never silently overwrite", () => {
     const inspection = await harness.provider.inspect();
 
     expect(() => assertConflictNotOverwrite(result)).not.toThrow();
-    expect(() => assertNoDeleteThenCreate(inspection.writeLog)).not.toThrow();
+    expect(() => assertNoUnplannedRecreation(inspection.writeLog, [])).not.toThrow();
     await harness.dispose();
   });
 
@@ -125,7 +125,7 @@ describe("a write can never silently overwrite", () => {
     expect(outcomeKindOf(created)).toBe("created");
     expect(outcomeKindOf(okValue(replacement))).toBe("conflict");
     expect(inspection.objects.map((event) => event.uid.value)).toContain("replaced");
-    expect(() => assertNoDeleteThenCreate(inspection.writeLog)).not.toThrow();
+    expect(() => assertNoUnplannedRecreation(inspection.writeLog, [])).not.toThrow();
     await harness.dispose();
   });
 
@@ -160,7 +160,7 @@ describe("a write can never silently overwrite", () => {
     await harness.dispose();
   });
 
-  test("CONF-O39: two concurrent writers cannot both succeed against one version", async () => {
+  test("CONF-O44: two concurrent writers cannot both succeed against one version", async () => {
     const harness = await referenceHarness();
     const created = okValue(
       await write(harness.provider, harness.environment, createIntent("contended", meeting)),
@@ -196,9 +196,11 @@ describe("a write can never silently overwrite", () => {
   });
 
   test("CONF-O25: the generated case passes for the reference provider", async () => {
-    await expect(
-      runReferenceCase("CONF-O25", conflictingOn(conflictOnKey("replaced-again"))),
-    ).resolves.toBeUndefined();
+    await expect(runReferenceCase("CONF-O25")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O44: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O44")).resolves.toBeUndefined();
   });
 
   test("CONF-O36: the generated case passes for the reference provider", async () => {

--- a/packages/sync-kit/conformance/tests/writes.test.ts
+++ b/packages/sync-kit/conformance/tests/writes.test.ts
@@ -1,0 +1,210 @@
+import type { WriteIntent, WriteOutcome } from "@keeper.sh/sync-protocol";
+import { describe, expect, test } from "vitest";
+import {
+  assertConflictNotOverwrite,
+  assertNoDeleteThenCreate,
+  assertNoUnconditionalWrite,
+} from "../src/assertions/outcome";
+import { conflictingOn } from "../src/fixtures";
+import { failureOf, okValue, write } from "./support/drive";
+import { referenceHarness, runReferenceCase } from "./support/harness";
+import { createIntent, occurrence, timedAt, updateIntent } from "./support/protocol";
+
+const meeting = occurrence("Design review", timedAt("2026-03-02T09:00:00.000Z", "2026-03-02T10:00:00.000Z"));
+const movedMeeting = occurrence("Design review", timedAt("2026-03-02T11:00:00.000Z", "2026-03-02T12:00:00.000Z"));
+
+const outcomeKindOf = (outcome: WriteOutcome): string => outcome.kind;
+
+const versionOf = (outcome: WriteOutcome): string => {
+  if ("version" in outcome) {
+    return outcome.version.value;
+  }
+  return "no-version";
+};
+
+const remoteIdOf = (outcome: WriteOutcome): string => {
+  if ("remote" in outcome) {
+    return outcome.remote.id.value;
+  }
+  return "no-remote";
+};
+
+const echoKindOf = (outcome: WriteOutcome): string => {
+  if ("echo" in outcome) {
+    return outcome.echo.kind;
+  }
+  return "no-echo";
+};
+
+const conflictOnKey =
+  (key: string) =>
+  (intent: WriteIntent): boolean =>
+    intent.kind === "create" && intent.idempotencyKey.value === key;
+
+describe("a write can never silently overwrite", () => {
+  test("CONF-O14: a replayed create with the same idempotency key produces one object", async () => {
+    const harness = await referenceHarness();
+    const intent = createIntent("replayed-create", meeting);
+
+    const first = okValue(await write(harness.provider, harness.environment, intent));
+    const second = okValue(await write(harness.provider, harness.environment, intent));
+    const inspection = await harness.provider.inspect();
+
+    expect(outcomeKindOf(first)).toBe("created");
+    expect(["alreadyExists", "unchanged"]).toContain(outcomeKindOf(second));
+    expect(inspection.objects).toHaveLength(1);
+    await harness.dispose();
+  });
+
+  test("CONF-O14: the replay returns the same RemoteRef as the original create", async () => {
+    const harness = await referenceHarness();
+    const intent = createIntent("replayed-ref", meeting);
+
+    const first = okValue(await write(harness.provider, harness.environment, intent));
+    const second = okValue(await write(harness.provider, harness.environment, intent));
+
+    expect(remoteIdOf(second)).toBe(remoteIdOf(first));
+    expect(remoteIdOf(first)).not.toBe("no-remote");
+    await harness.dispose();
+  });
+
+  test("CONF-O15: a conflicting create is a typed conflict, never a delete-then-create", async () => {
+    const harness = await referenceHarness(conflictingOn(conflictOnKey("conflicting-create")));
+    const intent = createIntent("conflicting-create", meeting);
+
+    const result = await write(harness.provider, harness.environment, intent);
+    const inspection = await harness.provider.inspect();
+
+    expect(() => assertConflictNotOverwrite(result)).not.toThrow();
+    expect(() => assertNoDeleteThenCreate(inspection.writeLog)).not.toThrow();
+    await harness.dispose();
+  });
+
+  test("CONF-O15: the conflict carries the precondition that was actually observed", async () => {
+    const harness = await referenceHarness(conflictingOn(conflictOnKey("observed")));
+
+    const outcome = okValue(
+      await write(harness.provider, harness.environment, createIntent("observed", meeting)),
+    );
+
+    expect(outcomeKindOf(outcome)).toBe("conflict");
+    expect("observed" in outcome).toBe(true);
+    await harness.dispose();
+  });
+
+  test("CONF-O7: an unbuildable newest revision withholds the identity rather than writing the older one", async () => {
+    await expect(runReferenceCase("CONF-O7")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O18: an adapter that cannot echo reports notObserved, and notObserved is not matched", async () => {
+    const harness = await referenceHarness();
+
+    const outcome = okValue(
+      await write(harness.provider, harness.environment, createIntent("echoed", meeting)),
+    );
+
+    expect(echoKindOf(outcome)).not.toBe("notObserved");
+    expect(echoKindOf(outcome)).not.toBe("no-echo");
+    expect(harness.supports.echoesWrites).toBe(true);
+    await harness.dispose();
+  });
+
+  test("CONF-O25: a replace whose create half fails reports the delete separately", async () => {
+    const harness = await referenceHarness(conflictingOn(conflictOnKey("replaced-again")));
+    const created = okValue(
+      await write(harness.provider, harness.environment, createIntent("replaced", meeting)),
+    );
+
+    const replacement = await write(
+      harness.provider,
+      harness.environment,
+      createIntent("replaced-again", movedMeeting),
+    );
+    const inspection = await harness.provider.inspect();
+
+    expect(outcomeKindOf(created)).toBe("created");
+    expect(failureOf(replacement).kind).toBe("conflict");
+    expect(() => assertNoDeleteThenCreate(inspection.writeLog)).not.toThrow();
+    await harness.dispose();
+  });
+
+  test("CONF-O36: moving one occurrence is a single conditional write, not delete plus add", async () => {
+    const harness = await referenceHarness();
+    const created = okValue(
+      await write(harness.provider, harness.environment, createIntent("occurrence", meeting)),
+    );
+    await write(
+      harness.provider,
+      harness.environment,
+      updateIntent("id-occurrence", movedMeeting, versionOf(created)),
+    );
+    const inspection = await harness.provider.inspect();
+
+    expect(() => assertNoUnconditionalWrite(inspection.writeLog)).not.toThrow();
+    expect(inspection.writeLog.filter((entry) => entry.intent.kind === "delete")).toEqual([]);
+    await harness.dispose();
+  });
+
+  test("CONF-O39: a precondition derived from our own submission is refused", async () => {
+    const harness = await referenceHarness();
+    okValue(await write(harness.provider, harness.environment, createIntent("rewritten", meeting)));
+
+    const stale = await write(
+      harness.provider,
+      harness.environment,
+      updateIntent("id-rewritten", movedMeeting, "fp-rewritten"),
+    );
+
+    expect(failureOf(stale).kind).toBe("conflict");
+    await harness.dispose();
+  });
+
+  test("CONF-O39: two concurrent writers cannot both succeed against one version", async () => {
+    const harness = await referenceHarness();
+    const created = okValue(
+      await write(harness.provider, harness.environment, createIntent("contended", meeting)),
+    );
+    const version = versionOf(created);
+
+    const both = await Promise.all([
+      write(harness.provider, harness.environment, updateIntent("id-contended", meeting, version)),
+      write(
+        harness.provider,
+        harness.environment,
+        updateIntent("id-contended", movedMeeting, version),
+      ),
+    ]);
+    const conflicts = both.filter((result) => !result.ok);
+
+    expect(conflicts).toHaveLength(1);
+    await harness.dispose();
+  });
+
+  test("CONF-O14: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O14")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O15: the generated case passes for the reference provider", async () => {
+    await expect(
+      runReferenceCase("CONF-O15", conflictingOn(conflictOnKey("conflicting-create"))),
+    ).resolves.toBeUndefined();
+  });
+
+  test("CONF-O18: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O18")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O25: the generated case passes for the reference provider", async () => {
+    await expect(
+      runReferenceCase("CONF-O25", conflictingOn(conflictOnKey("replaced-again"))),
+    ).resolves.toBeUndefined();
+  });
+
+  test("CONF-O36: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O36")).resolves.toBeUndefined();
+  });
+
+  test("CONF-O39: the generated case passes for the reference provider", async () => {
+    await expect(runReferenceCase("CONF-O39")).resolves.toBeUndefined();
+  });
+});

--- a/packages/sync-kit/conformance/tests/writes.test.ts
+++ b/packages/sync-kit/conformance/tests/writes.test.ts
@@ -123,7 +123,8 @@ describe("a write can never silently overwrite", () => {
     const inspection = await harness.provider.inspect();
 
     expect(outcomeKindOf(created)).toBe("created");
-    expect(failureOf(replacement).kind).toBe("conflict");
+    expect(outcomeKindOf(okValue(replacement))).toBe("conflict");
+    expect(inspection.objects.map((event) => event.uid.value)).toContain("replaced");
     expect(() => assertNoDeleteThenCreate(inspection.writeLog)).not.toThrow();
     await harness.dispose();
   });

--- a/packages/sync-kit/conformance/tsconfig.json
+++ b/packages/sync-kit/conformance/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@keeper.sh/typescript-config",
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/sync-kit/conformance/vitest.config.ts
+++ b/packages/sync-kit/conformance/vitest.config.ts
@@ -4,8 +4,8 @@ export default defineConfig({
   test: {
     globals: true,
     include: ["./tests/**/*.test.ts"],
-    testTimeout: 5000,
-    hookTimeout: 5000,
+    testTimeout: 30000,
+    hookTimeout: 30000,
     typecheck: {
       enabled: true,
       include: ["./tests/**/*.test-d.ts"],

--- a/packages/sync-kit/conformance/vitest.config.ts
+++ b/packages/sync-kit/conformance/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["./tests/**/*.test.ts"],
+    testTimeout: 5000,
+    hookTimeout: 5000,
+    typecheck: {
+      enabled: true,
+      include: ["./tests/**/*.test-d.ts"],
+      tsconfig: "./tsconfig.json",
+    },
+  },
+});

--- a/packages/sync-kit/conformance/vitest.config.ts
+++ b/packages/sync-kit/conformance/vitest.config.ts
@@ -4,8 +4,8 @@ export default defineConfig({
   test: {
     globals: true,
     include: ["./tests/**/*.test.ts"],
-    testTimeout: 30000,
-    hookTimeout: 30000,
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     typecheck: {
       enabled: true,
       include: ["./tests/**/*.test-d.ts"],


### PR DESCRIPTION
Fourth and last of the scoped sync-kit packages: `@keeper.sh/sync-conformance`, the executable specification every adapter runs against itself. `runConformance({ name, supports, create })` generates the case set, and a declared capability selects which branch of a case pair is generated — it never removes a case, so an adapter cannot opt out of a guarantee by declaring less. Stacked on #817.

- 309 tests, and **119 of them are negative controls**: one mutant per case id, each required to fail exactly its own case and nothing else. That is the suite proving it isn't vacuous, which is the only thing that makes a conformance suite worth shipping.
- Ships an in-memory reference provider that passes the whole suite, plus four composable fixtures — truncate a page, expire a cursor, force a precondition conflict, stall a request forever. The stall is `new Promise(() => {})`, a permanently pending promise rather than a long timer, so a missing deadline surfaces as a failure instead of a slow test.
- The reference provider deliberately rewrites what it is given (whole-second truncation, CRLF, trim), which breaks any adapter that trusts its own submission rather than re-reading.
- Hygiene is enforced by tests, not convention: no `Bun.sleep`, no `AbortSignal.timeout`, no `node:timers/promises`, and no wall-clock assertions anywhere. Every ledger citation must name a real file and a verbatim test name.
- Verified uncached three times end to end: 57/57 turbo tasks each run.

Note on placement: this is the package headed for the private tests repo under the SQLite/TH3 split. It is here for now so it can compile and run against the other three layers; moving it is mechanical and nothing needs to merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWminUmH2kMq6fQShPLgvE
