### PR TITLE
fix(worker): stop a file save abandoning the jobs the worker holds

### DIFF
--- a/services/worker/package.json
+++ b/services/worker/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "dev": "bun run --watch .",
+    "dev": "bun run .",
     "build": "bun scripts/build.ts",
     "start": "bun run dist/index.js",
     "types": "tsc --noEmit",


### PR DESCRIPTION
`bun --watch` re-evaluates the module in the same process on every file save: same pid, no signal. `entry()` wires its cleanup to SIGTERM/SIGINT only, so the one call to `worker.close()` never runs on a reload and the previous Worker is abandoned mid-job — its lock renewal timers die with the old module scope, but its Redis locks survive their full TTL.

Because a job id is derived from the pair, every later enqueue for that pair is then deduplicated into the abandoned job and dropped, so the pair stops syncing and reports nothing until the lock expires. Three local incidents were stranded 361.7s, 386.8s and 388.1s — `lockDuration` plus one stalled interval, every time.

Running the worker without `--watch` means a code change takes a real restart, which sends SIGTERM, which drains. Verified that the async cleanup completes on that path: registering the listener suppresses default termination.

Closing the previous worker through a `Symbol.for` global on reload was tried first and does not work — Bun resets globals across the reload, so the abandoned instance is unreachable.