### PR TITLE
feat(web): offer Pro from the dashboard, not only from a locked feature

### DIFF
--- a/applications/web/src/routes/(dashboard)/dashboard/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/index.tsx
@@ -45,7 +45,6 @@ import { useAnimatedSWR } from "@/hooks/use-animated-swr";
 import { SyncStatus } from "@/features/dashboard/components/sync-status";
 import CreditCard from "lucide-react/dist/esm/icons/credit-card";
 import Sparkles from "lucide-react/dist/esm/icons/sparkles";
-import { getCommercialMode } from "@/config/commercial";
 import { useSubscription, fetchSubscriptionStateWithApi } from "@/hooks/use-subscription";
 import { openCustomerPortal } from "@/utils/checkout";
 
@@ -63,7 +62,10 @@ async function loadSubscription(context: {
 }
 
 export const Route = createFileRoute("/(dashboard)/dashboard/")({
-  loader: async ({ context }) => ({ subscription: await loadSubscription(context) }),
+  loader: async ({ context }) => ({
+    commercialMode: context.runtimeConfig.commercialMode,
+    subscription: await loadSubscription(context),
+  }),
   component: DashboardPage,
 });
 
@@ -133,7 +135,7 @@ interface RefreshStatus {
 
 function PlanMenu() {
   const navigate = useNavigate();
-  const { subscription: loaderSubscription } = Route.useLoaderData();
+  const { commercialMode, subscription: loaderSubscription } = Route.useLoaderData();
   const { data: subscription, isLoading: subscriptionLoading } = useSubscription({
     fallbackData: loaderSubscription,
   });
@@ -153,7 +155,7 @@ function PlanMenu() {
     }
   };
 
-  if (!getCommercialMode()) {
+  if (!commercialMode) {
     return null;
   }
 

--- a/applications/web/src/routes/(dashboard)/dashboard/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/index.tsx
@@ -7,7 +7,6 @@ import CalendarPlus from "lucide-react/dist/esm/icons/calendar-plus";
 import CalendarDays from "lucide-react/dist/esm/icons/calendar-days";
 import Link2 from "lucide-react/dist/esm/icons/link-2";
 import Settings from "lucide-react/dist/esm/icons/settings";
-import CircleArrowUp from "lucide-react/dist/esm/icons/circle-arrow-up";
 import LogOut from "lucide-react/dist/esm/icons/log-out";
 import MessageSquare from "lucide-react/dist/esm/icons/message-square";
 import Bug from "lucide-react/dist/esm/icons/bug";
@@ -44,10 +43,27 @@ import { ProviderIconStack } from "@/components/ui/primitives/provider-icon-stac
 import { pluralize } from "@/lib/pluralize";
 import { useAnimatedSWR } from "@/hooks/use-animated-swr";
 import { SyncStatus } from "@/features/dashboard/components/sync-status";
+import CreditCard from "lucide-react/dist/esm/icons/credit-card";
+import Sparkles from "lucide-react/dist/esm/icons/sparkles";
 import { getCommercialMode } from "@/config/commercial";
-import { useEntitlements } from "@/hooks/use-entitlements";
+import { useSubscription, fetchSubscriptionStateWithApi } from "@/hooks/use-subscription";
+import { openCustomerPortal } from "@/utils/checkout";
+
+async function loadSubscription(context: {
+  fetchApi: <T>(path: string, init?: RequestInit) => Promise<T>;
+  runtimeConfig: { commercialMode: boolean };
+}) {
+  if (!context.runtimeConfig.commercialMode) return undefined;
+  try {
+    return await fetchSubscriptionStateWithApi(context.fetchApi);
+  } catch (error) {
+    console.error("[subscription] dashboard loader preload failed, deferring to the client read:", error);
+    return undefined;
+  }
+}
 
 export const Route = createFileRoute("/(dashboard)/dashboard/")({
+  loader: async ({ context }) => ({ subscription: await loadSubscription(context) }),
   component: DashboardPage,
 });
 
@@ -83,7 +99,7 @@ function DashboardPage() {
             <NavigationMenuItemTrailing />
           </NavigationMenuLinkItem>
         </NavigationMenu>
-        <UpgradeMenu />
+        <PlanMenu />
         <NavigationMenu>
           <AccountsPopover />
           <NavigationMenuLinkItem to="/dashboard/settings">
@@ -115,22 +131,41 @@ interface RefreshStatus {
   tone: "muted" | "danger";
 }
 
-function UpgradeMenu() {
-  const { data: entitlements } = useEntitlements();
+function PlanMenu() {
+  const navigate = useNavigate();
+  const { subscription: loaderSubscription } = Route.useLoaderData();
+  const { data: subscription, isLoading: subscriptionLoading } = useSubscription({
+    fallbackData: loaderSubscription,
+  });
+  const isPro = subscription?.plan === "pro";
+  const [isManaging, setIsManaging] = useState(false);
 
-  if (!getCommercialMode() || entitlements?.plan !== "free") {
+  const handleManagePlan = async () => {
+    if (!isPro) {
+      navigate({ to: "/dashboard/upgrade" });
+      return;
+    }
+    setIsManaging(true);
+    try {
+      await openCustomerPortal();
+    } catch {
+      setIsManaging(false);
+    }
+  };
+
+  if (!getCommercialMode()) {
     return null;
   }
 
   return (
-    <NavigationMenu>
-      <NavigationMenuLinkItem to="/dashboard/upgrade">
+    <NavigationMenu variant={isPro ? "default" : "highlight"}>
+      <NavigationMenuButtonItem onClick={handleManagePlan} disabled={isManaging || subscriptionLoading}>
         <NavigationMenuItemIcon>
-          <CircleArrowUp size={15} />
+          {isPro ? <CreditCard size={15} /> : <Sparkles size={15} />}
         </NavigationMenuItemIcon>
-        <NavigationMenuItemLabel>Upgrade to Pro</NavigationMenuItemLabel>
+        <NavigationMenuItemLabel>{isPro ? "Manage Plan" : "Upgrade to Pro"}</NavigationMenuItemLabel>
         <NavigationMenuItemTrailing />
-      </NavigationMenuLinkItem>
+      </NavigationMenuButtonItem>
     </NavigationMenu>
   );
 }

--- a/applications/web/src/routes/(dashboard)/dashboard/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/index.tsx
@@ -7,6 +7,7 @@ import CalendarPlus from "lucide-react/dist/esm/icons/calendar-plus";
 import CalendarDays from "lucide-react/dist/esm/icons/calendar-days";
 import Link2 from "lucide-react/dist/esm/icons/link-2";
 import Settings from "lucide-react/dist/esm/icons/settings";
+import CircleArrowUp from "lucide-react/dist/esm/icons/circle-arrow-up";
 import LogOut from "lucide-react/dist/esm/icons/log-out";
 import MessageSquare from "lucide-react/dist/esm/icons/message-square";
 import Bug from "lucide-react/dist/esm/icons/bug";
@@ -43,6 +44,8 @@ import { ProviderIconStack } from "@/components/ui/primitives/provider-icon-stac
 import { pluralize } from "@/lib/pluralize";
 import { useAnimatedSWR } from "@/hooks/use-animated-swr";
 import { SyncStatus } from "@/features/dashboard/components/sync-status";
+import { getCommercialMode } from "@/config/commercial";
+import { useEntitlements } from "@/hooks/use-entitlements";
 
 export const Route = createFileRoute("/(dashboard)/dashboard/")({
   component: DashboardPage,
@@ -80,6 +83,7 @@ function DashboardPage() {
             <NavigationMenuItemTrailing />
           </NavigationMenuLinkItem>
         </NavigationMenu>
+        <UpgradeMenu />
         <NavigationMenu>
           <AccountsPopover />
           <NavigationMenuLinkItem to="/dashboard/settings">
@@ -109,6 +113,26 @@ function DashboardPage() {
 interface RefreshStatus {
   message: string;
   tone: "muted" | "danger";
+}
+
+function UpgradeMenu() {
+  const { data: entitlements } = useEntitlements();
+
+  if (!getCommercialMode() || entitlements?.plan !== "free") {
+    return null;
+  }
+
+  return (
+    <NavigationMenu>
+      <NavigationMenuLinkItem to="/dashboard/upgrade">
+        <NavigationMenuItemIcon>
+          <CircleArrowUp size={15} />
+        </NavigationMenuItemIcon>
+        <NavigationMenuItemLabel>Upgrade to Pro</NavigationMenuItemLabel>
+        <NavigationMenuItemTrailing />
+      </NavigationMenuLinkItem>
+    </NavigationMenu>
+  );
 }
 
 function CalendarSourcesMenu() {

--- a/applications/web/src/routes/(dashboard)/dashboard/settings/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/settings/index.tsx
@@ -1,11 +1,9 @@
 import { useCallback, useRef, useState } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import CreditCard from "lucide-react/dist/esm/icons/credit-card";
 import KeyRound from "lucide-react/dist/esm/icons/key-round";
 import KeySquare from "lucide-react/dist/esm/icons/key-square";
 import Lock from "lucide-react/dist/esm/icons/lock";
 import Mail from "lucide-react/dist/esm/icons/mail";
-import Sparkles from "lucide-react/dist/esm/icons/sparkles";
 import Cookie from "lucide-react/dist/esm/icons/cookie";
 import Trash2 from "lucide-react/dist/esm/icons/trash-2";
 import { pluralize } from "@/lib/pluralize";
@@ -39,33 +37,17 @@ import { useEffectiveConsent } from "@/hooks/use-effective-consent";
 import { Text } from "@/components/ui/primitives/text";
 import { resolveErrorMessage } from "@/utils/errors";
 import { fetchAuthCapabilitiesWithApi } from "@/lib/auth-capabilities";
-import { getCommercialMode } from "@/config/commercial";
-import { useSubscription, fetchSubscriptionStateWithApi } from "@/hooks/use-subscription";
-import { openCustomerPortal } from "@/utils/checkout";
-
-async function loadSubscription(context: { runtimeConfig: { commercialMode: boolean }; fetchApi: <T>(path: string, init?: RequestInit) => Promise<T> }) {
-  if (!context.runtimeConfig.commercialMode) return undefined;
-  try {
-    return await fetchSubscriptionStateWithApi(context.fetchApi);
-  } catch (error) {
-    console.error("[subscription] settings loader preload failed, deferring to the client read:", error);
-    return undefined;
-  }
-}
 
 export const Route = createFileRoute("/(dashboard)/dashboard/settings/")({
   loader: async ({ context }) => {
-    const [authCapabilities, subscription] = await Promise.all([
-      fetchAuthCapabilitiesWithApi(context.fetchApi),
-      loadSubscription(context),
-    ]);
-    return { authCapabilities, subscription };
+    const authCapabilities = await fetchAuthCapabilitiesWithApi(context.fetchApi);
+    return { authCapabilities };
   },
   component: SettingsPage,
 });
 
 function SettingsPage() {
-  const { authCapabilities, subscription: loaderSubscription } = Route.useLoaderData();
+  const { authCapabilities } = Route.useLoaderData();
   const { user } = useSession();
   const navigate = useNavigate();
   const passwordRef = useRef<HTMLInputElement>(null);
@@ -77,11 +59,6 @@ function SettingsPage() {
       : (user?.email ?? "");
   const { data: apiTokens = [] } = useApiTokens();
   const { data: passkeys = [] } = usePasskeys(authCapabilities.supportsPasskeys);
-  const { data: subscription, isLoading: subscriptionLoading } = useSubscription({
-    fallbackData: loaderSubscription,
-  });
-  const isPro = subscription?.plan === "pro";
-  const [isManaging, setIsManaging] = useState(false);
   const analyticsConsent = useEffectiveConsent();
   const handleAnalyticsToggle = useCallback((checked: boolean) => {
     track(ANALYTICS_EVENTS.analytics_consent_changed, { granted: checked });
@@ -91,18 +68,6 @@ function SettingsPage() {
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
-  const handleManagePlan = async () => {
-    if (!isPro) {
-      navigate({ to: "/dashboard/upgrade" });
-      return;
-    }
-    setIsManaging(true);
-    try {
-      await openCustomerPortal();
-    } catch {
-      setIsManaging(false);
-    }
-  };
 
 
   const handleDeleteAccount = async () => {
@@ -179,17 +144,6 @@ function SettingsPage() {
           <NavigationMenuItemLabel>Analytics Cookies</NavigationMenuItemLabel>
         </NavigationMenuToggleItem>
       </NavigationMenu>
-      {getCommercialMode() && (
-        <NavigationMenu variant={isPro ? "default" : "highlight"}>
-          <NavigationMenuButtonItem onClick={handleManagePlan} disabled={isManaging || subscriptionLoading}>
-            <NavigationMenuItemIcon>
-              {isPro ? <CreditCard size={15} /> : <Sparkles size={15} />}
-            </NavigationMenuItemIcon>
-            <NavigationMenuItemLabel>{isPro ? "Manage Plan" : "Upgrade to Pro"}</NavigationMenuItemLabel>
-            <NavigationMenuItemTrailing />
-          </NavigationMenuButtonItem>
-        </NavigationMenu>
-      )}
       <NavigationMenu>
         <NavigationMenuButtonItem onClick={() => setDeleteOpen(true)}>
           <NavigationMenuItemIcon>

--- a/applications/web/tests/routes/subscription-route-loaders.test.ts
+++ b/applications/web/tests/routes/subscription-route-loaders.test.ts
@@ -288,6 +288,26 @@ describe("dashboard route loader", () => {
     expect(errorSpy).toHaveBeenCalled();
   });
 
+  it("reports commercial mode from the loader, so the row server-renders", async () => {
+    const { fetchApi } = createApi((path) =>
+      path === CUSTOMER_STATE_PATH ? new HttpError(500, path) : { plan: "pro" },
+    );
+
+    const data = (await runDashboardLoader(fetchApi)) as { commercialMode: unknown };
+
+    expect(data.commercialMode).toBe(true);
+  });
+
+  it("reports commercial mode as off without reaching for the window", async () => {
+    const { fetchApi } = createApi(() => ({}));
+
+    const data = (await runDashboardLoader(fetchApi, { commercialMode: false })) as {
+      commercialMode: unknown;
+    };
+
+    expect(data.commercialMode).toBe(false);
+  });
+
   it("does not read the plan at all outside commercial mode", async () => {
     const { calls, fetchApi } = createApi(() => ({}));
 

--- a/applications/web/tests/routes/subscription-route-loaders.test.ts
+++ b/applications/web/tests/routes/subscription-route-loaders.test.ts
@@ -3,11 +3,13 @@ import { isRedirect } from "@tanstack/react-router";
 import { HttpError } from "../../src/lib/fetcher";
 import { Route as UpgradeRoute } from "../../src/routes/(dashboard)/dashboard/upgrade/index";
 import { Route as SettingsRoute } from "../../src/routes/(dashboard)/dashboard/settings/index";
+import { Route as DashboardRoute } from "../../src/routes/(dashboard)/dashboard/index";
 
 type RouteOptions = { options: Record<string, unknown> };
 
 const upgradeRoute = UpgradeRoute as unknown as RouteOptions;
 const settingsRoute = SettingsRoute as unknown as RouteOptions;
+const dashboardRoute = DashboardRoute as unknown as RouteOptions;
 
 const CUSTOMER_STATE_PATH = "/api/auth/customer/state";
 const ENTITLEMENTS_PATH = "/api/entitlements";
@@ -56,6 +58,16 @@ const runSettingsLoader = async (
   { commercialMode = true } = {},
 ) => {
   const loader = settingsRoute.options.loader as (args: unknown) => Promise<unknown>;
+  return loader({
+    context: { fetchApi, runtimeConfig: { commercialMode } },
+  });
+};
+
+const runDashboardLoader = async (
+  fetchApi: <T>(path: string) => Promise<T>,
+  { commercialMode = true } = {},
+) => {
+  const loader = dashboardRoute.options.loader as (args: unknown) => Promise<unknown>;
   return loader({
     context: { fetchApi, runtimeConfig: { commercialMode } },
   });
@@ -225,72 +237,76 @@ describe("settings route loader", () => {
     (path, callIndex) =>
       path === CAPABILITIES_PATH ? capabilitiesBody : respond(path, callIndex);
 
-  it("preloads a paying customer as pro through the fallback", async () => {
-    const { calls, fetchApi } = createApi(
-      respondWithCapabilities((path) =>
-        path === CUSTOMER_STATE_PATH ? new HttpError(500, path) : { plan: "pro" },
-      ),
+  it("still renders the page when the plan reads are down", async () => {
+    const { fetchApi } = createApi(
+      respondWithCapabilities((path) => new HttpError(503, path)),
     );
 
-    const data = (await runSettingsLoader(fetchApi)) as {
-      subscription: unknown;
-    };
+    const data = (await runSettingsLoader(fetchApi)) as { authCapabilities: unknown };
+
+    expect(data.authCapabilities).toMatchObject({ credentialMode: "email" });
+  });
+
+  it("no longer reads the plan, which the dashboard preloads instead", async () => {
+    const { calls, fetchApi } = createApi(respondWithCapabilities(() => ({})));
+
+    await runSettingsLoader(fetchApi);
+
+    expect(calls).toEqual([CAPABILITIES_PATH]);
+  });
+});
+
+describe("dashboard route loader", () => {
+  it("preloads a paying customer as pro through the fallback", async () => {
+    const { calls, fetchApi } = createApi((path) =>
+      path === CUSTOMER_STATE_PATH ? new HttpError(500, path) : { plan: "pro" },
+    );
+
+    const data = (await runDashboardLoader(fetchApi)) as { subscription: unknown };
 
     expect(data.subscription).toEqual({ plan: "pro", interval: null });
     expect(calls).toContain(ENTITLEMENTS_PATH);
   });
 
   it("never preloads a plan the fallback did not actually report", async () => {
-    const { fetchApi } = createApi(
-      respondWithCapabilities((path) =>
-        path === CUSTOMER_STATE_PATH ? new HttpError(500, path) : { plan: "enterprise" },
-      ),
+    const { fetchApi } = createApi((path) =>
+      path === CUSTOMER_STATE_PATH ? new HttpError(500, path) : { plan: "enterprise" },
     );
 
-    const data = (await runSettingsLoader(fetchApi)) as {
-      subscription: unknown;
-    };
+    const data = (await runDashboardLoader(fetchApi)) as { subscription: unknown };
 
     expect(data.subscription).toBeUndefined();
     expect(errorSpy).toHaveBeenCalled();
   });
 
   it("still renders the page when both plan reads are down", async () => {
-    const { fetchApi } = createApi(
-      respondWithCapabilities((path) => new HttpError(503, path)),
-    );
+    const { fetchApi } = createApi((path) => new HttpError(503, path));
 
-    const data = (await runSettingsLoader(fetchApi)) as {
-      authCapabilities: unknown;
-      subscription: unknown;
-    };
+    const data = (await runDashboardLoader(fetchApi)) as { subscription: unknown };
 
-    expect(data.authCapabilities).toMatchObject({ credentialMode: "email" });
     expect(data.subscription).toBeUndefined();
     expect(errorSpy).toHaveBeenCalled();
   });
 
   it("does not read the plan at all outside commercial mode", async () => {
-    const { calls, fetchApi } = createApi(respondWithCapabilities(() => ({})));
+    const { calls, fetchApi } = createApi(() => ({}));
 
-    const data = (await runSettingsLoader(fetchApi, { commercialMode: false })) as {
+    const data = (await runDashboardLoader(fetchApi, { commercialMode: false })) as {
       subscription: unknown;
     };
 
     expect(data.subscription).toBeUndefined();
-    expect(calls).toEqual([CAPABILITIES_PATH]);
+    expect(calls).toEqual([]);
   });
 
   it("converges on the same preload across repeated runs during the outage", async () => {
     const results: unknown[] = [];
 
     for (let run = 0; run < 3; run += 1) {
-      const { fetchApi } = createApi(
-        respondWithCapabilities((path) =>
-          path === CUSTOMER_STATE_PATH ? new HttpError(429, path) : { plan: "pro" },
-        ),
+      const { fetchApi } = createApi((path) =>
+        path === CUSTOMER_STATE_PATH ? new HttpError(429, path) : { plan: "pro" },
       );
-      const data = (await runSettingsLoader(fetchApi)) as { subscription: unknown };
+      const data = (await runDashboardLoader(fetchApi)) as { subscription: unknown };
       results.push(data.subscription);
     }
 
@@ -298,11 +314,9 @@ describe("settings route loader", () => {
   });
 
   it("does not send a paying customer to a login screen it cannot reach when the session expires", async () => {
-    const { fetchApi } = createApi(
-      respondWithCapabilities((path) => new HttpError(401, path)),
-    );
+    const { fetchApi } = createApi((path) => new HttpError(401, path));
 
-    const data = (await runSettingsLoader(fetchApi)) as { subscription: unknown };
+    const data = (await runDashboardLoader(fetchApi)) as { subscription: unknown };
 
     expect(data.subscription).toBeUndefined();
   });


### PR DESCRIPTION
Upgrading was only reachable by first walking into a locked feature and following the link inside its gate, so a free user who has not tried a Pro feature yet has nowhere to go. This adds a persistent **Upgrade to Pro** row on the dashboard, in its own group between the feedback group and the accounts and settings group.

It renders only in commercial mode and only while the plan is `free`, so self-hosted instances and existing Pro users never see it.

The links inside `PremiumFeatureGate` and `UpgradeHint` are left alone: they name the specific feature that is locked, and removing them would leave those gates without an action.