### PR TITLE
fix(worker): say which call a wedged sync pass was still waiting on

### DIFF
--- a/packages/calendar/src/core/telemetry/in-flight.ts
+++ b/packages/calendar/src/core/telemetry/in-flight.ts
@@ -1,0 +1,53 @@
+import { widelog } from "widelogger";
+import {
+  beginInFlight,
+  describeInFlight,
+  endInFlight,
+  snapshotInFlight,
+} from "@keeper.sh/database";
+import type { InFlightKind, InFlightSnapshot } from "@keeper.sh/database";
+
+const EMPTY = 0;
+
+/*
+ * The oldest open operation is promoted to its own fields because it is the one that
+ * answers "why": everything else in the stack is waiting behind it.
+ */
+const recordInFlightOnWideEvent = (prefix: string): void => {
+  const calls = snapshotInFlight();
+  widelog.set(`${prefix}.open_count`, calls.length);
+  if (calls.length === EMPTY) {
+    return;
+  }
+  const [oldest] = calls;
+  if (!oldest) {
+    return;
+  }
+  widelog.set(`${prefix}.blocking_kind`, oldest.kind);
+  widelog.set(`${prefix}.blocking_target`, oldest.target);
+  widelog.set(`${prefix}.blocking_elapsed_ms`, oldest.elapsedMs);
+  widelog.set(`${prefix}.open_stack`, describeInFlight());
+};
+
+const measureInFlight = async <TResult>(
+  kind: InFlightKind,
+  target: string,
+  operation: () => Promise<TResult>,
+): Promise<TResult> => {
+  const callId = beginInFlight(kind, target);
+  try {
+    return await operation();
+  } finally {
+    endInFlight(callId);
+  }
+};
+
+export {
+  beginInFlight,
+  describeInFlight,
+  endInFlight,
+  measureInFlight,
+  recordInFlightOnWideEvent,
+  snapshotInFlight,
+};
+export type { InFlightKind, InFlightSnapshot };

--- a/packages/calendar/src/core/telemetry/segments.ts
+++ b/packages/calendar/src/core/telemetry/segments.ts
@@ -1,4 +1,6 @@
 import { widelog } from "widelogger";
+import { beginInFlight, endInFlight } from "./in-flight";
+import type { InFlightKind } from "./in-flight";
 
 /**
  * Every wait and work key below is a disjoint wall-clock slice of the per-source
@@ -38,14 +40,29 @@ const recordSegment = (key: IngestSegmentKey, durationMs: number): void => {
   widelog.count(ACCOUNTED_SEGMENT_KEY, rounded);
 };
 
+const SEGMENT_IN_FLIGHT_KINDS = {
+  "wait.advisory_lock_ms": "lock",
+  "wait.db_pool_ms": "db_pool",
+  "wait.rate_limiter_ms": "rate_limit",
+  "wait.source_lock_ms": "lock",
+  "work.db_commit_ms": "db_query",
+  "work.db_read_ms": "db_query",
+  "work.db_write_ms": "db_query",
+} as const;
+
+const resolveInFlightKind = (key: IngestSegmentKey): InFlightKind =>
+  SEGMENT_IN_FLIGHT_KINDS[key as keyof typeof SEGMENT_IN_FLIGHT_KINDS] ?? "segment";
+
 const measureSegment = async <TResult>(
   key: IngestSegmentKey,
   operation: () => Promise<TResult>,
 ): Promise<TResult> => {
   const startedAt = performance.now();
+  const callId = beginInFlight(resolveInFlightKind(key), key);
   try {
     return await operation();
   } finally {
+    endInFlight(callId);
     recordSegment(key, performance.now() - startedAt);
   }
 };
@@ -88,11 +105,14 @@ const recordRedisCommandDuration = (durationMs: number): void => {
 
 const measureRedisCommand = async <TResult>(
   operation: () => Promise<TResult>,
+  command = "redis",
 ): Promise<TResult> => {
   const startedAt = performance.now();
+  const callId = beginInFlight("redis", command);
   try {
     return await operation();
   } finally {
+    endInFlight(callId);
     recordRedisCommandDuration(performance.now() - startedAt);
   }
 };

--- a/packages/calendar/src/core/utils/fetch-with-timeout.ts
+++ b/packages/calendar/src/core/utils/fetch-with-timeout.ts
@@ -1,3 +1,5 @@
+import { beginInFlight, endInFlight } from "../telemetry/in-flight";
+
 class RequestTimeoutError extends Error {
   public readonly timeoutMs: number;
 
@@ -54,6 +56,23 @@ const buildTimeoutSignal = (timeoutMs: number, externalSignal?: AbortSignal | nu
   };
 };
 
+const resolveRawTarget = (input: string | URL | Request): string => {
+  if (input instanceof Request) {
+    return input.url;
+  }
+  return String(input);
+};
+
+const describeTarget = (input: string | URL | Request): string => {
+  const raw = resolveRawTarget(input);
+  try {
+    const { host, pathname } = new URL(raw);
+    return `${host}${pathname}`;
+  } catch {
+    return raw;
+  }
+};
+
 const fetchWithTimeout = async (
   input: string | URL | Request,
   init: RequestInit,
@@ -61,6 +80,7 @@ const fetchWithTimeout = async (
   externalSignal?: AbortSignal,
 ): Promise<Response> => {
   const { signal, isTimeout } = buildTimeoutSignal(timeoutMs, externalSignal);
+  const callId = beginInFlight("provider_http", describeTarget(input));
   try {
     return await fetch(input, { ...init, signal });
   } catch (error) {
@@ -68,6 +88,8 @@ const fetchWithTimeout = async (
       throw new RequestTimeoutError(timeoutMs);
     }
     throw error;
+  } finally {
+    endInFlight(callId);
   }
 };
 

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -39,6 +39,16 @@ export {
   REDIS_COMMAND_MAX_KEY,
   type IngestSegmentKey,
 } from "./core/telemetry/segments";
+export {
+  beginInFlight,
+  describeInFlight,
+  endInFlight,
+  measureInFlight,
+  recordInFlightOnWideEvent,
+  snapshotInFlight,
+  type InFlightKind,
+  type InFlightSnapshot,
+} from "./core/telemetry/in-flight";
 export { isOAuthReauthRequiredError } from "./core/oauth/error-classification";
 export {
   buildReauthenticationDemandFields,

--- a/packages/calendar/src/providers/google/source/utils/list-calendars.ts
+++ b/packages/calendar/src/providers/google/source/utils/list-calendars.ts
@@ -5,6 +5,8 @@ import {
 import type { GoogleCalendarListEntry } from "../types";
 import { GOOGLE_CALENDAR_LIST_URL } from "../../shared/api";
 import { isSimpleAuthError } from "../../shared/errors";
+import { fetchWithTimeout } from "../../../../core/utils/fetch-with-timeout";
+import { PROVIDER_INGEST_REQUEST_TIMEOUT_MS } from "@keeper.sh/constants";
 
 class CalendarListError extends Error {
   public readonly status: number;
@@ -48,12 +50,16 @@ const fetchCalendarPage = async (
     url.searchParams.set("pageToken", pageToken);
   }
 
-  const response = await fetch(url.toString(), {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
+  const response = await fetchWithTimeout(
+    url.toString(),
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
     },
+    PROVIDER_INGEST_REQUEST_TIMEOUT_MS,
     signal,
-  });
+  );
 
   if (!response.ok) {
     const authRequired = isSimpleAuthError(response.status);

--- a/packages/calendar/src/providers/outlook/source/utils/list-calendars.ts
+++ b/packages/calendar/src/providers/outlook/source/utils/list-calendars.ts
@@ -1,6 +1,8 @@
 import type { OutlookCalendarListEntry, OutlookCalendarListResponse } from "../types";
 import { MICROSOFT_GRAPH_API } from "../../shared/api";
 import { isSimpleAuthError } from "../../shared/errors";
+import { fetchWithTimeout } from "../../../../core/utils/fetch-with-timeout";
+import { PROVIDER_INGEST_REQUEST_TIMEOUT_MS } from "@keeper.sh/constants";
 
 const INVALID_RESPONSE_STATUS = 502;
 
@@ -106,12 +108,16 @@ const fetchCalendarPage = async (
     url.searchParams.set("$select", "id,name,color,isDefaultCalendar,canEdit,owner");
   }
 
-  const response = await fetch(url.toString(), {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
+  const response = await fetchWithTimeout(
+    url.toString(),
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
     },
+    PROVIDER_INGEST_REQUEST_TIMEOUT_MS,
     signal,
-  });
+  );
 
   if (!response.ok) {
     const authRequired = isSimpleAuthError(response.status);

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -19,3 +19,10 @@ export {
   createMigrationReadinessDatabase,
   waitForDatabaseMigrations,
 } from "./database/migration-readiness";
+export {
+  beginInFlight,
+  describeInFlight,
+  endInFlight,
+  snapshotInFlight,
+} from "./utils/in-flight";
+export type { InFlightKind, InFlightSnapshot } from "./utils/in-flight";

--- a/packages/database/src/utils/in-flight.ts
+++ b/packages/database/src/utils/in-flight.ts
@@ -1,0 +1,70 @@
+/*
+ * Every measure helper in the codebase records in its `finally`, so an operation that
+ * is still running has contributed nothing to the wide event: when a pass wedges, the
+ * one operation worth naming is the only one missing. This registry is the inverse —
+ * it holds what has started and not yet returned, so a job killed mid-flight can still
+ * say what it was waiting on.
+ *
+ * It lives here, with no dependencies of its own, because the database is the lowest
+ * package that the query hook and the calendar telemetry can both reach.
+ */
+type InFlightKind =
+  | "caldav"
+  | "db_pool"
+  | "db_query"
+  | "lock"
+  | "provider_http"
+  | "rate_limit"
+  | "redis"
+  | "segment";
+
+interface InFlightCall {
+  kind: InFlightKind;
+  startedAt: number;
+  target: string;
+}
+
+interface InFlightSnapshot {
+  elapsedMs: number;
+  kind: InFlightKind;
+  target: string;
+}
+
+const MILLISECOND_PRECISION = 100;
+const CALL_ID_STEP = 1;
+
+const inFlightCalls = new Map<number, InFlightCall>();
+let nextCallId = CALL_ID_STEP;
+
+const roundMs = (durationMs: number): number =>
+  Math.round(durationMs * MILLISECOND_PRECISION) / MILLISECOND_PRECISION;
+
+const beginInFlight = (kind: InFlightKind, target: string): number => {
+  const callId = nextCallId;
+  nextCallId += CALL_ID_STEP;
+  inFlightCalls.set(callId, { kind, startedAt: performance.now(), target });
+  return callId;
+};
+
+const endInFlight = (callId: number): void => {
+  inFlightCalls.delete(callId);
+};
+
+const snapshotInFlight = (): InFlightSnapshot[] => {
+  const now = performance.now();
+  return [...inFlightCalls.values()]
+    .map((call) => ({
+      elapsedMs: roundMs(now - call.startedAt),
+      kind: call.kind,
+      target: call.target,
+    }))
+    .toSorted((left, right) => right.elapsedMs - left.elapsedMs);
+};
+
+const describeInFlight = (): string =>
+  snapshotInFlight()
+    .map((call) => `${call.kind}:${call.target}@${String(call.elapsedMs)}ms`)
+    .join(" | ");
+
+export { beginInFlight, describeInFlight, endInFlight, snapshotInFlight };
+export type { InFlightKind, InFlightSnapshot };

--- a/packages/database/src/utils/pool-telemetry.ts
+++ b/packages/database/src/utils/pool-telemetry.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { beginInFlight, endInFlight } from "./in-flight";
 
 interface DatabasePoolWindowSample {
   inFlight: number;
@@ -85,15 +86,23 @@ const transactionStates = new WeakMap<object, TransactionState>();
  * park `waitsForConnection` at true. `catch` and `finally` are own methods reaching the
  * raw `then`, so they must route through the hooked one or a query settles unreleased.
  */
+const NO_IN_FLIGHT = -1;
+const QUERY_LABEL_LIMIT = 120;
+
+const labelStatement = (statement: string): string =>
+  statement.replaceAll(/\s+/gu, " ").trim().slice(0, QUERY_LABEL_LIMIT);
+
 const instrumentQuery = (
   query: object,
   transactional: boolean,
   transactionState: TransactionState | undefined,
+  statement: string,
 ): object => {
   const scope = windowScopes.getStore() ?? null;
 
   let state: "unissued" | "issued" | "settled" = "unissued";
   let startedAt = 0;
+  let inFlightId = NO_IN_FLIGHT;
 
   const issue = (): void => {
     if (state !== "unissued") {
@@ -125,6 +134,7 @@ const instrumentQuery = (
     }
 
     startedAt = performance.now();
+    inFlightId = beginInFlight("db_query", labelStatement(statement));
   };
 
   const settle = (failed: boolean): void => {
@@ -132,6 +142,7 @@ const instrumentQuery = (
       return;
     }
     state = "settled";
+    endInFlight(inFlightId);
     const durationMs = performance.now() - startedAt;
     counters.inFlight -= 1;
     if (!transactional) {
@@ -234,6 +245,7 @@ const instrumentClient = (
       originalUnsafe.call(client, query, params),
       transactional,
       transactionStates.get(client),
+      query,
     );
 
   for (const method of TRANSACTION_METHODS) {

--- a/packages/database/tests/utils/pool-telemetry-unawaited.test.ts
+++ b/packages/database/tests/utils/pool-telemetry-unawaited.test.ts
@@ -13,7 +13,7 @@ interface FakeQuery extends PromiseLike<unknown> {
 const createFakeClient = () => {
   const pending: PromiseWithResolvers<unknown[]>[] = [];
   const client = {
-    unsafe: (): object => {
+    unsafe: (_statement: string): object => {
       const deferred = Promise.withResolvers<unknown[]>();
       pending.push(deferred);
       return deferred.promise;
@@ -33,7 +33,7 @@ describe("database pool telemetry for queries that are never awaited", () => {
 
     withDatabasePoolWindow((readWindow): void => {
       for (let index = 0; index < 10; index += 1) {
-        client.unsafe();
+        client.unsafe("select 1");
       }
 
       const sample = readWindow();
@@ -48,10 +48,10 @@ describe("database pool telemetry for queries that are never awaited", () => {
 
     await withDatabasePoolWindow(async (readWindow): Promise<void> => {
       for (let index = 0; index < 10; index += 1) {
-        client.unsafe();
+        client.unsafe("select 1");
       }
 
-      const query = client.unsafe() as FakeQuery;
+      const query = client.unsafe("select 1") as FakeQuery;
       const awaited = query.then((result) => result);
       pending.at(-1)?.resolve([]);
       await awaited;
@@ -68,7 +68,7 @@ describe("database pool telemetry for queries that are never awaited", () => {
     instrumentDatabasePool(client, 2);
 
     await withDatabasePoolWindow(async (readWindow): Promise<void> => {
-      const query = client.unsafe() as FakeQuery;
+      const query = client.unsafe("select 1") as FakeQuery;
       const viaThen = query.then((result) => result);
       const viaCatch = query.catch(() => null);
       const viaFinally = query.finally(() => null);
@@ -91,7 +91,7 @@ describe("database pool telemetry for queries that are never awaited", () => {
     instrumentDatabasePool(client, 2);
 
     await withDatabasePoolWindow(async (readWindow): Promise<void> => {
-      const query = client.unsafe() as FakeQuery;
+      const query = client.unsafe("select 1") as FakeQuery;
       const first = query.catch(() => "handled");
       const second = query.catch(() => "handled");
 

--- a/packages/database/tests/utils/pool-telemetry-window-edges.test.ts
+++ b/packages/database/tests/utils/pool-telemetry-window-edges.test.ts
@@ -8,7 +8,7 @@ import {
 const createFakeClient = () => {
   const pending: PromiseWithResolvers<unknown[]>[] = [];
   const client = {
-    unsafe: (): object => {
+    unsafe: (_statement: string): object => {
       const deferred = Promise.withResolvers<unknown[]>();
       pending.push(deferred);
       return deferred.promise;
@@ -36,7 +36,7 @@ describe("database pool telemetry window boundaries", () => {
     const { client, pending } = createFakeClient();
     instrumentDatabasePool(client, 10);
 
-    const early = client.unsafe() as PromiseLike<unknown>;
+    const early = client.unsafe("select 1") as PromiseLike<unknown>;
     await withDatabasePoolWindow(async (window): Promise<void> => {
       await settleAfter(pending[0], 25);
       await early;
@@ -52,7 +52,7 @@ describe("database pool telemetry window boundaries", () => {
     const { client, pending } = createFakeClient();
     instrumentDatabasePool(client, 10);
 
-    const early = client.unsafe() as PromiseLike<unknown>;
+    const early = client.unsafe("select 1") as PromiseLike<unknown>;
     await withDatabasePoolWindow(async (window): Promise<void> => {
       pending[0]?.reject(new Error("connection terminated"));
       await expect(early).rejects.toThrow("connection terminated");
@@ -69,7 +69,7 @@ describe("database pool telemetry window boundaries", () => {
     instrumentDatabasePool(client, 10);
 
     await withDatabasePoolWindow(async (window): Promise<void> => {
-      const inflight = (client.unsafe() as PromiseLike<unknown>).then((result) => result);
+      const inflight = (client.unsafe("select 1") as PromiseLike<unknown>).then((result) => result);
       const sample = window();
 
       expect(sample.queryCount).toBe(1);
@@ -89,7 +89,7 @@ describe("database pool telemetry window boundaries", () => {
     const samples: string[] = [];
     for (let round = 0; round < 5; round += 1) {
       await withDatabasePoolWindow(async (window): Promise<void> => {
-        const query = client.unsafe() as PromiseLike<unknown>;
+        const query = client.unsafe("select 1") as PromiseLike<unknown>;
         pending[round]?.resolve([]);
         await query;
         const sample = window();
@@ -112,7 +112,7 @@ describe("database pool telemetry window boundaries", () => {
     instrumentDatabasePool(client, 10);
 
     await withDatabasePoolWindow(async (window): Promise<void> => {
-      const query = client.unsafe() as PromiseLike<unknown>;
+      const query = client.unsafe("select 1") as PromiseLike<unknown>;
       pending[0]?.resolve([]);
       await query;
       const sample = window();

--- a/packages/database/tests/utils/pool-telemetry.test.ts
+++ b/packages/database/tests/utils/pool-telemetry.test.ts
@@ -12,7 +12,7 @@ const TEST_DATABASE_URL = process.env.KEEPER_TEST_DATABASE_URL;
 const createFakeClient = () => {
   const pending: PromiseWithResolvers<unknown[]>[] = [];
   const client = {
-    unsafe: (): object => {
+    unsafe: (_statement: string): object => {
       const deferred = Promise.withResolvers<unknown[]>();
       pending.push(deferred);
       return deferred.promise;
@@ -31,8 +31,8 @@ describe("database pool telemetry", () => {
     instrumentDatabasePool(client, 2);
 
     await withDatabasePoolWindow(async (readWindow): Promise<void> => {
-      const first = (client.unsafe() as PromiseLike<unknown>).then((result) => result);
-      const second = (client.unsafe() as PromiseLike<unknown>).then((result) => result);
+      const first = (client.unsafe("select 1") as PromiseLike<unknown>).then((result) => result);
+      const second = (client.unsafe("select 1") as PromiseLike<unknown>).then((result) => result);
 
       expect(readWindow().inFlight).toBe(2);
       expect(readWindow().queryCount).toBe(2);
@@ -56,7 +56,7 @@ describe("database pool telemetry", () => {
     instrumentDatabasePool(client, 2);
 
     await withDatabasePoolWindow(async (readWindow): Promise<void> => {
-      const queries = ([client.unsafe(), client.unsafe(), client.unsafe()] as PromiseLike<unknown>[])
+      const queries = ([client.unsafe("select 1"), client.unsafe("select 1"), client.unsafe("select 1")] as PromiseLike<unknown>[])
         .map((query) => query.then((result) => result));
 
       expect(readWindow().queuedQueryCount).toBe(1);
@@ -76,7 +76,7 @@ describe("database pool telemetry", () => {
     instrumentDatabasePool(client, 2);
 
     await withDatabasePoolWindow(async (readWindow): Promise<void> => {
-      const query = client.unsafe() as PromiseLike<unknown>;
+      const query = client.unsafe("select 1") as PromiseLike<unknown>;
       pending[0]?.reject(new Error("connection closed"));
       await expect(Promise.resolve(query)).rejects.toThrow("connection closed");
 
@@ -91,14 +91,14 @@ describe("database pool telemetry", () => {
     const { client, pending } = createFakeClient();
     instrumentDatabasePool(client, 2);
 
-    const before = client.unsafe() as PromiseLike<unknown>;
+    const before = client.unsafe("select 1") as PromiseLike<unknown>;
     pending[0]?.resolve([]);
     await before;
 
     await withDatabasePoolWindow(async (readWindow): Promise<void> => {
       expect(readWindow().queryCount).toBe(0);
 
-      const during = client.unsafe() as PromiseLike<unknown>;
+      const during = client.unsafe("select 1") as PromiseLike<unknown>;
       pending[1]?.resolve([]);
       await during;
 

--- a/services/worker/src/processor.ts
+++ b/services/worker/src/processor.ts
@@ -14,6 +14,7 @@ import {
   getDatabaseErrorDetails,
   resolveDatabaseErrorClassification,
 } from "@keeper.sh/database";
+import { recordInFlightOnWideEvent } from "@keeper.sh/calendar";
 import { database, refreshLockRedis, refreshLockStore } from "./context";
 import { context, widelog } from "./utils/logging";
 import { applySyncEventFields } from "./utils/sync-event-fields";
@@ -221,8 +222,27 @@ const processJob = (
     const deadlineMs = Date.now() + USER_TIMEOUT_MS;
 
     const deadlineController = new AbortController();
-    const deadlineTimer = setTimeout(() => deadlineController.abort(), USER_TIMEOUT_MS);
     let needsFlush = true;
+    let deadlineFlushed = false;
+    /*
+     * Aborting the signal is advisory: an await that never observes it keeps the job
+     * running past this deadline, past the queue's lock, and into a stall that is
+     * terminated without ever reaching the flush in the finally below. Writing the
+     * event here — from the timer, which fires whether or not the work cooperates —
+     * is what makes a wedged pass say which call it was still waiting on.
+     */
+    const deadlineTimer = setTimeout(() => {
+      deadlineController.abort();
+      widelog.set("timeout.fired", true);
+      widelog.set("timeout.kind", "job_deadline");
+      widelog.set("timeout.limit_ms", USER_TIMEOUT_MS);
+      widelog.set("error.slug", "sync-deadline-exceeded");
+      recordInFlightOnWideEvent("third_party");
+      widelog.set("outcome", "timeout");
+      widelog.flush();
+      deadlineFlushed = true;
+      needsFlush = false;
+    }, USER_TIMEOUT_MS);
     const pendingDestinationSyncs: Promise<void>[] = [];
 
     try {
@@ -367,14 +387,14 @@ const processJob = (
     } finally {
       await Promise.all(pendingDestinationSyncs);
       clearTimeout(deadlineTimer);
-      if (deadlineController.signal.aborted) {
+      if (deadlineController.signal.aborted && !deadlineFlushed) {
         widelog.set("timeout.fired", true);
         widelog.set("timeout.kind", "job_deadline");
         widelog.set("timeout.limit_ms", USER_TIMEOUT_MS);
         widelog.set("error.slug", "sync-deadline-exceeded");
         needsFlush = true;
       }
-      if (needsFlush) {
+      if (needsFlush && !deadlineFlushed) {
         widelog.flush();
       }
     }


### PR DESCRIPTION
A sync job that hangs is terminated by the queue after `lockDuration` and never flushes its wide event, so the pair goes silent while its job id keeps every later enqueue deduplicated. Every `measure*` helper records in its `finally`, so the one operation still running is the only one missing from the event — the culprit was systematically invisible.

- Adds an in-flight registry that holds what has started and not returned, hooked into `instrumentQuery` (every drizzle query, labelled with its SQL), the measured segments (lock, pool, rate-limiter, db read/write/commit), Redis commands and provider HTTP.
- Writes the deadline event from the timer instead of the `finally`. `deadlineController.abort()` is advisory, so an await that ignores the signal never reaches the flush; the timer fires either way and now carries `third_party.blocking_kind`, `blocking_target`, `blocking_elapsed_ms` and the open stack.
- Bounds the two `list-calendars` fetches, which had no timeout of their own and relied on a caller-supplied signal.