### PR TITLE
perf(cron): ingest calendars that have never been ingested first

### DIFF
--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -48,7 +48,7 @@ import {
   oauthCredentialsTable,
   sourceDestinationMappingsTable,
 } from "@keeper.sh/database/schema";
-import { and, arrayContains, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
+import { and, arrayContains, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
 import { withCronWideEvent } from "@/utils/with-wide-event";
 import { context, widelog } from "@/utils/logging";
 import { database, refreshLockRedis, refreshLockStore } from "@/context";
@@ -855,7 +855,16 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
         eq(calendarsTable.disabled, false),
         ...buildOAuthSourceIdFilter(calendarIds),
       ),
-    );
+    )
+  /*
+   * A calendar that has never completed an ingest goes to the front of the pass.
+   * The listing is otherwise unordered, which in practice is heap order: a calendar
+   * connected a minute ago sits behind the whole fleet, and a new user's first
+   * ingest is the one wait they judge the product by. ingestWindowRecordedAt is
+   * written by the first successful ingest of every source family, so null here
+   * means exactly "never ingested".
+   */
+    .orderBy(desc(isNull(calendarsTable.ingestWindowRecordedAt)));
 
   const settlements = await allSettledWithConcurrency(
     oauthSources.map((source) => {
@@ -1071,7 +1080,8 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
         arrayContains(calendarsTable.capabilities, ["pull"]),
         eq(calendarsTable.disabled, false),
       ),
-    );
+    )
+    .orderBy(desc(isNull(calendarsTable.ingestWindowRecordedAt)));
 
   const settlements = await allSettledWithConcurrency(
     caldavSources.map((source) => {
@@ -1229,7 +1239,8 @@ const ingestIcsSources = async (): Promise<IngestionBatchResult> => {
         eq(calendarsTable.calendarType, "ical"),
         eq(calendarsTable.disabled, false),
       ),
-    );
+    )
+    .orderBy(desc(isNull(calendarsTable.ingestWindowRecordedAt)));
 
   const settlements = await allSettledWithConcurrency(
     icsSources.map((source) => {

--- a/services/cron/tests/jobs/ingest-sources-selection.test.ts
+++ b/services/cron/tests/jobs/ingest-sources-selection.test.ts
@@ -1,10 +1,17 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { and, arrayContains, eq, inArray } from "drizzle-orm";
+import { and, arrayContains, desc, eq, inArray, isNull } from "drizzle-orm";
 import { calendarsTable } from "@keeper.sh/database/schema";
+import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 import type { ingestOAuthSources as ingestOAuthSourcesFn } from "../../src/jobs/ingest-sources";
 
 const capturedPredicates: unknown[] = [];
+const capturedOrderings: unknown[] = [];
 
+/*
+ * A real resolved promise carrying an orderBy method comes back from where(): the
+ * listing queries chain into orderBy(), while other selects in the same job
+ * stop at where() or limit() and are awaited directly.
+ */
 const createQueryBuilder = () => {
   const builder: Record<string, unknown> = {};
   const chain = (): unknown => builder;
@@ -15,7 +22,12 @@ const createQueryBuilder = () => {
   builder.limit = () => Promise.resolve([]);
   builder.where = (predicate: unknown) => {
     capturedPredicates.push(predicate);
-    return Promise.resolve([]);
+    return Object.assign(Promise.resolve([]), {
+      orderBy: (ordering: unknown) => {
+        capturedOrderings.push(ordering);
+        return Promise.resolve([]);
+      },
+    });
   };
 
   return builder;
@@ -28,8 +40,10 @@ const fakeDatabase = {
 
 let ingestOAuthSources: typeof ingestOAuthSourcesFn = () =>
   Promise.reject(new Error("Module not loaded"));
+let job: typeof ingestSourcesJob | null = null;
 
-vi.mock("../../src/env", () => ({ default: {} }));
+/* ENCRYPTION_KEY set so the CalDAV family does not early-return before its listing. */
+vi.mock("../../src/env", () => ({ default: { ENCRYPTION_KEY: "test-key" } }));
 vi.mock("../../src/context", () => ({
   database: fakeDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },
@@ -53,11 +67,14 @@ vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
 }));
 
 beforeAll(async () => {
-  ({ ingestOAuthSources } = await import("../../src/jobs/ingest-sources"));
+  const module = await import("../../src/jobs/ingest-sources");
+  ({ ingestOAuthSources } = module);
+  job = module.default;
 });
 
 beforeEach(() => {
   capturedPredicates.length = 0;
+  capturedOrderings.length = 0;
 });
 
 describe("ingestOAuthSources selection", () => {
@@ -86,5 +103,23 @@ describe("ingestOAuthSources selection", () => {
     await ingestOAuthSources([]);
 
     expect(capturedPredicates).toHaveLength(0);
+  });
+
+  it("puts calendars that have never completed an ingest at the front", async () => {
+    await ingestOAuthSources();
+
+    expect(capturedOrderings).toEqual([
+      desc(isNull(calendarsTable.ingestWindowRecordedAt)),
+    ]);
+  });
+
+  it("orders every source family the same way", async () => {
+    await job?.callback();
+
+    expect(capturedOrderings).toEqual([
+      desc(isNull(calendarsTable.ingestWindowRecordedAt)),
+      desc(isNull(calendarsTable.ingestWindowRecordedAt)),
+      desc(isNull(calendarsTable.ingestWindowRecordedAt)),
+    ]);
   });
 });


### PR DESCRIPTION
Connecting an account does not trigger an ingest — it enqueues a destination push, which has nothing to copy until the cron rotation reaches the new calendars. The fleet listings carry no `ORDER BY`, so Postgres returns heap order and a calendar connected a minute ago sits behind the entire fleet. The user who churned this morning waited 14m38s for a first ingest *attempt* and left at 6m54s; every `sync:calendar` pass in between reported `in-sync` over zero events.

The 10-second doorbell (`push:pending-ingest`) is not the right vehicle: it is push-notification machinery — per-channel failure budgets and a deliberate pro-only gate — and every new signup is on the free plan.

Instead, each family's listing now orders by `ingestWindowRecordedAt IS NULL DESC`. That column is written inside the persistence transaction by the first successful ingest of every source family (Google, Outlook, CalDAV, ICS all report coverage), so null means exactly "never ingested". A pass starts every minute with its own concurrency slots, so a newly connected calendar is picked up within ~60s and takes a slot at the front instead of queueing behind the fleet.

No migration, no new state, no plan-gate questions. Veterans keep their existing (arbitrary) relative order.

Tests extend `ingest-sources-selection.test.ts`: the fake builder now carries the orderBy chain, one test pins the OAuth ordering, and one runs the whole job callback and pins the identical ordering across all three families (the CalDAV family early-returns without `ENCRYPTION_KEY`, so the env mock provides one). Negative control: removing any one family's `orderBy` fails the suite.

Worth knowing: an empty-but-live calendar still records coverage on first ingest, so nothing stays in the priority band forever.