### PR TITLE
perf(cron): raise the per-family ingest concurrency to 20

### DIFF
--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -68,7 +68,7 @@ import { selectIngestWideEventFields } from "@/utils/ingest-wide-event";
 
 const SOURCE_TIMEOUT_MS = INGEST_SOURCE_TIMEOUT_MS;
 const SOURCE_TIMEOUT_DATABASE_GRACE_MS = 5000;
-const SOURCE_CONCURRENCY = 5;
+const SOURCE_CONCURRENCY = 20;
 const SOURCE_INGEST_LOCK_KEY_PREFIX = "source-ingest:";
 
 /*


### PR DESCRIPTION
`SOURCE_CONCURRENCY` gates each provider family's ingest fan-out. At 5, a full-fleet pass cannot finish inside its own one-minute period — roughly 1,600 OAuth deltas at ~0.5s is ~160s of wall time at 5 slots, and ~150 CalDAV calls at ~9s is ~270s — so passes overlap continuously and a calendar can wait minutes for a slot. A new account measured an 8m36s wait this morning and churned before its first ingest ran.

The cap is not a resource limit. Across 400 ingests the rate limiter peaked at 19.4ms, the refresh lock at 180.7ms and the database pool at 46.8ms; essentially all elapsed time is provider HTTP, and the ingest holds a Redis skip-lock rather than a database connection across that call.

The three families run concurrently, so this takes the effective fan-out from ~15 to ~60.

This does not fix the structural problem — dispatch is still fused with execution inside the cron tick, so one slow fetch still holds a batch at its makespan. It buys room while that is addressed.

**Watch after deploy:** `concurrency.slot_wait_ms` should collapse. Watch `wait.db_pool_ms` against the 10-connection pool, and watch for Graph `MailboxConcurrency` (limit 4 per mailbox) errors — concurrency is global, not per account, so an account with more than four calendars in one batch can now exceed it more often than it did at 5.