### PR TITLE
perf(database): size each service's connection pool for its own workload

### DIFF
--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -35,6 +35,7 @@ services:
     env_file: .env
     environment:
       ENV: production
+      DATABASE_POOL_MAX: "15"
       NODE_EXTRA_CA_CERTS: /certs/global-bundle.pem
       BLOCK_PRIVATE_RESOLUTION: "true"
     volumes:
@@ -55,6 +56,7 @@ services:
     env_file: .env
     environment:
       ENV: production
+      DATABASE_POOL_MAX: "25"
       NODE_EXTRA_CA_CERTS: /certs/global-bundle.pem
       WORKER_JOB_QUEUE_ENABLED: "true"
       BLOCK_PRIVATE_RESOLUTION: "true"
@@ -71,6 +73,7 @@ services:
     env_file: .env
     environment:
       ENV: production
+      DATABASE_POOL_MAX: "25"
       NODE_EXTRA_CA_CERTS: /certs/global-bundle.pem
     volumes:
       - ./global-bundle.pem:/certs/global-bundle.pem:ro
@@ -87,6 +90,7 @@ services:
     env_file: .env
     environment:
       ENV: production
+      DATABASE_POOL_MAX: "5"
       NODE_EXTRA_CA_CERTS: /certs/global-bundle.pem
     volumes:
       - ./global-bundle.pem:/certs/global-bundle.pem:ro

--- a/packages/database/src/utils/database.ts
+++ b/packages/database/src/utils/database.ts
@@ -6,6 +6,7 @@ import { instrumentDatabasePool } from "./pool-telemetry";
 interface DatabasePoolOptions {
   statementTimeoutMs?: number;
   idleInTransactionTimeoutMs?: number;
+  maxConnections?: number;
 }
 
 const DEFAULT_STATEMENT_TIMEOUT_MS = 30_000;
@@ -74,6 +75,7 @@ const waitForConnection = async (database: DatabaseInstance): Promise<void> => {
 };
 
 const createDatabase = async (url: string, options?: DatabasePoolOptions): Promise<DatabaseInstance> => {
+  const maxConnections = options?.maxConnections ?? POOL_MAX_CONNECTIONS;
   const statementTimeoutMs = options?.statementTimeoutMs ?? DEFAULT_STATEMENT_TIMEOUT_MS;
   const idleInTransactionTimeoutMs =
     options?.idleInTransactionTimeoutMs ?? DEFAULT_IDLE_IN_TRANSACTION_TIMEOUT_MS;
@@ -81,7 +83,7 @@ const createDatabase = async (url: string, options?: DatabasePoolOptions): Promi
   const database = drizzle({
     connection: {
       url: connectionUrl,
-      max: POOL_MAX_CONNECTIONS,
+      max: maxConnections,
       idleTimeout: POOL_IDLE_TIMEOUT_SECONDS,
       maxLifetime: POOL_MAX_LIFETIME_SECONDS,
       prepare: PREPARED_STATEMENTS_ENABLED,
@@ -89,7 +91,7 @@ const createDatabase = async (url: string, options?: DatabasePoolOptions): Promi
   });
   instrumentDatabasePool(
     database.$client as unknown as Parameters<typeof instrumentDatabasePool>[0],
-    POOL_MAX_CONNECTIONS,
+    maxConnections,
   );
   await waitForConnection(database);
   return database;

--- a/services/api/src/context.ts
+++ b/services/api/src/context.ts
@@ -17,7 +17,7 @@ import type { OAuthStateStore, RefreshLockStore, DestinationSyncResult } from "@
 
 const MIN_TRUSTED_ORIGINS_COUNT = 0;
 
-const database = await createDatabase(env.DATABASE_URL);
+const database = await createDatabase(env.DATABASE_URL, { maxConnections: env.DATABASE_POOL_MAX });
 const redis = new Redis(env.REDIS_URL, {
   commandTimeout: 10_000,
   maxRetriesPerRequest: 3,

--- a/services/api/src/env.ts
+++ b/services/api/src/env.ts
@@ -5,6 +5,7 @@ const schema = {
   BETTER_AUTH_SECRET: "string",
   BETTER_AUTH_URL: "string.url",
   COMMERCIAL_MODE: "boolean?",
+  DATABASE_POOL_MAX: "number?",
   DATABASE_URL: "string.url",
   ENCRYPTION_KEY: "string?",
   FEEDBACK_EMAIL: "string?",

--- a/services/cron/src/context.ts
+++ b/services/cron/src/context.ts
@@ -6,7 +6,7 @@ import { resolveWebhookConfig } from "@keeper.sh/calendar";
 import type { RefreshLockStore } from "@keeper.sh/calendar";
 import { Polar } from "@polar-sh/sdk";
 
-const database = await createDatabase(env.DATABASE_URL);
+const database = await createDatabase(env.DATABASE_URL, { maxConnections: env.DATABASE_POOL_MAX });
 const webhookConfig = resolveWebhookConfig(env.WEBHOOK_PUBLIC_URL);
 
 const premiumService = createPremiumService({

--- a/services/cron/src/env.ts
+++ b/services/cron/src/env.ts
@@ -5,6 +5,7 @@ const schema = {
   BLOCK_PRIVATE_RESOLUTION: "boolean?",
   CALENDAR_REDISCOVERY_ENABLED: "boolean?",
   COMMERCIAL_MODE: "boolean?",
+  DATABASE_POOL_MAX: "number?",
   DATABASE_URL: "string.url",
   ENCRYPTION_KEY: "string?",
   GOOGLE_CLIENT_ID: "string?",

--- a/services/mcp/src/context.ts
+++ b/services/mcp/src/context.ts
@@ -5,7 +5,7 @@ import { createKeeperMcpHandler } from "./mcp-handler";
 import { createKeeperMcpToolset } from "./toolset";
 import { withWideEvent } from "./utils/middleware";
 
-const database = await createDatabase(env.DATABASE_URL);
+const database = await createDatabase(env.DATABASE_URL, { maxConnections: env.DATABASE_POOL_MAX });
 
 const { auth: baseAuth } = createAuth({
   database,

--- a/services/mcp/src/env.ts
+++ b/services/mcp/src/env.ts
@@ -4,6 +4,7 @@ const schema = {
   BETTER_AUTH_SECRET: "string",
   BETTER_AUTH_URL: "string.url",
   COMMERCIAL_MODE: "boolean?",
+  DATABASE_POOL_MAX: "number?",
   DATABASE_URL: "string.url",
   MCP_API_URL: "string.url?",
   MCP_PORT: "number",

--- a/services/worker/src/context.ts
+++ b/services/worker/src/context.ts
@@ -3,7 +3,7 @@ import { createDatabase } from "@keeper.sh/database";
 import Redis from "ioredis";
 import type { RefreshLockStore } from "@keeper.sh/calendar";
 
-const database = await createDatabase(env.DATABASE_URL);
+const database = await createDatabase(env.DATABASE_URL, { maxConnections: env.DATABASE_POOL_MAX });
 
 const REDIS_COMMAND_TIMEOUT_MS = 10_000;
 const REDIS_MAX_RETRIES = 3;

--- a/services/worker/src/env.ts
+++ b/services/worker/src/env.ts
@@ -1,6 +1,7 @@
 import arkenv from "arkenv";
 
 const schema = {
+  DATABASE_POOL_MAX: "number?",
   DATABASE_URL: "string.url",
   ENCRYPTION_KEY: "string?",
   GOOGLE_CLIENT_ID: "string?",


### PR DESCRIPTION
Every service builds its pool from the same `POOL_MAX_CONNECTIONS = 10`. During the concurrency-20 experiment (#849) that produced `db-connection-unavailable` at 2.0/min and pushed jobs into their deadlines (`provider-request-timeout` 6.25/min): cron wants far more than 10 connections under burst, while mcp needs almost none.

`createDatabase` now takes `maxConnections`, each service reads it from `DATABASE_POOL_MAX`, and the default stays 10 so self-hosted deployments — some of which run Postgres with a small `max_connections` — see no change. The deploy compose sets api 15, cron 25, worker 25, mcp 5.

**Sizing, from production measurements** (Loki, 16:09–16:20 UTC today, concurrency 20):

- Connection hold per ingest (advisory lock + read + write + commit + diff): p50 ≈ 100–200 ms, mean ≈ 300 ms under burst, p99 2–13 s.
- Burst arrival rate ≈ 20 ingests/s → average demand ≈ 6 connections (Little's law), but the p99 tail parks several connections at a time, so the pool must cover average demand plus tail-holders with margin: ≈ 12, doubled to 25.
- Worker matches its BullMQ concurrency of 25 — it bursts together with cron, since ingest completions enqueue destination syncs.
- The RDS ceiling is 189 (`SHOW max_connections`), with 8 local and ~3 reserved: ~178 usable. This allocation totals 70 (~39%), leaving room for migrations and a second app instance later; a uniform raise to 40 would have reached 90% for no measured benefit.

**Watch after deploy** (with ingest concurrency back at 5 once the failed #850 deploy ships, or at 20 if #849 is restored): `wait.db_pool_ms` p90 and the `db-connection-unavailable` / `provider-request-timeout` rates. RDS `DatabaseConnections` should settle near 40–75.