### PR TITLE
revert(cron): return ingest concurrency to 5

### DIFF
--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -68,7 +68,7 @@ import { selectIngestWideEventFields } from "@/utils/ingest-wide-event";
 
 const SOURCE_TIMEOUT_MS = INGEST_SOURCE_TIMEOUT_MS;
 const SOURCE_TIMEOUT_DATABASE_GRACE_MS = 5000;
-const SOURCE_CONCURRENCY = 20;
+const SOURCE_CONCURRENCY = 5;
 const SOURCE_INGEST_LOCK_KEY_PREFIX = "source-ingest:";
 
 /*


### PR DESCRIPTION
Reverts #849.

Raising `SOURCE_CONCURRENCY` to 20 moved the bottleneck from the slot queue onto the database pool, which has 10 connections against roughly 60 effective concurrent ingests.

Measured after deploy:

| | before | +15 min | now |
|---|---|---|---|
| slot_wait_ms median | 338,806 | 25,209 | 24,607 |
| db_pool_ms median | 2.4 | 15,309 | 68,776 |
| ingest duration median | — | — | 72,678 |
| error rate | 9% | 55% | 53% |

The slot wait did fall as intended, from 5m39s to about 25s. But jobs now spend a median of 69 seconds waiting for a database connection and are pushed into their 120s timeout, so the work does not complete. Errors are `db-connection-unavailable`, `db-statement-timeout` and `provider-request-timeout`.

Reverting restores the previous behaviour, which is slow but completes.

The pool ceiling has to be raised alongside any concurrency increase, and that needs checking against the RDS instance's own `max_connections` before it is attempted again.