### PR TITLE
perf(cron): schedule ingest by user, pro users first

### DIFF
--- a/packages/calendar/src/core/utils/concurrency.ts
+++ b/packages/calendar/src/core/utils/concurrency.ts
@@ -51,13 +51,6 @@ interface AllSettledGroupedOptions {
   taskConcurrency?: number;
 }
 
-/*
- * Like allSettledWithConcurrency, but the unit of scheduling is the group: up to
- * groupConcurrency groups run at once, and each group runs its own tasks at
- * taskConcurrency. One group with many tasks occupies one group slot rather than
- * the whole budget, so no key can starve the others. Results come back in the
- * original task order, because callers pair settlements to inputs by index.
- */
 const allSettledGroupedWithConcurrency = async <TResult>(
   tasks: (() => Promise<TResult>)[],
   groupKeys: string[],
@@ -76,10 +69,7 @@ const allSettledGroupedWithConcurrency = async <TResult>(
 
   const results: PromiseSettledResult<TResult>[] = Array.from({ length: tasks.length });
   const groupTasks = [...groupedIndexes.values()].map((indexes) => async () => {
-    /*
-     * Kept indexes and tasks stay paired: filtering tasks alone would shift every
-     * later settlement onto the wrong index, and callers attribute by index.
-     */
+    /* Callers attribute by index, so settlements must stay paired to their input index. */
     const keptIndexes = indexes.filter((index) => Boolean(tasks[index]));
     const settled = await allSettledWithConcurrency(
       keptIndexes.flatMap((index) => {

--- a/packages/calendar/src/core/utils/concurrency.ts
+++ b/packages/calendar/src/core/utils/concurrency.ts
@@ -46,5 +46,60 @@ const allSettledWithConcurrency = async <TResult>(
   return results;
 };
 
-export { allSettledWithConcurrency };
-export type { AllSettledWithConcurrencyOptions };
+interface AllSettledGroupedOptions {
+  groupConcurrency?: number;
+  taskConcurrency?: number;
+}
+
+/*
+ * Like allSettledWithConcurrency, but the unit of scheduling is the group: up to
+ * groupConcurrency groups run at once, and each group runs its own tasks at
+ * taskConcurrency. One group with many tasks occupies one group slot rather than
+ * the whole budget, so no key can starve the others. Results come back in the
+ * original task order, because callers pair settlements to inputs by index.
+ */
+const allSettledGroupedWithConcurrency = async <TResult>(
+  tasks: (() => Promise<TResult>)[],
+  groupKeys: string[],
+  options: AllSettledGroupedOptions = {},
+): Promise<PromiseSettledResult<TResult>[]> => {
+  const groupedIndexes = new Map<string, number[]>();
+  for (let index = 0; index < tasks.length; index++) {
+    const key = groupKeys[index] ?? "";
+    const bucket = groupedIndexes.get(key);
+    if (bucket) {
+      bucket.push(index);
+    } else {
+      groupedIndexes.set(key, [index]);
+    }
+  }
+
+  const results: PromiseSettledResult<TResult>[] = Array.from({ length: tasks.length });
+  const groupTasks = [...groupedIndexes.values()].map((indexes) => async () => {
+    const groupTaskList = indexes.flatMap((index) => {
+      const task = tasks[index];
+      if (!task) {
+        return [];
+      }
+      return [task];
+    });
+    const settled = await allSettledWithConcurrency(groupTaskList, {
+      concurrency: options.taskConcurrency ?? DEFAULT_CONCURRENCY,
+    });
+    for (const [position, settlement] of settled.entries()) {
+      const originalIndex = indexes[position];
+      if (typeof originalIndex === "number" && settlement) {
+        results[originalIndex] = settlement;
+      }
+    }
+  });
+
+  await allSettledWithConcurrency(groupTasks, {
+    concurrency: options.groupConcurrency ?? DEFAULT_CONCURRENCY,
+  });
+
+  return results;
+};
+
+export { allSettledGroupedWithConcurrency, allSettledWithConcurrency };
+export type { AllSettledGroupedOptions, AllSettledWithConcurrencyOptions };

--- a/packages/calendar/src/core/utils/concurrency.ts
+++ b/packages/calendar/src/core/utils/concurrency.ts
@@ -76,18 +76,23 @@ const allSettledGroupedWithConcurrency = async <TResult>(
 
   const results: PromiseSettledResult<TResult>[] = Array.from({ length: tasks.length });
   const groupTasks = [...groupedIndexes.values()].map((indexes) => async () => {
-    const groupTaskList = indexes.flatMap((index) => {
-      const task = tasks[index];
-      if (!task) {
-        return [];
-      }
-      return [task];
-    });
-    const settled = await allSettledWithConcurrency(groupTaskList, {
-      concurrency: options.taskConcurrency ?? DEFAULT_CONCURRENCY,
-    });
+    /*
+     * Kept indexes and tasks stay paired: filtering tasks alone would shift every
+     * later settlement onto the wrong index, and callers attribute by index.
+     */
+    const keptIndexes = indexes.filter((index) => Boolean(tasks[index]));
+    const settled = await allSettledWithConcurrency(
+      keptIndexes.flatMap((index) => {
+        const task = tasks[index];
+        if (!task) {
+          return [];
+        }
+        return [task];
+      }),
+      { concurrency: options.taskConcurrency ?? DEFAULT_CONCURRENCY },
+    );
     for (const [position, settlement] of settled.entries()) {
-      const originalIndex = indexes[position];
+      const originalIndex = keptIndexes[position];
       if (typeof originalIndex === "number" && settlement) {
         results[originalIndex] = settlement;
       }

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -142,7 +142,7 @@ export {
 } from "./ics/utils/timezone-instant";
 export { RateLimiter, type RateLimiterConfig } from "./core/utils/rate-limiter";
 export { createGoogleUserRateLimiter, createRedisRateLimiter, type RedisRateLimiter, type RedisRateLimiterConfig } from "./core/utils/redis-rate-limiter";
-export { allSettledWithConcurrency, type AllSettledWithConcurrencyOptions } from "./core/utils/concurrency";
+export { allSettledGroupedWithConcurrency, allSettledWithConcurrency, type AllSettledGroupedOptions, type AllSettledWithConcurrencyOptions } from "./core/utils/concurrency";
 export { getErrorMessage } from "./core/utils/error";
 export {
   buildCalendarBackoffState,

--- a/packages/calendar/tests/core/utils/grouped-concurrency.test.ts
+++ b/packages/calendar/tests/core/utils/grouped-concurrency.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { allSettledGroupedWithConcurrency } from "../../../src/core/utils/concurrency";
+
+const settle = (delayMs: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+
+describe("allSettledGroupedWithConcurrency", () => {
+  it("returns settlements in the original task order", async () => {
+    const tasks = [3, 1, 4, 1, 5].map((value, index) => async () => {
+      await settle(value);
+      return index;
+    });
+
+    const results = await allSettledGroupedWithConcurrency(
+      tasks,
+      ["b", "a", "b", "a", "c"],
+      { groupConcurrency: 2, taskConcurrency: 1 },
+    );
+
+    expect(results.map((result) => result.status === "fulfilled" && result.value))
+      .toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("never runs one group's tasks past its own cap", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const tasks = Array.from({ length: 6 }, () => async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await settle(10);
+      inFlight -= 1;
+    });
+
+    await allSettledGroupedWithConcurrency(
+      tasks,
+      ["one-user", "one-user", "one-user", "one-user", "one-user", "one-user"],
+      { groupConcurrency: 5, taskConcurrency: 2 },
+    );
+
+    expect(peak).toBe(2);
+  });
+
+  it("lets other groups finish while a large group is still working", async () => {
+    const finished: string[] = [];
+    const slowGroup = Array.from({ length: 8 }, (_unused, index) => async () => {
+      await settle(15);
+      finished.push(`slow-${index}`);
+    });
+    const fastTask = async () => {
+      await settle(1);
+      finished.push("fast");
+    };
+
+    await allSettledGroupedWithConcurrency(
+      [...slowGroup, fastTask],
+      [...slowGroup.map(() => "hog"), "small"],
+      { groupConcurrency: 2, taskConcurrency: 1 },
+    );
+
+    expect(finished.indexOf("fast")).toBeLessThan(finished.indexOf("slow-2"));
+  });
+
+  it("isolates one task's rejection to its own settlement", async () => {
+    const results = await allSettledGroupedWithConcurrency(
+      [
+        () => Promise.resolve("first"),
+        () => Promise.reject(new Error("boom")),
+        () => Promise.resolve("third"),
+      ],
+      ["a", "a", "b"],
+      { groupConcurrency: 2, taskConcurrency: 2 },
+    );
+
+    expect(results.map((result) => result.status)).toEqual([
+      "fulfilled", "rejected", "fulfilled",
+    ]);
+  });
+});

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -75,8 +75,9 @@ const SOURCE_TIMEOUT_DATABASE_GRACE_MS = 5000;
  * one slot. A seventeen-calendar account occupies one slot instead of the whole
  * budget, so no user's backlog can starve another user's freshness. The per-user
  * cap is a per-pass budget against Graph's documented MailboxConcurrency of four,
- * not a hard ceiling: passes overlap (overrunProtection is off) and the skip-lock
- * is per calendar, so stacked slow passes can still reach the provider limit.
+ * not a hard ceiling: cron passes are serial (cronbake re-arms only after a pass
+ * completes), but webhook-driven syncs in the worker hit the same mailbox
+ * independently, so combined traffic can still reach the provider limit.
  */
 const SOURCE_CONCURRENCY = 5;
 const USER_CALENDAR_CONCURRENCY = 2;

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -69,17 +69,12 @@ import { selectIngestWideEventFields } from "@/utils/ingest-wide-event";
 
 const SOURCE_TIMEOUT_MS = INGEST_SOURCE_TIMEOUT_MS;
 const SOURCE_TIMEOUT_DATABASE_GRACE_MS = 5000;
+const SOURCE_CONCURRENCY = 5;
 /*
- * The unit of scheduling is the user: SOURCE_CONCURRENCY users ingest at once per
- * family, and each user's calendars run at USER_CALENDAR_CONCURRENCY within that
- * one slot. A seventeen-calendar account occupies one slot instead of the whole
- * budget, so no user's backlog can starve another user's freshness. The per-user
- * cap is a per-pass budget against Graph's documented MailboxConcurrency of four,
- * not a hard ceiling: cron passes are serial (cronbake re-arms only after a pass
- * completes), but webhook-driven syncs in the worker hit the same mailbox
+ * A per-pass budget against Graph's documented MailboxConcurrency of four, not a
+ * hard ceiling: webhook-driven syncs in the worker hit the same mailbox
  * independently, so combined traffic can still reach the provider limit.
  */
-const SOURCE_CONCURRENCY = 5;
 const USER_CALENDAR_CONCURRENCY = 2;
 const SOURCE_INGEST_LOCK_KEY_PREFIX = "source-ingest:";
 
@@ -870,14 +865,10 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
       ),
     )
   /*
-   * Two tiers, unordered within each: calendars that have never completed an
-   * ingest go first — a new user's first ingest is the one wait they judge the
-   * product by, and ingestWindowRecordedAt is written by the first successful
-   * ingest of every family, so null means exactly "never ingested". Pro users
-   * come next, so a pro calendar whose push notification was dropped is repaired
-   * within one pass rather than after the whole rotation. The plan is coalesced
-   * because most free users have no subscription row at all, and a bare NULL
-   * would sort ahead of 'pro' under DESC.
+   * Null ingestWindowRecordedAt means exactly "never ingested": it is written by
+   * the first successful ingest of every family. The plan is coalesced because most
+   * free users have no subscription row at all, and a bare NULL would sort ahead of
+   * 'pro' under DESC.
    */
     .orderBy(
       desc(isNull(calendarsTable.ingestWindowRecordedAt)),

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -74,8 +74,9 @@ const SOURCE_TIMEOUT_DATABASE_GRACE_MS = 5000;
  * family, and each user's calendars run at USER_CALENDAR_CONCURRENCY within that
  * one slot. A seventeen-calendar account occupies one slot instead of the whole
  * budget, so no user's backlog can starve another user's freshness. The per-user
- * cap also keeps concurrent calls per provider account under Graph's documented
- * MailboxConcurrency of four.
+ * cap is a per-pass budget against Graph's documented MailboxConcurrency of four,
+ * not a hard ceiling: passes overlap (overrunProtection is off) and the skip-lock
+ * is per calendar, so stacked slow passes can still reach the provider limit.
  */
 const SOURCE_CONCURRENCY = 5;
 const USER_CALENDAR_CONCURRENCY = 2;
@@ -868,16 +869,18 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
       ),
     )
   /*
-   * A calendar that has never completed an ingest goes to the front of the pass.
-   * The listing is otherwise unordered, which in practice is heap order: a calendar
-   * connected a minute ago sits behind the whole fleet, and a new user's first
-   * ingest is the one wait they judge the product by. ingestWindowRecordedAt is
-   * written by the first successful ingest of every source family, so null here
-   * means exactly "never ingested".
+   * Two tiers, unordered within each: calendars that have never completed an
+   * ingest go first — a new user's first ingest is the one wait they judge the
+   * product by, and ingestWindowRecordedAt is written by the first successful
+   * ingest of every family, so null means exactly "never ingested". Pro users
+   * come next, so a pro calendar whose push notification was dropped is repaired
+   * within one pass rather than after the whole rotation. The plan is coalesced
+   * because most free users have no subscription row at all, and a bare NULL
+   * would sort ahead of 'pro' under DESC.
    */
     .orderBy(
       desc(isNull(calendarsTable.ingestWindowRecordedAt)),
-      desc(sql`${userSubscriptionsTable.plan} = 'pro'`),
+      desc(sql`coalesce(${userSubscriptionsTable.plan}, 'free') = 'pro'`),
     );
 
   const settlements = await allSettledGroupedWithConcurrency(
@@ -1099,7 +1102,7 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
     )
     .orderBy(
       desc(isNull(calendarsTable.ingestWindowRecordedAt)),
-      desc(sql`${userSubscriptionsTable.plan} = 'pro'`),
+      desc(sql`coalesce(${userSubscriptionsTable.plan}, 'free') = 'pro'`),
     );
 
   const settlements = await allSettledGroupedWithConcurrency(
@@ -1263,7 +1266,7 @@ const ingestIcsSources = async (): Promise<IngestionBatchResult> => {
     )
     .orderBy(
       desc(isNull(calendarsTable.ingestWindowRecordedAt)),
-      desc(sql`${userSubscriptionsTable.plan} = 'pro'`),
+      desc(sql`coalesce(${userSubscriptionsTable.plan}, 'free') = 'pro'`),
     );
 
   const settlements = await allSettledGroupedWithConcurrency(

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -1,7 +1,7 @@
 import type { CronOptions } from "cronbake";
 import {
   ingestSource,
-  allSettledWithConcurrency,
+  allSettledGroupedWithConcurrency,
   insertEventStatesWithConflictResolution,
   buildEventStateInsertRow,
   createGoogleTokenRefresher,
@@ -47,6 +47,7 @@ import {
   eventStatesTable,
   oauthCredentialsTable,
   sourceDestinationMappingsTable,
+  userSubscriptionsTable,
 } from "@keeper.sh/database/schema";
 import { and, arrayContains, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
 import { withCronWideEvent } from "@/utils/with-wide-event";
@@ -68,7 +69,16 @@ import { selectIngestWideEventFields } from "@/utils/ingest-wide-event";
 
 const SOURCE_TIMEOUT_MS = INGEST_SOURCE_TIMEOUT_MS;
 const SOURCE_TIMEOUT_DATABASE_GRACE_MS = 5000;
+/*
+ * The unit of scheduling is the user: SOURCE_CONCURRENCY users ingest at once per
+ * family, and each user's calendars run at USER_CALENDAR_CONCURRENCY within that
+ * one slot. A seventeen-calendar account occupies one slot instead of the whole
+ * budget, so no user's backlog can starve another user's freshness. The per-user
+ * cap also keeps concurrent calls per provider account under Graph's documented
+ * MailboxConcurrency of four.
+ */
 const SOURCE_CONCURRENCY = 5;
+const USER_CALENDAR_CONCURRENCY = 2;
 const SOURCE_INGEST_LOCK_KEY_PREFIX = "source-ingest:";
 
 /*
@@ -849,6 +859,7 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
     .from(calendarsTable)
     .innerJoin(calendarAccountsTable, eq(calendarsTable.accountId, calendarAccountsTable.id))
     .innerJoin(oauthCredentialsTable, eq(calendarAccountsTable.oauthCredentialId, oauthCredentialsTable.id))
+    .leftJoin(userSubscriptionsTable, eq(calendarsTable.userId, userSubscriptionsTable.userId))
     .where(
       and(
         arrayContains(calendarsTable.capabilities, ["pull"]),
@@ -864,9 +875,12 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
    * written by the first successful ingest of every source family, so null here
    * means exactly "never ingested".
    */
-    .orderBy(desc(isNull(calendarsTable.ingestWindowRecordedAt)));
+    .orderBy(
+      desc(isNull(calendarsTable.ingestWindowRecordedAt)),
+      desc(sql`${userSubscriptionsTable.plan} = 'pro'`),
+    );
 
-  const settlements = await allSettledWithConcurrency(
+  const settlements = await allSettledGroupedWithConcurrency(
     oauthSources.map((source) => {
       const enqueuedAt = Date.now();
       return () =>
@@ -1038,7 +1052,8 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
         }),
       SOURCE_TIMEOUT_MS);
     }),
-    { concurrency: SOURCE_CONCURRENCY },
+oauthSources.map((source) => source.userId),
+    { groupConcurrency: SOURCE_CONCURRENCY, taskConcurrency: USER_CALENDAR_CONCURRENCY },
   );
 
   return summariseIngestionSettlements(
@@ -1075,15 +1090,19 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
     .from(calendarsTable)
     .innerJoin(calendarAccountsTable, eq(calendarsTable.accountId, calendarAccountsTable.id))
     .innerJoin(caldavCredentialsTable, eq(calendarAccountsTable.caldavCredentialId, caldavCredentialsTable.id))
+    .leftJoin(userSubscriptionsTable, eq(calendarsTable.userId, userSubscriptionsTable.userId))
     .where(
       and(
         arrayContains(calendarsTable.capabilities, ["pull"]),
         eq(calendarsTable.disabled, false),
       ),
     )
-    .orderBy(desc(isNull(calendarsTable.ingestWindowRecordedAt)));
+    .orderBy(
+      desc(isNull(calendarsTable.ingestWindowRecordedAt)),
+      desc(sql`${userSubscriptionsTable.plan} = 'pro'`),
+    );
 
-  const settlements = await allSettledWithConcurrency(
+  const settlements = await allSettledGroupedWithConcurrency(
     caldavSources.map((source) => {
       const enqueuedAt = Date.now();
       return () =>
@@ -1210,7 +1229,8 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
         }),
       SOURCE_TIMEOUT_MS);
     }),
-    { concurrency: SOURCE_CONCURRENCY },
+caldavSources.map((source) => source.userId),
+    { groupConcurrency: SOURCE_CONCURRENCY, taskConcurrency: USER_CALENDAR_CONCURRENCY },
   );
 
   return summariseIngestionSettlements(
@@ -1234,15 +1254,19 @@ const ingestIcsSources = async (): Promise<IngestionBatchResult> => {
       ingestWindowRecordedAt: calendarsTable.ingestWindowRecordedAt,
     })
     .from(calendarsTable)
+    .leftJoin(userSubscriptionsTable, eq(calendarsTable.userId, userSubscriptionsTable.userId))
     .where(
       and(
         eq(calendarsTable.calendarType, "ical"),
         eq(calendarsTable.disabled, false),
       ),
     )
-    .orderBy(desc(isNull(calendarsTable.ingestWindowRecordedAt)));
+    .orderBy(
+      desc(isNull(calendarsTable.ingestWindowRecordedAt)),
+      desc(sql`${userSubscriptionsTable.plan} = 'pro'`),
+    );
 
-  const settlements = await allSettledWithConcurrency(
+  const settlements = await allSettledGroupedWithConcurrency(
     icsSources.map((source) => {
       const enqueuedAt = Date.now();
       return () =>
@@ -1341,7 +1365,8 @@ const ingestIcsSources = async (): Promise<IngestionBatchResult> => {
         }),
       SOURCE_TIMEOUT_MS);
     }),
-    { concurrency: SOURCE_CONCURRENCY },
+icsSources.map((source) => source.userId),
+    { groupConcurrency: SOURCE_CONCURRENCY, taskConcurrency: USER_CALENDAR_CONCURRENCY },
   );
 
   return summariseIngestionSettlements(

--- a/services/cron/tests/jobs/ingest-sources-selection.test.ts
+++ b/services/cron/tests/jobs/ingest-sources-selection.test.ts
@@ -116,10 +116,8 @@ describe("ingestOAuthSources selection", () => {
   });
 
   /*
-   * Rendered SQL, not the AST: a user with no subscription row yields a NULL plan,
-   * and a bare `plan = 'pro' DESC` sorts those NULLs ahead of every pro user —
-   * inverting the priority for exactly the majority case. The coalesce is what
-   * makes the ordering mean what it says, so its presence is pinned as text.
+   * Pinned as rendered SQL, not AST: without the coalesce, NULL plans sort ahead
+   * of every pro user, inverting the priority for the majority case.
    */
   it("renders a null-safe pro ordering", async () => {
     await ingestOAuthSources();

--- a/services/cron/tests/jobs/ingest-sources-selection.test.ts
+++ b/services/cron/tests/jobs/ingest-sources-selection.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { and, arrayContains, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import { calendarsTable, userSubscriptionsTable } from "@keeper.sh/database/schema";
 import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 import type { ingestOAuthSources as ingestOAuthSourcesFn } from "../../src/jobs/ingest-sources";
@@ -110,8 +111,25 @@ describe("ingestOAuthSources selection", () => {
 
     expect(capturedOrderings).toEqual([[
       desc(isNull(calendarsTable.ingestWindowRecordedAt)),
-      desc(sql`${userSubscriptionsTable.plan} = 'pro'`),
+      desc(sql`coalesce(${userSubscriptionsTable.plan}, 'free') = 'pro'`),
     ]]);
+  });
+
+  /*
+   * Rendered SQL, not the AST: a user with no subscription row yields a NULL plan,
+   * and a bare `plan = 'pro' DESC` sorts those NULLs ahead of every pro user —
+   * inverting the priority for exactly the majority case. The coalesce is what
+   * makes the ordering mean what it says, so its presence is pinned as text.
+   */
+  it("renders a null-safe pro ordering", async () => {
+    await ingestOAuthSources();
+
+    const dialect = new PgDialect();
+    const [ordering] = capturedOrderings as [unknown[]];
+    const rendered = dialect.sqlToQuery(ordering[1] as Parameters<PgDialect["sqlToQuery"]>[0]);
+
+    expect(rendered.sql).toContain("coalesce(");
+    expect(rendered.sql).toContain("= 'pro'");
   });
 
   it("orders every source family the same way", async () => {
@@ -119,13 +137,13 @@ describe("ingestOAuthSources selection", () => {
 
     expect(capturedOrderings).toEqual([[
       desc(isNull(calendarsTable.ingestWindowRecordedAt)),
-      desc(sql`${userSubscriptionsTable.plan} = 'pro'`),
+      desc(sql`coalesce(${userSubscriptionsTable.plan}, 'free') = 'pro'`),
     ], [
       desc(isNull(calendarsTable.ingestWindowRecordedAt)),
-      desc(sql`${userSubscriptionsTable.plan} = 'pro'`),
+      desc(sql`coalesce(${userSubscriptionsTable.plan}, 'free') = 'pro'`),
     ], [
       desc(isNull(calendarsTable.ingestWindowRecordedAt)),
-      desc(sql`${userSubscriptionsTable.plan} = 'pro'`),
+      desc(sql`coalesce(${userSubscriptionsTable.plan}, 'free') = 'pro'`),
     ]]);
   });
 });

--- a/services/cron/tests/jobs/ingest-sources-selection.test.ts
+++ b/services/cron/tests/jobs/ingest-sources-selection.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { and, arrayContains, desc, eq, inArray, isNull } from "drizzle-orm";
-import { calendarsTable } from "@keeper.sh/database/schema";
+import { and, arrayContains, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { calendarsTable, userSubscriptionsTable } from "@keeper.sh/database/schema";
 import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 import type { ingestOAuthSources as ingestOAuthSourcesFn } from "../../src/jobs/ingest-sources";
 
@@ -23,8 +23,8 @@ const createQueryBuilder = () => {
   builder.where = (predicate: unknown) => {
     capturedPredicates.push(predicate);
     return Object.assign(Promise.resolve([]), {
-      orderBy: (ordering: unknown) => {
-        capturedOrderings.push(ordering);
+      orderBy: (...orderings: unknown[]) => {
+        capturedOrderings.push(orderings);
         return Promise.resolve([]);
       },
     });
@@ -105,21 +105,27 @@ describe("ingestOAuthSources selection", () => {
     expect(capturedPredicates).toHaveLength(0);
   });
 
-  it("puts calendars that have never completed an ingest at the front", async () => {
+  it("puts never-ingested calendars first, then pro users", async () => {
     await ingestOAuthSources();
 
-    expect(capturedOrderings).toEqual([
+    expect(capturedOrderings).toEqual([[
       desc(isNull(calendarsTable.ingestWindowRecordedAt)),
-    ]);
+      desc(sql`${userSubscriptionsTable.plan} = 'pro'`),
+    ]]);
   });
 
   it("orders every source family the same way", async () => {
     await job?.callback();
 
-    expect(capturedOrderings).toEqual([
+    expect(capturedOrderings).toEqual([[
       desc(isNull(calendarsTable.ingestWindowRecordedAt)),
+      desc(sql`${userSubscriptionsTable.plan} = 'pro'`),
+    ], [
       desc(isNull(calendarsTable.ingestWindowRecordedAt)),
+      desc(sql`${userSubscriptionsTable.plan} = 'pro'`),
+    ], [
       desc(isNull(calendarsTable.ingestWindowRecordedAt)),
-    ]);
+      desc(sql`${userSubscriptionsTable.plan} = 'pro'`),
+    ]]);
   });
 });


### PR DESCRIPTION
The ingest fleet was one flat list of calendars processed 5-at-a-time per family, in arbitrary order, with no plan awareness. Three measured consequences: a 17-calendar signup occupied every slot while other users waited; a pro user's freshness was set by the fleet's slowest tail (a deleted event took 8m51s to leave Fastmail today because its lost push notification fell back to the ~9-minute rotation); and nothing stopped five concurrent jobs landing on one Outlook mailbox against Graph's per-mailbox limit of four.

Two changes, inside the existing job:

**The unit of scheduling is now the user.** A new `allSettledGroupedWithConcurrency` runs up to `SOURCE_CONCURRENCY` (5) users at once per family, each user's calendars at `USER_CALENDAR_CONCURRENCY` (2) within that one slot, and returns settlements in original order — the reauthentication demands pair to accounts by index, so order preservation is load-bearing. One user's backlog now occupies one slot instead of the whole budget, and per-account concurrency is capped at 2, under Graph's limit. Effective per-family concurrency rises from 5 to up to 10; the cron pool was sized to 25 in #851 with measured ~300ms mean connection holds, so ~30 fleet-wide concurrent ingests demand ~15 connections on average.

**Users are ordered: never-ingested first, then pro.** The listings left-join `user_subscriptions` and sort `plan = 'pro'` after #852's null-window ordering. Correction to an earlier version of this description: cron passes are serial (cronbake re-arms the timer only after a pass completes), so steady-state cadence for every user equals the pass makespan — ordering does not shorten it. What ordering changes is who waits within a pass: pro and never-ingested calendars are picked up in the pass's first seconds instead of its tail, so a pro user's staleness after any tick is near the minimum the makespan allows, and first ingests are never stuck behind the fleet's backlog. Self-hosted deployments have an empty subscriptions table, so the ordering is a no-op there and everyone stays equal.

What this does not fix: total fleet makespan. The tail is still the same amount of HTTP work (halved-ish by the doubled effective concurrency); pro-first decides who waits, the dispatch/execution un-fuse is still what shrinks the wait.

Tests: `grouped-concurrency.test.ts` pins order preservation, the per-group cap (a six-task group at cap 2 peaks at exactly 2), non-starvation (a small group finishes while an eight-task group is mid-flight), and rejection isolation. The selection test pins both ordering terms across all three families.

**Watch after deploy:** pass makespan (the true cadence for everyone) and pro ingests clustering at pass start, `slot_wait` distribution, Graph 429/`MailboxConcurrency` errors (should fall), and pass-completion bursts (should tighten from ~9min toward ~4–5min).
