### PR TITLE
feat(cron): give every provider family its own rate protection

### DIFF
--- a/packages/calendar/src/core/sync-engine/ingest.ts
+++ b/packages/calendar/src/core/sync-engine/ingest.ts
@@ -19,10 +19,7 @@ import { recordSegment } from "../telemetry/segments";
 
 type IngestWideEventFields = Record<string, boolean | number | string>;
 
-/*
- * Identifier lists are a capped sample; an uncapped one would push the line
- * past what the log pipeline keeps and take the counters with it.
- */
+/* Capped sample: an uncapped list would push the line past what the log pipeline keeps. */
 const WIDE_EVENT_LIST_LIMIT = 20;
 const WIDE_EVENT_LIST_MAX_LENGTH = 2048;
 
@@ -49,10 +46,7 @@ const summarizeWideEventList = (
   Math.max(values.length - WIDE_EVENT_LIST_LIMIT, 0),
 );
 
-/**
- * Events the provider reported that never reach the diff, so the diff removes
- * their stored state. These counts are the only trace that removal leaves.
- */
+/** These counts are the only trace that the removal leaves. */
 interface DiscardedSourceEventCounts {
   outsideSyncWindow: number;
   unrepresentable: number;
@@ -61,10 +55,7 @@ interface DiscardedSourceEventCounts {
 interface FetchEventsResult {
   events: SourceEvent[];
   discardedEventCounts?: DiscardedSourceEventCounts;
-  /**
-   * Keeper's own mirrored events, skipped on purpose. Kept out of
-   * `discardedEventCounts` so those stay zero on a healthy mirrored calendar.
-   */
+  /** Kept out of `discardedEventCounts` so those stay zero on a healthy mirrored calendar. */
   selfAuthoredEventCount?: number;
   changedEventIds?: string[];
   snapshot?: CalendarSnapshotChange;
@@ -75,11 +66,7 @@ interface FetchEventsResult {
   unchanged?: boolean;
   skippedResourceCount?: number;
   skippedResourceReasons?: string[];
-  /**
-   * Events the provider returned that Keeper cannot represent (an RDATE series,
-   * a timezone no runtime can interpret). They stay in `events` so removal stays
-   * computed against the full feed; only ingestion withholds them.
-   */
+  /** Stay in `events` so removal stays computed against the full feed; only ingestion withholds them. */
   unsupportedEventUids?: string[];
   syncWindow?: SyncWindow;
   coverage?: {
@@ -107,12 +94,7 @@ interface IngestionPersistence {
   flush: (changes: IngestionChanges) => Promise<void>;
 }
 
-/**
- * The persist-time currency probe, offered separately from the work itself:
- * a caller that queues the work behind a serial writer can settle the probe's
- * Redis round trip before it takes the slot, and gets back a short-circuit
- * result when the lease is gone or the probe could not answer.
- */
+/** Offered separately so a queueing caller can settle the Redis round trip off its writer slot. */
 type IngestionPersistencePreflight = () => Promise<IngestionResult | null>;
 
 type IngestionPersistenceWork = ((
@@ -161,11 +143,9 @@ interface IngestionResult {
 const EMPTY_RESULT: IngestionResult = { eventsAdded: 0, eventsRemoved: 0 };
 
 /*
- * Only delta sources need this. A snapshot source re-reports its whole coverage
- * every fetch, so the snapshot diff already removes whatever it stopped
- * reporting; pruning on top of that would delete the unbounded history an ICS
- * feed still reports. A delta source only reports changes, so a stored event
- * that fell outside a narrowed window would otherwise be stranded forever.
+ * Delta sources only: a snapshot source's diff already removes what it stopped reporting, so
+ * pruning on top would delete the unbounded history an ICS feed still reports. A delta
+ * source's stored event outside a narrowed window would otherwise be stranded forever.
  */
 const getNonRecurringStoredEventIdsOutsideWindow = (
   events: (Pick<StoredSourceEventState, "endTime" | "id" | "startTime"> & {
@@ -189,12 +169,9 @@ const getNonRecurringStoredEventIdsOutsideWindow = (
 type CurrencyProbeResult = "current" | "currency-unconfirmed" | "superseded";
 
 /*
- * The probe is Redis I/O on the sync lease, so it can fail for reasons that
- * have nothing to do with the provider. A rejection is contained here rather
- * than escaping: an unanswerable probe must neither commit a possibly-stale
- * snapshot nor surface as an ingest error, which every family's backoff gate
- * would charge to the provider. Mirrors resetIngestBackoffIfCurrent in
- * services/cron/src/jobs/ingest-sources.ts.
+ * Redis I/O that can fail for reasons unrelated to the provider, so a rejection is contained:
+ * an unanswerable probe must neither commit a possibly-stale snapshot nor surface as an
+ * ingest error that the backoff gate would charge to the provider.
  */
 const probeCurrency = async (
   wideEvent: IngestWideEventFields,
@@ -231,10 +208,8 @@ const ingestSource = async (options: IngestSourceOptions): Promise<IngestionResu
   let flushed = false;
 
   /*
-   * Part of the diff runs inside the persistence transaction's callback, which a
-   * pooled driver invokes in the async context of whoever released the connection.
-   * A widelog call there would land on another source's event, so the diff is
-   * accumulated locally and recorded once below, back in this function's context.
+   * A pooled driver invokes the transaction callback in the async context of whoever released
+   * the connection, so a widelog call there would land on another source's event.
    */
   let diffMs = 0;
   const measureDiff = <TResult>(operation: () => TResult): TResult => {
@@ -287,11 +262,7 @@ const ingestSource = async (options: IngestSourceOptions): Promise<IngestionResu
           },
         ));
       if (overBudget.length > 0) {
-        /*
-         * A widened sync range can pull a pathological series over the occurrence
-         * budget. Drop those series and keep ingesting the rest, so one bad series
-         * cannot push the whole calendar into permanent ingestion backoff.
-         */
+        /* Dropped rather than failed, so one bad series cannot back off the whole calendar. */
         const overBudgetUids = new Set(overBudget.map(({ uid }) => uid));
         sourceEvents = sourceEvents.filter(({ uid }) => !overBudgetUids.has(uid));
         wideEvent["recurrence.over_budget_count"] = overBudget.length;
@@ -307,14 +278,9 @@ const ingestSource = async (options: IngestSourceOptions): Promise<IngestionResu
     }
 
     /*
-     * Re-probe currency at persist time. The transaction thunk can sit in a
-     * serial flush queue long after the pre-enqueue probe above passed; if the
-     * sync lease was reclaimed in the meantime, a fresher holder may already
-     * have committed, and flushing this run's snapshot would revert it.
-     *
-     * The probe is offered to the caller as `preflight` so a queueing caller can
-     * settle this Redis round trip off its writer slot; a caller that ignores it
-     * still gets the probe from inside the work callback below.
+     * The thunk can sit in a flush queue long after the pre-enqueue probe passed; if the lease
+     * was reclaimed meanwhile, a fresher holder may have committed and this snapshot would
+     * revert it.
      */
     let persistProbePending = true;
     const persistTimePreflight = async (): Promise<IngestionResult | null> => {
@@ -393,9 +359,8 @@ const ingestSource = async (options: IngestSourceOptions): Promise<IngestionResu
               isDeltaSync,
             ),
             /*
-             * Removal is computed against the unfiltered fetch. An over-budget series is
-             * only withheld from ingestion; treating it as absent here would delete the
-             * states it already has, turning a stalled series into deleted user events.
+             * Removal is computed against the unfiltered fetch: treating a withheld
+             * over-budget series as absent would turn a stalled series into deleted events.
              */
             ...buildSourceEventStateIdsToRemove(
               existingEvents,

--- a/packages/calendar/src/core/sync-engine/ingest.ts
+++ b/packages/calendar/src/core/sync-engine/ingest.ts
@@ -107,9 +107,19 @@ interface IngestionPersistence {
   flush: (changes: IngestionChanges) => Promise<void>;
 }
 
-type IngestionPersistenceWork = (
+/**
+ * The persist-time currency probe, offered separately from the work itself:
+ * a caller that queues the work behind a serial writer can settle the probe's
+ * Redis round trip before it takes the slot, and gets back a short-circuit
+ * result when the lease is gone or the probe could not answer.
+ */
+type IngestionPersistencePreflight = () => Promise<IngestionResult | null>;
+
+type IngestionPersistenceWork = ((
   persistence: IngestionPersistence,
-) => Promise<IngestionResult>;
+) => Promise<IngestionResult>) & {
+  preflight?: IngestionPersistencePreflight;
+};
 
 interface BaseIngestSourceOptions {
   calendarId: string;
@@ -174,6 +184,38 @@ const getNonRecurringStoredEventIdsOutsideWindow = (
     }
   }
   return eventIds;
+};
+
+type CurrencyProbeResult = "current" | "currency-unconfirmed" | "superseded";
+
+/*
+ * The probe is Redis I/O on the sync lease, so it can fail for reasons that
+ * have nothing to do with the provider. A rejection is contained here rather
+ * than escaping: an unanswerable probe must neither commit a possibly-stale
+ * snapshot nor surface as an ingest error, which every family's backoff gate
+ * would charge to the provider. Mirrors resetIngestBackoffIfCurrent in
+ * services/cron/src/jobs/ingest-sources.ts.
+ */
+const probeCurrency = async (
+  wideEvent: IngestWideEventFields,
+  isCurrent?: () => Promise<boolean>,
+): Promise<CurrencyProbeResult> => {
+  if (!isCurrent) {
+    return "current";
+  }
+  try {
+    if (await isCurrent()) {
+      return "current";
+    }
+    return "superseded";
+  } catch (error) {
+    let message = String(error);
+    if (error instanceof Error) {
+      ({ message } = error);
+    }
+    wideEvent["currency_probe.error"] = message;
+    return "currency-unconfirmed";
+  }
 };
 
 const ingestSource = async (options: IngestSourceOptions): Promise<IngestionResult> => {
@@ -257,23 +299,41 @@ const ingestSource = async (options: IngestSourceOptions): Promise<IngestionResu
       }
     }
 
-    if (isCurrent && !(await isCurrent())) {
-      wideEvent["outcome"] = "superseded";
+    const preEnqueueCurrency = await probeCurrency(wideEvent, isCurrent);
+    if (preEnqueueCurrency !== "current") {
+      wideEvent["outcome"] = preEnqueueCurrency;
       wideEvent["flushed"] = false;
       return EMPTY_RESULT;
     }
 
-    return await withPersistenceTransaction(async ({ readExistingEvents, flush }) => {
-      /*
-       * Re-probe currency at persist time. The transaction thunk can sit in a
-       * serial flush queue long after the pre-enqueue probe above passed; if the
-       * sync lease was reclaimed in the meantime, a fresher holder may already
-       * have committed, and flushing this run's snapshot would revert it.
-       */
-      if (isCurrent && !(await isCurrent())) {
-        wideEvent["outcome"] = "superseded";
-        wideEvent["flushed"] = false;
-        return EMPTY_RESULT;
+    /*
+     * Re-probe currency at persist time. The transaction thunk can sit in a
+     * serial flush queue long after the pre-enqueue probe above passed; if the
+     * sync lease was reclaimed in the meantime, a fresher holder may already
+     * have committed, and flushing this run's snapshot would revert it.
+     *
+     * The probe is offered to the caller as `preflight` so a queueing caller can
+     * settle this Redis round trip off its writer slot; a caller that ignores it
+     * still gets the probe from inside the work callback below.
+     */
+    let persistProbePending = true;
+    const persistTimePreflight = async (): Promise<IngestionResult | null> => {
+      persistProbePending = false;
+      const currency = await probeCurrency(wideEvent, isCurrent);
+      if (currency === "current") {
+        return null;
+      }
+      wideEvent["outcome"] = currency;
+      wideEvent["flushed"] = false;
+      return EMPTY_RESULT;
+    };
+
+    const persistenceWork = async ({ readExistingEvents, flush }: IngestionPersistence) => {
+      if (persistProbePending) {
+        const superseded = await persistTimePreflight();
+        if (superseded) {
+          return superseded;
+        }
       }
 
       if (fetchResult.unchanged) {
@@ -402,7 +462,11 @@ const ingestSource = async (options: IngestSourceOptions): Promise<IngestionResu
         eventsAdded: eventsToAdd.length,
         eventsRemoved: eventStateIdsToRemove.length,
       };
-    });
+    };
+
+    return await withPersistenceTransaction(
+      Object.assign(persistenceWork, { preflight: persistTimePreflight }),
+    );
   } catch (error) {
     wideEvent["outcome"] = "error";
     wideEvent["flushed"] = flushed;
@@ -438,6 +502,7 @@ export type {
   IngestWideEventFields,
   IngestSourceOptions,
   IngestionPersistence,
+  IngestionPersistencePreflight,
   IngestionPersistenceWork,
   IngestionResult,
   IngestionChanges,

--- a/packages/calendar/src/core/sync-engine/ingest.ts
+++ b/packages/calendar/src/core/sync-engine/ingest.ts
@@ -45,7 +45,6 @@ const summarizeWideEventList = (
   Math.max(values.length - WIDE_EVENT_LIST_LIMIT, 0),
 );
 
-/** These counts are the only trace that the removal leaves. */
 interface DiscardedSourceEventCounts {
   outsideSyncWindow: number;
   unrepresentable: number;
@@ -54,7 +53,6 @@ interface DiscardedSourceEventCounts {
 interface FetchEventsResult {
   events: SourceEvent[];
   discardedEventCounts?: DiscardedSourceEventCounts;
-  /** Kept out of `discardedEventCounts` so those stay zero on a healthy mirrored calendar. */
   selfAuthoredEventCount?: number;
   changedEventIds?: string[];
   snapshot?: CalendarSnapshotChange;
@@ -65,7 +63,6 @@ interface FetchEventsResult {
   unchanged?: boolean;
   skippedResourceCount?: number;
   skippedResourceReasons?: string[];
-  /** Stay in `events` so removal stays computed against the full feed; only ingestion withholds them. */
   unsupportedEventUids?: string[];
   syncWindow?: SyncWindow;
   coverage?: {
@@ -93,7 +90,6 @@ interface IngestionPersistence {
   flush: (changes: IngestionChanges) => Promise<void>;
 }
 
-/** Offered separately so a queueing caller can settle the Redis round trip off its writer slot. */
 type IngestionPersistencePreflight = () => Promise<IngestionResult | null>;
 
 type IngestionPersistenceWork = ((
@@ -167,11 +163,13 @@ const getNonRecurringStoredEventIdsOutsideWindow = (
 
 type CurrencyProbeResult = "current" | "currency-unconfirmed" | "superseded";
 
-/*
- * Redis I/O that can fail for reasons unrelated to the provider, so a rejection is contained:
- * an unanswerable probe must neither commit a possibly-stale snapshot nor surface as an
- * ingest error that the backoff gate would charge to the provider.
- */
+const resolveErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+};
+
 const probeCurrency = async (
   wideEvent: IngestWideEventFields,
   isCurrent?: () => Promise<boolean>,
@@ -185,11 +183,7 @@ const probeCurrency = async (
     }
     return "superseded";
   } catch (error) {
-    let message = String(error);
-    if (error instanceof Error) {
-      ({ message } = error);
-    }
-    wideEvent["currency_probe.error"] = message;
+    wideEvent["currency_probe.error"] = resolveErrorMessage(error);
     return "currency-unconfirmed";
   }
 };
@@ -261,7 +255,6 @@ const ingestSource = async (options: IngestSourceOptions): Promise<IngestionResu
           },
         ));
       if (overBudget.length > 0) {
-        /* Dropped rather than failed, so one bad series cannot back off the whole calendar. */
         const overBudgetUids = new Set(overBudget.map(({ uid }) => uid));
         sourceEvents = sourceEvents.filter(({ uid }) => !overBudgetUids.has(uid));
         wideEvent["recurrence.over_budget_count"] = overBudget.length;
@@ -276,11 +269,6 @@ const ingestSource = async (options: IngestSourceOptions): Promise<IngestionResu
       return EMPTY_RESULT;
     }
 
-    /*
-     * The thunk can sit in a flush queue long after the pre-enqueue probe passed; if the lease
-     * was reclaimed meanwhile, a fresher holder may have committed and this snapshot would
-     * revert it.
-     */
     let persistProbePending = true;
     const persistTimePreflight = async (): Promise<IngestionResult | null> => {
       persistProbePending = false;

--- a/packages/calendar/src/core/sync-engine/ingest.ts
+++ b/packages/calendar/src/core/sync-engine/ingest.ts
@@ -19,7 +19,6 @@ import { recordSegment } from "../telemetry/segments";
 
 type IngestWideEventFields = Record<string, boolean | number | string>;
 
-/* Capped sample: an uncapped list would push the line past what the log pipeline keeps. */
 const WIDE_EVENT_LIST_LIMIT = 20;
 const WIDE_EVENT_LIST_MAX_LENGTH = 2048;
 

--- a/packages/calendar/src/core/sync-engine/ingest.ts
+++ b/packages/calendar/src/core/sync-engine/ingest.ts
@@ -264,6 +264,18 @@ const ingestSource = async (options: IngestSourceOptions): Promise<IngestionResu
     }
 
     return await withPersistenceTransaction(async ({ readExistingEvents, flush }) => {
+      /*
+       * Re-probe currency at persist time. The transaction thunk can sit in a
+       * serial flush queue long after the pre-enqueue probe above passed; if the
+       * sync lease was reclaimed in the meantime, a fresher holder may already
+       * have committed, and flushing this run's snapshot would revert it.
+       */
+      if (isCurrent && !(await isCurrent())) {
+        wideEvent["outcome"] = "superseded";
+        wideEvent["flushed"] = false;
+        return EMPTY_RESULT;
+      }
+
       if (fetchResult.unchanged) {
         wideEvent["outcome"] = "unchanged";
         wideEvent["flushed"] = false;

--- a/packages/calendar/src/core/telemetry/segments.ts
+++ b/packages/calendar/src/core/telemetry/segments.ts
@@ -16,6 +16,7 @@ type IngestSegmentKey =
   | "wait.token_refresh_ms"
   | "wait.rate_limiter_ms"
   | "wait.provider_retry_ms"
+  | "wait.flush_reserve_ms"
   | "wait.db_pool_ms"
   | "wait.advisory_lock_ms"
   | "work.provider_http_ms"

--- a/packages/calendar/src/core/utils/leased-semaphore.ts
+++ b/packages/calendar/src/core/utils/leased-semaphore.ts
@@ -34,8 +34,13 @@ interface RedisLeaseClient {
  * pacing-park.ts).
  */
 const sleepWithSignal = (delayMs: number, signal?: AbortSignal): Promise<void> => {
+  /*
+   * No park flag on an already-consumed deadline: it may have been eaten by a
+   * provider call that takes no signal, and stamping it would exempt a
+   * provider-consumed deadline from ingest backoff. Only the abort observed
+   * while actually parked below is pre-contact.
+   */
   if (signal?.aborted) {
-    flagPacingParkAbortReason(signal.reason);
     return Promise.reject(signal.reason);
   }
   return new Promise((resolve, reject) => {

--- a/packages/calendar/src/core/utils/leased-semaphore.ts
+++ b/packages/calendar/src/core/utils/leased-semaphore.ts
@@ -1,0 +1,96 @@
+import { measureRedisCommand } from "../telemetry/segments";
+
+const RETRY_BASE_MS = 200;
+const RETRY_JITTER_MS = 150;
+
+interface SemaphoreLease {
+  slotKey: string;
+  token: string;
+}
+
+interface LeasedSemaphore {
+  acquireLease(key: string, signal?: AbortSignal): Promise<SemaphoreLease>;
+  release(lease: SemaphoreLease): Promise<void>;
+}
+
+interface LeasedSemaphoreConfig {
+  capacity: number;
+  ttlMs: number;
+}
+
+interface RedisLeaseClient {
+  del(...keys: string[]): Promise<number>;
+  set(key: string, value: string, ...options: string[]): Promise<string | null>;
+}
+
+const sleepWithSignal = (delayMs: number, signal?: AbortSignal): Promise<void> => {
+  if (signal?.aborted) {
+    return Promise.reject(signal.reason);
+  }
+  return new Promise((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const onAbort = (): void => {
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+      reject(signal?.reason);
+    };
+    timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, delayMs);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+};
+
+/*
+ * Each slot is its own Redis key claimed with SET NX PX, so a crashed holder's
+ * lease expires on its own instead of wedging the account the way a bare
+ * INCR/DECR counter would.
+ */
+const createLeasedSemaphore = (
+  redis: RedisLeaseClient,
+  config: LeasedSemaphoreConfig,
+): LeasedSemaphore => {
+  const { capacity, ttlMs } = config;
+
+  const tryAcquire = async (key: string): Promise<SemaphoreLease | null> => {
+    const token = crypto.randomUUID();
+    for (let slot = 0; slot < capacity; slot += 1) {
+      const slotKey = `semaphore:${key}:slot:${slot}`;
+      const granted = await measureRedisCommand(() =>
+        redis.set(slotKey, token, "NX", "PX", String(ttlMs)));
+      if (granted !== null) {
+        return { slotKey, token };
+      }
+    }
+    return null;
+  };
+
+  const acquireLease = async (key: string, signal?: AbortSignal): Promise<SemaphoreLease> => {
+    while (true) {
+      signal?.throwIfAborted();
+      const lease = await tryAcquire(key);
+      if (lease !== null) {
+        return lease;
+      }
+      // Jitter keeps parked acquirers from stampeding Redis in lockstep.
+      const delayMs = RETRY_BASE_MS + Math.floor(Math.random() * RETRY_JITTER_MS);
+      await sleepWithSignal(delayMs, signal);
+    }
+  };
+
+  const release = async (lease: SemaphoreLease): Promise<void> => {
+    await measureRedisCommand(() => redis.del(lease.slotKey));
+  };
+
+  return { acquireLease, release };
+};
+
+export { createLeasedSemaphore };
+export type {
+  LeasedSemaphore,
+  LeasedSemaphoreConfig,
+  RedisLeaseClient,
+  SemaphoreLease,
+};

--- a/packages/calendar/src/core/utils/leased-semaphore.ts
+++ b/packages/calendar/src/core/utils/leased-semaphore.ts
@@ -3,7 +3,6 @@ import { flagPacingParkAbortReason } from "./pacing-park";
 
 const RETRY_BASE_MS = 200;
 const RETRY_JITTER_MS = 150;
-// Margin guarding against DEL landing on a slot reclaimed right at the TTL edge.
 const RELEASE_SAFETY_MS = 1000;
 
 interface SemaphoreLease {
@@ -27,12 +26,7 @@ interface RedisLeaseClient {
   set(key: string, value: string, ...options: string[]): Promise<string | null>;
 }
 
-/* Parked on keeper's own cap, ahead of any request the lease would authorize. */
 const sleepWithSignal = (delayMs: number, signal?: AbortSignal): Promise<void> => {
-  /*
-   * No park flag on an already-consumed deadline: it may have been eaten by a provider call
-   * that takes no signal, and stamping it would exempt that from ingest backoff.
-   */
   if (signal?.aborted) {
     return Promise.reject(signal.reason);
   }

--- a/packages/calendar/src/core/utils/leased-semaphore.ts
+++ b/packages/calendar/src/core/utils/leased-semaphore.ts
@@ -2,8 +2,11 @@ import { measureRedisCommand } from "../telemetry/segments";
 
 const RETRY_BASE_MS = 200;
 const RETRY_JITTER_MS = 150;
+// Margin guarding against DEL landing on a slot reclaimed right at the TTL edge.
+const RELEASE_SAFETY_MS = 1000;
 
 interface SemaphoreLease {
+  safeToDeleteUntil: number;
   slotKey: string;
   token: string;
 }
@@ -58,10 +61,17 @@ const createLeasedSemaphore = (
     const token = crypto.randomUUID();
     for (let slot = 0; slot < capacity; slot += 1) {
       const slotKey = `semaphore:${key}:slot:${slot}`;
+      /*
+       * Timestamped BEFORE the SET is sent: the server applies the PX expiry
+       * at some point at or after this instant, so the key cannot lapse before
+       * requestedAt + ttlMs. Inside that window (minus a safety margin) the
+       * slot provably still holds this token, making a bare DEL exact.
+       */
+      const requestedAt = Date.now();
       const granted = await measureRedisCommand(() =>
         redis.set(slotKey, token, "NX", "PX", String(ttlMs)));
       if (granted !== null) {
-        return { slotKey, token };
+        return { safeToDeleteUntil: requestedAt + ttlMs - RELEASE_SAFETY_MS, slotKey, token };
       }
     }
     return null;
@@ -80,7 +90,17 @@ const createLeasedSemaphore = (
     }
   };
 
+  /*
+   * The lease client exposes only SET/DEL (no GET, no EVAL), so ownership is
+   * fenced by time instead of a compare-and-delete script: once the lease's
+   * safe-delete window has passed, the slot may already have expired and been
+   * reclaimed by another holder, and deleting it would break the capacity
+   * bound. Past the window the DEL is skipped and the TTL reaps the key.
+   */
   const release = async (lease: SemaphoreLease): Promise<void> => {
+    if (Date.now() >= lease.safeToDeleteUntil) {
+      return;
+    }
     await measureRedisCommand(() => redis.del(lease.slotKey));
   };
 

--- a/packages/calendar/src/core/utils/leased-semaphore.ts
+++ b/packages/calendar/src/core/utils/leased-semaphore.ts
@@ -1,4 +1,5 @@
 import { measureRedisCommand } from "../telemetry/segments";
+import { flagPacingParkAbortReason } from "./pacing-park";
 
 const RETRY_BASE_MS = 200;
 const RETRY_JITTER_MS = 150;
@@ -26,8 +27,15 @@ interface RedisLeaseClient {
   set(key: string, value: string, ...options: string[]): Promise<string | null>;
 }
 
+/*
+ * Reached only after every slot came back claimed: the caller is parked on
+ * keeper's own concurrency cap, ahead of any request the lease would
+ * authorize, so an abort observed here is stamped as a pacing park (see
+ * pacing-park.ts).
+ */
 const sleepWithSignal = (delayMs: number, signal?: AbortSignal): Promise<void> => {
   if (signal?.aborted) {
+    flagPacingParkAbortReason(signal.reason);
     return Promise.reject(signal.reason);
   }
   return new Promise((resolve, reject) => {
@@ -36,6 +44,7 @@ const sleepWithSignal = (delayMs: number, signal?: AbortSignal): Promise<void> =
       if (timer !== null) {
         clearTimeout(timer);
       }
+      flagPacingParkAbortReason(signal?.reason);
       reject(signal?.reason);
     };
     timer = setTimeout(() => {

--- a/packages/calendar/src/core/utils/leased-semaphore.ts
+++ b/packages/calendar/src/core/utils/leased-semaphore.ts
@@ -27,18 +27,11 @@ interface RedisLeaseClient {
   set(key: string, value: string, ...options: string[]): Promise<string | null>;
 }
 
-/*
- * Reached only after every slot came back claimed: the caller is parked on
- * keeper's own concurrency cap, ahead of any request the lease would
- * authorize, so an abort observed here is stamped as a pacing park (see
- * pacing-park.ts).
- */
+/* Parked on keeper's own cap, ahead of any request the lease would authorize. */
 const sleepWithSignal = (delayMs: number, signal?: AbortSignal): Promise<void> => {
   /*
-   * No park flag on an already-consumed deadline: it may have been eaten by a
-   * provider call that takes no signal, and stamping it would exempt a
-   * provider-consumed deadline from ingest backoff. Only the abort observed
-   * while actually parked below is pre-contact.
+   * No park flag on an already-consumed deadline: it may have been eaten by a provider call
+   * that takes no signal, and stamping it would exempt that from ingest backoff.
    */
   if (signal?.aborted) {
     return Promise.reject(signal.reason);
@@ -61,9 +54,8 @@ const sleepWithSignal = (delayMs: number, signal?: AbortSignal): Promise<void> =
 };
 
 /*
- * Each slot is its own Redis key claimed with SET NX PX, so a crashed holder's
- * lease expires on its own instead of wedging the account the way a bare
- * INCR/DECR counter would.
+ * Each slot is its own key claimed with SET NX PX, so a crashed holder's lease expires on
+ * its own instead of wedging the account the way a bare INCR/DECR counter would.
  */
 const createLeasedSemaphore = (
   redis: RedisLeaseClient,
@@ -76,10 +68,8 @@ const createLeasedSemaphore = (
     for (let slot = 0; slot < capacity; slot += 1) {
       const slotKey = `semaphore:${key}:slot:${slot}`;
       /*
-       * Timestamped BEFORE the SET is sent: the server applies the PX expiry
-       * at some point at or after this instant, so the key cannot lapse before
-       * requestedAt + ttlMs. Inside that window (minus a safety margin) the
-       * slot provably still holds this token, making a bare DEL exact.
+       * Timestamped BEFORE the SET: the server applies PX at or after this instant, so the
+       * key cannot lapse before requestedAt + ttlMs, which is what makes a bare DEL exact.
        */
       const requestedAt = Date.now();
       const granted = await measureRedisCommand(() =>
@@ -105,11 +95,9 @@ const createLeasedSemaphore = (
   };
 
   /*
-   * The lease client exposes only SET/DEL (no GET, no EVAL), so ownership is
-   * fenced by time instead of a compare-and-delete script: once the lease's
-   * safe-delete window has passed, the slot may already have expired and been
-   * reclaimed by another holder, and deleting it would break the capacity
-   * bound. Past the window the DEL is skipped and the TTL reaps the key.
+   * The lease client exposes only SET/DEL (no GET, no EVAL), so ownership is fenced by time
+   * rather than a compare-and-delete script: past the safe window the slot may already have
+   * been reclaimed, and deleting it would break the capacity bound.
    */
   const release = async (lease: SemaphoreLease): Promise<void> => {
     if (Date.now() >= lease.safeToDeleteUntil) {

--- a/packages/calendar/src/core/utils/pacing-park.ts
+++ b/packages/calendar/src/core/utils/pacing-park.ts
@@ -1,11 +1,7 @@
 /*
- * A deadline abort observed while the caller was parked on keeper-internal
- * pacing — the shared per-host rate-limiter window, the per-user Google
- * limiter, or an account concurrency semaphore — fired before the paced
- * provider request was sent, so the provider was never on the other side of
- * the timeout. The abort reason is flagged in place (never wrapped) so its
- * identity and class are preserved for callers that assert on either, exactly
- * like the serial-flush reserve-abort flag.
+ * A deadline abort observed while parked on keeper-internal pacing fired before the paced
+ * request was sent, so the provider was never on the other side of the timeout. Flagged in
+ * place, never wrapped, so the reason's identity and class survive for callers.
  */
 const PACING_PARK_ABORT_FLAG = "ingestPacingParkAborted";
 

--- a/packages/calendar/src/core/utils/pacing-park.ts
+++ b/packages/calendar/src/core/utils/pacing-park.ts
@@ -1,0 +1,22 @@
+/*
+ * A deadline abort observed while the caller was parked on keeper-internal
+ * pacing — the shared per-host rate-limiter window, the per-user Google
+ * limiter, or an account concurrency semaphore — fired before the paced
+ * provider request was sent, so the provider was never on the other side of
+ * the timeout. The abort reason is flagged in place (never wrapped) so its
+ * identity and class are preserved for callers that assert on either, exactly
+ * like the serial-flush reserve-abort flag.
+ */
+const PACING_PARK_ABORT_FLAG = "ingestPacingParkAborted";
+
+const flagPacingParkAbortReason = (reason: unknown): void => {
+  if (reason instanceof Error) {
+    Object.assign(reason, { [PACING_PARK_ABORT_FLAG]: true });
+  }
+};
+
+const isIngestPacingParkAbortError = (error: unknown): boolean =>
+  error instanceof Error
+  && (error as Error & Record<string, unknown>)[PACING_PARK_ABORT_FLAG] === true;
+
+export { flagPacingParkAbortReason, isIngestPacingParkAbortError };

--- a/packages/calendar/src/core/utils/pacing-park.ts
+++ b/packages/calendar/src/core/utils/pacing-park.ts
@@ -1,8 +1,3 @@
-/*
- * A deadline abort observed while parked on keeper-internal pacing fired before the paced
- * request was sent, so the provider was never on the other side of the timeout. Flagged in
- * place, never wrapped, so the reason's identity and class survive for callers.
- */
 const PACING_PARK_ABORT_FLAG = "ingestPacingParkAborted";
 
 const flagPacingParkAbortReason = (reason: unknown): void => {

--- a/packages/calendar/src/core/utils/redis-rate-limiter.ts
+++ b/packages/calendar/src/core/utils/redis-rate-limiter.ts
@@ -4,6 +4,8 @@ import {
 } from "@keeper.sh/constants";
 import { widelog } from "widelogger";
 import { measureRedisCommand, recordSegment } from "../telemetry/segments";
+import { createLeasedSemaphore } from "./leased-semaphore";
+import type { RedisLeaseClient, SemaphoreLease } from "./leased-semaphore";
 
 const MS_PER_MINUTE = 60_000;
 const RETRY_POLL_MS = 100;
@@ -190,9 +192,63 @@ const createGoogleUserRateLimiter = (
   { requestsPerMinute: GOOGLE_LANE_REQUESTS_PER_MINUTE[lane] },
 );
 
-export { createGoogleUserRateLimiter, createRedisRateLimiter };
+// Modest default so many workers hitting one CalDAV/ICS host stay polite together.
+const HOST_REQUESTS_PER_MINUTE = 30;
+
+interface HostRateLimiterOptions {
+  requestsPerMinute?: number;
+}
+
+/*
+ * Keyed by target host, not user: CalDAV/ICS servers throttle by origin traffic,
+ * so every worker fetching from the same host must draw from one shared budget.
+ */
+const createHostRateLimiter = (
+  redis: RedisScriptClient,
+  host: string,
+  options?: HostRateLimiterOptions,
+): RedisRateLimiter => createRedisRateLimiter(
+  redis,
+  `ratelimit:host:${host}`,
+  { requestsPerMinute: options?.requestsPerMinute ?? HOST_REQUESTS_PER_MINUTE },
+);
+
+// One under Graph's documented MailboxConcurrency of 4, leaving headroom for user traffic.
+const OUTLOOK_ACCOUNT_CONCURRENCY = 3;
+// Comfortably above the 120s ingest timeout so a live holder never loses its lease mid-run.
+const OUTLOOK_LEASE_TTL_MS = 150_000;
+
+interface OutlookAccountSemaphore {
+  acquireLease(signal?: AbortSignal): Promise<SemaphoreLease>;
+  release(lease: SemaphoreLease): Promise<void>;
+}
+
+const createOutlookAccountSemaphore = (
+  redis: RedisLeaseClient,
+  accountId: string,
+): OutlookAccountSemaphore => {
+  const semaphore = createLeasedSemaphore(redis, {
+    capacity: OUTLOOK_ACCOUNT_CONCURRENCY,
+    ttlMs: OUTLOOK_LEASE_TTL_MS,
+  });
+  const key = `outlook:account:${accountId}`;
+
+  return {
+    acquireLease: (signal?: AbortSignal) => semaphore.acquireLease(key, signal),
+    release: (lease: SemaphoreLease) => semaphore.release(lease),
+  };
+};
+
+export {
+  createGoogleUserRateLimiter,
+  createHostRateLimiter,
+  createOutlookAccountSemaphore,
+  createRedisRateLimiter,
+};
 export type {
   GoogleRateLimitLane,
+  HostRateLimiterOptions,
+  OutlookAccountSemaphore,
   RedisRateLimiter,
   RedisRateLimiterConfig,
   RedisScriptClient,

--- a/packages/calendar/src/core/utils/redis-rate-limiter.ts
+++ b/packages/calendar/src/core/utils/redis-rate-limiter.ts
@@ -188,17 +188,12 @@ const createGoogleUserRateLimiter = (
   { requestsPerMinute: GOOGLE_LANE_REQUESTS_PER_MINUTE[lane] },
 );
 
-// Modest default so many workers hitting one CalDAV/ICS host stay polite together.
 const HOST_REQUESTS_PER_MINUTE = 30;
 
 interface HostRateLimiterOptions {
   requestsPerMinute?: number;
 }
 
-/*
- * Keyed by target host, not user: CalDAV/ICS servers throttle by origin traffic,
- * so every worker fetching from the same host must draw from one shared budget.
- */
 const createHostRateLimiter = (
   redis: RedisScriptClient,
   host: string,
@@ -209,9 +204,7 @@ const createHostRateLimiter = (
   { requestsPerMinute: options?.requestsPerMinute ?? HOST_REQUESTS_PER_MINUTE },
 );
 
-// One under Graph's documented MailboxConcurrency of 4, leaving headroom for user traffic.
 const OUTLOOK_ACCOUNT_CONCURRENCY = 3;
-// Comfortably above the 120s ingest timeout so a live holder never loses its lease mid-run.
 const OUTLOOK_LEASE_TTL_MS = 150_000;
 
 interface OutlookAccountSemaphore {

--- a/packages/calendar/src/core/utils/redis-rate-limiter.ts
+++ b/packages/calendar/src/core/utils/redis-rate-limiter.ts
@@ -25,18 +25,9 @@ interface RedisScriptClient {
 }
 
 /**
- * Lua script for atomic sliding window rate limiting.
- *
  * KEYS[1] = sorted set key
- * ARGV[1] = window start (now - 60s) in ms
- * ARGV[2] = current time in ms
- * ARGV[3] = count of slots to acquire
- * ARGV[4] = max requests per minute
- *
- * Returns { waitTime, occupancy }:
- *   waitTime 0 = acquired successfully
- *   waitTime > 0 = wait time in ms before retrying
- *   occupancy = slots already held in the window when the decision was taken
+ * ARGV = [window start ms, now ms, slots to acquire, max requests per minute]
+ * Returns [waitTime, occupancy]; waitTime 0 means acquired.
  */
 const ACQUIRE_SCRIPT = `
   redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
@@ -96,20 +87,14 @@ const sleep = (delayMs: number): Promise<void> =>
     setTimeout(resolve, delayMs);
   });
 
-/*
- * Reached only after a throttled decision: the caller is parked on the shared
- * pacing window, ahead of the provider request the permit would authorize, so
- * an abort observed here is stamped as a pacing park (see pacing-park.ts).
- */
+/* Parked on the shared window, ahead of the request the permit would authorize. */
 const waitForRetry = (delayMs: number, signal?: AbortSignal): Promise<void> => {
   if (!signal) {
     return sleep(delayMs);
   }
   /*
-   * No park flag on an already-consumed deadline: it may have been eaten by a
-   * provider call that takes no signal, and stamping it would exempt a
-   * provider-consumed deadline from ingest backoff. Only the abort observed
-   * while actually parked below is pre-contact.
+   * No park flag on an already-consumed deadline: it may have been eaten by a provider call
+   * that takes no signal, and stamping it would exempt that from ingest backoff.
    */
   if (signal.aborted) {
     return Promise.reject(signal.reason);
@@ -190,10 +175,8 @@ const GOOGLE_LANE_REQUESTS_PER_MINUTE: Record<GoogleRateLimitLane, number> = {
 };
 
 /*
- * One key for both lanes: Google's quota is per user however it is spent, so separate
- * keys would let the two jobs together sail past the real limit. The lanes differ only
- * in how much of that shared key each may claim, which reserves headroom for ingestion
- * without raising the total.
+ * One key for both lanes: Google's quota is per user however it is spent, so separate keys
+ * would let the two jobs together sail past the real limit.
  */
 const createGoogleUserRateLimiter = (
   redis: RedisScriptClient,

--- a/packages/calendar/src/core/utils/redis-rate-limiter.ts
+++ b/packages/calendar/src/core/utils/redis-rate-limiter.ts
@@ -105,8 +105,13 @@ const waitForRetry = (delayMs: number, signal?: AbortSignal): Promise<void> => {
   if (!signal) {
     return sleep(delayMs);
   }
+  /*
+   * No park flag on an already-consumed deadline: it may have been eaten by a
+   * provider call that takes no signal, and stamping it would exempt a
+   * provider-consumed deadline from ingest backoff. Only the abort observed
+   * while actually parked below is pre-contact.
+   */
   if (signal.aborted) {
-    flagPacingParkAbortReason(signal.reason);
     return Promise.reject(signal.reason);
   }
   return new Promise((resolve, reject) => {

--- a/packages/calendar/src/core/utils/redis-rate-limiter.ts
+++ b/packages/calendar/src/core/utils/redis-rate-limiter.ts
@@ -5,6 +5,7 @@ import {
 import { widelog } from "widelogger";
 import { measureRedisCommand, recordSegment } from "../telemetry/segments";
 import { createLeasedSemaphore } from "./leased-semaphore";
+import { flagPacingParkAbortReason } from "./pacing-park";
 import type { RedisLeaseClient, SemaphoreLease } from "./leased-semaphore";
 
 const MS_PER_MINUTE = 60_000;
@@ -95,16 +96,23 @@ const sleep = (delayMs: number): Promise<void> =>
     setTimeout(resolve, delayMs);
   });
 
+/*
+ * Reached only after a throttled decision: the caller is parked on the shared
+ * pacing window, ahead of the provider request the permit would authorize, so
+ * an abort observed here is stamped as a pacing park (see pacing-park.ts).
+ */
 const waitForRetry = (delayMs: number, signal?: AbortSignal): Promise<void> => {
   if (!signal) {
     return sleep(delayMs);
   }
   if (signal.aborted) {
+    flagPacingParkAbortReason(signal.reason);
     return Promise.reject(signal.reason);
   }
   return new Promise((resolve, reject) => {
     const timeoutSignal = AbortSignal.timeout(delayMs);
     const onAbort = (): void => {
+      flagPacingParkAbortReason(signal.reason);
       reject(signal.reason);
     };
     const onTimeout = (): void => {

--- a/packages/calendar/src/core/utils/serial-flush-worker.ts
+++ b/packages/calendar/src/core/utils/serial-flush-worker.ts
@@ -1,11 +1,18 @@
 const DEFAULT_CAPACITY = 50;
 
 interface SerialFlushWorkerOptions {
+  budget?: number;
   capacity?: number;
+}
+
+interface FlushReservation<TItem, TResult> {
+  release(): void;
+  submit(item: TItem): Promise<TResult>;
 }
 
 interface SerialFlushWorker<TItem, TResult> {
   close(): Promise<void>;
+  reserve(weight: number, signal?: AbortSignal): Promise<FlushReservation<TItem, TResult>>;
   submit(item: TItem, signal?: AbortSignal): Promise<TResult>;
 }
 
@@ -20,20 +27,35 @@ interface SlotWaiter {
   reject: (reason: unknown) => void;
 }
 
+interface WeightWaiter {
+  aborted: () => boolean;
+  grant: () => void;
+  reject: (reason: unknown) => void;
+  weight: number;
+}
+
 /*
  * Bounded serial worker: many callers may submit concurrently, but `run` is
  * invoked one item at a time in submission order. Once `capacity` items are
  * queued, further submits park until a slot frees, so queued memory stays
  * bounded no matter how fast producers go.
+ *
+ * When `budget` is set the worker also supports weighted reservations:
+ * `reserve(weight)` acquires that many weight units BEFORE any payload
+ * exists, parking FIFO when the budget is exhausted, so callers can gate
+ * expensive fetches on available memory budget rather than item counts.
  */
 const createSerialFlushWorker = <TItem, TResult>(
   run: (item: TItem) => Promise<TResult>,
   options?: SerialFlushWorkerOptions,
 ): SerialFlushWorker<TItem, TResult> => {
   const capacity = options?.capacity ?? DEFAULT_CAPACITY;
+  const budget = options?.budget;
   const queue: QueuedItem<TItem, TResult>[] = [];
   const slotWaiters: SlotWaiter[] = [];
+  const weightWaiters: WeightWaiter[] = [];
   const idleWaiters: (() => void)[] = [];
+  let outstandingWeight = 0;
   let closed = false;
   let pumping = false;
 
@@ -44,6 +66,29 @@ const createSerialFlushWorker = <TItem, TResult>(
       if (waiter && waiter.grant()) {
         return;
       }
+    }
+  };
+
+  const grantWeight = (): void => {
+    if (typeof budget !== "number") {
+      return;
+    }
+    // FIFO: only the head may be admitted, and only while it fits the budget.
+    while (weightWaiters.length > 0) {
+      const [head] = weightWaiters;
+      if (!head) {
+        return;
+      }
+      if (head.aborted()) {
+        // An aborted waiter already rejected; drop it so it cannot block the line.
+        weightWaiters.shift();
+        continue;
+      }
+      if (outstandingWeight + head.weight > budget) {
+        return;
+      }
+      weightWaiters.shift();
+      head.grant();
     }
   };
 
@@ -112,10 +157,110 @@ const createSerialFlushWorker = <TItem, TResult>(
     });
   };
 
+  const createReservation = (weight: number): FlushReservation<TItem, TResult> => {
+    let freed = false;
+    /*
+     * A reservation's weight is freed exactly once: by release() or when its
+     * submitted run settles. Further calls are no-ops so the budget never
+     * goes negative and admits unbounded reservations.
+     */
+    const free = (): void => {
+      if (freed) {
+        return;
+      }
+      freed = true;
+      outstandingWeight -= weight;
+      grantWeight();
+    };
+    const reservationSubmit = (item: TItem): Promise<TResult> => {
+      if (closed) {
+        free();
+        return Promise.reject(new Error("serial flush worker is closed"));
+      }
+      // The weight already bounds this payload, so no item-count gating here.
+      return new Promise<TResult>((resolve, reject) => {
+        queue.push({
+          item,
+          reject: (reason: unknown): void => {
+            free();
+            reject(reason);
+          },
+          resolve: (value: TResult): void => {
+            free();
+            resolve(value);
+          },
+        });
+        pump().catch((error: unknown) => {
+          free();
+          reject(error);
+        });
+      });
+    };
+    return { release: free, submit: reservationSubmit };
+  };
+
+  const reserve = (
+    weight: number,
+    signal?: AbortSignal,
+  ): Promise<FlushReservation<TItem, TResult>> => {
+    if (closed) {
+      return Promise.reject(new Error("serial flush worker is closed"));
+    }
+    if (typeof budget !== "number") {
+      return Promise.reject(new Error("reserve requires a budget"));
+    }
+    if (signal?.aborted) {
+      return Promise.reject(signal.reason);
+    }
+    /*
+     * Whale rule: a payload heavier than the whole budget clamps to the full
+     * budget and is granted when the worker is otherwise idle, never deadlocking.
+     */
+    const clamped = Math.min(weight, budget);
+    return new Promise<FlushReservation<TItem, TResult>>((resolve, reject) => {
+      const grantNow = (): void => {
+        outstandingWeight += clamped;
+        resolve(createReservation(clamped));
+      };
+      if (weightWaiters.length === 0 && outstandingWeight + clamped <= budget) {
+        grantNow();
+        return;
+      }
+      /*
+       * An abort while parked acquired nothing, so it must free nothing: the
+       * waiter marks itself aborted and grantWeight drops it from the FIFO
+       * without ever touching outstandingWeight.
+       */
+      let abortedWhileParked = false;
+      const onAbort = (): void => {
+        abortedWhileParked = true;
+        reject(signal?.reason);
+      };
+      const waiter: WeightWaiter = {
+        aborted: (): boolean => abortedWhileParked,
+        grant: (): void => {
+          signal?.removeEventListener("abort", onAbort);
+          grantNow();
+        },
+        reject: (reason: unknown): void => {
+          signal?.removeEventListener("abort", onAbort);
+          reject(reason);
+        },
+        weight: clamped,
+      };
+      weightWaiters.push(waiter);
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
+  };
+
   const close = (): Promise<void> => {
     closed = true;
     // Parked submits never made it into the queue; they cannot drain.
     for (const waiter of slotWaiters.splice(0)) {
+      waiter.reject(new Error("serial flush worker is closed"));
+    }
+    // Parked reservers hold no weight yet; they cannot be granted after close.
+    for (const waiter of weightWaiters.splice(0)) {
       waiter.reject(new Error("serial flush worker is closed"));
     }
     if (!pumping && queue.length === 0) {
@@ -126,8 +271,8 @@ const createSerialFlushWorker = <TItem, TResult>(
     });
   };
 
-  return { close, submit };
+  return { close, reserve, submit };
 };
 
 export { createSerialFlushWorker };
-export type { SerialFlushWorker, SerialFlushWorkerOptions };
+export type { FlushReservation, SerialFlushWorker, SerialFlushWorkerOptions };

--- a/packages/calendar/src/core/utils/serial-flush-worker.ts
+++ b/packages/calendar/src/core/utils/serial-flush-worker.ts
@@ -1,0 +1,133 @@
+const DEFAULT_CAPACITY = 50;
+
+interface SerialFlushWorkerOptions {
+  capacity?: number;
+}
+
+interface SerialFlushWorker<TItem, TResult> {
+  close(): Promise<void>;
+  submit(item: TItem, signal?: AbortSignal): Promise<TResult>;
+}
+
+interface QueuedItem<TItem, TResult> {
+  item: TItem;
+  reject: (reason: unknown) => void;
+  resolve: (value: TResult) => void;
+}
+
+interface SlotWaiter {
+  grant: () => boolean;
+  reject: (reason: unknown) => void;
+}
+
+/*
+ * Bounded serial worker: many callers may submit concurrently, but `run` is
+ * invoked one item at a time in submission order. Once `capacity` items are
+ * queued, further submits park until a slot frees, so queued memory stays
+ * bounded no matter how fast producers go.
+ */
+const createSerialFlushWorker = <TItem, TResult>(
+  run: (item: TItem) => Promise<TResult>,
+  options?: SerialFlushWorkerOptions,
+): SerialFlushWorker<TItem, TResult> => {
+  const capacity = options?.capacity ?? DEFAULT_CAPACITY;
+  const queue: QueuedItem<TItem, TResult>[] = [];
+  const slotWaiters: SlotWaiter[] = [];
+  const idleWaiters: (() => void)[] = [];
+  let closed = false;
+  let pumping = false;
+
+  const grantSlot = (): void => {
+    // Skip waiters whose submits already aborted; the slot goes to the next live one.
+    while (slotWaiters.length > 0) {
+      const waiter = slotWaiters.shift();
+      if (waiter && waiter.grant()) {
+        return;
+      }
+    }
+  };
+
+  const pump = async (): Promise<void> => {
+    if (pumping) {
+      return;
+    }
+    pumping = true;
+    while (queue.length > 0) {
+      const next = queue.shift();
+      if (!next) {
+        break;
+      }
+      // Dequeuing frees a queue slot, so a parked submit may enqueue now.
+      grantSlot();
+      try {
+        next.resolve(await run(next.item));
+      } catch (error) {
+        // A failing flush rejects only its own submit; the worker keeps going.
+        next.reject(error);
+      }
+    }
+    pumping = false;
+    for (const notify of idleWaiters.splice(0)) {
+      notify();
+    }
+  };
+
+  const submit = (item: TItem, signal?: AbortSignal): Promise<TResult> => {
+    if (closed) {
+      return Promise.reject(new Error("serial flush worker is closed"));
+    }
+    if (signal?.aborted) {
+      return Promise.reject(signal.reason);
+    }
+    return new Promise<TResult>((resolve, reject) => {
+      const enqueue = (): void => {
+        queue.push({ item, reject, resolve });
+        pump().catch(reject);
+      };
+      if (queue.length < capacity) {
+        enqueue();
+        return;
+      }
+      let abortedWhileParked = false;
+      const onAbort = (): void => {
+        abortedWhileParked = true;
+        reject(signal?.reason);
+      };
+      const waiter: SlotWaiter = {
+        grant: (): boolean => {
+          signal?.removeEventListener("abort", onAbort);
+          if (abortedWhileParked) {
+            return false;
+          }
+          enqueue();
+          return true;
+        },
+        reject: (reason: unknown): void => {
+          signal?.removeEventListener("abort", onAbort);
+          reject(reason);
+        },
+      };
+      slotWaiters.push(waiter);
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
+  };
+
+  const close = (): Promise<void> => {
+    closed = true;
+    // Parked submits never made it into the queue; they cannot drain.
+    for (const waiter of slotWaiters.splice(0)) {
+      waiter.reject(new Error("serial flush worker is closed"));
+    }
+    if (!pumping && queue.length === 0) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      idleWaiters.push(resolve);
+    });
+  };
+
+  return { close, submit };
+};
+
+export { createSerialFlushWorker };
+export type { SerialFlushWorker, SerialFlushWorkerOptions };

--- a/packages/calendar/src/core/utils/serial-flush-worker.ts
+++ b/packages/calendar/src/core/utils/serial-flush-worker.ts
@@ -90,6 +90,25 @@ const resolveRunDeadlineMs = (item: unknown): number => {
   return DEFAULT_RUN_DEADLINE_MS;
 };
 
+/*
+ * An item may carry a `prepare` thunk: work that must run after this item's
+ * queue wait but before its run takes the serial writer slot — the ingest
+ * caller's persist-time Redis currency probe. Resolved the same way
+ * `deadlineAt` is, since items are plain objects or callable thunks. Returning
+ * a non-null value short-circuits the item: its submit settles with that value
+ * and `run` is never invoked.
+ */
+const resolvePrepare = (item: unknown): (() => unknown) | null => {
+  const carriesProperties = typeof item === "object" || typeof item === "function";
+  if (carriesProperties && item !== null && "prepare" in item) {
+    const { prepare } = item as { prepare: unknown };
+    if (typeof prepare === "function") {
+      return prepare as () => unknown;
+    }
+  }
+  return null;
+};
+
 interface SerialFlushWorkerOptions {
   budget?: number;
   capacity?: number;
@@ -147,6 +166,13 @@ const createSerialFlushWorker = <TItem, TResult>(
   const slotWaiters: SlotWaiter[] = [];
   const weightWaiters: WeightWaiter[] = [];
   const idleWaiters: (() => void)[] = [];
+  // Items queued for ownership of the single serial writer slot.
+  const writerSlotWaiters: (() => void)[] = [];
+  // The pump, waiting for that slot to go idle before dequeuing again.
+  const writerSlotFreeWaiters: (() => void)[] = [];
+  // Items dequeued but not yet settled: preparing, waiting for the slot, or running.
+  let inFlight = 0;
+  let writerSlotBusy = false;
   let outstandingWeight = 0;
   // Express grants that have overtaken the currently parked FIFO head.
   let expressOvertakes = 0;
@@ -223,33 +249,107 @@ const createSerialFlushWorker = <TItem, TResult>(
     }
   };
 
+  const notifyIfIdle = (): void => {
+    if (pumping || inFlight > 0 || queue.length > 0) {
+      return;
+    }
+    for (const notify of idleWaiters.splice(0)) {
+      notify();
+    }
+  };
+
+  const claimWriterSlot = (): boolean => {
+    if (writerSlotBusy) {
+      return false;
+    }
+    writerSlotBusy = true;
+    return true;
+  };
+
+  const whenWriterSlotOwned = (): Promise<void> => new Promise((resolve) => {
+    writerSlotWaiters.push(resolve);
+  });
+
+  const whenWriterSlotFree = (): Promise<void> => new Promise((resolve) => {
+    writerSlotFreeWaiters.push(resolve);
+  });
+
+  /*
+   * The slot is handed straight to the next owner in line, so runs stay
+   * strictly serial without a re-check race. It only goes idle — waking the
+   * pump to dequeue again — once nobody holds a claim on it.
+   */
+  const releaseWriterSlot = (): void => {
+    const nextOwner = writerSlotWaiters.shift();
+    if (nextOwner) {
+      nextOwner();
+      return;
+    }
+    writerSlotBusy = false;
+    for (const notify of writerSlotFreeWaiters.splice(0)) {
+      notify();
+    }
+  };
+
   /*
    * A half-open connection can leave `run` pending forever, making server-side
-   * timeouts unreachable. Racing each run against a client-side deadline keeps
+   * timeouts unreachable. Racing each item against a client-side deadline keeps
    * one wedged flush from stalling every family's persistence until restart.
    * The deadline only rejects the caller's promise: the run itself is awaited
    * to settlement, so a timed-out run keeps its reserved weight, keeps the
-   * pump blocked (runs stay strictly serial), and keeps close() waiting while
-   * its flushDatabase transaction is still live.
+   * writer slot held (runs stay strictly serial), and keeps close() waiting
+   * while its flushDatabase transaction is still live.
+   *
+   * The returned promise releases the pump, not the item: it settles once the
+   * item has either taken the writer slot or gone off-slot into its
+   * preparation, so a slow preparation never head-of-line stalls the runs
+   * behind it.
    */
-  const pump = async (): Promise<void> => {
-    if (pumping) {
-      return;
-    }
-    pumping = true;
-    while (queue.length > 0) {
-      const next = queue.shift();
-      if (!next) {
-        break;
+  const startItem = (next: QueuedItem<TItem, TResult>): Promise<unknown> => {
+    const admitted = Promise.withResolvers<null>();
+    const deadlineMs = resolveRunDeadlineMs(next.item);
+    let deadlineExpired = false;
+    const timer = setTimeout(() => {
+      deadlineExpired = true;
+      next.reject(new SerialFlushRunDeadlineError(deadlineMs));
+    }, deadlineMs);
+    const finish = (): void => {
+      clearTimeout(timer);
+      inFlight -= 1;
+      if (next.settle) {
+        next.settle();
       }
-      // Dequeuing frees a queue slot, so a parked submit may enqueue now.
-      grantSlot();
-      const deadlineMs = resolveRunDeadlineMs(next.item);
-      let deadlineExpired = false;
-      const timer = setTimeout(() => {
-        deadlineExpired = true;
-        next.reject(new SerialFlushRunDeadlineError(deadlineMs));
-      }, deadlineMs);
+      notifyIfIdle();
+    };
+    inFlight += 1;
+    const prepare = resolvePrepare(next.item);
+    const runLifecycle = async (): Promise<void> => {
+      if (prepare) {
+        try {
+          // A preparation that answers nothing may say so as either nullish value.
+          const prepared = await prepare() ?? null;
+          if (prepared !== null) {
+            // The preparation answered for the item; its run never happens.
+            if (!deadlineExpired) {
+              next.resolve(prepared as TResult);
+            }
+            admitted.resolve(null);
+            finish();
+            return;
+          }
+        } catch (error) {
+          if (!deadlineExpired) {
+            next.reject(error);
+          }
+          admitted.resolve(null);
+          finish();
+          return;
+        }
+      }
+      if (!claimWriterSlot()) {
+        await whenWriterSlotOwned();
+      }
+      admitted.resolve(null);
       try {
         const value = await run(next.item);
         if (!deadlineExpired) {
@@ -261,16 +361,41 @@ const createSerialFlushWorker = <TItem, TResult>(
           next.reject(error);
         }
       } finally {
-        clearTimeout(timer);
-        if (next.settle) {
-          next.settle();
-        }
+        releaseWriterSlot();
+        finish();
       }
+    };
+    runLifecycle().catch(next.reject);
+    /*
+     * An item whose preparation is already settled must claim the writer slot
+     * before the next item is dequeued: otherwise a whole backlog would prepare
+     * in one sweep and the last item's currency probe would predate its run by
+     * every run queued ahead of it. A preparation still outstanding resolves
+     * nothing here, so the immediate yield releases the pump instead.
+     */
+    return Promise.race([admitted.promise, Promise.resolve()]);
+  };
+
+  const pump = async (): Promise<void> => {
+    if (pumping) {
+      return;
+    }
+    pumping = true;
+    while (queue.length > 0) {
+      if (writerSlotBusy) {
+        await whenWriterSlotFree();
+        continue;
+      }
+      const next = queue.shift();
+      if (!next) {
+        break;
+      }
+      // Dequeuing frees a queue slot, so a parked submit may enqueue now.
+      grantSlot();
+      await startItem(next);
     }
     pumping = false;
-    for (const notify of idleWaiters.splice(0)) {
-      notify();
-    }
+    notifyIfIdle();
   };
 
   const submit = (item: TItem, signal?: AbortSignal): Promise<TResult> => {
@@ -410,8 +535,12 @@ const createSerialFlushWorker = <TItem, TResult>(
       return Promise.reject(new Error("reserve requires a budget"));
     }
     if (signal?.aborted) {
-      // The deadline burned out before the provider fetch could even be gated.
-      flagReserveAbortReason(signal.reason);
+      /*
+       * No park flag here: an already-consumed deadline may have been eaten by
+       * a provider call that takes no signal, and stamping it would exempt a
+       * provider-consumed deadline from ingest backoff. Only an abort observed
+       * while actually parked below is pre-contact.
+       */
       return Promise.reject(signal.reason);
     }
     /*
@@ -499,7 +628,7 @@ const createSerialFlushWorker = <TItem, TResult>(
     for (const waiter of weightWaiters.splice(0)) {
       waiter.reject(new SerialFlushWorkerClosedError());
     }
-    if (!pumping && queue.length === 0) {
+    if (!pumping && inFlight === 0 && queue.length === 0) {
       return Promise.resolve();
     }
     return new Promise((resolve) => {

--- a/packages/calendar/src/core/utils/serial-flush-worker.ts
+++ b/packages/calendar/src/core/utils/serial-flush-worker.ts
@@ -30,6 +30,26 @@ class SerialFlushRunDeadlineError extends Error {
 
 const isSerialFlushRunDeadlineError = (error: unknown): boolean =>
   error instanceof SerialFlushRunDeadlineError;
+
+/*
+ * A reserve abort fired while the caller was still parked on the worker's own
+ * budget — reserve-before-fetch ordering means the caller's provider was never
+ * contacted — so error classifiers must be able to tell this apart from the
+ * same deadline error class raised later, during a provider fetch. The abort
+ * reason is flagged in place (never wrapped) so its identity and class are
+ * preserved for callers that assert on either.
+ */
+const RESERVE_ABORT_FLAG = "serialFlushReserveAborted";
+
+const flagReserveAbortReason = (reason: unknown): void => {
+  if (reason instanceof Error) {
+    Object.assign(reason, { [RESERVE_ABORT_FLAG]: true });
+  }
+};
+
+const isSerialFlushReserveAbortError = (error: unknown): boolean =>
+  error instanceof Error &&
+  (error as Error & Record<string, unknown>)[RESERVE_ABORT_FLAG] === true;
 /*
  * Express lane for tiny reservations. Large reservations (cold-start fetches
  * sized at an eighth of the budget) can pin 100% of the budget while their
@@ -390,6 +410,8 @@ const createSerialFlushWorker = <TItem, TResult>(
       return Promise.reject(new Error("reserve requires a budget"));
     }
     if (signal?.aborted) {
+      // The deadline burned out before the provider fetch could even be gated.
+      flagReserveAbortReason(signal.reason);
       return Promise.reject(signal.reason);
     }
     /*
@@ -441,6 +463,7 @@ const createSerialFlushWorker = <TItem, TResult>(
       let abortedWhileParked = false;
       const onAbort = (): void => {
         abortedWhileParked = true;
+        flagReserveAbortReason(signal?.reason);
         reject(signal?.reason);
         /*
          * Reap immediately: if this waiter is the FIFO head, waiting for the
@@ -489,6 +512,7 @@ const createSerialFlushWorker = <TItem, TResult>(
 
 export {
   createSerialFlushWorker,
+  isSerialFlushReserveAbortError,
   isSerialFlushRunDeadlineError,
   isSerialFlushWorkerClosedError,
   SerialFlushRunDeadlineError,

--- a/packages/calendar/src/core/utils/serial-flush-worker.ts
+++ b/packages/calendar/src/core/utils/serial-flush-worker.ts
@@ -14,6 +14,22 @@ class SerialFlushWorkerClosedError extends Error {
 
 const isSerialFlushWorkerClosedError = (error: unknown): boolean =>
   error instanceof SerialFlushWorkerClosedError;
+
+/*
+ * Run-deadline rejections are likewise infrastructure: the pump's client-side
+ * deadline fired while a wedged flush held the writer, so the caller's
+ * provider was never at fault. Callers classifying errors must be able to
+ * recognize this without matching on message text.
+ */
+class SerialFlushRunDeadlineError extends Error {
+  constructor(deadlineMs: number) {
+    super(`serial flush run exceeded ${deadlineMs}ms deadline`);
+    this.name = "SerialFlushRunDeadlineError";
+  }
+}
+
+const isSerialFlushRunDeadlineError = (error: unknown): boolean =>
+  error instanceof SerialFlushRunDeadlineError;
 /*
  * Express lane for tiny reservations. Large reservations (cold-start fetches
  * sized at an eighth of the budget) can pin 100% of the budget while their
@@ -140,6 +156,8 @@ const createSerialFlushWorker = <TItem, TResult>(
       if (head.aborted()) {
         // An aborted waiter already rejected; drop it so it cannot block the line.
         weightWaiters.shift();
+        // Overtakes were counted against the dropped head; the lane reopens.
+        expressOvertakes = 0;
         continue;
       }
       if (outstandingWeight + head.weight > budget) {
@@ -171,6 +189,8 @@ const createSerialFlushWorker = <TItem, TResult>(
       if (head.aborted()) {
         // An aborted waiter already rejected; drop it so it cannot block the line.
         weightWaiters.shift();
+        // Overtakes were counted against the dropped head; the lane reopens.
+        expressOvertakes = 0;
         continue;
       }
       if (outstandingWeight + head.weight > ceiling) {
@@ -208,7 +228,7 @@ const createSerialFlushWorker = <TItem, TResult>(
       let deadlineExpired = false;
       const timer = setTimeout(() => {
         deadlineExpired = true;
-        next.reject(new Error(`serial flush run exceeded ${deadlineMs}ms deadline`));
+        next.reject(new SerialFlushRunDeadlineError(deadlineMs));
       }, deadlineMs);
       try {
         const value = await run(next.item);
@@ -303,6 +323,7 @@ const createSerialFlushWorker = <TItem, TResult>(
 
   const createReservation = (weight: number): FlushReservation<TItem, TResult> => {
     let freed = false;
+    let submitted = false;
     /*
      * A reservation's weight is freed exactly once: by release() or when its
      * submitted run settles. Further calls are no-ops so the budget never
@@ -316,7 +337,21 @@ const createSerialFlushWorker = <TItem, TResult>(
       outstandingWeight -= weight;
       grantWeight();
     };
+    /*
+     * Callers release() in a finally that also runs when submit() rejected on
+     * a deadline expiry, while the abandoned run still holds its payload and
+     * its flushDatabase transaction. After a submit, settle is therefore the
+     * ONLY path that may free the weight; release() only covers reservations
+     * that never submitted, so a fetch failure cannot strand weight forever.
+     */
+    const release = (): void => {
+      if (submitted) {
+        return;
+      }
+      free();
+    };
     const reservationSubmit = (item: TItem): Promise<TResult> => {
+      submitted = true;
       if (closed) {
         free();
         return Promise.reject(new SerialFlushWorkerClosedError());
@@ -341,7 +376,7 @@ const createSerialFlushWorker = <TItem, TResult>(
         });
       });
     };
-    return { release: free, submit: reservationSubmit };
+    return { release, submit: reservationSubmit };
   };
 
   const reserve = (
@@ -407,6 +442,12 @@ const createSerialFlushWorker = <TItem, TResult>(
       const onAbort = (): void => {
         abortedWhileParked = true;
         reject(signal?.reason);
+        /*
+         * Reap immediately: if this waiter is the FIFO head, waiting for the
+         * next release would leave a phantom head disabling the fast path and
+         * parking reservations that fit the budget right now.
+         */
+        grantWeight();
       };
       const waiter: WeightWaiter = {
         aborted: (): boolean => abortedWhileParked,
@@ -448,7 +489,9 @@ const createSerialFlushWorker = <TItem, TResult>(
 
 export {
   createSerialFlushWorker,
+  isSerialFlushRunDeadlineError,
   isSerialFlushWorkerClosedError,
+  SerialFlushRunDeadlineError,
   SerialFlushWorkerClosedError,
 };
 export type { FlushReservation, SerialFlushWorker, SerialFlushWorkerOptions };

--- a/packages/calendar/src/core/utils/serial-flush-worker.ts
+++ b/packages/calendar/src/core/utils/serial-flush-worker.ts
@@ -1,5 +1,59 @@
 const DEFAULT_CAPACITY = 50;
 
+/*
+ * Shutdown rejections are infrastructure, not payload or provider failures.
+ * Callers that classify errors (for example provider ingest backoff) must be
+ * able to recognize a closed writer without matching on message text.
+ */
+class SerialFlushWorkerClosedError extends Error {
+  constructor() {
+    super("serial flush worker is closed");
+    this.name = "SerialFlushWorkerClosedError";
+  }
+}
+
+const isSerialFlushWorkerClosedError = (error: unknown): boolean =>
+  error instanceof SerialFlushWorkerClosedError;
+/*
+ * Express lane for tiny reservations. Large reservations (cold-start fetches
+ * sized at an eighth of the budget) can pin 100% of the budget while their
+ * fetches merely sleep in a provider rate limiter, which would park every
+ * other caller of the shared worker in the FIFO. A reservation no heavier
+ * than budget/64 may instead be admitted immediately, oversubscribing the
+ * budget by at most budget/16, so healthy small work keeps flowing while the
+ * heavy holds drain. The oversubscription is bounded: once outstanding
+ * weight reaches budget + budget/16, tiny reservations park like everyone else.
+ */
+const EXPRESS_WEIGHT_DIVISOR = 64;
+const EXPRESS_HEADROOM_DIVISOR = 16;
+/*
+ * Anti-starvation bound: at most this many express grants may overtake a
+ * parked FIFO head. Once reached, the head is admitted under the same
+ * oversubscription ceiling the express lane uses, so sustained tiny traffic
+ * cannot park a cold-start or large-calendar reservation past its deadline
+ * while worst-case memory stays within budget + budget/16.
+ */
+const EXPRESS_MAX_OVERTAKES = 16;
+// Client-side bound on a single flush: any sane server-side deadline is far below this.
+const DEFAULT_RUN_DEADLINE_MS = 600_000;
+
+const resolveRunDeadlineMs = (item: unknown): number => {
+  /*
+   * Honor an item-carried absolute deadline when present; otherwise fall back.
+   * Items may be plain objects or callable thunks (the production ingest
+   * caller submits `() => task()` functions with a `deadlineAt` attached),
+   * so the probe must accept both typeof shapes.
+   */
+  const carriesProperties = typeof item === "object" || typeof item === "function";
+  if (carriesProperties && item !== null && "deadlineAt" in item) {
+    const { deadlineAt } = item as { deadlineAt: unknown };
+    if (typeof deadlineAt === "number" && Number.isFinite(deadlineAt)) {
+      return Math.max(deadlineAt - Date.now(), 0);
+    }
+  }
+  return DEFAULT_RUN_DEADLINE_MS;
+};
+
 interface SerialFlushWorkerOptions {
   budget?: number;
   capacity?: number;
@@ -20,6 +74,8 @@ interface QueuedItem<TItem, TResult> {
   item: TItem;
   reject: (reason: unknown) => void;
   resolve: (value: TResult) => void;
+  // Runs when the item's run() actually settles, even after a deadline expiry.
+  settle?: () => void;
 }
 
 interface SlotWaiter {
@@ -56,6 +112,8 @@ const createSerialFlushWorker = <TItem, TResult>(
   const weightWaiters: WeightWaiter[] = [];
   const idleWaiters: (() => void)[] = [];
   let outstandingWeight = 0;
+  // Express grants that have overtaken the currently parked FIFO head.
+  let expressOvertakes = 0;
   let closed = false;
   let pumping = false;
 
@@ -88,10 +146,52 @@ const createSerialFlushWorker = <TItem, TResult>(
         return;
       }
       weightWaiters.shift();
+      expressOvertakes = 0;
       head.grant();
     }
   };
 
+  /*
+   * Aged admission for a head the express lane has overtaken too many times:
+   * grant it under the express oversubscription ceiling instead of the plain
+   * budget, so express churn that keeps outstanding weight high cannot defer
+   * it forever. Admits at most the head; the rest of the FIFO still drains
+   * through grantWeight under the normal budget.
+   */
+  const grantOvertakenHead = (): void => {
+    if (typeof budget !== "number") {
+      return;
+    }
+    const ceiling = budget + budget / EXPRESS_HEADROOM_DIVISOR;
+    while (weightWaiters.length > 0) {
+      const [head] = weightWaiters;
+      if (!head) {
+        return;
+      }
+      if (head.aborted()) {
+        // An aborted waiter already rejected; drop it so it cannot block the line.
+        weightWaiters.shift();
+        continue;
+      }
+      if (outstandingWeight + head.weight > ceiling) {
+        return;
+      }
+      weightWaiters.shift();
+      expressOvertakes = 0;
+      head.grant();
+      return;
+    }
+  };
+
+  /*
+   * A half-open connection can leave `run` pending forever, making server-side
+   * timeouts unreachable. Racing each run against a client-side deadline keeps
+   * one wedged flush from stalling every family's persistence until restart.
+   * The deadline only rejects the caller's promise: the run itself is awaited
+   * to settlement, so a timed-out run keeps its reserved weight, keeps the
+   * pump blocked (runs stay strictly serial), and keeps close() waiting while
+   * its flushDatabase transaction is still live.
+   */
   const pump = async (): Promise<void> => {
     if (pumping) {
       return;
@@ -104,11 +204,27 @@ const createSerialFlushWorker = <TItem, TResult>(
       }
       // Dequeuing frees a queue slot, so a parked submit may enqueue now.
       grantSlot();
+      const deadlineMs = resolveRunDeadlineMs(next.item);
+      let deadlineExpired = false;
+      const timer = setTimeout(() => {
+        deadlineExpired = true;
+        next.reject(new Error(`serial flush run exceeded ${deadlineMs}ms deadline`));
+      }, deadlineMs);
       try {
-        next.resolve(await run(next.item));
+        const value = await run(next.item);
+        if (!deadlineExpired) {
+          next.resolve(value);
+        }
       } catch (error) {
         // A failing flush rejects only its own submit; the worker keeps going.
-        next.reject(error);
+        if (!deadlineExpired) {
+          next.reject(error);
+        }
+      } finally {
+        clearTimeout(timer);
+        if (next.settle) {
+          next.settle();
+        }
       }
     }
     pumping = false;
@@ -119,15 +235,43 @@ const createSerialFlushWorker = <TItem, TResult>(
 
   const submit = (item: TItem, signal?: AbortSignal): Promise<TResult> => {
     if (closed) {
-      return Promise.reject(new Error("serial flush worker is closed"));
+      return Promise.reject(new SerialFlushWorkerClosedError());
     }
     if (signal?.aborted) {
       return Promise.reject(signal.reason);
     }
     return new Promise<TResult>((resolve, reject) => {
       const enqueue = (): void => {
-        queue.push({ item, reject, resolve });
-        pump().catch(reject);
+        const detach = new AbortController();
+        const entry: QueuedItem<TItem, TResult> = {
+          item,
+          reject: (reason: unknown): void => {
+            detach.abort();
+            reject(reason);
+          },
+          resolve: (value: TResult): void => {
+            detach.abort();
+            resolve(value);
+          },
+        };
+        /*
+         * A queued item must observe its signal: abort removes and rejects it
+         * at its deadline instead of waiting for the pump to drain to it.
+         */
+        const onQueuedAbort = (): void => {
+          const index = queue.indexOf(entry);
+          if (index === -1) {
+            // Already dequeued by the pump; its own settlement handles cleanup.
+            return;
+          }
+          queue.splice(index, 1);
+          // Removing a queued item frees a slot for a parked submit.
+          grantSlot();
+          reject(signal?.reason);
+        };
+        queue.push(entry);
+        signal?.addEventListener("abort", onQueuedAbort, { once: true, signal: detach.signal });
+        pump().catch(entry.reject);
       };
       if (queue.length < capacity) {
         enqueue();
@@ -175,20 +319,21 @@ const createSerialFlushWorker = <TItem, TResult>(
     const reservationSubmit = (item: TItem): Promise<TResult> => {
       if (closed) {
         free();
-        return Promise.reject(new Error("serial flush worker is closed"));
+        return Promise.reject(new SerialFlushWorkerClosedError());
       }
       // The weight already bounds this payload, so no item-count gating here.
       return new Promise<TResult>((resolve, reject) => {
+        /*
+         * The weight is freed by `settle`, which fires only when run() itself
+         * settles — a deadline expiry rejects the caller but must NOT return
+         * the weight to the budget while the abandoned run still holds its
+         * payload and its flushDatabase transaction.
+         */
         queue.push({
           item,
-          reject: (reason: unknown): void => {
-            free();
-            reject(reason);
-          },
-          resolve: (value: TResult): void => {
-            free();
-            resolve(value);
-          },
+          reject,
+          resolve,
+          settle: free,
         });
         pump().catch((error: unknown) => {
           free();
@@ -204,7 +349,7 @@ const createSerialFlushWorker = <TItem, TResult>(
     signal?: AbortSignal,
   ): Promise<FlushReservation<TItem, TResult>> => {
     if (closed) {
-      return Promise.reject(new Error("serial flush worker is closed"));
+      return Promise.reject(new SerialFlushWorkerClosedError());
     }
     if (typeof budget !== "number") {
       return Promise.reject(new Error("reserve requires a budget"));
@@ -224,6 +369,33 @@ const createSerialFlushWorker = <TItem, TResult>(
       };
       if (weightWaiters.length === 0 && outstandingWeight + clamped <= budget) {
         grantNow();
+        return;
+      }
+      /*
+       * Express lane: a tiny reservation must not stall behind heavy holds
+       * that are only waiting on their providers. Bounded oversubscription
+       * keeps memory within budget + budget/16 in the worst case.
+       */
+      const expressCeiling = budget + budget / EXPRESS_HEADROOM_DIVISOR;
+      /*
+       * Fairness: once the overtake bound is reached, the express lane pauses
+       * and tiny reservations park like everyone else, so releases drain
+       * outstanding weight until the parked head fits and is admitted (which
+       * resets the counter and reopens the lane).
+       */
+      if (
+        clamped <= budget / EXPRESS_WEIGHT_DIVISOR &&
+        expressOvertakes < EXPRESS_MAX_OVERTAKES &&
+        outstandingWeight + clamped <= expressCeiling
+      ) {
+        if (weightWaiters.length > 0) {
+          expressOvertakes += 1;
+        }
+        grantNow();
+        // Fairness: after enough overtakes the parked head must be admitted.
+        if (expressOvertakes >= EXPRESS_MAX_OVERTAKES) {
+          grantOvertakenHead();
+        }
         return;
       }
       /*
@@ -257,11 +429,11 @@ const createSerialFlushWorker = <TItem, TResult>(
     closed = true;
     // Parked submits never made it into the queue; they cannot drain.
     for (const waiter of slotWaiters.splice(0)) {
-      waiter.reject(new Error("serial flush worker is closed"));
+      waiter.reject(new SerialFlushWorkerClosedError());
     }
     // Parked reservers hold no weight yet; they cannot be granted after close.
     for (const waiter of weightWaiters.splice(0)) {
-      waiter.reject(new Error("serial flush worker is closed"));
+      waiter.reject(new SerialFlushWorkerClosedError());
     }
     if (!pumping && queue.length === 0) {
       return Promise.resolve();
@@ -274,5 +446,9 @@ const createSerialFlushWorker = <TItem, TResult>(
   return { close, reserve, submit };
 };
 
-export { createSerialFlushWorker };
+export {
+  createSerialFlushWorker,
+  isSerialFlushWorkerClosedError,
+  SerialFlushWorkerClosedError,
+};
 export type { FlushReservation, SerialFlushWorker, SerialFlushWorkerOptions };

--- a/packages/calendar/src/core/utils/serial-flush-worker.ts
+++ b/packages/calendar/src/core/utils/serial-flush-worker.ts
@@ -1,10 +1,6 @@
 const DEFAULT_CAPACITY = 50;
 
-/*
- * Shutdown rejections are infrastructure, not payload or provider failures.
- * Callers that classify errors (for example provider ingest backoff) must be
- * able to recognize a closed writer without matching on message text.
- */
+/* Distinct class so error classifiers recognize a closed writer without matching message text. */
 class SerialFlushWorkerClosedError extends Error {
   constructor() {
     super("serial flush worker is closed");
@@ -15,12 +11,7 @@ class SerialFlushWorkerClosedError extends Error {
 const isSerialFlushWorkerClosedError = (error: unknown): boolean =>
   error instanceof SerialFlushWorkerClosedError;
 
-/*
- * Run-deadline rejections are likewise infrastructure: the pump's client-side
- * deadline fired while a wedged flush held the writer, so the caller's
- * provider was never at fault. Callers classifying errors must be able to
- * recognize this without matching on message text.
- */
+/* Infrastructure, not a provider fault: a wedged flush held the writer past the deadline. */
 class SerialFlushRunDeadlineError extends Error {
   constructor(deadlineMs: number) {
     super(`serial flush run exceeded ${deadlineMs}ms deadline`);
@@ -32,12 +23,10 @@ const isSerialFlushRunDeadlineError = (error: unknown): boolean =>
   error instanceof SerialFlushRunDeadlineError;
 
 /*
- * A reserve abort fired while the caller was still parked on the worker's own
- * budget — reserve-before-fetch ordering means the caller's provider was never
- * contacted — so error classifiers must be able to tell this apart from the
- * same deadline error class raised later, during a provider fetch. The abort
- * reason is flagged in place (never wrapped) so its identity and class are
- * preserved for callers that assert on either.
+ * Marks a deadline that expired while parked on the budget, before the provider was ever
+ * contacted, so classifiers can tell it from the same error class raised during a fetch.
+ * Flagged in place, never wrapped, so the reason's identity and class survive for callers
+ * that assert on either.
  */
 const RESERVE_ABORT_FLAG = "serialFlushReserveAborted";
 
@@ -51,34 +40,21 @@ const isSerialFlushReserveAbortError = (error: unknown): boolean =>
   error instanceof Error &&
   (error as Error & Record<string, unknown>)[RESERVE_ABORT_FLAG] === true;
 /*
- * Express lane for tiny reservations. Large reservations (cold-start fetches
- * sized at an eighth of the budget) can pin 100% of the budget while their
- * fetches merely sleep in a provider rate limiter, which would park every
- * other caller of the shared worker in the FIFO. A reservation no heavier
- * than budget/64 may instead be admitted immediately, oversubscribing the
- * budget by at most budget/16, so healthy small work keeps flowing while the
- * heavy holds drain. The oversubscription is bounded: once outstanding
- * weight reaches budget + budget/16, tiny reservations park like everyone else.
+ * Cold-start fetches sized at an eighth of the budget can pin all of it while merely
+ * sleeping in a provider rate limiter, parking every other caller. Reservations no heavier
+ * than budget/64 skip the FIFO, capping worst-case memory at budget + budget/16.
  */
 const EXPRESS_WEIGHT_DIVISOR = 64;
 const EXPRESS_HEADROOM_DIVISOR = 16;
-/*
- * Anti-starvation bound: at most this many express grants may overtake a
- * parked FIFO head. Once reached, the head is admitted under the same
- * oversubscription ceiling the express lane uses, so sustained tiny traffic
- * cannot park a cold-start or large-calendar reservation past its deadline
- * while worst-case memory stays within budget + budget/16.
- */
+/* Bounds the starvation the express lane can inflict on a parked FIFO head. */
 const EXPRESS_MAX_OVERTAKES = 16;
 // Client-side bound on a single flush: any sane server-side deadline is far below this.
 const DEFAULT_RUN_DEADLINE_MS = 600_000;
 
 const resolveRunDeadlineMs = (item: unknown): number => {
   /*
-   * Honor an item-carried absolute deadline when present; otherwise fall back.
-   * Items may be plain objects or callable thunks (the production ingest
-   * caller submits `() => task()` functions with a `deadlineAt` attached),
-   * so the probe must accept both typeof shapes.
+   * The ingest caller submits `() => task()` thunks with `deadlineAt` attached, so this
+   * probe must accept functions as well as plain objects.
    */
   const carriesProperties = typeof item === "object" || typeof item === "function";
   if (carriesProperties && item !== null && "deadlineAt" in item) {
@@ -90,14 +66,6 @@ const resolveRunDeadlineMs = (item: unknown): number => {
   return DEFAULT_RUN_DEADLINE_MS;
 };
 
-/*
- * An item may carry a `prepare` thunk: work that must run after this item's
- * queue wait but before its run takes the serial writer slot — the ingest
- * caller's persist-time Redis currency probe. Resolved the same way
- * `deadlineAt` is, since items are plain objects or callable thunks. Returning
- * a non-null value short-circuits the item: its submit settles with that value
- * and `run` is never invoked.
- */
 const resolvePrepare = (item: unknown): (() => unknown) | null => {
   const carriesProperties = typeof item === "object" || typeof item === "function";
   if (carriesProperties && item !== null && "prepare" in item) {
@@ -129,7 +97,6 @@ interface QueuedItem<TItem, TResult> {
   item: TItem;
   reject: (reason: unknown) => void;
   resolve: (value: TResult) => void;
-  // Runs when the item's run() actually settles, even after a deadline expiry.
   settle?: () => void;
 }
 
@@ -145,17 +112,6 @@ interface WeightWaiter {
   weight: number;
 }
 
-/*
- * Bounded serial worker: many callers may submit concurrently, but `run` is
- * invoked one item at a time in submission order. Once `capacity` items are
- * queued, further submits park until a slot frees, so queued memory stays
- * bounded no matter how fast producers go.
- *
- * When `budget` is set the worker also supports weighted reservations:
- * `reserve(weight)` acquires that many weight units BEFORE any payload
- * exists, parking FIFO when the budget is exhausted, so callers can gate
- * expensive fetches on available memory budget rather than item counts.
- */
 const createSerialFlushWorker = <TItem, TResult>(
   run: (item: TItem) => Promise<TResult>,
   options?: SerialFlushWorkerOptions,
@@ -166,21 +122,16 @@ const createSerialFlushWorker = <TItem, TResult>(
   const slotWaiters: SlotWaiter[] = [];
   const weightWaiters: WeightWaiter[] = [];
   const idleWaiters: (() => void)[] = [];
-  // Items queued for ownership of the single serial writer slot.
   const writerSlotWaiters: (() => void)[] = [];
-  // The pump, waiting for that slot to go idle before dequeuing again.
   const writerSlotFreeWaiters: (() => void)[] = [];
-  // Items dequeued but not yet settled: preparing, waiting for the slot, or running.
   let inFlight = 0;
   let writerSlotBusy = false;
   let outstandingWeight = 0;
-  // Express grants that have overtaken the currently parked FIFO head.
   let expressOvertakes = 0;
   let closed = false;
   let pumping = false;
 
   const grantSlot = (): void => {
-    // Skip waiters whose submits already aborted; the slot goes to the next live one.
     while (slotWaiters.length > 0) {
       const waiter = slotWaiters.shift();
       if (waiter && waiter.grant()) {
@@ -193,16 +144,13 @@ const createSerialFlushWorker = <TItem, TResult>(
     if (typeof budget !== "number") {
       return;
     }
-    // FIFO: only the head may be admitted, and only while it fits the budget.
     while (weightWaiters.length > 0) {
       const [head] = weightWaiters;
       if (!head) {
         return;
       }
       if (head.aborted()) {
-        // An aborted waiter already rejected; drop it so it cannot block the line.
         weightWaiters.shift();
-        // Overtakes were counted against the dropped head; the lane reopens.
         expressOvertakes = 0;
         continue;
       }
@@ -215,13 +163,7 @@ const createSerialFlushWorker = <TItem, TResult>(
     }
   };
 
-  /*
-   * Aged admission for a head the express lane has overtaken too many times:
-   * grant it under the express oversubscription ceiling instead of the plain
-   * budget, so express churn that keeps outstanding weight high cannot defer
-   * it forever. Admits at most the head; the rest of the FIFO still drains
-   * through grantWeight under the normal budget.
-   */
+  /* Admits the head above the plain budget so express churn cannot defer it forever. */
   const grantOvertakenHead = (): void => {
     if (typeof budget !== "number") {
       return;
@@ -233,9 +175,7 @@ const createSerialFlushWorker = <TItem, TResult>(
         return;
       }
       if (head.aborted()) {
-        // An aborted waiter already rejected; drop it so it cannot block the line.
         weightWaiters.shift();
-        // Overtakes were counted against the dropped head; the lane reopens.
         expressOvertakes = 0;
         continue;
       }
@@ -274,11 +214,7 @@ const createSerialFlushWorker = <TItem, TResult>(
     writerSlotFreeWaiters.push(resolve);
   });
 
-  /*
-   * The slot is handed straight to the next owner in line, so runs stay
-   * strictly serial without a re-check race. It only goes idle — waking the
-   * pump to dequeue again — once nobody holds a claim on it.
-   */
+  /* Handed straight to the next owner so runs stay strictly serial without a re-check race. */
   const releaseWriterSlot = (): void => {
     const nextOwner = writerSlotWaiters.shift();
     if (nextOwner) {
@@ -292,18 +228,10 @@ const createSerialFlushWorker = <TItem, TResult>(
   };
 
   /*
-   * A half-open connection can leave `run` pending forever, making server-side
-   * timeouts unreachable. Racing each item against a client-side deadline keeps
-   * one wedged flush from stalling every family's persistence until restart.
-   * The deadline only rejects the caller's promise: the run itself is awaited
-   * to settlement, so a timed-out run keeps its reserved weight, keeps the
-   * writer slot held (runs stay strictly serial), and keeps close() waiting
-   * while its flushDatabase transaction is still live.
-   *
-   * The returned promise releases the pump, not the item: it settles once the
-   * item has either taken the writer slot or gone off-slot into its
-   * preparation, so a slow preparation never head-of-line stalls the runs
-   * behind it.
+   * A half-open connection can leave `run` pending forever, making server-side timeouts
+   * unreachable. The deadline rejects only the caller's promise: the run is still awaited to
+   * settlement, so it keeps its weight, keeps the writer slot, and keeps close() waiting
+   * while its flushDatabase transaction is live.
    */
   const startItem = (next: QueuedItem<TItem, TResult>): Promise<unknown> => {
     const admitted = Promise.withResolvers<null>();
@@ -326,10 +254,8 @@ const createSerialFlushWorker = <TItem, TResult>(
     const runLifecycle = async (): Promise<void> => {
       if (prepare) {
         try {
-          // A preparation that answers nothing may say so as either nullish value.
           const prepared = await prepare() ?? null;
           if (prepared !== null) {
-            // The preparation answered for the item; its run never happens.
             if (!deadlineExpired) {
               next.resolve(prepared as TResult);
             }
@@ -356,7 +282,6 @@ const createSerialFlushWorker = <TItem, TResult>(
           next.resolve(value);
         }
       } catch (error) {
-        // A failing flush rejects only its own submit; the worker keeps going.
         if (!deadlineExpired) {
           next.reject(error);
         }
@@ -367,11 +292,9 @@ const createSerialFlushWorker = <TItem, TResult>(
     };
     runLifecycle().catch(next.reject);
     /*
-     * An item whose preparation is already settled must claim the writer slot
-     * before the next item is dequeued: otherwise a whole backlog would prepare
-     * in one sweep and the last item's currency probe would predate its run by
-     * every run queued ahead of it. A preparation still outstanding resolves
-     * nothing here, so the immediate yield releases the pump instead.
+     * A settled preparation must claim the writer slot before the next dequeue, or a whole
+     * backlog would prepare in one sweep and the last item's currency probe would predate
+     * its run by every run queued ahead of it.
      */
     return Promise.race([admitted.promise, Promise.resolve()]);
   };
@@ -390,7 +313,6 @@ const createSerialFlushWorker = <TItem, TResult>(
       if (!next) {
         break;
       }
-      // Dequeuing frees a queue slot, so a parked submit may enqueue now.
       grantSlot();
       await startItem(next);
     }
@@ -419,18 +341,12 @@ const createSerialFlushWorker = <TItem, TResult>(
             resolve(value);
           },
         };
-        /*
-         * A queued item must observe its signal: abort removes and rejects it
-         * at its deadline instead of waiting for the pump to drain to it.
-         */
         const onQueuedAbort = (): void => {
           const index = queue.indexOf(entry);
           if (index === -1) {
-            // Already dequeued by the pump; its own settlement handles cleanup.
             return;
           }
           queue.splice(index, 1);
-          // Removing a queued item frees a slot for a parked submit.
           grantSlot();
           reject(signal?.reason);
         };
@@ -469,11 +385,7 @@ const createSerialFlushWorker = <TItem, TResult>(
   const createReservation = (weight: number): FlushReservation<TItem, TResult> => {
     let freed = false;
     let submitted = false;
-    /*
-     * A reservation's weight is freed exactly once: by release() or when its
-     * submitted run settles. Further calls are no-ops so the budget never
-     * goes negative and admits unbounded reservations.
-     */
+    /* Idempotent: a double free would drive the budget negative and admit unbounded work. */
     const free = (): void => {
       if (freed) {
         return;
@@ -483,11 +395,9 @@ const createSerialFlushWorker = <TItem, TResult>(
       grantWeight();
     };
     /*
-     * Callers release() in a finally that also runs when submit() rejected on
-     * a deadline expiry, while the abandoned run still holds its payload and
-     * its flushDatabase transaction. After a submit, settle is therefore the
-     * ONLY path that may free the weight; release() only covers reservations
-     * that never submitted, so a fetch failure cannot strand weight forever.
+     * A no-op after submit, deliberately: callers release() in a finally that also runs when
+     * submit() rejected on a deadline, while the abandoned run still holds its payload and
+     * transaction. Past submit, only settle may free the weight.
      */
     const release = (): void => {
       if (submitted) {
@@ -501,14 +411,7 @@ const createSerialFlushWorker = <TItem, TResult>(
         free();
         return Promise.reject(new SerialFlushWorkerClosedError());
       }
-      // The weight already bounds this payload, so no item-count gating here.
       return new Promise<TResult>((resolve, reject) => {
-        /*
-         * The weight is freed by `settle`, which fires only when run() itself
-         * settles — a deadline expiry rejects the caller but must NOT return
-         * the weight to the budget while the abandoned run still holds its
-         * payload and its flushDatabase transaction.
-         */
         queue.push({
           item,
           reject,
@@ -543,10 +446,7 @@ const createSerialFlushWorker = <TItem, TResult>(
        */
       return Promise.reject(signal.reason);
     }
-    /*
-     * Whale rule: a payload heavier than the whole budget clamps to the full
-     * budget and is granted when the worker is otherwise idle, never deadlocking.
-     */
+    /* A payload heavier than the whole budget clamps to it rather than deadlocking forever. */
     const clamped = Math.min(weight, budget);
     return new Promise<FlushReservation<TItem, TResult>>((resolve, reject) => {
       const grantNow = (): void => {
@@ -557,18 +457,7 @@ const createSerialFlushWorker = <TItem, TResult>(
         grantNow();
         return;
       }
-      /*
-       * Express lane: a tiny reservation must not stall behind heavy holds
-       * that are only waiting on their providers. Bounded oversubscription
-       * keeps memory within budget + budget/16 in the worst case.
-       */
       const expressCeiling = budget + budget / EXPRESS_HEADROOM_DIVISOR;
-      /*
-       * Fairness: once the overtake bound is reached, the express lane pauses
-       * and tiny reservations park like everyone else, so releases drain
-       * outstanding weight until the parked head fits and is admitted (which
-       * resets the counter and reopens the lane).
-       */
       if (
         clamped <= budget / EXPRESS_WEIGHT_DIVISOR &&
         expressOvertakes < EXPRESS_MAX_OVERTAKES &&
@@ -578,27 +467,18 @@ const createSerialFlushWorker = <TItem, TResult>(
           expressOvertakes += 1;
         }
         grantNow();
-        // Fairness: after enough overtakes the parked head must be admitted.
         if (expressOvertakes >= EXPRESS_MAX_OVERTAKES) {
           grantOvertakenHead();
         }
         return;
       }
-      /*
-       * An abort while parked acquired nothing, so it must free nothing: the
-       * waiter marks itself aborted and grantWeight drops it from the FIFO
-       * without ever touching outstandingWeight.
-       */
+      /* A park abort acquired nothing, so it must free nothing. */
       let abortedWhileParked = false;
       const onAbort = (): void => {
         abortedWhileParked = true;
         flagReserveAbortReason(signal?.reason);
         reject(signal?.reason);
-        /*
-         * Reap immediately: if this waiter is the FIFO head, waiting for the
-         * next release would leave a phantom head disabling the fast path and
-         * parking reservations that fit the budget right now.
-         */
+        /* Reaped now: a phantom head would disable the fast path for reservations that fit. */
         grantWeight();
       };
       const waiter: WeightWaiter = {
@@ -620,11 +500,9 @@ const createSerialFlushWorker = <TItem, TResult>(
 
   const close = (): Promise<void> => {
     closed = true;
-    // Parked submits never made it into the queue; they cannot drain.
     for (const waiter of slotWaiters.splice(0)) {
       waiter.reject(new SerialFlushWorkerClosedError());
     }
-    // Parked reservers hold no weight yet; they cannot be granted after close.
     for (const waiter of weightWaiters.splice(0)) {
       waiter.reject(new SerialFlushWorkerClosedError());
     }

--- a/packages/calendar/src/ics/utils/pull-remote-calendar.ts
+++ b/packages/calendar/src/ics/utils/pull-remote-calendar.ts
@@ -49,12 +49,45 @@ const parseUrlWithCredentials = (url: string): ParsedUrl => {
 
 const ICS_USER_AGENT = "Keeper/1.0 (+https://www.keeper.sh)";
 
+/* Not in the shared HTTP_STATUS map; 206 is a fetch-integrity concern local to this fetcher. */
+const HTTP_STATUS_PARTIAL_CONTENT = 206;
+
+const CALENDAR_END_PATTERN = /(?:^|[\r\n])END:VCALENDAR[ \t]*(?:[\r\n]|$)/i;
+
+/*
+ * VERSION and PRODID sit at the top of a feed, so a body truncated anywhere
+ * after the header still parses into a strictly smaller event set. Persisting
+ * that fragment as authoritative makes the snapshot diff delete the stored
+ * state of every event after the cut, then re-add them all on the next
+ * complete fetch. END:VCALENDAR is the only end-of-document marker iCalendar
+ * has; a body missing it is truncated, not smaller.
+ */
+const assertCalendarBodyComplete = (ical: string): void => {
+  if (!CALENDAR_END_PATTERN.test(ical)) {
+    throw new CalendarFetchError(
+      "Calendar feed is truncated: missing END:VCALENDAR terminator.",
+    );
+  }
+};
+
 const fetchRemoteText = async (url: string, options?: SafeFetchOptions): Promise<string> => {
   const { url: cleanUrl, headers } = parseUrlWithCredentials(url);
   const safeFetch = createSafeFetch(options);
   const response = await safeFetch(cleanUrl, {
     headers: { "User-Agent": ICS_USER_AGENT, ...headers },
   });
+
+  /*
+   * Response.ok is true for every 2xx status, 206 included. A range response
+   * body is a fragment of the feed; treating it as the whole feed would make
+   * the snapshot diff delete every stored event outside the range.
+   */
+  if (response.status === HTTP_STATUS_PARTIAL_CONTENT) {
+    throw new CalendarFetchError(
+      "Calendar server returned a partial (206) response; refusing to treat a fragment as the whole feed.",
+      response.status,
+    );
+  }
 
   if (!response.ok) {
     if (response.status === HTTP_STATUS.UNAUTHORIZED || response.status === HTTP_STATUS.FORBIDDEN) {
@@ -120,6 +153,7 @@ async function pullRemoteCalendar(
   const outputs = normalizeOutputToArray(output);
   const normalizedUrl = normalizeCalendarUrl(url);
   const ical = await fetchRemoteText(normalizedUrl, options);
+  assertCalendarBodyComplete(ical);
   const json = parseIcsCalendarLenient({ icsString: ical, patches: [coerceCompliantDate] });
 
   if (!json.version || !json.prodId) {

--- a/packages/calendar/src/ics/utils/pull-remote-calendar.ts
+++ b/packages/calendar/src/ics/utils/pull-remote-calendar.ts
@@ -55,12 +55,9 @@ const HTTP_STATUS_PARTIAL_CONTENT = 206;
 const CALENDAR_END_PATTERN = /(?:^|[\r\n])END:VCALENDAR[ \t]*(?:[\r\n]|$)/i;
 
 /*
- * VERSION and PRODID sit at the top of a feed, so a body truncated anywhere
- * after the header still parses into a strictly smaller event set. Persisting
- * that fragment as authoritative makes the snapshot diff delete the stored
- * state of every event after the cut, then re-add them all on the next
- * complete fetch. END:VCALENDAR is the only end-of-document marker iCalendar
- * has; a body missing it is truncated, not smaller.
+ * A body truncated after the header still parses into a strictly smaller event set, which
+ * the snapshot diff would treat as deletions. END:VCALENDAR is iCalendar's only
+ * end-of-document marker, so a body missing it is truncated, not smaller.
  */
 const assertCalendarBodyComplete = (ical: string): void => {
   if (!CALENDAR_END_PATTERN.test(ical)) {
@@ -77,11 +74,7 @@ const fetchRemoteText = async (url: string, options?: SafeFetchOptions): Promise
     headers: { "User-Agent": ICS_USER_AGENT, ...headers },
   });
 
-  /*
-   * Response.ok is true for every 2xx status, 206 included. A range response
-   * body is a fragment of the feed; treating it as the whole feed would make
-   * the snapshot diff delete every stored event outside the range.
-   */
+  /* Response.ok covers 206 too, and a range fragment would diff as deletions. */
   if (response.status === HTTP_STATUS_PARTIAL_CONTENT) {
     throw new CalendarFetchError(
       "Calendar server returned a partial (206) response; refusing to treat a fragment as the whole feed.",
@@ -142,9 +135,6 @@ async function pullRemoteCalendar(output: OutputJSON, url: string, options?: Saf
 
 async function pullRemoteCalendar(output: OutputICALOrJSON, url: string, options?: SafeFetchOptions): Promise<ICalOrJSON>;
 
-/**
- * @throws
- */
 async function pullRemoteCalendar(
   output: OutputJSON | OutputICal | OutputICALOrJSON,
   url: string,

--- a/packages/calendar/src/ics/utils/pull-remote-calendar.ts
+++ b/packages/calendar/src/ics/utils/pull-remote-calendar.ts
@@ -49,16 +49,10 @@ const parseUrlWithCredentials = (url: string): ParsedUrl => {
 
 const ICS_USER_AGENT = "Keeper/1.0 (+https://www.keeper.sh)";
 
-/* Not in the shared HTTP_STATUS map; 206 is a fetch-integrity concern local to this fetcher. */
 const HTTP_STATUS_PARTIAL_CONTENT = 206;
 
 const CALENDAR_END_PATTERN = /(?:^|[\r\n])END:VCALENDAR[ \t]*(?:[\r\n]|$)/i;
 
-/*
- * A body truncated after the header still parses into a strictly smaller event set, which
- * the snapshot diff would treat as deletions. END:VCALENDAR is iCalendar's only
- * end-of-document marker, so a body missing it is truncated, not smaller.
- */
 const assertCalendarBodyComplete = (ical: string): void => {
   if (!CALENDAR_END_PATTERN.test(ical)) {
     throw new CalendarFetchError(

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -145,6 +145,7 @@ export { createGoogleUserRateLimiter, createHostRateLimiter, createOutlookAccoun
 export { createLeasedSemaphore, type LeasedSemaphore, type LeasedSemaphoreConfig, type RedisLeaseClient, type SemaphoreLease } from "./core/utils/leased-semaphore";
 export { allSettledGroupedWithConcurrency, allSettledWithConcurrency, type AllSettledGroupedOptions, type AllSettledWithConcurrencyOptions } from "./core/utils/concurrency";
 export { getErrorMessage } from "./core/utils/error";
+export { createSerialFlushWorker, type SerialFlushWorker, type SerialFlushWorkerOptions } from "./core/utils/serial-flush-worker";
 export {
   buildCalendarBackoffState,
   RESET_CALENDAR_BACKOFF_STATE,

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -145,7 +145,7 @@ export { createGoogleUserRateLimiter, createHostRateLimiter, createOutlookAccoun
 export { createLeasedSemaphore, type LeasedSemaphore, type LeasedSemaphoreConfig, type RedisLeaseClient, type SemaphoreLease } from "./core/utils/leased-semaphore";
 export { allSettledGroupedWithConcurrency, allSettledWithConcurrency, type AllSettledGroupedOptions, type AllSettledWithConcurrencyOptions } from "./core/utils/concurrency";
 export { getErrorMessage } from "./core/utils/error";
-export { createSerialFlushWorker, type FlushReservation, type SerialFlushWorker, type SerialFlushWorkerOptions } from "./core/utils/serial-flush-worker";
+export { createSerialFlushWorker, isSerialFlushWorkerClosedError, SerialFlushWorkerClosedError, type FlushReservation, type SerialFlushWorker, type SerialFlushWorkerOptions } from "./core/utils/serial-flush-worker";
 export {
   buildCalendarBackoffState,
   RESET_CALENDAR_BACKOFF_STATE,

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -145,7 +145,7 @@ export { createGoogleUserRateLimiter, createHostRateLimiter, createOutlookAccoun
 export { createLeasedSemaphore, type LeasedSemaphore, type LeasedSemaphoreConfig, type RedisLeaseClient, type SemaphoreLease } from "./core/utils/leased-semaphore";
 export { allSettledGroupedWithConcurrency, allSettledWithConcurrency, type AllSettledGroupedOptions, type AllSettledWithConcurrencyOptions } from "./core/utils/concurrency";
 export { getErrorMessage } from "./core/utils/error";
-export { createSerialFlushWorker, isSerialFlushWorkerClosedError, SerialFlushWorkerClosedError, type FlushReservation, type SerialFlushWorker, type SerialFlushWorkerOptions } from "./core/utils/serial-flush-worker";
+export { createSerialFlushWorker, isSerialFlushRunDeadlineError, isSerialFlushWorkerClosedError, SerialFlushRunDeadlineError, SerialFlushWorkerClosedError, type FlushReservation, type SerialFlushWorker, type SerialFlushWorkerOptions } from "./core/utils/serial-flush-worker";
 export {
   buildCalendarBackoffState,
   RESET_CALENDAR_BACKOFF_STATE,

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -143,9 +143,10 @@ export {
 export { RateLimiter, type RateLimiterConfig } from "./core/utils/rate-limiter";
 export { createGoogleUserRateLimiter, createHostRateLimiter, createOutlookAccountSemaphore, createRedisRateLimiter, type HostRateLimiterOptions, type OutlookAccountSemaphore, type RedisRateLimiter, type RedisRateLimiterConfig } from "./core/utils/redis-rate-limiter";
 export { createLeasedSemaphore, type LeasedSemaphore, type LeasedSemaphoreConfig, type RedisLeaseClient, type SemaphoreLease } from "./core/utils/leased-semaphore";
+export { flagPacingParkAbortReason, isIngestPacingParkAbortError } from "./core/utils/pacing-park";
 export { allSettledGroupedWithConcurrency, allSettledWithConcurrency, type AllSettledGroupedOptions, type AllSettledWithConcurrencyOptions } from "./core/utils/concurrency";
 export { getErrorMessage } from "./core/utils/error";
-export { createSerialFlushWorker, isSerialFlushRunDeadlineError, isSerialFlushWorkerClosedError, SerialFlushRunDeadlineError, SerialFlushWorkerClosedError, type FlushReservation, type SerialFlushWorker, type SerialFlushWorkerOptions } from "./core/utils/serial-flush-worker";
+export { createSerialFlushWorker, isSerialFlushReserveAbortError, isSerialFlushRunDeadlineError, isSerialFlushWorkerClosedError, SerialFlushRunDeadlineError, SerialFlushWorkerClosedError, type FlushReservation, type SerialFlushWorker, type SerialFlushWorkerOptions } from "./core/utils/serial-flush-worker";
 export {
   buildCalendarBackoffState,
   RESET_CALENDAR_BACKOFF_STATE,

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -141,7 +141,8 @@ export {
   wallTimeToInstant,
 } from "./ics/utils/timezone-instant";
 export { RateLimiter, type RateLimiterConfig } from "./core/utils/rate-limiter";
-export { createGoogleUserRateLimiter, createRedisRateLimiter, type RedisRateLimiter, type RedisRateLimiterConfig } from "./core/utils/redis-rate-limiter";
+export { createGoogleUserRateLimiter, createHostRateLimiter, createOutlookAccountSemaphore, createRedisRateLimiter, type HostRateLimiterOptions, type OutlookAccountSemaphore, type RedisRateLimiter, type RedisRateLimiterConfig } from "./core/utils/redis-rate-limiter";
+export { createLeasedSemaphore, type LeasedSemaphore, type LeasedSemaphoreConfig, type RedisLeaseClient, type SemaphoreLease } from "./core/utils/leased-semaphore";
 export { allSettledGroupedWithConcurrency, allSettledWithConcurrency, type AllSettledGroupedOptions, type AllSettledWithConcurrencyOptions } from "./core/utils/concurrency";
 export { getErrorMessage } from "./core/utils/error";
 export {

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -145,7 +145,7 @@ export { createGoogleUserRateLimiter, createHostRateLimiter, createOutlookAccoun
 export { createLeasedSemaphore, type LeasedSemaphore, type LeasedSemaphoreConfig, type RedisLeaseClient, type SemaphoreLease } from "./core/utils/leased-semaphore";
 export { allSettledGroupedWithConcurrency, allSettledWithConcurrency, type AllSettledGroupedOptions, type AllSettledWithConcurrencyOptions } from "./core/utils/concurrency";
 export { getErrorMessage } from "./core/utils/error";
-export { createSerialFlushWorker, type SerialFlushWorker, type SerialFlushWorkerOptions } from "./core/utils/serial-flush-worker";
+export { createSerialFlushWorker, type FlushReservation, type SerialFlushWorker, type SerialFlushWorkerOptions } from "./core/utils/serial-flush-worker";
 export {
   buildCalendarBackoffState,
   RESET_CALENDAR_BACKOFF_STATE,

--- a/packages/calendar/src/providers/caldav/shared/client.ts
+++ b/packages/calendar/src/providers/caldav/shared/client.ts
@@ -188,6 +188,14 @@ class CalDAVClient {
     return this.resolvedAuthMethod?.() ?? null;
   }
 
+  /*
+   * The host rate limiter meters requests per minute, so every origin request
+   * must draw its own permit before it is sent.
+   */
+  private async chargeRequest(): Promise<void> {
+    await this.config.onBeforeRequest?.();
+  }
+
   private async getClient(): Promise<DAVClientInstance> {
     if (!this.client) {
       const safeFetch = createSafeFetch(this.safeFetchOptions);
@@ -212,6 +220,7 @@ class CalDAVClient {
   async discoverCalendars(): Promise<CalendarInfo[]> {
     const calendars = await mapAuthenticationFailure(async () => {
       const client = await this.getClient();
+      await this.chargeRequest();
       return measureProviderRequest(() => client.fetchCalendars());
     });
 
@@ -242,6 +251,7 @@ class CalDAVClient {
     iCalString: string;
   }): Promise<void> {
     const client = await this.getClient();
+    await this.chargeRequest();
 
     const response = await client.createCalendarObject({
       calendar: { url: params.calendarUrl },
@@ -272,6 +282,7 @@ class CalDAVClient {
     etag?: string;
   }): Promise<void> {
     const client = await this.getClient();
+    await this.chargeRequest();
 
     const response = await client.deleteCalendarObject({
       calendarObject: { url: params.objectUrl, etag: params.etag },
@@ -287,6 +298,7 @@ class CalDAVClient {
     return mapAuthenticationFailure(async () => {
       const client = await this.getClient();
       const objectUrl = CalDAVClient.normalizeUrl(params.calendarUrl, params.filename);
+      await this.chargeRequest();
       const objects = await client.fetchCalendarObjects({
         calendar: { url: params.calendarUrl },
         objectUrls: [objectUrl],
@@ -305,6 +317,7 @@ class CalDAVClient {
     return mapAuthenticationFailure(async () => {
       const client = await this.getClient();
 
+      await this.chargeRequest();
       const queryResponses = await measureProviderRequest(() => client.calendarQuery({
         depth: "1",
         filters: buildCalendarObjectFilters(params.timeRange),
@@ -328,6 +341,7 @@ class CalDAVClient {
       const batchResults: CalendarObject[][] = [];
 
       for (const objectUrls of batches) {
+        await this.chargeRequest();
         const objects = await measureProviderRequest(() => client.fetchCalendarObjects({
           calendar: { url: params.calendarUrl },
           objectUrls,

--- a/packages/calendar/src/providers/caldav/shared/client.ts
+++ b/packages/calendar/src/providers/caldav/shared/client.ts
@@ -199,9 +199,19 @@ class CalDAVClient {
   private async getClient(): Promise<DAVClientInstance> {
     if (!this.client) {
       const safeFetch = createSafeFetch(this.safeFetchOptions);
+      /*
+       * Charging in the fetch pipeline rather than at the operation call sites
+       * is what makes the invariant hold: tsdav issues an eager account
+       * discovery trio from createDAVClient, and the digest handshake retries
+       * each request, none of which pass through an operation method.
+       */
+      const chargedFetch: typeof safeFetch = async (...args) => {
+        await this.chargeRequest();
+        return safeFetch(...args);
+      };
       const { fetch: digestAwareFetch, getResolvedMethod } = createDigestAwareFetch({
         credentials: this.config.credentials,
-        baseFetch: safeFetch,
+        baseFetch: chargedFetch,
         knownAuthMethod: this.config.authMethod,
       });
       this.resolvedAuthMethod = getResolvedMethod;
@@ -220,7 +230,6 @@ class CalDAVClient {
   async discoverCalendars(): Promise<CalendarInfo[]> {
     const calendars = await mapAuthenticationFailure(async () => {
       const client = await this.getClient();
-      await this.chargeRequest();
       return measureProviderRequest(() => client.fetchCalendars());
     });
 
@@ -251,7 +260,6 @@ class CalDAVClient {
     iCalString: string;
   }): Promise<void> {
     const client = await this.getClient();
-    await this.chargeRequest();
 
     const response = await client.createCalendarObject({
       calendar: { url: params.calendarUrl },
@@ -282,7 +290,6 @@ class CalDAVClient {
     etag?: string;
   }): Promise<void> {
     const client = await this.getClient();
-    await this.chargeRequest();
 
     const response = await client.deleteCalendarObject({
       calendarObject: { url: params.objectUrl, etag: params.etag },
@@ -298,7 +305,6 @@ class CalDAVClient {
     return mapAuthenticationFailure(async () => {
       const client = await this.getClient();
       const objectUrl = CalDAVClient.normalizeUrl(params.calendarUrl, params.filename);
-      await this.chargeRequest();
       const objects = await client.fetchCalendarObjects({
         calendar: { url: params.calendarUrl },
         objectUrls: [objectUrl],
@@ -317,7 +323,6 @@ class CalDAVClient {
     return mapAuthenticationFailure(async () => {
       const client = await this.getClient();
 
-      await this.chargeRequest();
       const queryResponses = await measureProviderRequest(() => client.calendarQuery({
         depth: "1",
         filters: buildCalendarObjectFilters(params.timeRange),
@@ -341,7 +346,6 @@ class CalDAVClient {
       const batchResults: CalendarObject[][] = [];
 
       for (const objectUrls of batches) {
-        await this.chargeRequest();
         const objects = await measureProviderRequest(() => client.fetchCalendarObjects({
           calendar: { url: params.calendarUrl },
           objectUrls,

--- a/packages/calendar/src/providers/caldav/shared/client.ts
+++ b/packages/calendar/src/providers/caldav/shared/client.ts
@@ -188,7 +188,6 @@ class CalDAVClient {
     return this.resolvedAuthMethod?.() ?? null;
   }
 
-  /* The host limiter meters requests per minute, so every origin request draws its own permit. */
   private async chargeRequest(): Promise<void> {
     await this.config.onBeforeRequest?.();
   }
@@ -196,11 +195,6 @@ class CalDAVClient {
   private async getClient(): Promise<DAVClientInstance> {
     if (!this.client) {
       const safeFetch = createSafeFetch(this.safeFetchOptions);
-      /*
-       * Charged in the fetch pipeline, not at operation call sites: tsdav issues an eager
-       * discovery trio from createDAVClient and the digest handshake retries each request,
-       * none of which pass through an operation method.
-       */
       const chargedFetch: typeof safeFetch = async (...args) => {
         await this.chargeRequest();
         return safeFetch(...args);

--- a/packages/calendar/src/providers/caldav/shared/client.ts
+++ b/packages/calendar/src/providers/caldav/shared/client.ts
@@ -188,10 +188,7 @@ class CalDAVClient {
     return this.resolvedAuthMethod?.() ?? null;
   }
 
-  /*
-   * The host rate limiter meters requests per minute, so every origin request
-   * must draw its own permit before it is sent.
-   */
+  /* The host limiter meters requests per minute, so every origin request draws its own permit. */
   private async chargeRequest(): Promise<void> {
     await this.config.onBeforeRequest?.();
   }
@@ -200,10 +197,9 @@ class CalDAVClient {
     if (!this.client) {
       const safeFetch = createSafeFetch(this.safeFetchOptions);
       /*
-       * Charging in the fetch pipeline rather than at the operation call sites
-       * is what makes the invariant hold: tsdav issues an eager account
-       * discovery trio from createDAVClient, and the digest handshake retries
-       * each request, none of which pass through an operation method.
+       * Charged in the fetch pipeline, not at operation call sites: tsdav issues an eager
+       * discovery trio from createDAVClient and the digest handshake retries each request,
+       * none of which pass through an operation method.
        */
       const chargedFetch: typeof safeFetch = async (...args) => {
         await this.chargeRequest();

--- a/packages/calendar/src/providers/caldav/source/fetch-adapter.ts
+++ b/packages/calendar/src/providers/caldav/source/fetch-adapter.ts
@@ -14,6 +14,8 @@ interface CalDAVSourceFetcherConfig {
   password: string;
   safeFetchOptions?: SafeFetchOptions;
   plan: SourceIngestionPlan;
+  /* Awaited before every HTTP request the fetch sends to the origin. */
+  onBeforeRequest?: () => Promise<void> | void;
 }
 
 interface CalDAVSourceFetcher {
@@ -24,6 +26,7 @@ const createCalDAVSourceFetcher = (config: CalDAVSourceFetcherConfig): CalDAVSou
   const client = new CalDAVClient({
     authMethod: config.authMethod,
     credentials: { password: config.password, username: config.username },
+    onBeforeRequest: config.onBeforeRequest,
     serverUrl: config.serverUrl,
   }, config.safeFetchOptions);
 

--- a/packages/calendar/src/providers/caldav/source/fetch-adapter.ts
+++ b/packages/calendar/src/providers/caldav/source/fetch-adapter.ts
@@ -14,7 +14,6 @@ interface CalDAVSourceFetcherConfig {
   password: string;
   safeFetchOptions?: SafeFetchOptions;
   plan: SourceIngestionPlan;
-  /* Awaited before every HTTP request the fetch sends to the origin. */
   onBeforeRequest?: () => Promise<void> | void;
 }
 

--- a/packages/calendar/src/providers/caldav/source/fetch-adapter.ts
+++ b/packages/calendar/src/providers/caldav/source/fetch-adapter.ts
@@ -3,7 +3,7 @@ import type { FetchEventsResult } from "../../../core/sync-engine/ingest";
 import type { SafeFetchOptions } from "../../../utils/safe-fetch";
 import { isCalDAVEventInSyncWindow, partitionCalDAVSourceEvents } from "./window";
 import { CalDAVClient } from "../shared/client";
-import { parseICalCalendarsToRemoteEvents } from "../shared/ics";
+import { assertAllResourcesRead, parseICalCalendarsToRemoteEvents } from "../shared/ics";
 import { measureSyncSegment } from "../../../core/telemetry/segments";
 
 interface CalDAVSourceFetcherConfig {
@@ -50,6 +50,12 @@ const createCalDAVSourceFetcher = (config: CalDAVSourceFetcherConfig): CalDAVSou
       "work.transform_ms",
       () => {
         const parsed = parseICalCalendarsToRemoteEvents(objects.map(({ data }) => data ?? ""));
+        /*
+         * Ingestion diffs stored event_states against this fetch, so a missing
+         * event means "absent" here: a partial read would delete every event in
+         * the unreadable resources and re-add them next pass. Fail instead.
+         */
+        assertAllResourcesRead(parsed);
         return {
           resources: parsed,
           ...partitionCalDAVSourceEvents(parsed.events, syncWindow),

--- a/packages/calendar/src/providers/caldav/types.ts
+++ b/packages/calendar/src/providers/caldav/types.ts
@@ -75,6 +75,8 @@ interface CalDAVClientConfig {
     password: string;
   };
   authMethod?: "basic" | "digest";
+  /* Awaited before every HTTP request the client sends to the origin. */
+  onBeforeRequest?: () => Promise<void> | void;
 }
 
 interface CalendarInfo {

--- a/packages/calendar/src/providers/outlook/source/fetch-adapter.ts
+++ b/packages/calendar/src/providers/outlook/source/fetch-adapter.ts
@@ -1,4 +1,5 @@
 import type { FetchEventsResult } from "../../../core/sync-engine/ingest";
+import type { RedisRateLimiter } from "../../../core/utils/redis-rate-limiter";
 import type { SourceIngestionPlan } from "../../../core/sync/sync-range";
 import { encodeStoredSyncToken, resolveSyncTokenForWindow } from "../../../core/oauth/sync-token";
 import { getOAuthSyncTokenVersion } from "../../../core/oauth/sync-window";
@@ -12,6 +13,7 @@ interface OutlookSourceFetcherConfig {
   calendarId: string;
   externalCalendarId: string;
   syncToken: string | null;
+  rateLimiter?: RedisRateLimiter;
   signal?: AbortSignal;
   plan: SourceIngestionPlan;
 }
@@ -25,6 +27,7 @@ const createOutlookSourceFetcher = (config: OutlookSourceFetcherConfig): Outlook
     const fetchOptions: Parameters<typeof fetchCalendarEvents>[0] = {
       accessToken: config.accessToken,
       calendarId: config.externalCalendarId,
+      rateLimiter: config.rateLimiter,
       signal: config.signal,
     };
     const { futureRange, historicRange, window: syncWindow } = config.plan;

--- a/packages/calendar/src/providers/outlook/source/types.ts
+++ b/packages/calendar/src/providers/outlook/source/types.ts
@@ -1,3 +1,5 @@
+import type { RedisRateLimiter } from "../../../core/utils/redis-rate-limiter";
+
 interface OutlookCalendarListEntry {
   id: string;
   name: string;
@@ -57,6 +59,7 @@ interface FetchEventsOptions {
   deltaLink?: string;
   timeMin?: Date;
   timeMax?: Date;
+  rateLimiter?: RedisRateLimiter;
   signal?: AbortSignal;
 }
 

--- a/packages/calendar/src/providers/outlook/source/utils/fetch-events.ts
+++ b/packages/calendar/src/providers/outlook/source/utils/fetch-events.ts
@@ -177,7 +177,6 @@ const fetchEventsPage = async (
   const { accessToken } = options;
   const url = getRequestUrl(options);
 
-  // Take the mailbox concurrency lease before every Graph request goes out.
   if (options.rateLimiter) {
     await options.rateLimiter.acquire(1, options.signal);
   }

--- a/packages/calendar/src/providers/outlook/source/utils/fetch-events.ts
+++ b/packages/calendar/src/providers/outlook/source/utils/fetch-events.ts
@@ -6,6 +6,7 @@ import type {
   EventTimeSlot,
 } from "../types";
 import type { MicrosoftApiError, OutlookDateTime } from "../../types";
+import type { RedisRateLimiter } from "../../../../core/utils/redis-rate-limiter";
 import { MICROSOFT_GRAPH_API, GONE_STATUS } from "../../shared/api";
 import { isAuthError, isSimpleAuthError } from "../../shared/errors";
 import { parseEventTime } from "../../shared/date-time";
@@ -69,6 +70,7 @@ interface PageFetchOptions {
   timeMin?: Date;
   timeMax?: Date;
   nextLink?: string;
+  rateLimiter?: RedisRateLimiter;
   signal?: AbortSignal;
 }
 
@@ -174,6 +176,12 @@ const fetchEventsPage = async (
 ): Promise<PageFetchResult | FullSyncRequiredResult> => {
   const { accessToken } = options;
   const url = getRequestUrl(options);
+
+  // Take the mailbox concurrency lease before every Graph request goes out.
+  if (options.rateLimiter) {
+    await options.rateLimiter.acquire(1, options.signal);
+  }
+
   const timeout = buildTimeoutSignal(REQUEST_TIMEOUT_MS, options.signal);
 
   const response = await measureProviderRequest(() => fetch(url.toString(), {
@@ -225,6 +233,7 @@ const fetchSeriesMasterInstances = async (
   timeMin: Date,
   timeMax: Date,
   signal?: AbortSignal,
+  rateLimiter?: RedisRateLimiter,
 ): Promise<OutlookCalendarEvent[]> => {
   const calendarPath = encodeURIComponent(calendarId);
   const masterPath = encodeURIComponent(masterId);
@@ -242,6 +251,7 @@ const fetchSeriesMasterInstances = async (
       accessToken,
       calendarId,
       nextLink,
+      rateLimiter,
       signal,
     });
     if (pageResult.fullSyncRequired) {
@@ -268,6 +278,7 @@ const expandSeriesMasters = async (
   timeMin: Date,
   timeMax: Date,
   signal?: AbortSignal,
+  rateLimiter?: RedisRateLimiter,
 ): Promise<ExpandedSeriesMasters> => {
   const expanded: OutlookCalendarEvent[] = [];
   let unexpandedSeriesMasterCount = 0;
@@ -283,6 +294,7 @@ const expandSeriesMasters = async (
       timeMin,
       timeMax,
       signal,
+      rateLimiter,
     );
     if (instances.length === 0) {
       unexpandedSeriesMasterCount += 1;
@@ -310,7 +322,7 @@ const deduplicateOutlookEvents = (events: OutlookCalendarEvent[]): OutlookCalend
 };
 
 const fetchCalendarEvents = async (options: FetchEventsOptions): Promise<FetchEventsResult> => {
-  const { accessToken, calendarId, deltaLink, timeMin, timeMax, signal } = options;
+  const { accessToken, calendarId, deltaLink, timeMin, timeMax, rateLimiter, signal } = options;
 
   const changedEventsById = new Map<string, OutlookCalendarEvent>();
   const changedEventsWithoutId: OutlookCalendarEvent[] = [];
@@ -333,6 +345,7 @@ const fetchCalendarEvents = async (options: FetchEventsOptions): Promise<FetchEv
     accessToken,
     calendarId,
     deltaLink,
+    rateLimiter,
     timeMax,
     timeMin,
     signal,
@@ -352,6 +365,7 @@ const fetchCalendarEvents = async (options: FetchEventsOptions): Promise<FetchEv
       accessToken,
       calendarId,
       nextLink,
+      rateLimiter,
       timeMax,
       timeMin,
       signal,
@@ -395,6 +409,7 @@ const fetchCalendarEvents = async (options: FetchEventsOptions): Promise<FetchEv
       timeMin,
       timeMax,
       signal,
+      rateLimiter,
     );
     latestChangedEvents = deduplicateOutlookEvents(expansion.events);
     ({ unexpandedSeriesMasterCount } = expansion);

--- a/packages/calendar/tests/core/sync-engine/ingest-discard-telemetry.test.ts
+++ b/packages/calendar/tests/core/sync-engine/ingest-discard-telemetry.test.ts
@@ -4,6 +4,7 @@ import type { IngestWideEventFields, IngestionChanges } from "../../../src/core/
 import type { StoredSourceEventState } from "../../../src/core/source/stored-event-state";
 import { createGoogleSourceFetcher } from "../../../src/providers/google/source/fetch-adapter";
 import { createCalDAVSourceFetcher } from "../../../src/providers/caldav/source/fetch-adapter";
+import { CalDAVUnreadableResourceError } from "../../../src/providers/caldav/shared/ics";
 import { createSourceIngestionPlan } from "../../../src/core/sync/sync-range";
 
 const NOW = new Date("2026-06-15T00:00:00.000Z");
@@ -384,25 +385,31 @@ describe("CalDAV discards", () => {
     davMocks.fetchCalendars.mockResolvedValue([]);
   });
 
-  it("reports the unreadable resource whose stored event it deletes", async () => {
+  it("fails the run instead of deleting the stored event of an unreadable resource", async () => {
     answerWith([
       icsFor("readable@example.com", "20260620T090000Z", "20260620T100000Z"),
       TRUNCATED_ICS,
     ]);
     const fetcher = createCalDAVFetcher();
 
-    const run = await runIngest("caldav-calendar", () => fetcher.fetchEvents(), [
+    /*
+     * A partial multiget must never become the authoritative snapshot: the
+     * diff would delete the stored event of the unreadable resource and
+     * re-add it on the next pass.
+     */
+    const failure = await runIngest("caldav-calendar", () => fetcher.fetchEvents(), [
       storedEvent({ id: "state-readable", sourceEventUid: "readable@example.com" }),
       storedEvent({ id: "state-truncated", sourceEventUid: "truncated@example.com" }),
-    ]);
+    ]).then(
+      () => null,
+      (error: unknown) => error,
+    );
 
-    expect(run.changes[0]?.deletes).toEqual(["state-truncated"]);
-    const wideEvent = run.wideEvents[0] ?? {};
-    const discardKeys = Object.keys(wideEvent).filter((key) =>
-      key.includes("discard") || key.includes("skipped") || key.includes("unsupported"));
-    expect(discardKeys).not.toEqual([]);
-    expect(wideEvent["source_events.skipped_resources"]).toBe(1);
-    expect(wideEvent["source_events.skipped_resource_reasons"]).toContain("END:VEVENT");
+    expect(failure).toBeInstanceOf(CalDAVUnreadableResourceError);
+    if (failure instanceof CalDAVUnreadableResourceError) {
+      expect(failure.skippedResourceCount).toBe(1);
+      expect(failure.skippedResourceReasons.join("; ")).toContain("END:VEVENT");
+    }
   });
 
   it("counts a stored event dropped for falling outside the sync window", async () => {

--- a/packages/calendar/tests/core/sync-engine/ingest-discard-telemetry.test.ts
+++ b/packages/calendar/tests/core/sync-engine/ingest-discard-telemetry.test.ts
@@ -392,11 +392,6 @@ describe("CalDAV discards", () => {
     ]);
     const fetcher = createCalDAVFetcher();
 
-    /*
-     * A partial multiget must never become the authoritative snapshot: the
-     * diff would delete the stored event of the unreadable resource and
-     * re-add it on the next pass.
-     */
     const failure = await runIngest("caldav-calendar", () => fetcher.fetchEvents(), [
       storedEvent({ id: "state-readable", sourceEventUid: "readable@example.com" }),
       storedEvent({ id: "state-truncated", sourceEventUid: "truncated@example.com" }),

--- a/packages/calendar/tests/core/sync-engine/ingest-unreadable-resource-thrash.test.ts
+++ b/packages/calendar/tests/core/sync-engine/ingest-unreadable-resource-thrash.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ingestSource } from "../../../src/core/sync-engine/ingest";
+import { buildEventStateInsertRow } from "../../../src/core/source/write-event-states";
+import type { StoredSourceEventState } from "../../../src/core/source/stored-event-state";
+import { createCalDAVSourceFetcher } from "../../../src/providers/caldav/source/fetch-adapter";
+import { createSourceIngestionPlan } from "../../../src/core/sync/sync-range";
+
+const NOW = new Date("2026-06-15T00:00:00.000Z");
+const PLAN = createSourceIngestionPlan("1_month", "2_years", NOW);
+
+const davMocks = vi.hoisted(() => ({
+  calendarQuery: vi.fn(),
+  fetchCalendarObjects: vi.fn(),
+  fetchCalendars: vi.fn(),
+}));
+
+vi.mock("tsdav", () => ({
+  DAVNamespaceShort: { DAV: "d" },
+  createDAVClient: () => Promise.resolve({
+    calendarQuery: davMocks.calendarQuery,
+    fetchCalendarObjects: davMocks.fetchCalendarObjects,
+    fetchCalendars: davMocks.fetchCalendars,
+  }),
+}));
+
+// Postgres reads an absent optional value back as null, never undefined.
+const nullify = <Value,>(value: Value | null): Value | null => value ?? null;
+
+let nextRowId = 0;
+
+const persistInsert = (
+  calendarId: string,
+  event: Parameters<typeof buildEventStateInsertRow>[1],
+): StoredSourceEventState => {
+  const row = buildEventStateInsertRow(calendarId, event);
+  nextRowId += 1;
+  return {
+    availability: nullify(row.availability ?? null),
+    description: nullify(row.description ?? null),
+    endTime: row.endTime,
+    exceptionDates: nullify(row.exceptionDates ?? null),
+    id: `row-${String(nextRowId)}`,
+    isAllDay: nullify(row.isAllDay ?? null),
+    location: nullify(row.location ?? null),
+    recurrenceId: nullify(row.recurrenceId ?? null),
+    recurrenceRule: nullify(row.recurrenceRule ?? null),
+    sourceEventId: nullify(row.sourceEventId ?? null),
+    sourceEventType: nullify(row.sourceEventType ?? null),
+    sourceEventUid: row.sourceEventUid,
+    startTime: row.startTime,
+    startTimeZone: nullify(row.startTimeZone ?? null),
+    title: nullify(row.title ?? null),
+  } as StoredSourceEventState;
+};
+
+const CALENDAR_ID = "caldav-unreadable-resource";
+
+const buildIcs = (uid: string, body: string): string =>
+  [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//Probe//Probe//EN",
+    "BEGIN:VEVENT",
+    `UID:${uid}`,
+    body,
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+const STABLE_ICS = buildIcs(
+  "stable-1",
+  ["DTSTAMP:20260601T000000Z", "DTSTART:20260620T090000Z", "DTEND:20260620T100000Z", "SUMMARY:Stable"].join("\r\n"),
+);
+
+const FLICKERING_ICS = buildIcs(
+  "flickering-1",
+  ["DTSTAMP:20260601T000000Z", "DTSTART:20260622T090000Z", "DTEND:20260622T100000Z", "SUMMARY:Flickering"].join("\r\n"),
+);
+
+const STABLE_URL = "/cal/stable-1.ics";
+const FLICKERING_URL = "/cal/flickering-1.ics";
+
+/*
+ * The upstream calendar never changes across rounds. Only the readability of
+ * the second resource flickers: on the second round the server transiently
+ * returns an empty calendar-data body for it (e.g. mid-write), which the
+ * client counts as returned, not missing.
+ */
+const answerRound = (flickeringData: string): void => {
+  const resources = [
+    { data: STABLE_ICS, url: STABLE_URL },
+    { data: flickeringData, url: FLICKERING_URL },
+  ];
+  davMocks.calendarQuery.mockResolvedValue(
+    resources.map((resource) => ({ href: resource.url, props: { getetag: `"${resource.url}"` } })),
+  );
+  davMocks.fetchCalendarObjects.mockResolvedValue(resources);
+};
+
+interface RoundResult {
+  added: number;
+  removed: number;
+}
+
+const createRoundRunner = () => {
+  let store: StoredSourceEventState[] = [];
+
+  const runRound = async (): Promise<RoundResult> => {
+    const fetcher = createCalDAVSourceFetcher({
+      calendarUrl: "https://dav.example.com/cal/",
+      password: "password",
+      plan: PLAN,
+      serverUrl: "https://dav.example.com",
+      username: "user",
+    });
+
+    const result = await ingestSource({
+      calendarId: CALENDAR_ID,
+      fetchEvents: () => fetcher.fetchEvents(),
+      flush: (changes) => {
+        const deleted = new Set(changes.deletes);
+        store = [
+          ...store.filter((entry) => !deleted.has(entry.id)),
+          ...changes.inserts.map((insert) => persistInsert(CALENDAR_ID, insert)),
+        ];
+        return Promise.resolve();
+      },
+      readExistingEvents: () => Promise.resolve([...store]),
+    });
+
+    return { added: result.eventsAdded, removed: result.eventsRemoved };
+  };
+
+  return { runRound };
+};
+
+describe("CalDAV ingest with a transiently unreadable resource", () => {
+  beforeEach(() => {
+    nextRowId = 0;
+    vi.clearAllMocks();
+    davMocks.fetchCalendars.mockResolvedValue([
+      { displayName: "Cal", url: "https://dav.example.com/cal/" },
+    ]);
+  });
+
+  it("does not delete then re-add events whose resource was transiently unreadable", async () => {
+    const { runRound } = createRoundRunner();
+
+    // Round 1: both resources readable — both events ingested.
+    answerRound(FLICKERING_ICS);
+    const first = await runRound();
+    expect(first.added).toBe(2);
+    expect(first.removed).toBe(0);
+
+    /*
+     * Round 2: identical upstream state, but the second resource's body comes
+     * back empty (unreadable, not absent). Ingesting the same upstream state
+     * again must be a no-op: nothing changed upstream, so nothing may be
+     * removed. If the round cannot tell unreadable from absent it must fail,
+     * not persist the partial snapshot as authoritative.
+     */
+    answerRound("");
+    let removedOnUnreadableRound = 0;
+    try {
+      const second = await runRound();
+      removedOnUnreadableRound = second.removed;
+    } catch {
+      // Failing the round is the safe outcome: the stored state stays intact.
+    }
+    expect(
+      removedOnUnreadableRound,
+      "steady-state upstream must never produce removals on a repeat ingest",
+    ).toBe(0);
+
+    // Round 3: the resource reads normally again — still nothing changed upstream.
+    answerRound(FLICKERING_ICS);
+    const third = await runRound();
+    expect(
+      third.added,
+      "a readable-again resource must not be re-added: that is add/remove thrash",
+    ).toBe(0);
+    expect(third.removed).toBe(0);
+  });
+});

--- a/packages/calendar/tests/core/sync-engine/ingest-unreadable-resource-thrash.test.ts
+++ b/packages/calendar/tests/core/sync-engine/ingest-unreadable-resource-thrash.test.ts
@@ -80,12 +80,7 @@ const FLICKERING_ICS = buildIcs(
 const STABLE_URL = "/cal/stable-1.ics";
 const FLICKERING_URL = "/cal/flickering-1.ics";
 
-/*
- * The upstream calendar never changes across rounds. Only the readability of
- * the second resource flickers: on the second round the server transiently
- * returns an empty calendar-data body for it (e.g. mid-write), which the
- * client counts as returned, not missing.
- */
+// An empty calendar-data body counts as returned, not missing: unreadable looks deleted.
 const answerRound = (flickeringData: string): void => {
   const resources = [
     { data: STABLE_ICS, url: STABLE_URL },
@@ -146,19 +141,12 @@ describe("CalDAV ingest with a transiently unreadable resource", () => {
   it("does not delete then re-add events whose resource was transiently unreadable", async () => {
     const { runRound } = createRoundRunner();
 
-    // Round 1: both resources readable — both events ingested.
     answerRound(FLICKERING_ICS);
     const first = await runRound();
     expect(first.added).toBe(2);
     expect(first.removed).toBe(0);
 
-    /*
-     * Round 2: identical upstream state, but the second resource's body comes
-     * back empty (unreadable, not absent). Ingesting the same upstream state
-     * again must be a no-op: nothing changed upstream, so nothing may be
-     * removed. If the round cannot tell unreadable from absent it must fail,
-     * not persist the partial snapshot as authoritative.
-     */
+    // Upstream is unchanged, so the round must fail rather than persist a partial snapshot.
     answerRound("");
     let removedOnUnreadableRound = 0;
     try {
@@ -172,7 +160,6 @@ describe("CalDAV ingest with a transiently unreadable resource", () => {
       "steady-state upstream must never produce removals on a repeat ingest",
     ).toBe(0);
 
-    // Round 3: the resource reads normally again — still nothing changed upstream.
     answerRound(FLICKERING_ICS);
     const third = await runRound();
     expect(

--- a/packages/calendar/tests/core/sync-engine/lease-lost-queued-flush.test.ts
+++ b/packages/calendar/tests/core/sync-engine/lease-lost-queued-flush.test.ts
@@ -5,26 +5,9 @@ import type { StoredSourceEventState } from "../../../src/core/source/stored-eve
 import type { SourceEvent } from "../../../src/core/types";
 
 /*
- * Lock currency is probed exactly once, BEFORE the flush thunk is enqueued
- * (ingest.ts: `if (isCurrent && !(await isCurrent()))` runs ahead of
- * withPersistenceTransaction). The cron persistence transaction
- * (services/cron/src/jobs/ingest-sources.ts createIngestionPersistenceTransaction)
- * never re-consults isCurrent/isHeld inside the queued transaction — only
- * signal.throwIfAborted(). So a thunk parked in the serial flush pump can
- * outlive its Redis lease (reclaim by TTL is a designed event: "The lock TTL
- * already reclaims the hold"), a second lock-respecting writer (the API's
- * ingestIcsSource, which flushes directly through the pooled database) can
- * commit a FRESHER snapshot, and the stale thunk then commits over it.
- *
- * This test models that interleaving faithfully:
- *  - isCurrent returns true at the pre-enqueue probe (lease still held),
- *  - the lease is lost while the thunk waits in the queue,
- *  - a fresh writer commits upstream state [X, Y],
- *  - the parked stale thunk (fetched [X]) finally runs.
- *
- * Invariant under attack: no interleaving may persist a stale snapshot over a
- * fresher one. A run whose lease was lost before its flush ran must not
- * remove events the fresher holder just committed.
+ * Lock currency is probed once before the flush thunk is enqueued and never
+ * re-consulted inside the queued transaction, so a parked thunk can outlive its
+ * lease. No such interleaving may persist a stale snapshot over a fresher one.
  */
 
 const CALENDAR_ID = "calendar-lease-lost-queued-flush";
@@ -68,7 +51,6 @@ const applyChanges = (store: Store, changes: IngestionChanges): void => {
   store.rows = [...store.rows, ...changes.inserts.map(toStored)];
 };
 
-/* The API's ingestIcsSource path: holds the lock, flushes directly. */
 const runFreshHolder = (
   store: Store,
   events: SourceEvent[],
@@ -90,19 +72,11 @@ describe("queued flush after the Redis lease is lost", () => {
 
     const store: Store = { rows: [toStored(eventX)] };
 
-    /* True while the cron run's Redis lease is held; flips on reclaim. */
     let leaseHeld = true;
 
     const { promise: gate, resolve: releaseGate } = Promise.withResolvers<null>();
     const { promise: enqueued, resolve: markEnqueued } = Promise.withResolvers<null>();
 
-    /*
-     * Cron run C fetches while upstream is [X]. Its pre-enqueue isCurrent probe
-     * passes (lease still held), then the thunk parks in the serial flush pump
-     * behind other calendars' flushes — exactly what reservation.submit does in
-     * createIngestionPersistenceTransaction, where the transaction body has no
-     * isCurrent/isHeld consultation.
-     */
     const cronRun = ingestSource({
       calendarId: CALENDAR_ID,
       fetchEvents: () => Promise.resolve({ events: [eventX] }),
@@ -120,38 +94,22 @@ describe("queued flush after the Redis lease is lost", () => {
       },
     });
 
-    /* The probe has passed and the thunk is queued. */
     await enqueued;
 
-    /*
-     * The lease is reclaimed while C's thunk waits (Redis TTL expiry — a
-     * designed event per ingest-sources.ts: "The lock TTL already reclaims the
-     * hold"). From here on, C is no longer the lock holder.
-     */
+    // Reclaim by TTL while the thunk waits is a designed event, not a fault.
     leaseHeld = false;
 
-    /* A fresh holder acquires the lock and commits upstream state [X, Y]. */
     const freshResult = await runFreshHolder(store, [eventX, eventY]);
     expect(freshResult.eventsAdded).toBe(1);
     expect(store.rows.map((row) => row.sourceEventUid).toSorted())
       .toEqual(["event-x", "event-y"]);
 
-    /* The pump dequeues C's stale thunk. Its lease is gone; it must not write. */
     releaseGate(null);
     await cronRun;
 
-    /*
-     * The fresher snapshot [X, Y] must survive: a writer that lost its lease
-     * before flushing may not delete what the current holder committed.
-     */
     expect(store.rows.map((row) => row.sourceEventUid).toSorted())
       .toEqual(["event-x", "event-y"]);
 
-    /*
-     * Convergence: upstream is still [X, Y], so re-ingesting the same state
-     * must be a no-op. If C's stale flush deleted Y, this pass re-adds it —
-     * a remove/add pair on the destination with no upstream change.
-     */
     const repeat = await runFreshHolder(store, [eventX, eventY]);
     expect(repeat.eventsAdded).toBe(0);
     expect(repeat.eventsRemoved).toBe(0);

--- a/packages/calendar/tests/core/sync-engine/lease-lost-queued-flush.test.ts
+++ b/packages/calendar/tests/core/sync-engine/lease-lost-queued-flush.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import { ingestSource } from "../../../src/core/sync-engine/ingest";
+import type { IngestionChanges } from "../../../src/core/sync-engine/ingest";
+import type { StoredSourceEventState } from "../../../src/core/source/stored-event-state";
+import type { SourceEvent } from "../../../src/core/types";
+
+/*
+ * Lock currency is probed exactly once, BEFORE the flush thunk is enqueued
+ * (ingest.ts: `if (isCurrent && !(await isCurrent()))` runs ahead of
+ * withPersistenceTransaction). The cron persistence transaction
+ * (services/cron/src/jobs/ingest-sources.ts createIngestionPersistenceTransaction)
+ * never re-consults isCurrent/isHeld inside the queued transaction — only
+ * signal.throwIfAborted(). So a thunk parked in the serial flush pump can
+ * outlive its Redis lease (reclaim by TTL is a designed event: "The lock TTL
+ * already reclaims the hold"), a second lock-respecting writer (the API's
+ * ingestIcsSource, which flushes directly through the pooled database) can
+ * commit a FRESHER snapshot, and the stale thunk then commits over it.
+ *
+ * This test models that interleaving faithfully:
+ *  - isCurrent returns true at the pre-enqueue probe (lease still held),
+ *  - the lease is lost while the thunk waits in the queue,
+ *  - a fresh writer commits upstream state [X, Y],
+ *  - the parked stale thunk (fetched [X]) finally runs.
+ *
+ * Invariant under attack: no interleaving may persist a stale snapshot over a
+ * fresher one. A run whose lease was lost before its flush ran must not
+ * remove events the fresher holder just committed.
+ */
+
+const CALENDAR_ID = "calendar-lease-lost-queued-flush";
+
+const storedIdFor = (event: SourceEvent): string => `${event.uid}::stored`;
+
+const toStored = (event: SourceEvent): StoredSourceEventState => ({
+  availability: event.availability ?? null,
+  description: event.description ?? null,
+  endTime: event.endTime,
+  exceptionDates: null,
+  id: storedIdFor(event),
+  isAllDay: event.isAllDay ?? false,
+  location: event.location ?? null,
+  recurrenceId: event.recurrenceId ?? null,
+  recurrenceRule: null,
+  sourceEventId: event.sourceEventId ?? null,
+  sourceEventType: event.sourceEventType ?? "default",
+  sourceEventUid: event.uid,
+  startTime: event.startTime,
+  startTimeZone: event.startTimeZone ?? null,
+  title: event.title ?? null,
+});
+
+const makeEvent = (uid: string, startHour: number): SourceEvent => ({
+  availability: "busy",
+  endTime: new Date(Date.UTC(2026, 7, 20, startHour + 1)),
+  isAllDay: false,
+  startTime: new Date(Date.UTC(2026, 7, 20, startHour)),
+  title: uid,
+  uid,
+});
+
+interface Store {
+  rows: StoredSourceEventState[];
+}
+
+const applyChanges = (store: Store, changes: IngestionChanges): void => {
+  const deleted = new Set(changes.deletes);
+  store.rows = store.rows.filter((row) => !deleted.has(row.id));
+  store.rows = [...store.rows, ...changes.inserts.map(toStored)];
+};
+
+/* The API's ingestIcsSource path: holds the lock, flushes directly. */
+const runFreshHolder = (
+  store: Store,
+  events: SourceEvent[],
+): Promise<{ eventsAdded: number; eventsRemoved: number }> =>
+  ingestSource({
+    calendarId: CALENDAR_ID,
+    fetchEvents: () => Promise.resolve({ events }),
+    readExistingEvents: () => Promise.resolve([...store.rows]),
+    flush: (changes) => {
+      applyChanges(store, changes);
+      return Promise.resolve();
+    },
+  });
+
+describe("queued flush after the Redis lease is lost", () => {
+  it("a stale thunk whose lease was reclaimed must not commit over the fresher holder's snapshot", async () => {
+    const eventX = makeEvent("event-x", 9);
+    const eventY = makeEvent("event-y", 13);
+
+    const store: Store = { rows: [toStored(eventX)] };
+
+    /* True while the cron run's Redis lease is held; flips on reclaim. */
+    let leaseHeld = true;
+
+    let releaseGate: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    let markEnqueued: () => void = () => {};
+    const enqueued = new Promise<void>((resolve) => {
+      markEnqueued = resolve;
+    });
+
+    /*
+     * Cron run C fetches while upstream is [X]. Its pre-enqueue isCurrent probe
+     * passes (lease still held), then the thunk parks in the serial flush pump
+     * behind other calendars' flushes — exactly what reservation.submit does in
+     * createIngestionPersistenceTransaction, where the transaction body has no
+     * isCurrent/isHeld consultation.
+     */
+    const cronRun = ingestSource({
+      calendarId: CALENDAR_ID,
+      fetchEvents: () => Promise.resolve({ events: [eventX] }),
+      isCurrent: () => Promise.resolve(leaseHeld),
+      withPersistenceTransaction: async (work) => {
+        markEnqueued();
+        await gate;
+        return work({
+          readExistingEvents: () => Promise.resolve([...store.rows]),
+          flush: (changes) => {
+            applyChanges(store, changes);
+            return Promise.resolve();
+          },
+        });
+      },
+    });
+
+    /* The probe has passed and the thunk is queued. */
+    await enqueued;
+
+    /*
+     * The lease is reclaimed while C's thunk waits (Redis TTL expiry — a
+     * designed event per ingest-sources.ts: "The lock TTL already reclaims the
+     * hold"). From here on, C is no longer the lock holder.
+     */
+    leaseHeld = false;
+
+    /* A fresh holder acquires the lock and commits upstream state [X, Y]. */
+    const freshResult = await runFreshHolder(store, [eventX, eventY]);
+    expect(freshResult.eventsAdded).toBe(1);
+    expect(store.rows.map((row) => row.sourceEventUid).toSorted())
+      .toEqual(["event-x", "event-y"]);
+
+    /* The pump dequeues C's stale thunk. Its lease is gone; it must not write. */
+    releaseGate();
+    await cronRun;
+
+    /*
+     * The fresher snapshot [X, Y] must survive: a writer that lost its lease
+     * before flushing may not delete what the current holder committed.
+     */
+    expect(store.rows.map((row) => row.sourceEventUid).toSorted())
+      .toEqual(["event-x", "event-y"]);
+
+    /*
+     * Convergence: upstream is still [X, Y], so re-ingesting the same state
+     * must be a no-op. If C's stale flush deleted Y, this pass re-adds it —
+     * a remove/add pair on the destination with no upstream change.
+     */
+    const repeat = await runFreshHolder(store, [eventX, eventY]);
+    expect(repeat.eventsAdded).toBe(0);
+    expect(repeat.eventsRemoved).toBe(0);
+  });
+});

--- a/packages/calendar/tests/core/sync-engine/lease-lost-queued-flush.test.ts
+++ b/packages/calendar/tests/core/sync-engine/lease-lost-queued-flush.test.ts
@@ -93,14 +93,8 @@ describe("queued flush after the Redis lease is lost", () => {
     /* True while the cron run's Redis lease is held; flips on reclaim. */
     let leaseHeld = true;
 
-    let releaseGate: () => void = () => {};
-    const gate = new Promise<void>((resolve) => {
-      releaseGate = resolve;
-    });
-    let markEnqueued: () => void = () => {};
-    const enqueued = new Promise<void>((resolve) => {
-      markEnqueued = resolve;
-    });
+    const { promise: gate, resolve: releaseGate } = Promise.withResolvers<null>();
+    const { promise: enqueued, resolve: markEnqueued } = Promise.withResolvers<null>();
 
     /*
      * Cron run C fetches while upstream is [X]. Its pre-enqueue isCurrent probe
@@ -114,7 +108,7 @@ describe("queued flush after the Redis lease is lost", () => {
       fetchEvents: () => Promise.resolve({ events: [eventX] }),
       isCurrent: () => Promise.resolve(leaseHeld),
       withPersistenceTransaction: async (work) => {
-        markEnqueued();
+        markEnqueued(null);
         await gate;
         return work({
           readExistingEvents: () => Promise.resolve([...store.rows]),
@@ -143,7 +137,7 @@ describe("queued flush after the Redis lease is lost", () => {
       .toEqual(["event-x", "event-y"]);
 
     /* The pump dequeues C's stale thunk. Its lease is gone; it must not write. */
-    releaseGate();
+    releaseGate(null);
     await cronRun;
 
     /*

--- a/packages/calendar/tests/core/utils/host-rate-limiter.test.ts
+++ b/packages/calendar/tests/core/utils/host-rate-limiter.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHostRateLimiter } from "../../../src/core/utils/redis-rate-limiter";
+
+const DEFAULT_HOST_REQUESTS_PER_WINDOW = 30;
+
+const acquireArguments = async (host: string): Promise<string[]> => {
+  const redis = { eval: vi.fn(() => Promise.resolve([0, 0])) };
+  await createHostRateLimiter(redis, host).acquire(1);
+  return vi.mocked(redis.eval).mock.calls[0]?.slice(2) as string[];
+};
+
+describe("createHostRateLimiter", () => {
+  it("meters two limiters for the same host against one shared key", async () => {
+    const [firstKey] = await acquireArguments("caldav.fastmail.com");
+    const [secondKey] = await acquireArguments("caldav.fastmail.com");
+
+    expect(firstKey).toContain("caldav.fastmail.com");
+    expect(secondKey).toBe(firstKey);
+  });
+
+  it("keys different hosts independently so one host cannot starve another", async () => {
+    const [fastmailKey] = await acquireArguments("caldav.fastmail.com");
+    const [icloudKey] = await acquireArguments("caldav.icloud.com");
+
+    expect(fastmailKey).not.toBe(icloudKey);
+  });
+
+  it("defaults to a modest budget of 30 requests per window", async () => {
+    const limitArguments = await acquireArguments("caldav.fastmail.com");
+
+    expect(Number(limitArguments.at(-1))).toBe(DEFAULT_HOST_REQUESTS_PER_WINDOW);
+  });
+
+  it("waits for the window instead of proceeding when the host budget is spent", async () => {
+    vi.useFakeTimers();
+    try {
+      const redis = {
+        eval: vi
+          .fn()
+          .mockResolvedValueOnce([250, DEFAULT_HOST_REQUESTS_PER_WINDOW])
+          .mockResolvedValueOnce([0, 0]),
+      };
+      if (typeof createHostRateLimiter !== "function") {
+        throw new TypeError("createHostRateLimiter is not exported from redis-rate-limiter");
+      }
+      const limiter = createHostRateLimiter(redis, "caldav.fastmail.com");
+
+      let resolved = false;
+      const pending = limiter.acquire(1).then(() => {
+        resolved = true;
+        return null;
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(resolved).toBe(false);
+      expect(redis.eval).toHaveBeenCalledOnce();
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      await pending;
+      expect(resolved).toBe(true);
+      expect(redis.eval).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/calendar/tests/core/utils/leased-semaphore.test.ts
+++ b/packages/calendar/tests/core/utils/leased-semaphore.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLeasedSemaphore } from "../../../src/core/utils/leased-semaphore";
+
+const CAPACITY = 2;
+const TTL_MS = 5000;
+const SETTLE_MS = 500;
+
+interface FakeEntry {
+  expiresAt: number;
+  value: string;
+}
+
+/*
+ * In-memory stand-in for the Redis lease client, mirroring the fake-redis style of
+ * redis-rate-limiter.test.ts but stateful: leases must live as independently expiring
+ * keys (SET NX PX per slot), so the fake honors NX and PX against the fake-timer clock.
+ */
+class FakeRedis {
+  public store = new Map<string, FakeEntry>();
+
+  private prune(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.store) {
+      if (entry.expiresAt <= now) {
+        this.store.delete(key);
+      }
+    }
+  }
+
+  public set(key: string, value: string, ...options: string[]): Promise<string | null> {
+    this.prune();
+    let expiresAt = Number.POSITIVE_INFINITY;
+    let onlyIfAbsent = false;
+    for (let index = 0; index < options.length; index += 1) {
+      const option = String(options[index]).toUpperCase();
+      if (option === "NX") {
+        onlyIfAbsent = true;
+      }
+      if (option === "PX") {
+        expiresAt = Date.now() + Number(options[index + 1]);
+        index += 1;
+      }
+    }
+    if (onlyIfAbsent && this.store.has(key)) {
+      return Promise.resolve(null);
+    }
+    this.store.set(key, { expiresAt, value });
+    return Promise.resolve("OK");
+  }
+
+  public del(...keys: string[]): Promise<number> {
+    this.prune();
+    let removed = 0;
+    for (const key of keys) {
+      if (this.store.delete(key)) {
+        removed += 1;
+      }
+    }
+    return Promise.resolve(removed);
+  }
+}
+
+interface SettlementProbe {
+  status: "pending" | "rejected" | "resolved";
+}
+
+const probe = (promise: Promise<unknown>): SettlementProbe => {
+  const state: SettlementProbe = { status: "pending" };
+  promise
+    .then(() => {
+      state.status = "resolved";
+      return null;
+    })
+    .catch(() => {
+      state.status = "rejected";
+    });
+  return state;
+};
+
+describe("createLeasedSemaphore", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("grants exactly capacity concurrent leases and parks the next acquirer", async () => {
+    const redis = new FakeRedis();
+    const semaphore = createLeasedSemaphore(redis, { capacity: CAPACITY, ttlMs: TTL_MS });
+
+    const first = await semaphore.acquireLease("account-1");
+    const second = await semaphore.acquireLease("account-1");
+    expect(first).toBeTruthy();
+    expect(second).toBeTruthy();
+
+    const waiter = probe(semaphore.acquireLease("account-1"));
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(waiter.status).toBe("pending");
+  });
+
+  it("admits a waiter as soon as a lease is released", async () => {
+    const redis = new FakeRedis();
+    const semaphore = createLeasedSemaphore(redis, { capacity: CAPACITY, ttlMs: TTL_MS });
+
+    const first = await semaphore.acquireLease("account-1");
+    await semaphore.acquireLease("account-1");
+    const waiter = probe(semaphore.acquireLease("account-1"));
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(waiter.status).toBe("pending");
+
+    await semaphore.release(first);
+    // Well under TTL_MS in total, so admission can only come from the release.
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(waiter.status).toBe("resolved");
+  });
+
+  it("frees a crashed holder's slot after its TTL expires", async () => {
+    const redis = new FakeRedis();
+    const semaphore = createLeasedSemaphore(redis, { capacity: 1, ttlMs: TTL_MS });
+
+    // Acquired but never released, as if the holder crashed mid-flight.
+    await semaphore.acquireLease("account-1");
+    const waiter = probe(semaphore.acquireLease("account-1"));
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(waiter.status).toBe("pending");
+
+    // Past the lease TTL plus retry slack, the slot must come back on its own.
+    await vi.advanceTimersByTimeAsync(TTL_MS + 3000);
+    expect(waiter.status).toBe("resolved");
+  });
+
+  it("stops a parked waiter with the abort reason when the signal aborts", async () => {
+    const redis = new FakeRedis();
+    const semaphore = createLeasedSemaphore(redis, { capacity: 1, ttlMs: TTL_MS });
+
+    await semaphore.acquireLease("account-1");
+    const controller = new AbortController();
+    const pending = semaphore.acquireLease("account-1", controller.signal);
+    const waiter = probe(pending);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(waiter.status).toBe("pending");
+
+    controller.abort(new Error("source deadline exceeded"));
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(waiter.status).toBe("rejected");
+    await expect(pending).rejects.toThrow("source deadline exceeded");
+  });
+});

--- a/packages/calendar/tests/core/utils/leased-semaphore.test.ts
+++ b/packages/calendar/tests/core/utils/leased-semaphore.test.ts
@@ -4,17 +4,13 @@ import { createLeasedSemaphore } from "../../../src/core/utils/leased-semaphore"
 const CAPACITY = 2;
 const TTL_MS = 5000;
 const SETTLE_MS = 500;
+const WELL_UNDER_TTL_MS = 2000;
 
 interface FakeEntry {
   expiresAt: number;
   value: string;
 }
 
-/*
- * In-memory stand-in for the Redis lease client, mirroring the fake-redis style of
- * redis-rate-limiter.test.ts but stateful: leases must live as independently expiring
- * keys (SET NX PX per slot), so the fake honors NX and PX against the fake-timer clock.
- */
 class FakeRedis {
   public store = new Map<string, FakeEntry>();
 
@@ -111,8 +107,7 @@ describe("createLeasedSemaphore", () => {
     expect(waiter.status).toBe("pending");
 
     await semaphore.release(first);
-    // Well under TTL_MS in total, so admission can only come from the release.
-    await vi.advanceTimersByTimeAsync(2000);
+    await vi.advanceTimersByTimeAsync(WELL_UNDER_TTL_MS);
     expect(waiter.status).toBe("resolved");
   });
 
@@ -120,13 +115,11 @@ describe("createLeasedSemaphore", () => {
     const redis = new FakeRedis();
     const semaphore = createLeasedSemaphore(redis, { capacity: 1, ttlMs: TTL_MS });
 
-    // Acquired but never released, as if the holder crashed mid-flight.
     await semaphore.acquireLease("account-1");
     const waiter = probe(semaphore.acquireLease("account-1"));
     await vi.advanceTimersByTimeAsync(SETTLE_MS);
     expect(waiter.status).toBe("pending");
 
-    // Past the lease TTL plus retry slack, the slot must come back on its own.
     await vi.advanceTimersByTimeAsync(TTL_MS + 3000);
     expect(waiter.status).toBe("resolved");
   });
@@ -136,19 +129,15 @@ describe("createLeasedSemaphore", () => {
     const semaphore = createLeasedSemaphore(redis, { capacity: 1, ttlMs: TTL_MS });
 
     const stale = await semaphore.acquireLease("account-1");
-    // The stale holder's TTL lapses without a release, freeing the slot key.
     await vi.advanceTimersByTimeAsync(TTL_MS + 1000);
 
-    // A second acquirer reclaims the same slot with a fresh token.
     const fresh = await semaphore.acquireLease("account-1");
     expect(fresh.slotKey).toBe(stale.slotKey);
     expect(fresh.token).not.toBe(stale.token);
 
-    // The stale holder finally releases; it must not delete the fresh lease.
     await semaphore.release(stale);
     expect(redis.store.get(fresh.slotKey)?.value).toBe(fresh.token);
 
-    // Capacity bound: with the fresh lease still held, a third acquirer must park.
     const waiter = probe(semaphore.acquireLease("account-1"));
     await vi.advanceTimersByTimeAsync(SETTLE_MS);
     expect(waiter.status).toBe("pending");

--- a/packages/calendar/tests/core/utils/leased-semaphore.test.ts
+++ b/packages/calendar/tests/core/utils/leased-semaphore.test.ts
@@ -131,6 +131,29 @@ describe("createLeasedSemaphore", () => {
     expect(waiter.status).toBe("resolved");
   });
 
+  it("does not let a stale holder's release destroy a lease reclaimed after TTL lapse", async () => {
+    const redis = new FakeRedis();
+    const semaphore = createLeasedSemaphore(redis, { capacity: 1, ttlMs: TTL_MS });
+
+    const stale = await semaphore.acquireLease("account-1");
+    // The stale holder's TTL lapses without a release, freeing the slot key.
+    await vi.advanceTimersByTimeAsync(TTL_MS + 1000);
+
+    // A second acquirer reclaims the same slot with a fresh token.
+    const fresh = await semaphore.acquireLease("account-1");
+    expect(fresh.slotKey).toBe(stale.slotKey);
+    expect(fresh.token).not.toBe(stale.token);
+
+    // The stale holder finally releases; it must not delete the fresh lease.
+    await semaphore.release(stale);
+    expect(redis.store.get(fresh.slotKey)?.value).toBe(fresh.token);
+
+    // Capacity bound: with the fresh lease still held, a third acquirer must park.
+    const waiter = probe(semaphore.acquireLease("account-1"));
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(waiter.status).toBe("pending");
+  });
+
   it("stops a parked waiter with the abort reason when the signal aborts", async () => {
     const redis = new FakeRedis();
     const semaphore = createLeasedSemaphore(redis, { capacity: 1, ttlMs: TTL_MS });

--- a/packages/calendar/tests/core/utils/outlook-account-semaphore.test.ts
+++ b/packages/calendar/tests/core/utils/outlook-account-semaphore.test.ts
@@ -4,17 +4,13 @@ import { createOutlookAccountSemaphore } from "../../../src/core/utils/redis-rat
 // One under Graph's documented MailboxConcurrency of 4.
 const OUTLOOK_CAPACITY = 3;
 const SETTLE_MS = 500;
+const WELL_UNDER_LEASE_TTL_MS = 2000;
 
 interface FakeEntry {
   expiresAt: number;
   value: string;
 }
 
-/*
- * In-memory stand-in for the Redis lease client, same shape as the fake in
- * leased-semaphore.test.ts: honors SET NX PX against the fake-timer clock so
- * per-slot leases behave like independently expiring keys.
- */
 class FakeRedis {
   public store = new Map<string, FakeEntry>();
 
@@ -115,8 +111,7 @@ describe("createOutlookAccountSemaphore", () => {
     expect(waiter.status).toBe("pending");
 
     await semaphore.release(first);
-    // Well under the lease TTL in total, so admission can only come from the release.
-    await vi.advanceTimersByTimeAsync(2000);
+    await vi.advanceTimersByTimeAsync(WELL_UNDER_LEASE_TTL_MS);
     expect(waiter.status).toBe("resolved");
   });
 
@@ -125,7 +120,6 @@ describe("createOutlookAccountSemaphore", () => {
     const semaphoreA = createOutlookAccountSemaphore(redis, "account-a");
     const semaphoreB = createOutlookAccountSemaphore(redis, "account-b");
 
-    // Fill account-a to capacity so any shared state would starve account-b.
     for (let index = 0; index < OUTLOOK_CAPACITY; index += 1) {
       await semaphoreA.acquireLease();
     }
@@ -133,7 +127,6 @@ describe("createOutlookAccountSemaphore", () => {
     await vi.advanceTimersByTimeAsync(SETTLE_MS);
     expect(parked.status).toBe("pending");
 
-    // Account-b must still get all three of its own slots without waiting.
     const grants = [];
     for (let index = 0; index < OUTLOOK_CAPACITY; index += 1) {
       grants.push(probe(semaphoreB.acquireLease()));

--- a/packages/calendar/tests/core/utils/outlook-account-semaphore.test.ts
+++ b/packages/calendar/tests/core/utils/outlook-account-semaphore.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createOutlookAccountSemaphore } from "../../../src/core/utils/redis-rate-limiter";
+
+// One under Graph's documented MailboxConcurrency of 4.
+const OUTLOOK_CAPACITY = 3;
+const SETTLE_MS = 500;
+
+interface FakeEntry {
+  expiresAt: number;
+  value: string;
+}
+
+/*
+ * In-memory stand-in for the Redis lease client, same shape as the fake in
+ * leased-semaphore.test.ts: honors SET NX PX against the fake-timer clock so
+ * per-slot leases behave like independently expiring keys.
+ */
+class FakeRedis {
+  public store = new Map<string, FakeEntry>();
+
+  private prune(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.store) {
+      if (entry.expiresAt <= now) {
+        this.store.delete(key);
+      }
+    }
+  }
+
+  public set(key: string, value: string, ...options: string[]): Promise<string | null> {
+    this.prune();
+    let expiresAt = Number.POSITIVE_INFINITY;
+    let onlyIfAbsent = false;
+    for (let index = 0; index < options.length; index += 1) {
+      const option = String(options[index]).toUpperCase();
+      if (option === "NX") {
+        onlyIfAbsent = true;
+      }
+      if (option === "PX") {
+        expiresAt = Date.now() + Number(options[index + 1]);
+        index += 1;
+      }
+    }
+    if (onlyIfAbsent && this.store.has(key)) {
+      return Promise.resolve(null);
+    }
+    this.store.set(key, { expiresAt, value });
+    return Promise.resolve("OK");
+  }
+
+  public del(...keys: string[]): Promise<number> {
+    this.prune();
+    let removed = 0;
+    for (const key of keys) {
+      if (this.store.delete(key)) {
+        removed += 1;
+      }
+    }
+    return Promise.resolve(removed);
+  }
+}
+
+interface SettlementProbe {
+  status: "pending" | "rejected" | "resolved";
+}
+
+const probe = (promise: Promise<unknown>): SettlementProbe => {
+  const state: SettlementProbe = { status: "pending" };
+  promise
+    .then(() => {
+      state.status = "resolved";
+      return null;
+    })
+    .catch(() => {
+      state.status = "rejected";
+    });
+  return state;
+};
+
+describe("createOutlookAccountSemaphore", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("grants exactly three concurrent leases per account and parks the fourth", async () => {
+    const redis = new FakeRedis();
+    const semaphore = createOutlookAccountSemaphore(redis, "account-a");
+
+    const leases = [];
+    for (let index = 0; index < OUTLOOK_CAPACITY; index += 1) {
+      leases.push(await semaphore.acquireLease());
+    }
+    for (const lease of leases) {
+      expect(lease).toBeTruthy();
+    }
+
+    const fourth = probe(semaphore.acquireLease());
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(fourth.status).toBe("pending");
+  });
+
+  it("admits a parked acquirer once a lease on the same account is released", async () => {
+    const redis = new FakeRedis();
+    const semaphore = createOutlookAccountSemaphore(redis, "account-a");
+
+    const first = await semaphore.acquireLease();
+    await semaphore.acquireLease();
+    await semaphore.acquireLease();
+    const waiter = probe(semaphore.acquireLease());
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(waiter.status).toBe("pending");
+
+    await semaphore.release(first);
+    // Well under the lease TTL in total, so admission can only come from the release.
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(waiter.status).toBe("resolved");
+  });
+
+  it("gives distinct accounts independent capacity", async () => {
+    const redis = new FakeRedis();
+    const semaphoreA = createOutlookAccountSemaphore(redis, "account-a");
+    const semaphoreB = createOutlookAccountSemaphore(redis, "account-b");
+
+    // Fill account-a to capacity so any shared state would starve account-b.
+    for (let index = 0; index < OUTLOOK_CAPACITY; index += 1) {
+      await semaphoreA.acquireLease();
+    }
+    const parked = probe(semaphoreA.acquireLease());
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(parked.status).toBe("pending");
+
+    // Account-b must still get all three of its own slots without waiting.
+    const grants = [];
+    for (let index = 0; index < OUTLOOK_CAPACITY; index += 1) {
+      grants.push(probe(semaphoreB.acquireLease()));
+    }
+    await vi.advanceTimersByTimeAsync(0);
+    for (const grant of grants) {
+      expect(grant.status).toBe("resolved");
+    }
+  });
+});

--- a/packages/calendar/tests/core/utils/serial-flush-worker.aborted-head-reap.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.aborted-head-reap.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { createSerialFlushWorker } from "../../../src/core/utils/serial-flush-worker";
+
+interface SettlementProbe {
+  status: "pending" | "rejected" | "resolved";
+}
+
+const probe = (promise: Promise<unknown>): SettlementProbe => {
+  const state: SettlementProbe = { status: "pending" };
+  promise
+    .then(() => {
+      state.status = "resolved";
+      return null;
+    })
+    .catch(() => {
+      state.status = "rejected";
+    });
+  return state;
+};
+
+const settle = async (): Promise<void> => {
+  for (let tick = 0; tick < 10; tick += 1) {
+    await Promise.resolve();
+  }
+};
+
+/*
+ * The local reservation shape mirrors the exported contract; runtime calls go
+ * through it as in the sibling weighted tests.
+ */
+interface FlushReservation {
+  release(): void;
+  submit(item: number): Promise<number>;
+}
+
+interface WeightedWorker {
+  close(): Promise<void>;
+  reserve(weight: number, signal?: AbortSignal): Promise<FlushReservation>;
+  submit(item: number, signal?: AbortSignal): Promise<number>;
+}
+
+const createWeightedWorker = (
+  run: (item: number) => Promise<number>,
+  budget: number,
+): WeightedWorker =>
+  createSerialFlushWorker(run, { budget } as never) as unknown as WeightedWorker;
+
+const neverRun = (item: number): Promise<number> => Promise.resolve(item);
+
+describe("aborted parked weight waiter is reaped immediately", () => {
+  it("admits a fitting reservation after the parked head aborts, without waiting for a release", async () => {
+    const worker = createWeightedWorker(neverRun, 64);
+
+    // Holder pins 32 of 64 and never releases.
+    await worker.reserve(32);
+
+    // A 40-weight reservation cannot fit (32 + 40 > 64), so it parks FIFO.
+    const controller = new AbortController();
+    const parked = probe(worker.reserve(40, controller.signal));
+    await settle();
+    expect(parked.status).toBe("pending");
+
+    // The parked waiter aborts: it rejected and must no longer block the line.
+    controller.abort(new Error("caller gave up"));
+    await settle();
+    expect(parked.status).toBe("rejected");
+
+    /*
+     * A fresh 16-weight reservation fits right now (32 + 16 <= 64). The
+     * comment at grantWeight promises an aborted waiter is dropped "so it
+     * cannot block the line" — so this must be admitted immediately, not
+     * parked behind the phantom until some unrelated holder releases.
+     */
+    const fitting = probe(worker.reserve(16));
+    await settle();
+    expect(fitting.status).toBe("resolved");
+  });
+});

--- a/packages/calendar/tests/core/utils/serial-flush-worker.aborted-head-reap.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.aborted-head-reap.test.ts
@@ -24,10 +24,6 @@ const settle = async (): Promise<void> => {
   }
 };
 
-/*
- * The local reservation shape mirrors the exported contract; runtime calls go
- * through it as in the sibling weighted tests.
- */
 interface FlushReservation {
   release(): void;
   submit(item: number): Promise<number>;
@@ -47,31 +43,29 @@ const createWeightedWorker = (
 
 const neverRun = (item: number): Promise<number> => Promise.resolve(item);
 
+const BUDGET = 64;
+const PINNED_WEIGHT = 32;
+const WEIGHT_TOO_LARGE_TO_FIT_BESIDE_PINNED = 40;
+const WEIGHT_THAT_FITS_BESIDE_PINNED = 16;
+
 describe("aborted parked weight waiter is reaped immediately", () => {
   it("admits a fitting reservation after the parked head aborts, without waiting for a release", async () => {
-    const worker = createWeightedWorker(neverRun, 64);
+    const worker = createWeightedWorker(neverRun, BUDGET);
 
-    // Holder pins 32 of 64 and never releases.
-    await worker.reserve(32);
+    await worker.reserve(PINNED_WEIGHT);
 
-    // A 40-weight reservation cannot fit (32 + 40 > 64), so it parks FIFO.
     const controller = new AbortController();
-    const parked = probe(worker.reserve(40, controller.signal));
+    const parked = probe(
+      worker.reserve(WEIGHT_TOO_LARGE_TO_FIT_BESIDE_PINNED, controller.signal),
+    );
     await settle();
     expect(parked.status).toBe("pending");
 
-    // The parked waiter aborts: it rejected and must no longer block the line.
     controller.abort(new Error("caller gave up"));
     await settle();
     expect(parked.status).toBe("rejected");
 
-    /*
-     * A fresh 16-weight reservation fits right now (32 + 16 <= 64). The
-     * comment at grantWeight promises an aborted waiter is dropped "so it
-     * cannot block the line" — so this must be admitted immediately, not
-     * parked behind the phantom until some unrelated holder releases.
-     */
-    const fitting = probe(worker.reserve(16));
+    const fitting = probe(worker.reserve(WEIGHT_THAT_FITS_BESIDE_PINNED));
     await settle();
     expect(fitting.status).toBe("resolved");
   });

--- a/packages/calendar/tests/core/utils/serial-flush-worker.deadline-release.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.deadline-release.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { createSerialFlushWorker } from "../../../src/core/utils/serial-flush-worker";
+import type { FlushReservation } from "../../../src/core/utils/serial-flush-worker";
+
+// Mirrors the cron wiring: the whole 64MB budget reserved by one cold-start fetch.
+const BUDGET = 64;
+const SHORT_DEADLINE_MS = 50;
+const SETTLE_WAIT_MS = 25;
+
+interface FlushItem {
+  deadlineAt?: number;
+  id: string;
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+describe("createSerialFlushWorker deadline expiry vs caller release()", () => {
+  it("keeps a timed-out run's weight held even when the caller's finally calls release()", async () => {
+    let releaseWedge: (() => void) | null = null;
+    const worker = createSerialFlushWorker(
+      async (item: FlushItem): Promise<string> => {
+        if (item.id === "wedge") {
+          // A half-open flushDatabase write: holds its transaction, never settles on its own.
+          await new Promise<void>((resolve) => {
+            releaseWedge = resolve;
+          });
+        }
+        return item.id;
+      },
+      { budget: BUDGET },
+    );
+
+    // Reservation A takes the full budget, then its run wedges past its deadline.
+    const reservationA = await worker.reserve(BUDGET);
+    const submitA = reservationA.submit({
+      deadlineAt: Date.now() + SHORT_DEADLINE_MS,
+      id: "wedge",
+    });
+    await expect(submitA).rejects.toThrow(/deadline/);
+
+    /*
+     * Production sequence (services/cron/src/jobs/ingest-sources.ts): every
+     * ingest family wraps its ingestSource call in
+     * `try { ... reservation.submit(...) ... } finally { reservation.release(); }`.
+     * The deadline rejection above propagates out of the try, so the finally
+     * runs release() while the abandoned run is still executing.
+     */
+    reservationA.release();
+
+    /*
+     * Settle-only invariant: the abandoned run is still executing — its
+     * payload and its single flushDatabase connection are both still live —
+     * so a full-budget reservation for B must stay parked until A's run
+     * actually settles, release() or not.
+     */
+    let grantedB: FlushReservation<FlushItem, string> | null = null;
+    const reserveB = worker.reserve(BUDGET).then((reservation) => {
+      grantedB = reservation;
+      return reservation;
+    });
+    await sleep(SETTLE_WAIT_MS);
+    expect(grantedB).toBeNull();
+
+    // Cleanup: settle the wedged run, then drain whatever the grant produced.
+    if (releaseWedge !== null) {
+      const settle = releaseWedge as () => void;
+      settle();
+    }
+    const reservationB = await reserveB;
+    reservationB.release();
+    await worker.close();
+  });
+});

--- a/packages/calendar/tests/core/utils/serial-flush-worker.deadline-release.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.deadline-release.test.ts
@@ -23,7 +23,6 @@ describe("createSerialFlushWorker deadline expiry vs caller release()", () => {
     const worker = createSerialFlushWorker(
       async (item: FlushItem): Promise<string> => {
         if (item.id === "wedge") {
-          // A half-open flushDatabase write: holds its transaction, never settles on its own.
           await new Promise<void>((resolve) => {
             releaseWedge = resolve;
           });
@@ -33,7 +32,6 @@ describe("createSerialFlushWorker deadline expiry vs caller release()", () => {
       { budget: BUDGET },
     );
 
-    // Reservation A takes the full budget, then its run wedges past its deadline.
     const reservationA = await worker.reserve(BUDGET);
     const submitA = reservationA.submit({
       deadlineAt: Date.now() + SHORT_DEADLINE_MS,
@@ -41,21 +39,9 @@ describe("createSerialFlushWorker deadline expiry vs caller release()", () => {
     });
     await expect(submitA).rejects.toThrow(/deadline/);
 
-    /*
-     * Production sequence (services/cron/src/jobs/ingest-sources.ts): every
-     * ingest family wraps its ingestSource call in
-     * `try { ... reservation.submit(...) ... } finally { reservation.release(); }`.
-     * The deadline rejection above propagates out of the try, so the finally
-     * runs release() while the abandoned run is still executing.
-     */
+    // Production wraps submit in try/finally, so release() runs while the abandoned run executes.
     reservationA.release();
 
-    /*
-     * Settle-only invariant: the abandoned run is still executing — its
-     * payload and its single flushDatabase connection are both still live —
-     * so a full-budget reservation for B must stay parked until A's run
-     * actually settles, release() or not.
-     */
     let grantedB: FlushReservation<FlushItem, string> | null = null;
     const reserveB = worker.reserve(BUDGET).then((reservation) => {
       grantedB = reservation;
@@ -64,7 +50,6 @@ describe("createSerialFlushWorker deadline expiry vs caller release()", () => {
     await sleep(SETTLE_WAIT_MS);
     expect(grantedB).toBeNull();
 
-    // Cleanup: settle the wedged run, then drain whatever the grant produced.
     if (releaseWedge !== null) {
       const settle = releaseWedge as () => void;
       settle();

--- a/packages/calendar/tests/core/utils/serial-flush-worker.deadline-weight-leak.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.deadline-weight-leak.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { createSerialFlushWorker } from "../../../src/core/utils/serial-flush-worker";
+import type { FlushReservation } from "../../../src/core/utils/serial-flush-worker";
+
+// Mirrors the cron wiring: the whole 64MB budget reserved by one cold-start fetch.
+const BUDGET = 64;
+const SHORT_DEADLINE_MS = 50;
+const SETTLE_WAIT_MS = 25;
+
+interface FlushItem {
+  deadlineAt?: number;
+  id: string;
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+describe("createSerialFlushWorker deadline expiry vs reserved weight", () => {
+  it("keeps a timed-out run's weight held and the pump blocked until the run settles", async () => {
+    let releaseWedge: (() => void) | null = null;
+    let activeRuns = 0;
+    let maxConcurrentRuns = 0;
+    const worker = createSerialFlushWorker(
+      async (item: FlushItem): Promise<string> => {
+        activeRuns += 1;
+        maxConcurrentRuns = Math.max(maxConcurrentRuns, activeRuns);
+        try {
+          if (item.id === "wedge") {
+            // A half-open flushDatabase write: holds its transaction, never settles on its own.
+            await new Promise<void>((resolve) => {
+              releaseWedge = resolve;
+            });
+          }
+          return item.id;
+        } finally {
+          activeRuns -= 1;
+        }
+      },
+      { budget: BUDGET },
+    );
+
+    // Reservation A takes the full budget, then its run wedges past its deadline.
+    const reservationA = await worker.reserve(BUDGET);
+    const submitA = reservationA.submit({
+      deadlineAt: Date.now() + SHORT_DEADLINE_MS,
+      id: "wedge",
+    });
+    await expect(submitA).rejects.toThrow(/deadline/);
+
+    /*
+     * The abandoned run is still executing: its payload and its single
+     * flushDatabase connection are both still live. A full-budget reservation
+     * for B must therefore stay parked until A's run actually settles.
+     */
+    let grantedB: FlushReservation<FlushItem, string> | null = null;
+    const reserveB = worker.reserve(BUDGET).then((reservation) => {
+      grantedB = reservation;
+      return reservation;
+    });
+    await sleep(SETTLE_WAIT_MS);
+    expect(grantedB).toBeNull();
+
+    /*
+     * And the serial worker must never run two flushes concurrently: if B had
+     * been admitted and submitted, its run would overlap A's abandoned run.
+     */
+    expect(maxConcurrentRuns).toBe(1);
+
+    // Cleanup: settle the wedged run, then drain whatever the grant produced.
+    if (releaseWedge !== null) {
+      const settle = releaseWedge as () => void;
+      settle();
+    }
+    const reservationB = await reserveB;
+    reservationB.release();
+    await worker.close();
+  });
+});

--- a/packages/calendar/tests/core/utils/serial-flush-worker.deadline-weight-leak.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.deadline-weight-leak.test.ts
@@ -28,7 +28,6 @@ describe("createSerialFlushWorker deadline expiry vs reserved weight", () => {
         maxConcurrentRuns = Math.max(maxConcurrentRuns, activeRuns);
         try {
           if (item.id === "wedge") {
-            // A half-open flushDatabase write: holds its transaction, never settles on its own.
             await new Promise<void>((resolve) => {
               releaseWedge = resolve;
             });
@@ -41,7 +40,6 @@ describe("createSerialFlushWorker deadline expiry vs reserved weight", () => {
       { budget: BUDGET },
     );
 
-    // Reservation A takes the full budget, then its run wedges past its deadline.
     const reservationA = await worker.reserve(BUDGET);
     const submitA = reservationA.submit({
       deadlineAt: Date.now() + SHORT_DEADLINE_MS,
@@ -49,11 +47,7 @@ describe("createSerialFlushWorker deadline expiry vs reserved weight", () => {
     });
     await expect(submitA).rejects.toThrow(/deadline/);
 
-    /*
-     * The abandoned run is still executing: its payload and its single
-     * flushDatabase connection are both still live. A full-budget reservation
-     * for B must therefore stay parked until A's run actually settles.
-     */
+    // The abandoned run still holds its payload and the single flushDatabase connection.
     let grantedB: FlushReservation<FlushItem, string> | null = null;
     const reserveB = worker.reserve(BUDGET).then((reservation) => {
       grantedB = reservation;
@@ -62,13 +56,8 @@ describe("createSerialFlushWorker deadline expiry vs reserved weight", () => {
     await sleep(SETTLE_WAIT_MS);
     expect(grantedB).toBeNull();
 
-    /*
-     * And the serial worker must never run two flushes concurrently: if B had
-     * been admitted and submitted, its run would overlap A's abandoned run.
-     */
     expect(maxConcurrentRuns).toBe(1);
 
-    // Cleanup: settle the wedged run, then drain whatever the grant produced.
     if (releaseWedge !== null) {
       const settle = releaseWedge as () => void;
       settle();

--- a/packages/calendar/tests/core/utils/serial-flush-worker.deadline.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.deadline.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSerialFlushWorker } from "../../../src/core/utils/serial-flush-worker";
+
+// A generous client-side bound: any sane flush deadline is far below ten minutes.
+const GENEROUS_DEADLINE_MS = 600_000;
+
+interface SettlementProbe {
+  status: "pending" | "rejected" | "resolved";
+}
+
+const probe = (promise: Promise<unknown>): SettlementProbe => {
+  const state: SettlementProbe = { status: "pending" };
+  promise
+    .then(() => {
+      state.status = "resolved";
+      return null;
+    })
+    .catch(() => {
+      state.status = "rejected";
+    });
+  return state;
+};
+
+describe("createSerialFlushWorker run deadline", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("rejects a wedged run at the bound and resumes the pump only once it settles", async () => {
+    let releaseWedge: (() => void) | null = null;
+    let wedgedCalls = 0;
+    const worker = createSerialFlushWorker((item: number): Promise<number> => {
+      if (item === 1) {
+        // A half-open connection: the flush stays pending until externally settled.
+        return new Promise<number>((resolve) => {
+          wedgedCalls += 1;
+          releaseWedge = (): void => {
+            resolve(item * 10);
+          };
+        });
+      }
+      return Promise.resolve(item * 10);
+    });
+
+    const wedged = probe(worker.submit(1));
+    const follower = worker.submit(2);
+    const followerProbe = probe(follower);
+
+    await vi.advanceTimersByTimeAsync(GENEROUS_DEADLINE_MS);
+
+    expect(wedgedCalls).toBe(1);
+    // The wedged item must be rejected by the deadline, not left pending forever.
+    expect(wedged.status).toBe("rejected");
+    /*
+     * But the pump must NOT move on while the abandoned run is still live: it
+     * still holds its payload and the single flushDatabase connection, so the
+     * next family's flush waits for it to actually settle.
+     */
+    expect(followerProbe.status).toBe("pending");
+
+    // Once the abandoned run finally settles, the pump resumes serially.
+    expect(releaseWedge).not.toBeNull();
+    const settle = releaseWedge as unknown as () => void;
+    settle();
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(follower).resolves.toBe(20);
+  });
+});

--- a/packages/calendar/tests/core/utils/serial-flush-worker.deadline.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.deadline.test.ts
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSerialFlushWorker } from "../../../src/core/utils/serial-flush-worker";
 
-// A generous client-side bound: any sane flush deadline is far below ten minutes.
-const GENEROUS_DEADLINE_MS = 600_000;
+const DEFAULT_RUN_DEADLINE_MS = 600_000;
 
 interface SettlementProbe {
   status: "pending" | "rejected" | "resolved";
@@ -35,7 +34,6 @@ describe("createSerialFlushWorker run deadline", () => {
     let wedgedCalls = 0;
     const worker = createSerialFlushWorker((item: number): Promise<number> => {
       if (item === 1) {
-        // A half-open connection: the flush stays pending until externally settled.
         return new Promise<number>((resolve) => {
           wedgedCalls += 1;
           releaseWedge = (): void => {
@@ -50,19 +48,13 @@ describe("createSerialFlushWorker run deadline", () => {
     const follower = worker.submit(2);
     const followerProbe = probe(follower);
 
-    await vi.advanceTimersByTimeAsync(GENEROUS_DEADLINE_MS);
+    await vi.advanceTimersByTimeAsync(DEFAULT_RUN_DEADLINE_MS);
 
     expect(wedgedCalls).toBe(1);
-    // The wedged item must be rejected by the deadline, not left pending forever.
     expect(wedged.status).toBe("rejected");
-    /*
-     * But the pump must NOT move on while the abandoned run is still live: it
-     * still holds its payload and the single flushDatabase connection, so the
-     * next family's flush waits for it to actually settle.
-     */
+    // The abandoned run still holds the single flushDatabase connection, so the pump waits.
     expect(followerProbe.status).toBe("pending");
 
-    // Once the abandoned run finally settles, the pump resumes serially.
     expect(releaseWedge).not.toBeNull();
     const settle = releaseWedge as unknown as () => void;
     settle();

--- a/packages/calendar/tests/core/utils/serial-flush-worker.express-starvation.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.express-starvation.test.ts
@@ -1,22 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { createSerialFlushWorker } from "../../../src/core/utils/serial-flush-worker";
 
-/*
- * Anti-starvation contract for the express lane. Proportions mirror production:
- * budget 64 units stands in for the 64 MiB WEIGHT_BUDGET, so budget/64 = 1 is
- * the express threshold (a warm <=1024-event calendar) and weight 8 = budget/8
- * is NEVER_INGESTED_WEIGHT (a cold-start calendar).
- */
+// 64 stands in for the 64 MiB WEIGHT_BUDGET, 1 for the express threshold, 8 for NEVER_INGESTED_WEIGHT.
 const BUDGET = 64;
-const HEAVY_WEIGHT = 8;
+const COLD_START_WEIGHT = 8;
 const EXPRESS_WEIGHT = 1;
 const HEAVY_HOLD_COUNT = 7;
-/*
- * How many express grants may overtake a parked FIFO head before the head must
- * be admitted. Any finite bound proves fairness; 50 is generous — each cycle
- * both grants a fresh express reservation and releases the previous one, so a
- * fair lane has 50 chances to age or admit the head.
- */
+// Any finite bound proves fairness; 50 gives a fair lane ample chances to admit the head.
 const MAX_EXPRESS_OVERTAKES = 50;
 
 const flushMicrotasks = async (): Promise<void> => {
@@ -48,27 +38,18 @@ describe("express lane starvation of the parked FIFO head", () => {
       { budget: BUDGET },
     );
 
-    // Seven concurrent cold-start holds pin 56 of 64 units, spanning their provider fetches.
     const heavyHolds = await Promise.all(
       Array.from({ length: HEAVY_HOLD_COUNT }, () =>
-        worker.reserve(HEAVY_WEIGHT),
+        worker.reserve(COLD_START_WEIGHT),
       ),
     );
 
-    // One express reservation is in flight, so outstanding sits at 57.
     let inFlightExpress = await worker.reserve(EXPRESS_WEIGHT);
 
-    // The next cold-start reservation cannot fit (57 + 8 > 64) and parks as FIFO head.
-    const headProbe = probe(worker.reserve(HEAVY_WEIGHT));
+    const headProbe = probe(worker.reserve(COLD_START_WEIGHT));
     await flushMicrotasks();
     expect(headProbe.settled).toBe(false);
 
-    /*
-     * Sustained express churn: every cycle a new 1-unit reservation is granted
-     * while the head is parked, then the previous one releases. Outstanding
-     * weight never drops below 57 at any grantWeight call, and express admits
-     * up to the 68-unit ceiling, so nothing ever bounds the overtaking.
-     */
     let overtakes = 0;
     while (overtakes < MAX_EXPRESS_OVERTAKES && !headProbe.settled) {
       const next = await worker.reserve(EXPRESS_WEIGHT);
@@ -78,12 +59,7 @@ describe("express lane starvation of the parked FIFO head", () => {
       await flushMicrotasks();
     }
 
-    /*
-     * Fairness bound: a parked head must not be overtaken by express grants
-     * indefinitely. On starving code the head is still pending after 50
-     * overtakes — exactly the pattern that walks a cold-start source past its
-     * 120s per-source deadline while warm calendars keep succeeding.
-     */
+    // Unbounded overtaking walks a cold-start source past its 120s per-source deadline.
     expect(headProbe.settled).toBe(true);
 
     inFlightExpress.release();

--- a/packages/calendar/tests/core/utils/serial-flush-worker.express-starvation.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.express-starvation.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { createSerialFlushWorker } from "../../../src/core/utils/serial-flush-worker";
+
+/*
+ * Anti-starvation contract for the express lane. Proportions mirror production:
+ * budget 64 units stands in for the 64 MiB WEIGHT_BUDGET, so budget/64 = 1 is
+ * the express threshold (a warm <=1024-event calendar) and weight 8 = budget/8
+ * is NEVER_INGESTED_WEIGHT (a cold-start calendar).
+ */
+const BUDGET = 64;
+const HEAVY_WEIGHT = 8;
+const EXPRESS_WEIGHT = 1;
+const HEAVY_HOLD_COUNT = 7;
+/*
+ * How many express grants may overtake a parked FIFO head before the head must
+ * be admitted. Any finite bound proves fairness; 50 is generous — each cycle
+ * both grants a fresh express reservation and releases the previous one, so a
+ * fair lane has 50 chances to age or admit the head.
+ */
+const MAX_EXPRESS_OVERTAKES = 50;
+
+const flushMicrotasks = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+interface Probe {
+  settled: boolean;
+}
+
+const probe = (promise: Promise<unknown>): Probe => {
+  const state: Probe = { settled: false };
+  promise
+    .then(() => {
+      state.settled = true;
+      return null;
+    })
+    .catch(() => {
+      state.settled = true;
+    });
+  return state;
+};
+
+describe("express lane starvation of the parked FIFO head", () => {
+  it("admits a parked cold-start reservation before unbounded express traffic overtakes it", async () => {
+    const worker = createSerialFlushWorker<number, number>(
+      (item) => Promise.resolve(item),
+      { budget: BUDGET },
+    );
+
+    // Seven concurrent cold-start holds pin 56 of 64 units, spanning their provider fetches.
+    const heavyHolds = await Promise.all(
+      Array.from({ length: HEAVY_HOLD_COUNT }, () =>
+        worker.reserve(HEAVY_WEIGHT),
+      ),
+    );
+
+    // One express reservation is in flight, so outstanding sits at 57.
+    let inFlightExpress = await worker.reserve(EXPRESS_WEIGHT);
+
+    // The next cold-start reservation cannot fit (57 + 8 > 64) and parks as FIFO head.
+    const headProbe = probe(worker.reserve(HEAVY_WEIGHT));
+    await flushMicrotasks();
+    expect(headProbe.settled).toBe(false);
+
+    /*
+     * Sustained express churn: every cycle a new 1-unit reservation is granted
+     * while the head is parked, then the previous one releases. Outstanding
+     * weight never drops below 57 at any grantWeight call, and express admits
+     * up to the 68-unit ceiling, so nothing ever bounds the overtaking.
+     */
+    let overtakes = 0;
+    while (overtakes < MAX_EXPRESS_OVERTAKES && !headProbe.settled) {
+      const next = await worker.reserve(EXPRESS_WEIGHT);
+      overtakes += 1;
+      inFlightExpress.release();
+      inFlightExpress = next;
+      await flushMicrotasks();
+    }
+
+    /*
+     * Fairness bound: a parked head must not be overtaken by express grants
+     * indefinitely. On starving code the head is still pending after 50
+     * overtakes — exactly the pattern that walks a cold-start source past its
+     * 120s per-source deadline while warm calendars keep succeeding.
+     */
+    expect(headProbe.settled).toBe(true);
+
+    inFlightExpress.release();
+    for (const hold of heavyHolds) {
+      hold.release();
+    }
+    await worker.close();
+  });
+});

--- a/packages/calendar/tests/core/utils/serial-flush-worker.item-deadline.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.item-deadline.test.ts
@@ -1,9 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSerialFlushWorker } from "../../../src/core/utils/serial-flush-worker";
 
-// The generic client-side fallback bound baked into the worker.
 const DEFAULT_RUN_DEADLINE_MS = 600_000;
-// A per-source deadline far below the fallback, as ingest-sources computes one.
 const ITEM_DEADLINE_MS = 5000;
 
 interface SettlementProbe {
@@ -24,13 +22,9 @@ const probe = (promise: Promise<unknown>): SettlementProbe => {
 };
 
 /*
- * The production caller (services/cron/src/jobs/ingest-sources.ts) instantiates
- * the worker with thunk items: `(task: () => Promise<IngestionResult>) => task()`.
- * The worker documents "Honor an item-carried absolute deadline when present",
- * so a thunk carrying its source's own `deadlineAt` must be bounded by that
- * deadline, not by the generic ten-minute fallback.
+ * Production submits thunk items, so the item carrying its own deadlineAt is a
+ * function with a property — not the plain object shape the worker's own tests use.
  */
-// A half-open connection: the flush stays pending forever.
 const wedged = (): Promise<number> =>
   new Promise<number>(() => {
     // Intentionally never settles, modeling a half-open connection.
@@ -59,14 +53,8 @@ describe("createSerialFlushWorker item-carried deadline on production-shaped ite
 
     const submitted = probe(worker.submit(task));
 
-    // Advance to the item's own deadline; well short of the generic fallback.
     await vi.advanceTimersByTimeAsync(ITEM_DEADLINE_MS);
     expect(ITEM_DEADLINE_MS).toBeLessThan(DEFAULT_RUN_DEADLINE_MS);
-    /*
-     * The item carried a finite absolute deadline, so the worker must reject
-     * the wedged flush here — not park it for the remaining ~595 seconds of
-     * the generic fallback while the source's own deadline has already passed.
-     */
     expect(submitted.status).toBe("rejected");
   });
 });

--- a/packages/calendar/tests/core/utils/serial-flush-worker.item-deadline.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.item-deadline.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSerialFlushWorker } from "../../../src/core/utils/serial-flush-worker";
+
+// The generic client-side fallback bound baked into the worker.
+const DEFAULT_RUN_DEADLINE_MS = 600_000;
+// A per-source deadline far below the fallback, as ingest-sources computes one.
+const ITEM_DEADLINE_MS = 5000;
+
+interface SettlementProbe {
+  status: "pending" | "rejected" | "resolved";
+}
+
+const probe = (promise: Promise<unknown>): SettlementProbe => {
+  const state: SettlementProbe = { status: "pending" };
+  promise
+    .then(() => {
+      state.status = "resolved";
+      return null;
+    })
+    .catch(() => {
+      state.status = "rejected";
+    });
+  return state;
+};
+
+/*
+ * The production caller (services/cron/src/jobs/ingest-sources.ts) instantiates
+ * the worker with thunk items: `(task: () => Promise<IngestionResult>) => task()`.
+ * The worker documents "Honor an item-carried absolute deadline when present",
+ * so a thunk carrying its source's own `deadlineAt` must be bounded by that
+ * deadline, not by the generic ten-minute fallback.
+ */
+// A half-open connection: the flush stays pending forever.
+const wedged = (): Promise<number> =>
+  new Promise<number>(() => {
+    // Intentionally never settles, modeling a half-open connection.
+  });
+
+interface DeadlineCarryingTask {
+  (): Promise<number>;
+  deadlineAt: number;
+}
+
+describe("createSerialFlushWorker item-carried deadline on production-shaped items", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("honors deadlineAt carried on a thunk item instead of the 10-minute fallback", async () => {
+    const worker = createSerialFlushWorker((task: () => Promise<number>) => task());
+
+    const task = Object.assign(wedged, {
+      deadlineAt: Date.now() + ITEM_DEADLINE_MS,
+    }) as DeadlineCarryingTask;
+
+    const submitted = probe(worker.submit(task));
+
+    // Advance to the item's own deadline; well short of the generic fallback.
+    await vi.advanceTimersByTimeAsync(ITEM_DEADLINE_MS);
+    expect(ITEM_DEADLINE_MS).toBeLessThan(DEFAULT_RUN_DEADLINE_MS);
+    /*
+     * The item carried a finite absolute deadline, so the worker must reject
+     * the wedged flush here — not park it for the remaining ~595 seconds of
+     * the generic fallback while the source's own deadline has already passed.
+     */
+    expect(submitted.status).toBe("rejected");
+  });
+});

--- a/packages/calendar/tests/core/utils/serial-flush-worker.large-head-starvation.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.large-head-starvation.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { createSerialFlushWorker } from "../../../src/core/utils/serial-flush-worker";
+import type { FlushReservation } from "../../../src/core/utils/serial-flush-worker";
+
+/*
+ * Anti-starvation contract for a LARGE parked head. Proportions mirror
+ * production: budget 64 units stands in for the 64 MiB WEIGHT_BUDGET, so
+ * budget/64 = 1 is the express threshold (a warm <=1024-event calendar) and
+ * 60 units is a large-calendar reservation just under the whale clamp.
+ *
+ * The aged-admission ceiling is budget + budget/16 = 68. Ten concurrent
+ * 1-unit express holds keep outstanding at 10, so the parked 60-unit head
+ * needs 70 <= 68 under grantOvertakenHead and 70 <= 64 under grantWeight —
+ * both impossible while express churn keeps replacing released holds. The
+ * EXPRESS_MAX_OVERTAKES bound must therefore pause express admission (or
+ * otherwise drain outstanding weight) so the head is eventually admitted;
+ * this test proves it never is.
+ */
+const BUDGET = 64;
+const EXPRESS_WEIGHT = 1;
+const TINY_HOLD_COUNT = 10;
+const HEAD_WEIGHT = 60;
+/*
+ * Each cycle releases one tiny hold and immediately reserves a replacement —
+ * exactly the sustained tiny traffic the EXPRESS_MAX_OVERTAKES comment claims
+ * cannot park a large-calendar reservation past its deadline. 200 cycles is
+ * 12.5x the overtake bound of 16, so any working aging scheme has admitted
+ * the head long before the loop ends.
+ */
+const CHURN_CYCLES = 200;
+
+const flushMicrotasks = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+interface ReservationProbe {
+  reservation: FlushReservation<number, number> | null;
+  settled: boolean;
+}
+
+const probeReserve = (
+  promise: Promise<FlushReservation<number, number>>,
+): ReservationProbe => {
+  const state: ReservationProbe = { reservation: null, settled: false };
+  promise
+    .then((reservation) => {
+      state.settled = true;
+      state.reservation = reservation;
+      return null;
+    })
+    .catch(() => {
+      state.settled = true;
+    });
+  return state;
+};
+
+describe("express churn starving a large parked head", () => {
+  it("admits a parked large-calendar reservation despite sustained tiny express churn", async () => {
+    const worker = createSerialFlushWorker<number, number>(
+      (item) => Promise.resolve(item),
+      { budget: BUDGET },
+    );
+
+    // Ten concurrent warm-calendar holds pin 10 of 64 units; 84% of the budget is idle.
+    let tinyHolds: FlushReservation<number, number>[] = await Promise.all(
+      Array.from({ length: TINY_HOLD_COUNT }, () =>
+        worker.reserve(EXPRESS_WEIGHT),
+      ),
+    );
+
+    // The large-calendar reservation cannot fit (10 + 60 > 64) and parks as FIFO head.
+    const headProbe = probeReserve(worker.reserve(HEAD_WEIGHT));
+    await flushMicrotasks();
+    expect(headProbe.settled).toBe(false);
+
+    /*
+     * Sustained tiny churn: release one warm hold, reserve a replacement.
+     * Replacement reserves are probed rather than awaited so that a correct
+     * implementation which parks express traffic once the overtake bound is
+     * reached cannot hang the loop; on such an implementation the releases
+     * drain outstanding weight until the head fits and is admitted.
+     */
+    let cycle = 0;
+    const parkedReplacements: ReservationProbe[] = [];
+    while (cycle < CHURN_CYCLES && !headProbe.settled) {
+      const oldest = tinyHolds.shift();
+      if (oldest) {
+        oldest.release();
+      }
+      const replacement = probeReserve(worker.reserve(EXPRESS_WEIGHT));
+      await flushMicrotasks();
+      if (replacement.settled && replacement.reservation) {
+        tinyHolds.push(replacement.reservation);
+      } else {
+        parkedReplacements.push(replacement);
+      }
+      cycle += 1;
+    }
+
+    /*
+     * Fairness guarantee under test: "sustained tiny traffic cannot park a
+     * cold-start or large-calendar reservation past its deadline". On the
+     * current code every replacement is express-granted BEFORE the head check,
+     * outstanding weight never drops below 10 at any admission check, and
+     * 10 + 60 = 70 exceeds both the budget (64) and the aged ceiling (68),
+     * so the head is still pending after 200 cycles — 12.5x the bound of 16.
+     */
+    expect(headProbe.settled).toBe(true);
+
+    if (headProbe.reservation) {
+      headProbe.reservation.release();
+    }
+    for (const hold of tinyHolds) {
+      hold.release();
+    }
+    for (const parked of parkedReplacements) {
+      await flushMicrotasks();
+      if (parked.reservation) {
+        parked.reservation.release();
+      }
+    }
+    tinyHolds = [];
+    await worker.close();
+  });
+});

--- a/packages/calendar/tests/core/utils/serial-flush-worker.large-head-starvation.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.large-head-starvation.test.ts
@@ -3,30 +3,15 @@ import { createSerialFlushWorker } from "../../../src/core/utils/serial-flush-wo
 import type { FlushReservation } from "../../../src/core/utils/serial-flush-worker";
 
 /*
- * Anti-starvation contract for a LARGE parked head. Proportions mirror
- * production: budget 64 units stands in for the 64 MiB WEIGHT_BUDGET, so
- * budget/64 = 1 is the express threshold (a warm <=1024-event calendar) and
- * 60 units is a large-calendar reservation just under the whale clamp.
- *
- * The aged-admission ceiling is budget + budget/16 = 68. Ten concurrent
- * 1-unit express holds keep outstanding at 10, so the parked 60-unit head
- * needs 70 <= 68 under grantOvertakenHead and 70 <= 64 under grantWeight —
- * both impossible while express churn keeps replacing released holds. The
- * EXPRESS_MAX_OVERTAKES bound must therefore pause express admission (or
- * otherwise drain outstanding weight) so the head is eventually admitted;
- * this test proves it never is.
+ * 64 units stands in for the 64 MiB WEIGHT_BUDGET. While ten 1-unit holds stand,
+ * the parked 60-unit head fits neither the budget (70 > 64) nor the aged ceiling
+ * (70 > 68), so express admission must pause to drain outstanding weight.
  */
 const BUDGET = 64;
 const EXPRESS_WEIGHT = 1;
 const TINY_HOLD_COUNT = 10;
 const HEAD_WEIGHT = 60;
-/*
- * Each cycle releases one tiny hold and immediately reserves a replacement —
- * exactly the sustained tiny traffic the EXPRESS_MAX_OVERTAKES comment claims
- * cannot park a large-calendar reservation past its deadline. 200 cycles is
- * 12.5x the overtake bound of 16, so any working aging scheme has admitted
- * the head long before the loop ends.
- */
+// 12.5x the overtake bound of 16, so any working aging scheme admits the head well within it.
 const CHURN_CYCLES = 200;
 
 const flushMicrotasks = async (): Promise<void> => {
@@ -62,25 +47,17 @@ describe("express churn starving a large parked head", () => {
       { budget: BUDGET },
     );
 
-    // Ten concurrent warm-calendar holds pin 10 of 64 units; 84% of the budget is idle.
     let tinyHolds: FlushReservation<number, number>[] = await Promise.all(
       Array.from({ length: TINY_HOLD_COUNT }, () =>
         worker.reserve(EXPRESS_WEIGHT),
       ),
     );
 
-    // The large-calendar reservation cannot fit (10 + 60 > 64) and parks as FIFO head.
     const headProbe = probeReserve(worker.reserve(HEAD_WEIGHT));
     await flushMicrotasks();
     expect(headProbe.settled).toBe(false);
 
-    /*
-     * Sustained tiny churn: release one warm hold, reserve a replacement.
-     * Replacement reserves are probed rather than awaited so that a correct
-     * implementation which parks express traffic once the overtake bound is
-     * reached cannot hang the loop; on such an implementation the releases
-     * drain outstanding weight until the head fits and is admitted.
-     */
+    // Awaiting replacements would hang once a correct implementation parks express traffic.
     let cycle = 0;
     const parkedReplacements: ReservationProbe[] = [];
     while (cycle < CHURN_CYCLES && !headProbe.settled) {
@@ -98,14 +75,6 @@ describe("express churn starving a large parked head", () => {
       cycle += 1;
     }
 
-    /*
-     * Fairness guarantee under test: "sustained tiny traffic cannot park a
-     * cold-start or large-calendar reservation past its deadline". On the
-     * current code every replacement is express-granted BEFORE the head check,
-     * outstanding weight never drops below 10 at any admission check, and
-     * 10 + 60 = 70 exceeds both the budget (64) and the aged ceiling (68),
-     * so the head is still pending after 200 cycles — 12.5x the bound of 16.
-     */
     expect(headProbe.settled).toBe(true);
 
     if (headProbe.reservation) {

--- a/packages/calendar/tests/core/utils/serial-flush-worker.queued-abort.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.queued-abort.test.ts
@@ -39,7 +39,6 @@ describe("serial flush worker queued abort", () => {
       return item;
     });
 
-    // The first item occupies the pump; the second parks in the queue.
     const first = worker.submit("first");
     const controller = new AbortController();
     const reason = new Error("source deadline hit");
@@ -49,7 +48,6 @@ describe("serial flush worker queued abort", () => {
     controller.abort(reason);
     await delay(SETTLE_MS);
 
-    // An aborted queued submit must settle at its deadline, not at queue drain.
     expect(secondProbe.status).toBe("rejected");
     expect(secondProbe.reason).toBe(reason);
 
@@ -57,7 +55,6 @@ describe("serial flush worker queued abort", () => {
     await first;
     await delay(SETTLE_MS);
 
-    // The aborted item must never have run.
     expect(ran).toEqual(["first"]);
 
     await worker.close();

--- a/packages/calendar/tests/core/utils/serial-flush-worker.queued-abort.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.queued-abort.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { createSerialFlushWorker } from "../../../src/core/utils/serial-flush-worker";
+
+const SETTLE_MS = 25;
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+interface SettlementProbe {
+  reason: unknown;
+  status: "pending" | "rejected" | "resolved";
+}
+
+const probe = (promise: Promise<unknown>): SettlementProbe => {
+  const state: SettlementProbe = { reason: null, status: "pending" };
+  promise
+    .then(() => {
+      state.status = "resolved";
+      return null;
+    })
+    .catch((error: unknown) => {
+      state.reason = error;
+      state.status = "rejected";
+    });
+  return state;
+};
+
+describe("serial flush worker queued abort", () => {
+  it("rejects a queued submit when its signal aborts, before queue drain", async () => {
+    const { promise: gate, resolve: releaseFirst } = Promise.withResolvers<null>();
+    const ran: string[] = [];
+    const worker = createSerialFlushWorker(async (item: string) => {
+      ran.push(item);
+      if (item === "first") {
+        await gate;
+      }
+      return item;
+    });
+
+    // The first item occupies the pump; the second parks in the queue.
+    const first = worker.submit("first");
+    const controller = new AbortController();
+    const reason = new Error("source deadline hit");
+    const second = worker.submit("second", controller.signal);
+    const secondProbe = probe(second);
+
+    controller.abort(reason);
+    await delay(SETTLE_MS);
+
+    // An aborted queued submit must settle at its deadline, not at queue drain.
+    expect(secondProbe.status).toBe("rejected");
+    expect(secondProbe.reason).toBe(reason);
+
+    releaseFirst(null);
+    await first;
+    await delay(SETTLE_MS);
+
+    // The aborted item must never have run.
+    expect(ran).toEqual(["first"]);
+
+    await worker.close();
+  });
+});

--- a/packages/calendar/tests/core/utils/serial-flush-worker.stale-prepare-window.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.stale-prepare-window.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSerialFlushWorker } from "../../../src/core/utils/serial-flush-worker";
+
+// Each flushDatabase run holds the serial writer slot this long.
+const RUN_DURATION_MS = 100;
+// The lease is reclaimed while item A's run is still on the slot.
+const LEASE_RECLAIM_AT_MS = 50;
+
+/*
+ * The production ingest caller attaches the persist-time Redis currency probe
+ * as the item's `prepare` (services/cron/src/jobs/ingest-sources.ts:633), and
+ * the probe marks itself consumed on entry (ingest.ts persistProbePending), so
+ * the run NEVER re-probes: the prepare result is the only currency check that
+ * stands between a queued snapshot and its flushDatabase commit.
+ *
+ * The worker documents that the preparation runs "after this item's queue
+ * wait" (serial-flush-worker.ts:93-101) and that the settled-prepare-to-run
+ * gap "stays as small as the runs already in flight" (:170-175). This test
+ * pins the behavioral consequence of that contract: a sync lease reclaimed
+ * while EARLIER items' runs are still draining must be observed by a LATER
+ * item's probe, so its stale snapshot short-circuits instead of committing
+ * over the fresher holder's data.
+ */
+interface ProbeCarryingItem {
+  name: string;
+  prepare: () => Promise<string | null>;
+  task: () => Promise<string>;
+}
+
+describe("serial flush worker persist-time probe staleness under queue depth", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("short-circuits a queued item whose lease was lost before its run slot", async () => {
+    const startedAt = Date.now();
+    let leaseHolder = "me";
+    const probeLog: string[] = [];
+    const runLog: string[] = [];
+
+    const worker = createSerialFlushWorker(
+      async (item: ProbeCarryingItem) => await item.task(),
+    );
+
+    const makeItem = (name: string): ProbeCarryingItem => ({
+      name,
+      prepare: (): Promise<string | null> => {
+        probeLog.push(`probe ${name} at ${Date.now() - startedAt}ms lease=${leaseHolder}`);
+        if (leaseHolder === "me") {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve(`superseded-${name}`);
+      },
+      task: (): Promise<string> =>
+        new Promise((resolve) => {
+          runLog.push(`run ${name} at ${Date.now() - startedAt}ms lease=${leaseHolder}`);
+          setTimeout(() => {
+            resolve(`committed-${name}`);
+          }, RUN_DURATION_MS);
+        }),
+    });
+
+    const submissions = [
+      worker.submit(makeItem("A")),
+      worker.submit(makeItem("B")),
+      worker.submit(makeItem("C")),
+    ];
+    // Swallow interim rejections so a short-circuit cannot trip unhandled-rejection noise.
+    for (const submission of submissions) {
+      submission.catch(() => "rejected");
+    }
+
+    /*
+     * The lease is reclaimed while A's run still holds the writer slot; a
+     * fresher holder commits from here on.
+     */
+    await vi.advanceTimersByTimeAsync(LEASE_RECLAIM_AT_MS);
+    leaseHolder = "someone-else";
+
+    // Drain all three serial runs (A finishes at 100ms, B at 200ms, C at 300ms).
+    await vi.advanceTimersByTimeAsync(RUN_DURATION_MS * 3);
+
+    const results = await Promise.all(submissions);
+
+    /*
+     * C's run slot opens at ~200ms, long after the lease was lost at 50ms.
+     * A probe that ran after C's queue wait — the worker's documented
+     * contract — sees lease=someone-else and must short-circuit, keeping the
+     * stale snapshot out of the database. If C instead reports
+     * "committed-C", its probe fired for the whole backlog in one pump
+     * sweep at ~0ms and its stale flush overwrote the fresher writer.
+     */
+    expect(
+      { probeLog, resultC: results[2], runLog },
+    ).toMatchObject({ resultC: "superseded-C" });
+  });
+});

--- a/packages/calendar/tests/core/utils/serial-flush-worker.stale-prepare-window.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.stale-prepare-window.test.ts
@@ -1,25 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSerialFlushWorker } from "../../../src/core/utils/serial-flush-worker";
 
-// Each flushDatabase run holds the serial writer slot this long.
 const RUN_DURATION_MS = 100;
-// The lease is reclaimed while item A's run is still on the slot.
+// Mid-run for item A, so the lease is lost while A still holds the writer slot.
 const LEASE_RECLAIM_AT_MS = 50;
 
 /*
- * The production ingest caller attaches the persist-time Redis currency probe
- * as the item's `prepare` (services/cron/src/jobs/ingest-sources.ts:633), and
- * the probe marks itself consumed on entry (ingest.ts persistProbePending), so
- * the run NEVER re-probes: the prepare result is the only currency check that
- * stands between a queued snapshot and its flushDatabase commit.
- *
- * The worker documents that the preparation runs "after this item's queue
- * wait" (serial-flush-worker.ts:93-101) and that the settled-prepare-to-run
- * gap "stays as small as the runs already in flight" (:170-175). This test
- * pins the behavioral consequence of that contract: a sync lease reclaimed
- * while EARLIER items' runs are still draining must be observed by a LATER
- * item's probe, so its stale snapshot short-circuits instead of committing
- * over the fresher holder's data.
+ * Production's persist-time currency probe marks itself consumed on entry, so the
+ * run never re-probes: the item's prepare result is the only check standing between
+ * a queued snapshot and its commit, and it must run after that item's queue wait.
  */
 interface ProbeCarryingItem {
   name: string;
@@ -74,26 +63,13 @@ describe("serial flush worker persist-time probe staleness under queue depth", (
       submission.catch(() => "rejected");
     }
 
-    /*
-     * The lease is reclaimed while A's run still holds the writer slot; a
-     * fresher holder commits from here on.
-     */
     await vi.advanceTimersByTimeAsync(LEASE_RECLAIM_AT_MS);
     leaseHolder = "someone-else";
 
-    // Drain all three serial runs (A finishes at 100ms, B at 200ms, C at 300ms).
     await vi.advanceTimersByTimeAsync(RUN_DURATION_MS * 3);
 
     const results = await Promise.all(submissions);
 
-    /*
-     * C's run slot opens at ~200ms, long after the lease was lost at 50ms.
-     * A probe that ran after C's queue wait — the worker's documented
-     * contract — sees lease=someone-else and must short-circuit, keeping the
-     * stale snapshot out of the database. If C instead reports
-     * "committed-C", its probe fired for the whole backlog in one pump
-     * sweep at ~0ms and its stale flush overwrote the fresher writer.
-     */
     expect(
       { probeLog, resultC: results[2], runLog },
     ).toMatchObject({ resultC: "superseded-C" });

--- a/packages/calendar/tests/core/utils/serial-flush-worker.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.test.ts
@@ -37,10 +37,6 @@ const createDeferred = (): Deferred => {
   return { promise, reject, resolve };
 };
 
-/*
- * Instrumented run whose completion is held open per item by a deferred, so tests can
- * pin exactly when the worker is allowed to move on to the next item.
- */
 const createGatedRun = () => {
   const gates = new Map<number, Deferred>();
   const started: number[] = [];
@@ -106,16 +102,14 @@ describe("createSerialFlushWorker", () => {
     const gated = createGatedRun();
     const worker = createSerialFlushWorker(gated.run, { capacity: 2 });
 
-    // Item 1 is picked up by the worker; items 2 and 3 fill the queue to capacity.
+    // Capacity counts only queued items, so item 1 runs while 2 and 3 fill the queue.
     const first = worker.submit(1);
     const second = worker.submit(2);
     const third = worker.submit(3);
-    // Item 4 finds the queue full, so its enqueue must wait on backpressure.
     const fourth = worker.submit(4);
     await vi.advanceTimersByTimeAsync(SETTLE_MS);
     expect(gated.started).toEqual([1]);
 
-    // Finishing item 1 frees a slot: item 2 starts and item 4 may now enqueue.
     gated.open(1);
     await vi.advanceTimersByTimeAsync(SETTLE_MS);
     expect(gated.started).toEqual([1, 2]);
@@ -161,7 +155,6 @@ describe("createSerialFlushWorker", () => {
     const gated = createGatedRun();
     const worker = createSerialFlushWorker(gated.run, { capacity: 1 });
 
-    // Item 1 occupies the worker; item 2 fills the single queue slot.
     const first = worker.submit(1);
     const second = worker.submit(2);
     await vi.advanceTimersByTimeAsync(SETTLE_MS);
@@ -177,7 +170,6 @@ describe("createSerialFlushWorker", () => {
     expect(blockedProbe.status).toBe("rejected");
     await expect(blocked).rejects.toThrow("caller gave up waiting");
 
-    // The worker keeps going and the aborted item never reaches run.
     gated.open(1);
     await vi.advanceTimersByTimeAsync(SETTLE_MS);
     gated.open(2);
@@ -199,7 +191,6 @@ describe("createSerialFlushWorker", () => {
     const closed = worker.close();
     const closedProbe = probe(closed);
 
-    // Only the first item has finished, so close must still be draining.
     await vi.advanceTimersByTimeAsync(RUN_MS + SETTLE_MS);
     expect(completions).toEqual([1]);
     expect(closedProbe.status).toBe("pending");

--- a/packages/calendar/tests/core/utils/serial-flush-worker.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSerialFlushWorker } from "../../../src/core/utils/serial-flush-worker";
+
+const RUN_MS = 20;
+const SETTLE_MS = 5;
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+interface SettlementProbe {
+  status: "pending" | "rejected" | "resolved";
+}
+
+const probe = (promise: Promise<unknown>): SettlementProbe => {
+  const state: SettlementProbe = { status: "pending" };
+  promise
+    .then(() => {
+      state.status = "resolved";
+      return null;
+    })
+    .catch(() => {
+      state.status = "rejected";
+    });
+  return state;
+};
+
+interface Deferred {
+  promise: Promise<number>;
+  reject: (reason: Error) => void;
+  resolve: (value: number) => void;
+}
+
+const createDeferred = (): Deferred => {
+  const { promise, reject, resolve } = Promise.withResolvers<number>();
+  return { promise, reject, resolve };
+};
+
+/*
+ * Instrumented run whose completion is held open per item by a deferred, so tests can
+ * pin exactly when the worker is allowed to move on to the next item.
+ */
+const createGatedRun = () => {
+  const gates = new Map<number, Deferred>();
+  const started: number[] = [];
+  const run = (item: number): Promise<number> => {
+    started.push(item);
+    const gate = createDeferred();
+    gates.set(item, gate);
+    return gate.promise;
+  };
+  const open = (item: number): void => {
+    gates.get(item)?.resolve(item * 10);
+  };
+  return { open, run, started };
+};
+
+describe("createSerialFlushWorker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("never overlaps run invocations even under many concurrent submits", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const worker = createSerialFlushWorker(async (item: number) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await delay(RUN_MS);
+      inFlight -= 1;
+      return item;
+    });
+
+    const submissions = [1, 2, 3, 4, 5].map((item) => worker.submit(item));
+    await vi.advanceTimersByTimeAsync(RUN_MS * 6);
+    await Promise.all(submissions);
+
+    expect(maxInFlight).toBe(1);
+  });
+
+  it("completes submits in first-in-first-out submission order", async () => {
+    const completions: number[] = [];
+    const worker = createSerialFlushWorker(async (item: number) => {
+      await delay(RUN_MS);
+      return item;
+    });
+
+    const submissions = [1, 2, 3, 4, 5].map((item) =>
+      worker.submit(item).then((result) => {
+        completions.push(result);
+        return result;
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(RUN_MS * 6);
+    await Promise.all(submissions);
+
+    expect(completions).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("holds the submit past capacity until a slot frees, then proceeds", async () => {
+    const gated = createGatedRun();
+    const worker = createSerialFlushWorker(gated.run, { capacity: 2 });
+
+    // Item 1 is picked up by the worker; items 2 and 3 fill the queue to capacity.
+    const first = worker.submit(1);
+    const second = worker.submit(2);
+    const third = worker.submit(3);
+    // Item 4 finds the queue full, so its enqueue must wait on backpressure.
+    const fourth = worker.submit(4);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(gated.started).toEqual([1]);
+
+    // Finishing item 1 frees a slot: item 2 starts and item 4 may now enqueue.
+    gated.open(1);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(gated.started).toEqual([1, 2]);
+
+    gated.open(2);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(gated.started).toEqual([1, 2, 3]);
+
+    gated.open(3);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(gated.started).toEqual([1, 2, 3, 4]);
+
+    gated.open(4);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    await expect(first).resolves.toBe(10);
+    await expect(second).resolves.toBe(20);
+    await expect(third).resolves.toBe(30);
+    await expect(fourth).resolves.toBe(40);
+  });
+
+  it("routes each result to its own submit and keeps processing after a failing run", async () => {
+    const worker = createSerialFlushWorker(async (item: number) => {
+      await delay(RUN_MS);
+      if (item === 2) {
+        throw new Error("flush failed for item 2");
+      }
+      return item * 10;
+    });
+
+    const first = worker.submit(1);
+    const second = worker.submit(2);
+    const secondProbe = probe(second);
+    const third = worker.submit(3);
+    await vi.advanceTimersByTimeAsync(RUN_MS * 4);
+
+    await expect(first).resolves.toBe(10);
+    expect(secondProbe.status).toBe("rejected");
+    await expect(second).rejects.toThrow("flush failed for item 2");
+    await expect(third).resolves.toBe(30);
+  });
+
+  it("rejects a backpressure-blocked submit with the abort reason and never runs its item", async () => {
+    const gated = createGatedRun();
+    const worker = createSerialFlushWorker(gated.run, { capacity: 1 });
+
+    // Item 1 occupies the worker; item 2 fills the single queue slot.
+    const first = worker.submit(1);
+    const second = worker.submit(2);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+
+    const controller = new AbortController();
+    const blocked = worker.submit(3, controller.signal);
+    const blockedProbe = probe(blocked);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(blockedProbe.status).toBe("pending");
+
+    controller.abort(new Error("caller gave up waiting"));
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(blockedProbe.status).toBe("rejected");
+    await expect(blocked).rejects.toThrow("caller gave up waiting");
+
+    // The worker keeps going and the aborted item never reaches run.
+    gated.open(1);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    gated.open(2);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    await expect(first).resolves.toBe(10);
+    await expect(second).resolves.toBe(20);
+    expect(gated.started).not.toContain(3);
+  });
+
+  it("drains already-queued items on close, then rejects later submits", async () => {
+    const completions: number[] = [];
+    const worker = createSerialFlushWorker(async (item: number) => {
+      await delay(RUN_MS);
+      completions.push(item);
+      return item;
+    });
+
+    const submissions = [1, 2, 3].map((item) => worker.submit(item));
+    const closed = worker.close();
+    const closedProbe = probe(closed);
+
+    // Only the first item has finished, so close must still be draining.
+    await vi.advanceTimersByTimeAsync(RUN_MS + SETTLE_MS);
+    expect(completions).toEqual([1]);
+    expect(closedProbe.status).toBe("pending");
+
+    await vi.advanceTimersByTimeAsync(RUN_MS * 3);
+    await Promise.all(submissions);
+    expect(completions).toEqual([1, 2, 3]);
+    expect(closedProbe.status).toBe("resolved");
+
+    const late = worker.submit(4);
+    const lateProbe = probe(late);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(lateProbe.status).toBe("rejected");
+    await expect(late).rejects.toThrow();
+    expect(completions).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/calendar/tests/core/utils/serial-flush-worker.weighted.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.weighted.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSerialFlushWorker } from "../../../src/core/utils/serial-flush-worker";
+
+const SETTLE_MS = 5;
+
+interface SettlementProbe {
+  status: "pending" | "rejected" | "resolved";
+}
+
+const probe = (promise: Promise<unknown>): SettlementProbe => {
+  const state: SettlementProbe = { status: "pending" };
+  promise
+    .then(() => {
+      state.status = "resolved";
+      return null;
+    })
+    .catch(() => {
+      state.status = "rejected";
+    });
+  return state;
+};
+
+interface Deferred {
+  promise: Promise<number>;
+  reject: (reason: Error) => void;
+  resolve: (value: number) => void;
+}
+
+const createDeferred = (): Deferred => {
+  const { promise, reject, resolve } = Promise.withResolvers<number>();
+  return { promise, reject, resolve };
+};
+
+/*
+ * Instrumented run whose completion is held open per item by a deferred, so tests can
+ * pin exactly when a reservation's weight is auto-freed by its run settling.
+ */
+const createGatedRun = () => {
+  const gates = new Map<number, Deferred>();
+  const started: number[] = [];
+  const run = (item: number): Promise<number> => {
+    started.push(item);
+    const gate = createDeferred();
+    gates.set(item, gate);
+    return gate.promise;
+  };
+  const open = (item: number): void => {
+    gates.get(item)?.resolve(item * 10);
+  };
+  const fail = (item: number, reason: Error): void => {
+    gates.get(item)?.reject(reason);
+  };
+  return { fail, open, run, started };
+};
+
+/*
+ * The weighted API does not exist yet, so the exported type has no reserve member.
+ * This local shape states the contract under test; the runtime calls go through it.
+ */
+interface FlushReservation {
+  release(): void;
+  submit(item: number): Promise<number>;
+}
+
+interface WeightedWorker {
+  close(): Promise<void>;
+  reserve(weight: number, signal?: AbortSignal): Promise<FlushReservation>;
+  submit(item: number, signal?: AbortSignal): Promise<number>;
+}
+
+const createWeightedWorker = (
+  run: (item: number) => Promise<number>,
+  budget: number,
+): WeightedWorker =>
+  createSerialFlushWorker(run, { budget } as never) as unknown as WeightedWorker;
+
+describe("createSerialFlushWorker weighted reservation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("grants concurrent reservations within budget and parks the reserve that would exceed it", async () => {
+    const gated = createGatedRun();
+    const worker = createWeightedWorker(gated.run, 10);
+
+    // Two 4-weight reservations fit inside a budget of 10.
+    const firstReservation = await worker.reserve(4);
+    const secondReservation = await worker.reserve(4);
+
+    // A third 4-weight reserve would take outstanding weight to 12 > 10, so it parks.
+    const third = worker.reserve(4);
+    const thirdProbe = probe(third);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(thirdProbe.status).toBe("pending");
+
+    // Releasing one 4-weight hold drops outstanding weight to 4, admitting the third.
+    firstReservation.release();
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(thirdProbe.status).toBe("resolved");
+
+    secondReservation.release();
+    const granted = await third;
+    granted.release();
+  });
+
+  it("clamps a reserve heavier than the whole budget and grants it when otherwise idle", async () => {
+    const gated = createGatedRun();
+    const worker = createWeightedWorker(gated.run, 10);
+
+    // A 3,000-event ICS feed can weigh more than the entire budget; it must not deadlock.
+    const whale = worker.reserve(25);
+    const whaleProbe = probe(whale);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(whaleProbe.status).toBe("resolved");
+
+    // The clamped whale holds the full budget, so any further reserve parks behind it.
+    const whaleReservation = await whale;
+    const small = worker.reserve(1);
+    const smallProbe = probe(small);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(smallProbe.status).toBe("pending");
+
+    whaleReservation.release();
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(smallProbe.status).toBe("resolved");
+    const smallReservation = await small;
+    smallReservation.release();
+  });
+
+  it("frees weight via explicit release when nothing was flushed", async () => {
+    const gated = createGatedRun();
+    const worker = createWeightedWorker(gated.run, 5);
+
+    const holder = await worker.reserve(5);
+    const waiting = worker.reserve(3);
+    const waitingProbe = probe(waiting);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(waitingProbe.status).toBe("pending");
+
+    // The fetch failed upstream: release() alone must return the weight.
+    holder.release();
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(waitingProbe.status).toBe("resolved");
+    const waitingReservation = await waiting;
+    waitingReservation.release();
+  });
+
+  it("frees weight automatically when the submitted item's run resolves", async () => {
+    const gated = createGatedRun();
+    const worker = createWeightedWorker(gated.run, 5);
+
+    const holder = await worker.reserve(5);
+    const flushed = holder.submit(1);
+    const waiting = worker.reserve(2);
+    const waitingProbe = probe(waiting);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(gated.started).toEqual([1]);
+    expect(waitingProbe.status).toBe("pending");
+
+    gated.open(1);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    await expect(flushed).resolves.toBe(10);
+    expect(waitingProbe.status).toBe("resolved");
+    const waitingReservation = await waiting;
+    waitingReservation.release();
+  });
+
+  it("frees weight automatically when the submitted item's run rejects", async () => {
+    const gated = createGatedRun();
+    const worker = createWeightedWorker(gated.run, 5);
+
+    const holder = await worker.reserve(5);
+    const flushed = holder.submit(1);
+    const flushedProbe = probe(flushed);
+    const waiting = worker.reserve(2);
+    const waitingProbe = probe(waiting);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(waitingProbe.status).toBe("pending");
+
+    // A failing flush still ends the reservation; its weight must not leak.
+    gated.fail(1, new Error("flush transaction failed"));
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(flushedProbe.status).toBe("rejected");
+    await expect(flushed).rejects.toThrow("flush transaction failed");
+    expect(waitingProbe.status).toBe("resolved");
+    const waitingReservation = await waiting;
+    waitingReservation.release();
+  });
+
+  it("does not free weight twice on double release or release after a settled submit", async () => {
+    const gated = createGatedRun();
+    const worker = createWeightedWorker(gated.run, 5);
+
+    // Double release: the second call must be a no-op, not a second credit of 5.
+    const doubled = await worker.reserve(5);
+    doubled.release();
+    doubled.release();
+
+    // Release after the submitted run already settled (auto-free): also a no-op.
+    const settled = await worker.reserve(5);
+    const flushed = settled.submit(1);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    gated.open(1);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    await expect(flushed).resolves.toBe(10);
+    settled.release();
+
+    // Over-freeing would drive outstanding accounting negative, in which case
+    // BOTH full-budget reservations below would be granted at once.
+    const firstFull = await worker.reserve(5);
+    const secondFull = worker.reserve(5);
+    const secondFullProbe = probe(secondFull);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(secondFullProbe.status).toBe("pending");
+
+    firstFull.release();
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(secondFullProbe.status).toBe("resolved");
+    const secondFullReservation = await secondFull;
+    secondFullReservation.release();
+  });
+
+  it("rejects a waiting reserve with the abort reason and frees nothing", async () => {
+    const gated = createGatedRun();
+    const worker = createWeightedWorker(gated.run, 5);
+
+    const holder = await worker.reserve(5);
+    const controller = new AbortController();
+    const blocked = worker.reserve(3, controller.signal);
+    const blockedProbe = probe(blocked);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(blockedProbe.status).toBe("pending");
+
+    controller.abort(new Error("collector gave up waiting"));
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(blockedProbe.status).toBe("rejected");
+    await expect(blocked).rejects.toThrow("collector gave up waiting");
+
+    // The aborted waiter acquired nothing, so once the holder releases exactly
+    // ONE full budget is available again: a 5-weight reserve fits, one more unit does not.
+    holder.release();
+    const exact = worker.reserve(5);
+    const exactProbe = probe(exact);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(exactProbe.status).toBe("resolved");
+
+    const overflow = worker.reserve(1);
+    const overflowProbe = probe(overflow);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(overflowProbe.status).toBe("pending");
+
+    const exactReservation = await exact;
+    exactReservation.release();
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(overflowProbe.status).toBe("resolved");
+    const overflowReservation = await overflow;
+    overflowReservation.release();
+  });
+
+  it("keeps unweighted submit and capacity behavior when budget is not set", async () => {
+    const gated = createGatedRun();
+    const worker = createSerialFlushWorker(gated.run, { capacity: 1 });
+
+    // Item 1 occupies the worker; item 2 fills the single queue slot; item 3 parks.
+    const first = worker.submit(1);
+    const second = worker.submit(2);
+    const third = worker.submit(3);
+    const thirdProbe = probe(third);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(gated.started).toEqual([1]);
+    expect(thirdProbe.status).toBe("pending");
+
+    gated.open(1);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    gated.open(2);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    gated.open(3);
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    await expect(first).resolves.toBe(10);
+    await expect(second).resolves.toBe(20);
+    await expect(third).resolves.toBe(30);
+  });
+});

--- a/packages/calendar/tests/core/utils/serial-flush-worker.weighted.test.ts
+++ b/packages/calendar/tests/core/utils/serial-flush-worker.weighted.test.ts
@@ -31,10 +31,6 @@ const createDeferred = (): Deferred => {
   return { promise, reject, resolve };
 };
 
-/*
- * Instrumented run whose completion is held open per item by a deferred, so tests can
- * pin exactly when a reservation's weight is auto-freed by its run settling.
- */
 const createGatedRun = () => {
   const gates = new Map<number, Deferred>();
   const started: number[] = [];
@@ -53,10 +49,7 @@ const createGatedRun = () => {
   return { fail, open, run, started };
 };
 
-/*
- * The weighted API does not exist yet, so the exported type has no reserve member.
- * This local shape states the contract under test; the runtime calls go through it.
- */
+// The exported worker type carries no reserve member, hence the local shape and casts.
 interface FlushReservation {
   release(): void;
   submit(item: number): Promise<number>;
@@ -87,17 +80,14 @@ describe("createSerialFlushWorker weighted reservation", () => {
     const gated = createGatedRun();
     const worker = createWeightedWorker(gated.run, 10);
 
-    // Two 4-weight reservations fit inside a budget of 10.
     const firstReservation = await worker.reserve(4);
     const secondReservation = await worker.reserve(4);
 
-    // A third 4-weight reserve would take outstanding weight to 12 > 10, so it parks.
     const third = worker.reserve(4);
     const thirdProbe = probe(third);
     await vi.advanceTimersByTimeAsync(SETTLE_MS);
     expect(thirdProbe.status).toBe("pending");
 
-    // Releasing one 4-weight hold drops outstanding weight to 4, admitting the third.
     firstReservation.release();
     await vi.advanceTimersByTimeAsync(SETTLE_MS);
     expect(thirdProbe.status).toBe("resolved");
@@ -117,7 +107,6 @@ describe("createSerialFlushWorker weighted reservation", () => {
     await vi.advanceTimersByTimeAsync(SETTLE_MS);
     expect(whaleProbe.status).toBe("resolved");
 
-    // The clamped whale holds the full budget, so any further reserve parks behind it.
     const whaleReservation = await whale;
     const small = worker.reserve(1);
     const smallProbe = probe(small);
@@ -141,7 +130,6 @@ describe("createSerialFlushWorker weighted reservation", () => {
     await vi.advanceTimersByTimeAsync(SETTLE_MS);
     expect(waitingProbe.status).toBe("pending");
 
-    // The fetch failed upstream: release() alone must return the weight.
     holder.release();
     await vi.advanceTimersByTimeAsync(SETTLE_MS);
     expect(waitingProbe.status).toBe("resolved");
@@ -181,7 +169,6 @@ describe("createSerialFlushWorker weighted reservation", () => {
     await vi.advanceTimersByTimeAsync(SETTLE_MS);
     expect(waitingProbe.status).toBe("pending");
 
-    // A failing flush still ends the reservation; its weight must not leak.
     gated.fail(1, new Error("flush transaction failed"));
     await vi.advanceTimersByTimeAsync(SETTLE_MS);
     expect(flushedProbe.status).toBe("rejected");
@@ -195,12 +182,10 @@ describe("createSerialFlushWorker weighted reservation", () => {
     const gated = createGatedRun();
     const worker = createWeightedWorker(gated.run, 5);
 
-    // Double release: the second call must be a no-op, not a second credit of 5.
     const doubled = await worker.reserve(5);
     doubled.release();
     doubled.release();
 
-    // Release after the submitted run already settled (auto-free): also a no-op.
     const settled = await worker.reserve(5);
     const flushed = settled.submit(1);
     await vi.advanceTimersByTimeAsync(SETTLE_MS);
@@ -240,8 +225,6 @@ describe("createSerialFlushWorker weighted reservation", () => {
     expect(blockedProbe.status).toBe("rejected");
     await expect(blocked).rejects.toThrow("collector gave up waiting");
 
-    // The aborted waiter acquired nothing, so once the holder releases exactly
-    // ONE full budget is available again: a 5-weight reserve fits, one more unit does not.
     holder.release();
     const exact = worker.reserve(5);
     const exactProbe = probe(exact);
@@ -265,7 +248,6 @@ describe("createSerialFlushWorker weighted reservation", () => {
     const gated = createGatedRun();
     const worker = createSerialFlushWorker(gated.run, { capacity: 1 });
 
-    // Item 1 occupies the worker; item 2 fills the single queue slot; item 3 parks.
     const first = worker.submit(1);
     const second = worker.submit(2);
     const third = worker.submit(3);

--- a/packages/calendar/tests/ics/utils/pull-remote-calendar-truncation.test.ts
+++ b/packages/calendar/tests/ics/utils/pull-remote-calendar-truncation.test.ts
@@ -28,12 +28,7 @@ const FULL_ICS = [
   "END:VCALENDAR",
 ].join("\r\n");
 
-/*
- * The feed cut mid-body: VERSION and PRODID survive at the top, event-1 is
- * intact, events 2-3 and END:VCALENDAR are gone. This is what a size-capping
- * proxy, a partial origin write with valid HTTP framing, or a 206 response
- * body looks like.
- */
+// Header and event-1 survive but END:VCALENDAR is gone, as from a size-capping proxy.
 const TRUNCATED_ICS = FULL_ICS.slice(0, FULL_ICS.indexOf("BEGIN:VEVENT\r\nUID:event-2"));
 
 describe("pullRemoteCalendar truncated feed", () => {
@@ -42,11 +37,6 @@ describe("pullRemoteCalendar truncated feed", () => {
   });
 
   it("rejects a body truncated after the header instead of returning a partial event set", async () => {
-    /*
-     * If this resolves, the strictly-smaller event set is persisted as an
-     * authoritative snapshot and the ingest diff mass-deletes every stored
-     * event after the cut, then re-adds them all on the next complete fetch.
-     */
     const { pullRemoteCalendar } = await import("../../../src/ics/utils/pull-remote-calendar");
     mockSafeFetch.mockResolvedValueOnce(new Response(TRUNCATED_ICS, { status: 200 }));
 
@@ -56,10 +46,7 @@ describe("pullRemoteCalendar truncated feed", () => {
   });
 
   it("rejects a 206 Partial Content body instead of treating it as the whole feed", async () => {
-    /*
-     * Response.ok is true for every 2xx status, 206 included, so a range
-     * response passes the only status gate in fetchRemoteText.
-     */
+    // Response.ok is true for every 2xx status, 206 included, so it clears the status gate.
     const { pullRemoteCalendar } = await import("../../../src/ics/utils/pull-remote-calendar");
     mockSafeFetch.mockResolvedValueOnce(new Response(TRUNCATED_ICS, { status: 206 }));
 

--- a/packages/calendar/tests/ics/utils/pull-remote-calendar-truncation.test.ts
+++ b/packages/calendar/tests/ics/utils/pull-remote-calendar-truncation.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { mockSafeFetch } = vi.hoisted(() => ({
+  mockSafeFetch: vi.fn<(...args: unknown[]) => Promise<Response>>(),
+}));
+
+vi.mock("../../../src/utils/safe-fetch", () => ({
+  createSafeFetch: () => mockSafeFetch,
+}));
+
+const buildEvent = (uid: string): string => [
+  "BEGIN:VEVENT",
+  `UID:${uid}@test`,
+  "DTSTAMP:20260517T000000Z",
+  "DTSTART:20260517T120000Z",
+  "DTEND:20260517T130000Z",
+  `SUMMARY:Event ${uid}`,
+  "END:VEVENT",
+].join("\r\n");
+
+const FULL_ICS = [
+  "BEGIN:VCALENDAR",
+  "VERSION:2.0",
+  "PRODID:-//Test//Test//EN",
+  buildEvent("event-1"),
+  buildEvent("event-2"),
+  buildEvent("event-3"),
+  "END:VCALENDAR",
+].join("\r\n");
+
+/*
+ * The feed cut mid-body: VERSION and PRODID survive at the top, event-1 is
+ * intact, events 2-3 and END:VCALENDAR are gone. This is what a size-capping
+ * proxy, a partial origin write with valid HTTP framing, or a 206 response
+ * body looks like.
+ */
+const TRUNCATED_ICS = FULL_ICS.slice(0, FULL_ICS.indexOf("BEGIN:VEVENT\r\nUID:event-2"));
+
+describe("pullRemoteCalendar truncated feed", () => {
+  beforeEach(() => {
+    mockSafeFetch.mockReset();
+  });
+
+  it("rejects a body truncated after the header instead of returning a partial event set", async () => {
+    /*
+     * If this resolves, the strictly-smaller event set is persisted as an
+     * authoritative snapshot and the ingest diff mass-deletes every stored
+     * event after the cut, then re-adds them all on the next complete fetch.
+     */
+    const { pullRemoteCalendar } = await import("../../../src/ics/utils/pull-remote-calendar");
+    mockSafeFetch.mockResolvedValueOnce(new Response(TRUNCATED_ICS, { status: 200 }));
+
+    await expect(
+      pullRemoteCalendar("json", "https://example.com/calendar.ics"),
+    ).rejects.toThrow();
+  });
+
+  it("rejects a 206 Partial Content body instead of treating it as the whole feed", async () => {
+    /*
+     * Response.ok is true for every 2xx status, 206 included, so a range
+     * response passes the only status gate in fetchRemoteText.
+     */
+    const { pullRemoteCalendar } = await import("../../../src/ics/utils/pull-remote-calendar");
+    mockSafeFetch.mockResolvedValueOnce(new Response(TRUNCATED_ICS, { status: 206 }));
+
+    await expect(
+      pullRemoteCalendar("json", "https://example.com/calendar.ics"),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/calendar/tests/providers/caldav/shared/client-discovery-charging.test.ts
+++ b/packages/calendar/tests/providers/caldav/shared/client-discovery-charging.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CalDAVClient } from "../../../../src/providers/caldav/shared/client";
+
+const SERVER_URL = "https://caldav.example.test";
+const PRINCIPAL_PATH = "/principals/user/";
+const HOME_PATH = "/cal/u/";
+const PERSONAL_PATH = "/cal/u/personal/";
+
+const XML_HEADERS = { "content-type": "text/xml; charset=utf-8" };
+
+const multistatus = (body: string): Response =>
+  new Response(
+    `<?xml version="1.0" encoding="utf-8" ?><d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/">${body}</d:multistatus>`,
+    { headers: XML_HEADERS, status: 207, statusText: "Multi-Status" },
+  );
+
+const principalResponse = (): Response =>
+  multistatus(
+    `<d:response><d:href>/</d:href><d:propstat><d:status>HTTP/1.1 200 OK</d:status><d:prop><d:current-user-principal><d:href>${PRINCIPAL_PATH}</d:href></d:current-user-principal></d:prop></d:propstat></d:response>`,
+  );
+
+const homeResponse = (): Response =>
+  multistatus(
+    `<d:response><d:href>${PRINCIPAL_PATH}</d:href><d:propstat><d:status>HTTP/1.1 200 OK</d:status><d:prop><c:calendar-home-set><d:href>${HOME_PATH}</d:href></c:calendar-home-set></d:prop></d:propstat></d:response>`,
+  );
+
+const calendarListResponse = (): Response =>
+  multistatus(
+    `<d:response><d:href>${PERSONAL_PATH}</d:href><d:propstat><d:status>HTTP/1.1 200 OK</d:status><d:prop><d:displayname>Personal</d:displayname><cs:getctag>ctag-Personal</cs:getctag><d:resourcetype><d:collection/><c:calendar/></d:resourcetype><c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set></d:prop></d:propstat></d:response>`,
+  );
+
+const supportedReportSetResponse = (path: string): Response =>
+  multistatus(
+    `<d:response><d:href>${path}</d:href><d:propstat><d:status>HTTP/1.1 200 OK</d:status><d:prop><d:supported-report-set/></d:prop></d:propstat></d:response>`,
+  );
+
+const requestUrl = (input: string | Request | URL): URL => {
+  if (input instanceof Request) {
+    return new URL(input.url);
+  }
+  return new URL(input.toString());
+};
+
+const respond = (path: string): Response => {
+  if (path === "/.well-known/caldav") {
+    return new Response("", { status: 404 });
+  }
+  if (path === "/") {
+    return principalResponse();
+  }
+  if (path === PRINCIPAL_PATH) {
+    return homeResponse();
+  }
+  if (path === HOME_PATH) {
+    return calendarListResponse();
+  }
+  return supportedReportSetResponse(path);
+};
+
+let originalFetch: typeof globalThis.fetch = globalThis.fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("CalDAV host-limiter charging during account discovery", () => {
+  it("draws a permit before every origin request, including the discovery PROPFIND trio", async () => {
+    let permitsDrawn = 0;
+    let requestsSent = 0;
+    const unchargedRequestPaths: string[] = [];
+
+    globalThis.fetch = ((input: string | Request | URL, init?: RequestInit) => {
+      const url = requestUrl(input);
+      requestsSent += 1;
+      if (requestsSent > permitsDrawn) {
+        unchargedRequestPaths.push(`${init?.method ?? "GET"} ${url.pathname}`);
+      }
+      return Promise.resolve(respond(url.pathname));
+    }) as unknown as typeof globalThis.fetch;
+
+    const client = new CalDAVClient({
+      credentials: { password: "app-specific-password", username: "user@example.test" },
+      onBeforeRequest: () => {
+        permitsDrawn += 1;
+      },
+      serverUrl: SERVER_URL,
+    });
+
+    await client.discoverCalendars();
+
+    /*
+     * The invariant at client.ts ("every origin request must draw its own
+     * permit before it is sent") requires that no request ever leaves the
+     * process without a matching charge.
+     */
+    expect(unchargedRequestPaths).toEqual([]);
+  });
+});

--- a/packages/calendar/tests/providers/caldav/shared/client-discovery-charging.test.ts
+++ b/packages/calendar/tests/providers/caldav/shared/client-discovery-charging.test.ts
@@ -92,11 +92,6 @@ describe("CalDAV host-limiter charging during account discovery", () => {
 
     await client.discoverCalendars();
 
-    /*
-     * The invariant at client.ts ("every origin request must draw its own
-     * permit before it is sent") requires that no request ever leaves the
-     * process without a matching charge.
-     */
     expect(unchargedRequestPaths).toEqual([]);
   });
 });

--- a/packages/calendar/tests/providers/caldav/source/empty-resource-telemetry.test.ts
+++ b/packages/calendar/tests/providers/caldav/source/empty-resource-telemetry.test.ts
@@ -4,6 +4,7 @@ import type { IngestWideEventFields } from "../../../../src/core/sync-engine/ing
 import type { StoredSourceEventState } from "../../../../src/core/source/stored-event-state";
 import type { SourceEvent } from "../../../../src/core/types";
 import { createCalDAVSourceFetcher } from "../../../../src/providers/caldav/source/fetch-adapter";
+import { CalDAVUnreadableResourceError } from "../../../../src/providers/caldav/shared/ics";
 import { createSourceIngestionPlan } from "../../../../src/core/sync/sync-range";
 
 const davMocks = vi.hoisted(() => ({
@@ -163,25 +164,34 @@ describe("CalDAV resources returned with an empty body", () => {
     davMocks.fetchCalendars.mockResolvedValue([]);
   });
 
-  it("counts the resource it could not read when the body came back empty", async () => {
+  it("fails the run and keeps the stored event when the body came back empty", async () => {
     const store = createStore();
     const first = await ingestCollection(store, [resource(STANDUP), resource(DINNER)]);
     expect(first.inserts.toSorted()).toEqual(["state-dinner@example.com", "state-standup@example.com"]);
 
-    const run = await ingestCollection(store, [resource(STANDUP), ""]);
+    const failure = await ingestCollection(store, [resource(STANDUP), ""]).then(
+      () => null,
+      (error: unknown) => error,
+    );
 
-    expect(run.deletes).toEqual(["state-dinner@example.com"]);
-    expect(discardTotal(run.wideEvent)).toBeGreaterThan(0);
+    expect(failure).toBeInstanceOf(CalDAVUnreadableResourceError);
+    if (failure instanceof CalDAVUnreadableResourceError) {
+      expect(failure.skippedResourceCount).toBe(1);
+    }
+    expect(store.ids()).toEqual(["state-dinner@example.com", "state-standup@example.com"]);
   });
 
-  it("counts an href answered with whitespace instead of a calendar", async () => {
+  it("fails an href answered with whitespace instead of a calendar", async () => {
     const store = createStore();
     await ingestCollection(store, [resource(STANDUP), resource(DINNER)]);
 
-    const run = await ingestCollection(store, [resource(STANDUP), "   "]);
+    const failure = await ingestCollection(store, [resource(STANDUP), "   "]).then(
+      () => null,
+      (error: unknown) => error,
+    );
 
-    expect(run.deletes).toEqual(["state-dinner@example.com"]);
-    expect(discardTotal(run.wideEvent)).toBeGreaterThan(0);
+    expect(failure).toBeInstanceOf(CalDAVUnreadableResourceError);
+    expect(store.ids()).toEqual(["state-dinner@example.com", "state-standup@example.com"]);
   });
 
   it("reports nothing discarded when every resource is readable", async () => {
@@ -195,22 +205,20 @@ describe("CalDAV resources returned with an empty body", () => {
     expect(discardTotal(run.wideEvent)).toBe(0);
   });
 
-  it("settles instead of churning while the body stays empty", async () => {
+  it("keeps the stored state intact while the body stays empty", async () => {
     const store = createStore();
     await ingestCollection(store, [resource(STANDUP), resource(DINNER)]);
-    const timeline: { deletes: number; inserts: number }[] = [];
+    const outcomes: string[] = [];
 
     for (let poll = 0; poll < 4; poll += 1) {
-      const run = await ingestCollection(store, [resource(STANDUP), ""]);
-      timeline.push({ deletes: run.deletes.length, inserts: run.inserts.length });
+      const outcome = await ingestCollection(store, [resource(STANDUP), ""]).then(
+        () => "flushed",
+        () => "failed",
+      );
+      outcomes.push(outcome);
     }
 
-    expect(timeline).toEqual([
-      { deletes: 1, inserts: 0 },
-      { deletes: 0, inserts: 0 },
-      { deletes: 0, inserts: 0 },
-      { deletes: 0, inserts: 0 },
-    ]);
-    expect(store.ids()).toEqual(["state-standup@example.com"]);
+    expect(outcomes).toEqual(["failed", "failed", "failed", "failed"]);
+    expect(store.ids()).toEqual(["state-dinner@example.com", "state-standup@example.com"]);
   });
 });

--- a/packages/calendar/tests/providers/caldav/source/fetch-adapter.test.ts
+++ b/packages/calendar/tests/providers/caldav/source/fetch-adapter.test.ts
@@ -4,6 +4,7 @@ import {
   isCalDAVEventInSyncWindow,
 } from "../../../../src/providers/caldav/source/fetch-adapter";
 import { createSourceIngestionPlan } from "../../../../src/core/sync/sync-range";
+import { CalDAVUnreadableResourceError } from "../../../../src/providers/caldav/shared/ics";
 
 const davMocks = vi.hoisted(() => ({
   calendarQuery: vi.fn(),
@@ -168,7 +169,7 @@ describe("createCalDAVSourceFetcher against an unreadable resource", () => {
     davMocks.fetchCalendars.mockResolvedValue([]);
   });
 
-  it("ingests the readable resources and reports the skipped count", async () => {
+  it("fails the fetch instead of returning a partial snapshot", async () => {
     answerQueryWith(objectPaths(3));
     answerMultigetWith((objectUrls) =>
       objectUrls.map((path, index) => ({
@@ -176,12 +177,21 @@ describe("createCalDAVSourceFetcher against an unreadable resource", () => {
         url: `${SERVER_URL}${path}`,
       })));
 
-    const result = await createFetcher().fetchEvents();
+    /*
+     * Ingestion diffs stored state against the returned events, so a partial
+     * read persisted as authoritative would delete every event in the
+     * unreadable resource and re-add it next pass.
+     */
+    const failure = await createFetcher().fetchEvents().then(
+      () => null,
+      (error: unknown) => error,
+    );
 
-    expect(result.events.map(({ uid }) => uid))
-      .toEqual(["native-0@example.com", "native-2@example.com"]);
-    expect(result.skippedResourceCount).toBe(1);
-    expect(result.skippedResourceReasons)
-      .toEqual(["Malformed ICS component boundary: missing END:VEVENT"]);
+    expect(failure).toBeInstanceOf(CalDAVUnreadableResourceError);
+    if (failure instanceof CalDAVUnreadableResourceError) {
+      expect(failure.skippedResourceCount).toBe(1);
+      expect(failure.skippedResourceReasons)
+        .toEqual(["Malformed ICS component boundary: missing END:VEVENT"]);
+    }
   });
 });

--- a/packages/calendar/tests/providers/caldav/source/fetch-adapter.test.ts
+++ b/packages/calendar/tests/providers/caldav/source/fetch-adapter.test.ts
@@ -177,11 +177,6 @@ describe("createCalDAVSourceFetcher against an unreadable resource", () => {
         url: `${SERVER_URL}${path}`,
       })));
 
-    /*
-     * Ingestion diffs stored state against the returned events, so a partial
-     * read persisted as authoritative would delete every event in the
-     * unreadable resource and re-add it next pass.
-     */
     const failure = await createFetcher().fetchEvents().then(
       () => null,
       (error: unknown) => error,

--- a/packages/calendar/tests/providers/outlook/source/rate-limiter-consumption.test.ts
+++ b/packages/calendar/tests/providers/outlook/source/rate-limiter-consumption.test.ts
@@ -35,11 +35,7 @@ describe("createOutlookSourceFetcher rate limiter consumption", () => {
     queuedFetch.preconnect = originalFetch.preconnect;
     globalThis.fetch = queuedFetch;
 
-    /*
-     * Mirror the runtime shape ingest-sources builds: params travel through a
-     * widened variable carrying the rate limiter, exactly as OAuthFetcherParams
-     * does when the cron job wires the Outlook account semaphore adapter in.
-     */
+    // Production passes the rate limiter through a widened params type, not the published one.
     const params: Parameters<typeof createOutlookSourceFetcher>[0] & {
       rateLimiter?: RedisRateLimiter;
     } = {
@@ -55,7 +51,6 @@ describe("createOutlookSourceFetcher rate limiter consumption", () => {
     await fetcher.fetchEvents();
 
     expect(graphRequests).toBeGreaterThan(0);
-    // The mailbox concurrency lease must be taken before any Graph request.
     expect(acquireCalls.length).toBeGreaterThan(0);
     expect(graphRequestsBeforeFirstAcquire).toBe(0);
   });

--- a/packages/calendar/tests/providers/outlook/source/rate-limiter-consumption.test.ts
+++ b/packages/calendar/tests/providers/outlook/source/rate-limiter-consumption.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { RedisRateLimiter } from "../../../../src/core/utils/redis-rate-limiter";
+import { createOutlookSourceFetcher } from "../../../../src/providers/outlook/source/fetch-adapter";
+import { createSourceIngestionPlan } from "../../../../src/core/sync/sync-range";
+
+const CALENDAR_ID = "calendar-id";
+const TEST_PLAN = createSourceIngestionPlan("1_week", "2_years");
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("createOutlookSourceFetcher rate limiter consumption", () => {
+  it("acquires the account semaphore before issuing a Graph request", async () => {
+    const acquireCalls: number[] = [];
+    let graphRequestsBeforeFirstAcquire = 0;
+    let graphRequests = 0;
+    const rateLimiter: RedisRateLimiter = {
+      acquire: (count: number): Promise<void> => {
+        acquireCalls.push(count);
+        return Promise.resolve();
+      },
+    };
+    const queuedFetch = (): Promise<Response> => {
+      graphRequests += 1;
+      if (acquireCalls.length === 0) {
+        graphRequestsBeforeFirstAcquire += 1;
+      }
+      return Promise.resolve(Response.json({
+        "@odata.deltaLink": "https://graph.microsoft.com/delta?$deltatoken=next",
+        value: [],
+      }));
+    };
+    queuedFetch.preconnect = originalFetch.preconnect;
+    globalThis.fetch = queuedFetch;
+
+    /*
+     * Mirror the runtime shape ingest-sources builds: params travel through a
+     * widened variable carrying the rate limiter, exactly as OAuthFetcherParams
+     * does when the cron job wires the Outlook account semaphore adapter in.
+     */
+    const params: Parameters<typeof createOutlookSourceFetcher>[0] & {
+      rateLimiter?: RedisRateLimiter;
+    } = {
+      accessToken: "test-token",
+      calendarId: CALENDAR_ID,
+      externalCalendarId: "calendar-id",
+      plan: TEST_PLAN,
+      rateLimiter,
+      syncToken: null,
+    };
+    const fetcher = createOutlookSourceFetcher(params);
+
+    await fetcher.fetchEvents();
+
+    expect(graphRequests).toBeGreaterThan(0);
+    // The mailbox concurrency lease must be taken before any Graph request.
+    expect(acquireCalls.length).toBeGreaterThan(0);
+    expect(graphRequestsBeforeFirstAcquire).toBe(0);
+  });
+});

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -1,4 +1,5 @@
-export { createDatabase, closeDatabase } from "./utils/database";
+export { createDatabase, closeDatabase, hasBoundedDatabaseCloseBegun } from "./utils/database";
+export type { CloseDatabaseOptions } from "./utils/database";
 export {
   classifyDatabaseError,
   getDatabaseErrorDetails,

--- a/packages/database/src/utils/database.ts
+++ b/packages/database/src/utils/database.ts
@@ -97,9 +97,37 @@ const createDatabase = async (url: string, options?: DatabasePoolOptions): Promi
   return database;
 };
 
-const closeDatabase = (database: DatabaseInstance): void => {
+interface CloseDatabaseOptions {
+  graceSeconds?: number;
+}
+
+/*
+ * Monotonic because it exists to answer one question after the fact: did a
+ * connection error arrive because keeper force-closed its own pool during
+ * shutdown? Once a bounded close has begun the process is on its way down and
+ * every later connection failure is downstream of it, so the flag never
+ * clears.
+ */
+let boundedCloseBegun = false;
+
+const hasBoundedDatabaseCloseBegun = (): boolean => boundedCloseBegun;
+
+/*
+ * Bun's no-argument close() awaits every in-flight query before the pool
+ * settles, which is what a graceful shutdown wants: an API or worker request
+ * mid-transaction gets to commit. Only a caller with its own drain deadline
+ * (cron) passes graceSeconds, bounding teardown so a wedged query cannot hold
+ * the process open until the supervisor SIGKILLs it.
+ */
+const closeDatabase = (database: DatabaseInstance, options?: CloseDatabaseOptions): void => {
+  const graceSeconds = options?.graceSeconds;
+  if (typeof graceSeconds === "number") {
+    boundedCloseBegun = true;
+    database.$client.close({ timeout: graceSeconds });
+    return;
+  }
   database.$client.close();
 };
 
-export { createDatabase, closeDatabase, DEFAULT_STATEMENT_TIMEOUT_MS };
-export type { DatabasePoolOptions, DatabaseInstance };
+export { createDatabase, closeDatabase, hasBoundedDatabaseCloseBegun, DEFAULT_STATEMENT_TIMEOUT_MS };
+export type { DatabasePoolOptions, DatabaseInstance, CloseDatabaseOptions };

--- a/packages/database/src/utils/database.ts
+++ b/packages/database/src/utils/database.ts
@@ -102,22 +102,17 @@ interface CloseDatabaseOptions {
 }
 
 /*
- * Monotonic because it exists to answer one question after the fact: did a
- * connection error arrive because keeper force-closed its own pool during
- * shutdown? Once a bounded close has begun the process is on its way down and
- * every later connection failure is downstream of it, so the flag never
- * clears.
+ * Monotonic: once a bounded close has begun the process is on its way down and every later
+ * connection failure is downstream of it, so the flag never clears.
  */
 let boundedCloseBegun = false;
 
 const hasBoundedDatabaseCloseBegun = (): boolean => boundedCloseBegun;
 
 /*
- * Bun's no-argument close() awaits every in-flight query before the pool
- * settles, which is what a graceful shutdown wants: an API or worker request
- * mid-transaction gets to commit. Only a caller with its own drain deadline
- * (cron) passes graceSeconds, bounding teardown so a wedged query cannot hold
- * the process open until the supervisor SIGKILLs it.
+ * Bun's no-argument close() awaits every in-flight query, which is what a graceful shutdown
+ * wants. Only a caller with its own drain deadline passes graceSeconds, bounding teardown so
+ * a wedged query cannot hold the process open until the supervisor SIGKILLs it.
  */
 const closeDatabase = (database: DatabaseInstance, options?: CloseDatabaseOptions): void => {
   const graceSeconds = options?.graceSeconds;

--- a/packages/database/tests/utils/close-database-api-shutdown.test.ts
+++ b/packages/database/tests/utils/close-database-api-shutdown.test.ts
@@ -4,21 +4,14 @@ import { closeDatabase, createDatabase } from "../../src/index";
 const TEST_DATABASE_URL = process.env.KEEPER_TEST_DATABASE_URL;
 
 /*
- * The API shutdown path (services/api/src/index.ts) runs
- * `server.stop(); closeDatabase(database);` with no request drain in between,
- * so any in-flight request's database work races pool teardown directly. The
- * previous unbounded close() awaited every in-flight statement — and even let
- * an open transaction issue further statements until it committed — so a
- * healthy request finished its write-back across a deploy's SIGTERM. The
- * caldav persist write-back the API runs in-request holds its advisory lock
- * minutes-scale (services/cron/src/jobs/ingest-sources.ts), far past any
- * two-second grace, while staying well inside the 30s statement_timeout the
- * pool itself configures. This pins the graceful half of shutdown: a healthy
- * in-flight transaction, comfortably under every configured statement bound,
- * must be allowed to finish when closeDatabase is called at API shutdown.
+ * The API stops its server and closes the database with no request drain in
+ * between, so an in-flight write-back races pool teardown. Such a write-back
+ * can run minutes-scale — far past any short grace, but well inside the pool's
+ * own statement_timeout — and must still be allowed to finish.
  */
 const HEALTHY_STATEMENT_SECONDS = 2;
 const STATEMENT_TIMEOUT_MS = 30_000;
+const STATEMENT_REACHES_SERVER_MS = 300;
 
 describe.skipIf(!TEST_DATABASE_URL)("closeDatabase during API shutdown", () => {
   it("lets a healthy in-flight write-back transaction finish", async () => {
@@ -27,10 +20,6 @@ describe.skipIf(!TEST_DATABASE_URL)("closeDatabase during API shutdown", () => {
       statementTimeoutMs: STATEMENT_TIMEOUT_MS,
     });
 
-    /*
-     * A request-scoped write-back: an open transaction doing healthy,
-     * statement_timeout-respecting work when SIGTERM lands.
-     */
     const writeBack = database
       .transaction(async (transaction) => {
         await transaction.execute(`select pg_sleep(${HEALTHY_STATEMENT_SECONDS})`);
@@ -42,18 +31,10 @@ describe.skipIf(!TEST_DATABASE_URL)("closeDatabase during API shutdown", () => {
         () => "rolled-back",
       );
 
-    /*
-     * Give the first statement time to reach the server, as it would have at
-     * the moment a deploy's SIGTERM arrives mid-request.
-     */
     await new Promise((resolve) => {
-      setTimeout(resolve, 300);
+      setTimeout(resolve, STATEMENT_REACHES_SERVER_MS);
     });
 
-    /*
-     * The API cleanup calls closeDatabase immediately after server.stop(),
-     * without draining in-flight requests.
-     */
     closeDatabase(database);
 
     expect(await writeBack).toBe("committed");

--- a/packages/database/tests/utils/close-database-api-shutdown.test.ts
+++ b/packages/database/tests/utils/close-database-api-shutdown.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { closeDatabase, createDatabase } from "../../src/index";
+
+const TEST_DATABASE_URL = process.env.KEEPER_TEST_DATABASE_URL;
+
+/*
+ * The API shutdown path (services/api/src/index.ts) runs
+ * `server.stop(); closeDatabase(database);` with no request drain in between,
+ * so any in-flight request's database work races pool teardown directly. The
+ * previous unbounded close() awaited every in-flight statement — and even let
+ * an open transaction issue further statements until it committed — so a
+ * healthy request finished its write-back across a deploy's SIGTERM. The
+ * caldav persist write-back the API runs in-request holds its advisory lock
+ * minutes-scale (services/cron/src/jobs/ingest-sources.ts), far past any
+ * two-second grace, while staying well inside the 30s statement_timeout the
+ * pool itself configures. This pins the graceful half of shutdown: a healthy
+ * in-flight transaction, comfortably under every configured statement bound,
+ * must be allowed to finish when closeDatabase is called at API shutdown.
+ */
+const HEALTHY_STATEMENT_SECONDS = 2;
+const STATEMENT_TIMEOUT_MS = 30_000;
+
+describe.skipIf(!TEST_DATABASE_URL)("closeDatabase during API shutdown", () => {
+  it("lets a healthy in-flight write-back transaction finish", async () => {
+    const database = await createDatabase(TEST_DATABASE_URL as string, {
+      maxConnections: 2,
+      statementTimeoutMs: STATEMENT_TIMEOUT_MS,
+    });
+
+    /*
+     * A request-scoped write-back: an open transaction doing healthy,
+     * statement_timeout-respecting work when SIGTERM lands.
+     */
+    const writeBack = database
+      .transaction(async (transaction) => {
+        await transaction.execute(`select pg_sleep(${HEALTHY_STATEMENT_SECONDS})`);
+        await transaction.execute(`select pg_sleep(${HEALTHY_STATEMENT_SECONDS})`);
+        return "committed";
+      })
+      .then(
+        (outcome) => outcome,
+        () => "rolled-back",
+      );
+
+    /*
+     * Give the first statement time to reach the server, as it would have at
+     * the moment a deploy's SIGTERM arrives mid-request.
+     */
+    await new Promise((resolve) => {
+      setTimeout(resolve, 300);
+    });
+
+    /*
+     * The API cleanup calls closeDatabase immediately after server.stop(),
+     * without draining in-flight requests.
+     */
+    closeDatabase(database);
+
+    expect(await writeBack).toBe("committed");
+  }, 30_000);
+});

--- a/packages/database/tests/utils/close-database-bounded.test.ts
+++ b/packages/database/tests/utils/close-database-bounded.test.ts
@@ -4,20 +4,15 @@ import { closeDatabase, createDatabase } from "../../src/index";
 const TEST_DATABASE_URL = process.env.KEEPER_TEST_DATABASE_URL;
 
 /*
- * The cron shutdown path bounds the flush drain at 2s precisely so a wedged
- * flush cannot keep the process alive until the supervisor SIGKILLs it
- * (services/cron/src/context.ts). After that deadline it calls
- * closeDatabase(flushDatabase, { graceSeconds }). Bun's SQL close() with no
- * options awaits every in-flight query before closing the pool, so if the
- * wedged query is still running, pool teardown inherits the very unbounded
- * wait the drain deadline was added to remove. This pins the requirement that
- * closeDatabase with an explicit grace settles the pool within the shutdown
- * bound even with a query still in flight. The unbounded default is pinned
- * separately by close-database-api-shutdown.test.ts.
+ * Bun's SQL close() with no options awaits every in-flight query, so pool
+ * teardown would inherit the very unbounded wait cron's drain deadline exists
+ * to remove. An explicit grace must settle the pool within the shutdown bound.
+ * The unbounded default is pinned by close-database-api-shutdown.test.ts.
  */
 const WEDGED_QUERY_SECONDS = 8;
 const SHUTDOWN_BOUND_MS = 3000;
 const CLOSE_GRACE_SECONDS = 2;
+const STATEMENT_REACHES_SERVER_MS = 300;
 
 describe.skipIf(!TEST_DATABASE_URL)("closeDatabase with a wedged in-flight query", () => {
   it("settles pool teardown within the shutdown bound", async () => {
@@ -35,16 +30,14 @@ describe.skipIf(!TEST_DATABASE_URL)("closeDatabase with a wedged in-flight query
       return capturedClose;
     }) as typeof client.close;
 
-    // A flush wedged mid-statement on the dedicated single connection.
     const wedged = database
       .execute(`select pg_sleep(${WEDGED_QUERY_SECONDS})`)
       .then(
         () => "completed",
         () => "aborted",
       );
-    // Give the statement time to reach the server before shutdown begins.
     await new Promise((resolve) => {
-      setTimeout(resolve, 300);
+      setTimeout(resolve, STATEMENT_REACHES_SERVER_MS);
     });
 
     const closeStartedAt = Date.now();
@@ -69,7 +62,7 @@ describe.skipIf(!TEST_DATABASE_URL)("closeDatabase with a wedged in-flight query
     }
     const elapsedMs = Date.now() - closeStartedAt;
 
-    // Let the wedged query finish so the suite exits cleanly either way.
+    /* Let the wedged query finish so the suite exits cleanly either way. */
     await wedged;
     await (capturedClose as unknown as Promise<unknown>).catch(() => null);
 

--- a/packages/database/tests/utils/close-database-bounded.test.ts
+++ b/packages/database/tests/utils/close-database-bounded.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { closeDatabase, createDatabase } from "../../src/index";
+
+const TEST_DATABASE_URL = process.env.KEEPER_TEST_DATABASE_URL;
+
+/*
+ * The cron shutdown path bounds the flush drain at 2s precisely so a wedged
+ * flush cannot keep the process alive until the supervisor SIGKILLs it
+ * (services/cron/src/context.ts). After that deadline it calls
+ * closeDatabase(flushDatabase, { graceSeconds }). Bun's SQL close() with no
+ * options awaits every in-flight query before closing the pool, so if the
+ * wedged query is still running, pool teardown inherits the very unbounded
+ * wait the drain deadline was added to remove. This pins the requirement that
+ * closeDatabase with an explicit grace settles the pool within the shutdown
+ * bound even with a query still in flight. The unbounded default is pinned
+ * separately by close-database-api-shutdown.test.ts.
+ */
+const WEDGED_QUERY_SECONDS = 8;
+const SHUTDOWN_BOUND_MS = 3000;
+const CLOSE_GRACE_SECONDS = 2;
+
+describe.skipIf(!TEST_DATABASE_URL)("closeDatabase with a wedged in-flight query", () => {
+  it("settles pool teardown within the shutdown bound", async () => {
+    const database = await createDatabase(TEST_DATABASE_URL as string, {
+      maxConnections: 1,
+      statementTimeoutMs: 60_000,
+    });
+
+    // Capture the promise closeDatabase discards so the teardown is observable.
+    const client = database.$client;
+    const originalClose = client.close.bind(client);
+    let capturedClose: Promise<unknown> | null = null;
+    (client as { close: typeof client.close }).close = ((options?: { timeout?: number }) => {
+      capturedClose = originalClose(options);
+      return capturedClose;
+    }) as typeof client.close;
+
+    // A flush wedged mid-statement on the dedicated single connection.
+    const wedged = database
+      .execute(`select pg_sleep(${WEDGED_QUERY_SECONDS})`)
+      .then(
+        () => "completed",
+        () => "aborted",
+      );
+    // Give the statement time to reach the server before shutdown begins.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 300);
+    });
+
+    const closeStartedAt = Date.now();
+    closeDatabase(database, { graceSeconds: CLOSE_GRACE_SECONDS });
+    expect(capturedClose).not.toBeNull();
+
+    let boundTimer: ReturnType<typeof setTimeout> | null = null;
+    const bound = new Promise<string>((resolve) => {
+      boundTimer = setTimeout(() => {
+        resolve("still-open");
+      }, SHUTDOWN_BOUND_MS);
+    });
+    const outcome = await Promise.race([
+      (capturedClose as unknown as Promise<unknown>).then(
+        () => "closed",
+        () => "closed",
+      ),
+      bound,
+    ]);
+    if (boundTimer !== null) {
+      clearTimeout(boundTimer);
+    }
+    const elapsedMs = Date.now() - closeStartedAt;
+
+    // Let the wedged query finish so the suite exits cleanly either way.
+    await wedged;
+    await (capturedClose as unknown as Promise<unknown>).catch(() => null);
+
+    expect(outcome, `pool still open ${elapsedMs}ms after closeDatabase`).toBe("closed");
+  }, 30_000);
+});

--- a/services/cron/src/context.ts
+++ b/services/cron/src/context.ts
@@ -1,4 +1,5 @@
 import env from "./env";
+import { drainFlushWriters } from "./utils/flush-drains";
 import { closeDatabase, createDatabase } from "@keeper.sh/database";
 import Redis from "ioredis";
 import { createPremiumService } from "@keeper.sh/premium";
@@ -14,7 +15,34 @@ const database = await createDatabase(env.DATABASE_URL, { maxConnections: env.DA
  */
 const flushDatabase = await createDatabase(env.DATABASE_URL, { maxConnections: 1 });
 
-const shutdownDatabases = (): void => {
+/*
+ * Registered flush writers are drained first so queued and in-flight flushes
+ * settle before the dedicated single-connection flushDatabase is closed
+ * underneath them. The drain is bounded: a single wedged flush (a run that
+ * never settles, e.g. a half-open connection) would otherwise keep the pump
+ * busy forever, and entrykit's SIGTERM cleanup awaits this function with no
+ * timeout of its own — the process would linger until the supervisor
+ * SIGKILLs it and the databases would never be closed.
+ */
+const FLUSH_DRAIN_DEADLINE_MS = 2000;
+
+const shutdownDatabases = async (): Promise<void> => {
+  // The settled tags swallow a post-deadline rejection so it cannot become unhandled.
+  const drain = drainFlushWriters().then(
+    () => "drained",
+    () => "drain-failed",
+  );
+  let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+  const deadline = new Promise<void>((resolve) => {
+    deadlineTimer = setTimeout(resolve, FLUSH_DRAIN_DEADLINE_MS);
+  });
+  try {
+    await Promise.race([drain, deadline]);
+  } finally {
+    if (deadlineTimer !== null) {
+      clearTimeout(deadlineTimer);
+    }
+  }
   closeDatabase(database);
   closeDatabase(flushDatabase);
 };

--- a/services/cron/src/context.ts
+++ b/services/cron/src/context.ts
@@ -25,6 +25,12 @@ const flushDatabase = await createDatabase(env.DATABASE_URL, { maxConnections: 1
  * SIGKILLs it and the databases would never be closed.
  */
 const FLUSH_DRAIN_DEADLINE_MS = 2000;
+/*
+ * Pool teardown gets the same bound as the drain: Bun's unbounded close awaits
+ * the very in-flight query the drain deadline just gave up on, so leaving it
+ * unbounded would hand the wedged flush back the time the deadline removed.
+ */
+const CLOSE_GRACE_SECONDS = 2;
 
 const shutdownDatabases = async (): Promise<void> => {
   // The settled tags swallow a post-deadline rejection so it cannot become unhandled.
@@ -43,8 +49,8 @@ const shutdownDatabases = async (): Promise<void> => {
       clearTimeout(deadlineTimer);
     }
   }
-  closeDatabase(database);
-  closeDatabase(flushDatabase);
+  closeDatabase(database, { graceSeconds: CLOSE_GRACE_SECONDS });
+  closeDatabase(flushDatabase, { graceSeconds: CLOSE_GRACE_SECONDS });
 };
 const webhookConfig = resolveWebhookConfig(env.WEBHOOK_PUBLIC_URL);
 

--- a/services/cron/src/context.ts
+++ b/services/cron/src/context.ts
@@ -1,5 +1,5 @@
 import env from "./env";
-import { createDatabase } from "@keeper.sh/database";
+import { closeDatabase, createDatabase } from "@keeper.sh/database";
 import Redis from "ioredis";
 import { createPremiumService } from "@keeper.sh/premium";
 import { resolveWebhookConfig } from "@keeper.sh/calendar";
@@ -7,6 +7,17 @@ import type { RefreshLockStore } from "@keeper.sh/calendar";
 import { Polar } from "@polar-sh/sdk";
 
 const database = await createDatabase(env.DATABASE_URL, { maxConnections: env.DATABASE_POOL_MAX });
+
+/*
+ * The flush writer gets its own single connection so ingest persistence
+ * cannot open concurrent write transactions no matter how many fetches run.
+ */
+const flushDatabase = await createDatabase(env.DATABASE_URL, { maxConnections: 1 });
+
+const shutdownDatabases = (): void => {
+  closeDatabase(database);
+  closeDatabase(flushDatabase);
+};
 const webhookConfig = resolveWebhookConfig(env.WEBHOOK_PUBLIC_URL);
 
 const premiumService = createPremiumService({
@@ -52,6 +63,8 @@ const polarClient = createPolarClient();
 
 export {
   database,
+  flushDatabase,
+  shutdownDatabases,
   premiumService,
   polarClient,
   refreshLockRedis,

--- a/services/cron/src/context.ts
+++ b/services/cron/src/context.ts
@@ -16,24 +16,18 @@ const database = await createDatabase(env.DATABASE_URL, { maxConnections: env.DA
 const flushDatabase = await createDatabase(env.DATABASE_URL, { maxConnections: 1 });
 
 /*
- * Registered flush writers are drained first so queued and in-flight flushes
- * settle before the dedicated single-connection flushDatabase is closed
- * underneath them. The drain is bounded: a single wedged flush (a run that
- * never settles, e.g. a half-open connection) would otherwise keep the pump
- * busy forever, and entrykit's SIGTERM cleanup awaits this function with no
- * timeout of its own — the process would linger until the supervisor
- * SIGKILLs it and the databases would never be closed.
+ * Writers drain before flushDatabase closes underneath them. The drain is bounded because
+ * entrykit's SIGTERM cleanup awaits this with no timeout of its own: one wedged flush would
+ * keep the process alive until the supervisor SIGKILLs it, leaving the databases unclosed.
  */
 const FLUSH_DRAIN_DEADLINE_MS = 2000;
 /*
- * Pool teardown gets the same bound as the drain: Bun's unbounded close awaits
- * the very in-flight query the drain deadline just gave up on, so leaving it
- * unbounded would hand the wedged flush back the time the deadline removed.
+ * Bun's unbounded close awaits the very in-flight query the drain deadline just gave up on,
+ * so leaving teardown unbounded would hand the wedged flush back the time the deadline removed.
  */
 const CLOSE_GRACE_SECONDS = 2;
 
 const shutdownDatabases = async (): Promise<void> => {
-  // The settled tags swallow a post-deadline rejection so it cannot become unhandled.
   const drain = drainFlushWriters().then(
     () => "drained",
     () => "drain-failed",

--- a/services/cron/src/context.ts
+++ b/services/cron/src/context.ts
@@ -1,5 +1,5 @@
 import env from "./env";
-import { drainFlushWriters } from "./utils/flush-drains";
+import { createFlushDrainRegistry } from "./utils/flush-drains";
 import { closeDatabase, createDatabase } from "@keeper.sh/database";
 import Redis from "ioredis";
 import { createPremiumService } from "@keeper.sh/premium";
@@ -15,11 +15,8 @@ const database = await createDatabase(env.DATABASE_URL, { maxConnections: env.DA
  */
 const flushDatabase = await createDatabase(env.DATABASE_URL, { maxConnections: 1 });
 
-/*
- * Writers drain before flushDatabase closes underneath them. The drain is bounded because
- * entrykit's SIGTERM cleanup awaits this with no timeout of its own: one wedged flush would
- * keep the process alive until the supervisor SIGKILLs it, leaving the databases unclosed.
- */
+const flushDrainRegistry = createFlushDrainRegistry();
+
 const FLUSH_DRAIN_DEADLINE_MS = 2000;
 /*
  * Bun's unbounded close awaits the very in-flight query the drain deadline just gave up on,
@@ -28,7 +25,7 @@ const FLUSH_DRAIN_DEADLINE_MS = 2000;
 const CLOSE_GRACE_SECONDS = 2;
 
 const shutdownDatabases = async (): Promise<void> => {
-  const drain = drainFlushWriters().then(
+  const drain = flushDrainRegistry.drain().then(
     () => "drained",
     () => "drain-failed",
   );
@@ -92,6 +89,7 @@ const polarClient = createPolarClient();
 export {
   database,
   flushDatabase,
+  flushDrainRegistry,
   shutdownDatabases,
   premiumService,
   polarClient,

--- a/services/cron/src/index.ts
+++ b/services/cron/src/index.ts
@@ -29,12 +29,9 @@ await entry({
       baker.stopAll();
       destroy();
       /*
-       * Order is load-bearing: shutdownDatabases() begins with the registered
-       * flush drain, and every drained flush re-probes currency at persist
-       * time through a redis.eval on the sync-lock handle. Disconnecting
-       * refreshLockRedis first makes that probe reject, so the flush reports
-       * "currency-unconfirmed" and discards the payload the drain exists to
-       * persist. Redis must outlive the drain.
+       * Order is load-bearing: every drained flush re-probes currency through a redis.eval
+       * on the sync-lock handle, so disconnecting first makes that probe reject and the
+       * flush discards the very payload the drain exists to persist.
        */
       await shutdownDatabases();
       shutdownRefreshLockRedis();

--- a/services/cron/src/index.ts
+++ b/services/cron/src/index.ts
@@ -4,7 +4,6 @@ import { getAllJobs } from "./utils/get-jobs";
 import { injectJobs } from "./utils/inject-jobs";
 import { registerJobs } from "./utils/register-jobs";
 import {
-  closeDatabase,
   createMigrationReadinessDatabase,
   waitForDatabaseMigrations,
 } from "@keeper.sh/database";
@@ -18,7 +17,7 @@ const jobsFolderPathname = join(import.meta.dirname, "jobs");
 
 await entry({
   main: async () => {
-    const { database, shutdownRefreshLockRedis } = await import("./context");
+    const { database, shutdownDatabases, shutdownRefreshLockRedis } = await import("./context");
     await waitForDatabaseMigrations(createMigrationReadinessDatabase(database));
 
     const jobs = await getAllJobs(jobsFolderPathname);
@@ -28,7 +27,7 @@ await entry({
     return () => {
       destroy();
       shutdownRefreshLockRedis();
-      closeDatabase(database);
+      shutdownDatabases();
     };
   },
   name: "cron",

--- a/services/cron/src/index.ts
+++ b/services/cron/src/index.ts
@@ -24,10 +24,10 @@ await entry({
     const injectedJobs = injectJobs(jobs);
     registerJobs(injectedJobs);
 
-    return () => {
+    return async (): Promise<void> => {
       destroy();
       shutdownRefreshLockRedis();
-      shutdownDatabases();
+      await shutdownDatabases();
     };
   },
   name: "cron",

--- a/services/cron/src/index.ts
+++ b/services/cron/src/index.ts
@@ -28,8 +28,16 @@ await entry({
     return async (): Promise<void> => {
       baker.stopAll();
       destroy();
-      shutdownRefreshLockRedis();
+      /*
+       * Order is load-bearing: shutdownDatabases() begins with the registered
+       * flush drain, and every drained flush re-probes currency at persist
+       * time through a redis.eval on the sync-lock handle. Disconnecting
+       * refreshLockRedis first makes that probe reject, so the flush reports
+       * "currency-unconfirmed" and discards the payload the drain exists to
+       * persist. Redis must outlive the drain.
+       */
       await shutdownDatabases();
+      shutdownRefreshLockRedis();
     };
   },
   name: "cron",

--- a/services/cron/src/index.ts
+++ b/services/cron/src/index.ts
@@ -8,6 +8,7 @@ import {
   waitForDatabaseMigrations,
 } from "@keeper.sh/database";
 import { destroy } from "./utils/logging";
+import { baker } from "./utils/baker";
 import { checkWorkerMigrationStatus } from "./migration-check";
 import env from "./env";
 
@@ -25,6 +26,7 @@ await entry({
     registerJobs(injectedJobs);
 
     return async (): Promise<void> => {
+      baker.stopAll();
       destroy();
       shutdownRefreshLockRedis();
       await shutdownDatabases();

--- a/services/cron/src/index.ts
+++ b/services/cron/src/index.ts
@@ -28,11 +28,6 @@ await entry({
     return async (): Promise<void> => {
       baker.stopAll();
       destroy();
-      /*
-       * Order is load-bearing: every drained flush re-probes currency through a redis.eval
-       * on the sync-lock handle, so disconnecting first makes that probe reject and the
-       * flush discards the very payload the drain exists to persist.
-       */
       await shutdownDatabases();
       shutdownRefreshLockRedis();
     };

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -194,6 +194,28 @@ const logIngestBackoff = (state: CalendarBackoffState): void => {
   }
 };
 
+/*
+ * Runs after the ingest's work has already committed, so both the isCurrent
+ * probe and the backoff-reset write are best-effort bookkeeping: a Redis blip
+ * in the probe (or a failed DB write) must never clobber the committed result
+ * with a rejection, and must never feed the backoff escalator.
+ */
+const resetIngestBackoffIfCurrent = async (
+  calendarId: string,
+  isCurrent: () => Promise<boolean>,
+): Promise<void> => {
+  try {
+    if (await isCurrent()) {
+      await resetIngestBackoff(calendarId);
+    }
+  } catch (error) {
+    widelog.errorFields(error, {
+      slug: "ingest-backoff-reset-failed",
+      retriable: true,
+    });
+  }
+};
+
 const runSourceIngest = async <TResult>(
   calendarId: string,
   signal: AbortSignal,
@@ -223,8 +245,8 @@ const runSourceIngest = async <TResult>(
     }
     try {
       const result = await work(lockResult.handle.isCurrent);
-      if (attempt.failureCount > 0 && await lockResult.handle.isCurrent()) {
-        await resetIngestBackoff(calendarId);
+      if (attempt.failureCount > 0) {
+        await resetIngestBackoffIfCurrent(calendarId, lockResult.handle.isCurrent);
       }
       return result;
     } catch (error) {
@@ -234,7 +256,16 @@ const runSourceIngest = async <TResult>(
       throw error;
     }
   } finally {
-    await lockResult.handle.release();
+    /*
+     * The lock TTL already reclaims the hold, so a failed release must never
+     * clobber the ingest result with a rejection.
+     */
+    await lockResult.handle.release().catch((error: unknown) => {
+      widelog.errorFields(error, {
+        slug: "source-lock-release-failed",
+        retriable: true,
+      });
+    });
   }
 };
 
@@ -426,7 +457,12 @@ const createIngestionPersistenceTransaction = (
   (work: IngestionPersistenceWork) => {
     const ledger = createPersistenceLedger();
     const requestedAt = performance.now();
-    return reservation.submit(() => flushDatabase.transaction(async (transaction) => {
+    /*
+     * The submitted thunk carries the source's absolute deadline so the flush
+     * worker's resolveRunDeadlineMs bounds a wedged run by this source's own
+     * deadline instead of the generic ten-minute fallback.
+     */
+    return reservation.submit(Object.assign(() => flushDatabase.transaction(async (transaction) => {
     ledger.grantedAt = performance.now();
     const setRemainingStatementTimeout = async (): Promise<void> => {
       signal.throwIfAborted();
@@ -574,7 +610,7 @@ const createIngestionPersistenceTransaction = (
       signal.throwIfAborted();
       ledger.callbackReturnedAt = performance.now();
       return result;
-    })).finally(() => {
+    }), { deadlineAt })).finally(() => {
       /*
        * This is the one instrumentation site whose own failure could rewrite the
        * ingest's result: a throw here would reject a committed transaction, or
@@ -1396,6 +1432,14 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
                 });
                 const fetcher = createCalDAVSourceFetcher({
                   calendarUrl: currentSource.calendarUrl ?? currentSource.serverUrl,
+                  /*
+                   * The host budget meters requests per minute, and a CalDAV
+                   * fetch issues discovery plus one REPORT per multiget batch,
+                   * so every origin request draws its own permit.
+                   */
+                  onBeforeRequest: async () => {
+                    await rateLimiter?.acquire(1, signal);
+                  },
                   serverUrl: currentSource.serverUrl,
                   username: currentSource.username,
                   password: decryptPassword(currentSource.encryptedPassword, encryptionKey),
@@ -1414,7 +1458,6 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
                   const ingestionResult = await ingestSource({
                     calendarId: source.calendarId,
                     fetchEvents: async () => {
-                      await rateLimiter?.acquire(1, signal);
                       const fetchResult = await fetcher.fetchEvents();
                       recordSkippedResources(
                         fetchResult.skippedResourceCount ?? 0,

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -83,19 +83,16 @@ const SOURCE_TIMEOUT_MS = INGEST_SOURCE_TIMEOUT_MS;
 const SOURCE_TIMEOUT_DATABASE_GRACE_MS = 5000;
 
 /*
- * Bound on how long a flush transaction may wait for its calendar's advisory
- * lock while holding the single serial writer slot. The same (namespace,
- * calendarId) lock is held minutes-scale by sync-user write-back and the API
- * caldav persist, so a contended calendar must fail ITS flush quickly instead
- * of parking every queued flush behind it until their deadlines expire.
+ * The same (namespace, calendarId) lock is held minutes-scale by sync-user write-back and
+ * the API caldav persist, so a contended calendar must fail ITS flush quickly instead of
+ * parking every queued flush behind it while it holds the single serial writer slot.
  */
 const ADVISORY_LOCK_WAIT_BOUND_MS = 5000;
 /*
- * Sized to the shared cron pool (DATABASE_POOL_MAX 25 in deploy/compose.yaml):
- * every launched source performs pooled reads before the weighted reserve() can
- * park it, so this is the only bound on that pre-reserve read herd. Groups times
- * USER_CALENDAR_CONCURRENCY must stay within the pool, leaving headroom for the
- * other cron jobs sharing `database`.
+ * Sized to the shared cron database pool (DATABASE_POOL_MAX 25 in deploy/compose.yaml):
+ * every launched source performs pooled reads BEFORE the weighted reserve() can park it,
+ * so groups times USER_CALENDAR_CONCURRENCY must stay within the pool with headroom for
+ * the other cron jobs sharing `database`.
  */
 const USER_GROUP_CONCURRENCY = 12;
 /*
@@ -124,15 +121,10 @@ const instrumentedLockRedis = {
 };
 
 /*
- * Cron passes are serial (cronbake re-arms only after a pass completes), but a
- * calendar's ingest can still be in flight when the next pass reaches it: a
- * timeout-abandoned run keeps executing after withAbortTimeout frees its
- * scheduler slot, and webhook-driven syncs contend for the same lock. That
- * duplicate is a routine identical run, not a mapping mutation: it must acquire
- * as "background" so IS_CURRENT stays true for the in-flight holder and its
- * completed fetch persists. With the default "preempting" class every such
- * overlap discarded the holder's finished work, and a source slower than its
- * deadline never recorded its first ingest.
+ * An overlapping pass is a routine identical run, not a mapping mutation, so it must
+ * acquire as "background" to keep IS_CURRENT true for the in-flight holder. Under the
+ * default "preempting" class every overlap discarded the holder's finished work, and a
+ * source slower than its deadline never recorded its first ingest.
  */
 const sourceIngestLock = createSyncLock(instrumentedLockRedis, "background");
 
@@ -195,10 +187,8 @@ const logIngestBackoff = (state: CalendarBackoffState): void => {
 };
 
 /*
- * Runs after the ingest's work has already committed, so both the isCurrent
- * probe and the backoff-reset write are best-effort bookkeeping: a Redis blip
- * in the probe (or a failed DB write) must never clobber the committed result
- * with a rejection, and must never feed the backoff escalator.
+ * Runs after the work has committed, so a Redis blip in the probe or a failed write must
+ * never clobber the committed result with a rejection, nor feed the backoff escalator.
  */
 const resetIngestBackoffIfCurrent = async (
   calendarId: string,
@@ -256,10 +246,7 @@ const runSourceIngest = async <TResult>(
       throw error;
     }
   } finally {
-    /*
-     * The lock TTL already reclaims the hold, so a failed release must never
-     * clobber the ingest result with a rejection.
-     */
+    /* The lock TTL already reclaims the hold, so a failed release must not reject. */
     await lockResult.handle.release().catch((error: unknown) => {
       widelog.errorFields(error, {
         slug: "source-lock-release-failed",
@@ -314,9 +301,8 @@ const resolveIngestErrorSlug = (error: unknown): string => {
 
 /*
  * A queued transaction's callback runs in the async context of whoever released the
- * connection (see packages/database/src/utils/pool-telemetry.ts), so nothing inside
- * it may call widelog. Everything is measured into this ledger and emitted once the
- * transaction promise resolves, back in the per-source context.
+ * connection (see packages/database/src/utils/pool-telemetry.ts), so nothing inside it may
+ * call widelog. Measured here and emitted once the transaction resolves, back in context.
  */
 interface PersistenceLedger {
   advisoryLockMs: number;
@@ -363,11 +349,7 @@ const measureLedgerWrite = async <TResult>(
 };
 
 const emitPersistenceLedger = (ledger: PersistenceLedger, requestedAt: number): void => {
-  /*
-   * A transaction that never got a connection is the pool-exhaustion case this
-   * exists to catch, so the wait still has to be charged; there is simply nothing
-   * after it to report.
-   */
+  /* Pool exhaustion is the case this exists to catch, so the wait is charged regardless. */
   if (ledger.grantedAt === 0) {
     recordSegment("wait.db_pool_ms", performance.now() - requestedAt);
     return;
@@ -388,41 +370,28 @@ const emitPersistenceLedger = (ledger: PersistenceLedger, requestedAt: number): 
 };
 
 /*
- * Collection is concurrent but writing is not: every source's persistence flush
- * runs through this bounded serial worker onto the dedicated single-connection
- * flushDatabase, so high fetch concurrency can never open concurrent write
- * transactions against Postgres. The bound matters as much as the serialization:
- * a bare promise chain would also serialize, but with nothing to stop an
- * unbounded backlog of fetched payloads queueing behind a slow flush. A failed
- * flush settles only its own source; a source aborted while parked frees its
- * slot without ever running.
+ * Collection is concurrent but writing is not, so high fetch concurrency can never open
+ * concurrent write transactions against Postgres. The bound matters as much as the
+ * serialization: a bare promise chain would also serialize, but with nothing to stop an
+ * unbounded backlog of fetched payloads queueing behind a slow flush.
  */
 const FLUSH_QUEUE_CAPACITY = 50;
 
 /*
- * The budget makes the bound memory-weighted rather than item-counted: a
- * source must reserve its estimated payload weight BEFORE its provider fetch
- * begins, so a full budget stops fetches from starting and blocked collectors
- * hold no payloads.
+ * Memory-weighted rather than item-counted: a source reserves its estimated payload weight
+ * BEFORE its fetch begins, so a full budget stops fetches and blocked collectors hold nothing.
  */
 const ingestFlushWriter = createSerialFlushWorker(
   (task: () => Promise<IngestionResult>) => task(),
   { budget: WEIGHT_BUDGET, capacity: FLUSH_QUEUE_CAPACITY },
 );
 
-/*
- * Shutdown must drain this writer before flushDatabase closes, or queued and
- * in-flight flushes are stranded with their budget still reserved.
- */
+/* Shutdown must drain this writer before flushDatabase closes, or flushes strand their budget. */
 registerFlushDrain(() => ingestFlushWriter.close());
 
 type IngestFlushReservation = FlushReservation<() => Promise<IngestionResult>, IngestionResult>;
 
-/*
- * Acquires the weighted flush reservation for one source before its provider
- * fetch is allowed to start. The wait is its own segment so "the budget was
- * full" never masquerades as provider rate limiting.
- */
+/* The wait is its own segment so "the budget was full" never masquerades as rate limiting. */
 const reserveIngestFlushWeight = async (
   calendarId: string,
   hasEverIngested: boolean,
@@ -430,7 +399,6 @@ const reserveIngestFlushWeight = async (
 ): Promise<IngestFlushReservation> => {
   const weight = await estimateIngestWeight(
     {
-      // The sizing read goes to the pooled database, never the flush writer.
       countStoredEvents: async (targetCalendarId: string): Promise<number> => {
         const rows = await database
           .select({ count: count() })
@@ -457,11 +425,7 @@ const createIngestionPersistenceTransaction = (
   (work: IngestionPersistenceWork) => {
     const ledger = createPersistenceLedger();
     const requestedAt = performance.now();
-    /*
-     * The submitted thunk carries the source's absolute deadline so the flush
-     * worker's resolveRunDeadlineMs bounds a wedged run by this source's own
-     * deadline instead of the generic ten-minute fallback.
-     */
+    /* Carries the source's own deadline so a wedged run is not bounded by the generic fallback. */
     return reservation.submit(Object.assign(() => flushDatabase.transaction(async (transaction) => {
     ledger.grantedAt = performance.now();
     const setRemainingStatementTimeout = async (): Promise<void> => {
@@ -480,10 +444,8 @@ const createIngestionPersistenceTransaction = (
       true
     )`);
     /*
-     * The advisory-lock wait runs under a small constant statement_timeout,
-     * never the source's full remaining deadline: the lock can be held
-     * minutes-scale elsewhere, and this transaction occupies the single
-     * serial writer slot while it waits.
+     * A small constant, never the source's full remaining deadline: the lock can be held
+     * minutes-scale elsewhere while this transaction occupies the single serial writer slot.
      */
     const boundedLockWaitMs = Math.max(
       1,
@@ -502,7 +464,6 @@ const createIngestionPersistenceTransaction = (
       ledger.advisoryLockMs += performance.now() - advisoryLockRequestedAt;
     }
     signal.throwIfAborted();
-    /* Restore the deadline-derived timeout for the persistence work itself. */
     await setRemainingStatementTimeout();
 
     const result = await work({
@@ -567,11 +528,7 @@ const createIngestionPersistenceTransaction = (
         if (changes.coverage) {
           const { futureRange, historicRange, window } = changes.coverage;
           await setRemainingStatementTimeout();
-          /*
-           * Snapshot sources report coverage on every run. The window is anchored to
-           * the start of the day, so rewriting it unconditionally would churn this row
-           * (and its updatedAt) once per tick rather than once per day.
-           */
+          /* The window is day-anchored, so an unconditional rewrite would churn updatedAt per tick. */
           ledger.writeCount += 1;
           await measureLedgerWrite(ledger, () => transaction
             .update(calendarsTable)
@@ -613,11 +570,8 @@ const createIngestionPersistenceTransaction = (
     }), {
       deadlineAt,
       /*
-       * The persist-time currency probe is Redis I/O on the sync-lock client
-       * (10s commandTimeout). It must settle here — after the queue wait, but
-       * BEFORE flushDatabase.transaction opens — so a Redis brownout never
-       * parks the sole flush connection, the advisory lock, or the serial
-       * writer slot.
+       * Redis I/O must settle after the queue wait but BEFORE the transaction opens, so a
+       * brownout never parks the sole flush connection, the advisory lock, or the writer slot.
        */
       prepare: async (): Promise<IngestionResult | null> => {
         const { preflight } = work;
@@ -627,11 +581,7 @@ const createIngestionPersistenceTransaction = (
         return await preflight();
       },
     })).finally(() => {
-      /*
-       * This is the one instrumentation site whose own failure could rewrite the
-       * ingest's result: a throw here would reject a committed transaction, or
-       * replace the real ingest error with a telemetry one.
-       */
+      /* A throw here would reject a committed transaction or mask the real ingest error. */
       try {
         emitPersistenceLedger(ledger, requestedAt);
       } catch (error) {
@@ -677,15 +627,12 @@ const resolveTargetHost = (target: string | null): string | null => {
 };
 
 /*
- * The semaphore's contract is per-run concurrency, not per-request pacing, so one
- * ingest run must hold exactly one lease: the first acquire takes it, later acquires
- * (pagination) reuse it. The lease TTL outlives the ingest timeout, so a crashed
- * holder frees its slot without an explicit release.
+ * Per-run concurrency, not per-request pacing: one ingest holds exactly one lease, and
+ * pagination reuses it. The TTL outlives the ingest timeout so a crashed holder still frees.
  */
 /*
- * One lease per source, released when the source's ingest finishes: leaving it to
- * the 150s TTL means an account's fourth calendar in a pass waits longer than its
- * own 120s deadline for a slot nobody is going to free.
+ * Released eagerly rather than at the 150s TTL: an account's fourth calendar in a pass
+ * would otherwise wait past its own 120s deadline for a slot nobody is going to free.
  */
 interface IngestRateLimiter extends RedisRateLimiter {
   dispose?: () => Promise<void>;
@@ -732,7 +679,6 @@ const resolveRateLimiter = (
     );
   }
 
-  /* CalDAV sources may be stored as 'caldav', 'fastmail', or 'icloud'. */
   if (isCalDAVProvider(provider)) {
     const host = resolveTargetHost(source.serverUrl ?? null);
     if (!host) {
@@ -1286,10 +1232,7 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
                 } finally {
                   /* A source that never submitted must not strand its weight. */
                   reservation.release();
-                  /*
-                   * The lease TTL already reclaims the slot, so a failed release
-                   * must never clobber the ingest result with a rejection.
-                   */
+                  /* The lease TTL already reclaims the slot, so a failed release must not reject. */
                   await rateLimiter?.dispose?.().catch((error: unknown) => {
                     widelog.errorFields(error, {
                       slug: "rate-limiter-dispose-failed",
@@ -1449,9 +1392,8 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
                 const fetcher = createCalDAVSourceFetcher({
                   calendarUrl: currentSource.calendarUrl ?? currentSource.serverUrl,
                   /*
-                   * The host budget meters requests per minute, and a CalDAV
-                   * fetch issues discovery plus one REPORT per multiget batch,
-                   * so every origin request draws its own permit.
+                   * The host budget meters requests per minute and a CalDAV fetch issues
+                   * discovery plus one REPORT per batch, so every origin request draws a permit.
                    */
                   onBeforeRequest: async () => {
                     await rateLimiter?.acquire(1, signal);

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -8,6 +8,8 @@ import {
   createMicrosoftTokenRefresher,
   createCoordinatedRefresher,
   createGoogleUserRateLimiter,
+  createHostRateLimiter,
+  createOutlookAccountSemaphore,
   ensureValidToken,
   isTimeoutError,
   buildCalendarBackoffState,
@@ -26,7 +28,8 @@ import {
   PROVIDER_INGEST_REQUEST_TIMEOUT_MS,
   REAUTHENTICATION_SOURCE_INGEST,
 } from "@keeper.sh/constants";
-import type { CalendarBackoffState, IngestWideEventFields, IngestionFetchEventsResult, IngestionPersistenceWork, RedisRateLimiter, RequiredSourceRanges, TokenState } from "@keeper.sh/calendar";
+import type { SemaphoreLease } from "@keeper.sh/calendar";
+import type { CalendarBackoffState, IngestWideEventFields, IngestionFetchEventsResult, IngestionPersistenceWork, OutlookAccountSemaphore, RedisLeaseClient, RedisRateLimiter, RequiredSourceRanges, TokenState } from "@keeper.sh/calendar";
 import {
   createIcsSourceFetcher,
   interpretFullDayTimedEventsAsAllDay,
@@ -91,6 +94,16 @@ const instrumentedLockRedis = {
 };
 
 const sourceIngestLock = createSyncLock(instrumentedLockRedis);
+
+/*
+ * The ioredis set overloads type expiry/condition tokens positionally, so the
+ * semaphore's variadic option list has to go through the generic command runner.
+ */
+const leaseLockRedis: RedisLeaseClient = {
+  del: (...keys: string[]): Promise<number> => refreshLockRedis.del(...keys),
+  set: (key: string, value: string, ...options: string[]): Promise<string | null> =>
+    refreshLockRedis.call("set", key, value, ...options) as Promise<string | null>,
+};
 
 const measureDatabaseRead = async <TResult>(
   read: () => PromiseLike<TResult>,
@@ -475,12 +488,96 @@ const resolveTokenRefresher = (provider: string) => {
   return null;
 };
 
-const resolveRateLimiter = (provider: string, userId: string): RedisRateLimiter | undefined => {
-  if (provider !== "google") {
-    return;
+interface RateLimiterSourceContext {
+  accountId?: string;
+  serverUrl?: string;
+  url?: string;
+  userId: string;
+}
+
+const resolveTargetHost = (target: string | null): string | null => {
+  if (!target) {
+    return null;
+  }
+  try {
+    return new URL(target).hostname;
+  } catch {
+    return null;
+  }
+};
+
+/*
+ * The semaphore's contract is per-run concurrency, not per-request pacing, so one
+ * ingest run must hold exactly one lease: the first acquire takes it, later acquires
+ * (pagination) reuse it. The lease TTL outlives the ingest timeout, so a crashed
+ * holder frees its slot without an explicit release.
+ */
+/*
+ * One lease per source, released when the source's ingest finishes: leaving it to
+ * the 150s TTL means an account's fourth calendar in a pass waits longer than its
+ * own 120s deadline for a slot nobody is going to free.
+ */
+interface IngestRateLimiter extends RedisRateLimiter {
+  dispose?: () => Promise<void>;
+}
+
+const createSemaphoreRateLimiterAdapter = (
+  semaphore: OutlookAccountSemaphore,
+): IngestRateLimiter => {
+  let lease: Promise<SemaphoreLease> | null = null;
+  return {
+    acquire: async (_count: number, signal?: AbortSignal): Promise<void> => {
+      if (!lease) {
+        lease = measureSegment("wait.rate_limiter_ms", () => semaphore.acquireLease(signal));
+      }
+      await lease;
+    },
+    dispose: async (): Promise<void> => {
+      if (!lease) {
+        return;
+      }
+      const held = await lease.catch(() => null);
+      lease = null;
+      if (held) {
+        await semaphore.release(held);
+      }
+    },
+  };
+};
+
+const resolveRateLimiter = (
+  provider: string,
+  source: RateLimiterSourceContext,
+): IngestRateLimiter | undefined => {
+  if (provider === "google") {
+    return createGoogleUserRateLimiter(refreshLockRedis, source.userId, "ingest");
   }
 
-  return createGoogleUserRateLimiter(refreshLockRedis, userId, "ingest");
+  if (provider === "outlook") {
+    if (!source.accountId) {
+      return;
+    }
+    return createSemaphoreRateLimiterAdapter(
+      createOutlookAccountSemaphore(leaseLockRedis, source.accountId),
+    );
+  }
+
+  if (provider === "caldav") {
+    const host = resolveTargetHost(source.serverUrl ?? null);
+    if (!host) {
+      return;
+    }
+    return createHostRateLimiter(refreshLockRedis, host);
+  }
+
+  if (provider !== "ical" && provider !== "ics") {
+    return;
+  }
+  const host = resolveTargetHost(source.url ?? null);
+  if (!host) {
+    return;
+  }
+  return createHostRateLimiter(refreshLockRedis, host);
 };
 
 const getRequiredSourceRanges = async (
@@ -966,12 +1063,16 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
                 if (ingestionState.fullSyncReason) {
                   widelog.set("full_sync.reason", ingestionState.fullSyncReason);
                 }
+                const rateLimiter = resolveRateLimiter(currentSource.provider, {
+                  accountId: currentSource.accountId,
+                  userId: currentSource.userId,
+                });
                 const fetcher = resolveOAuthFetcher(currentSource.provider, {
                   accessToken: tokenState.accessToken,
                   calendarId: source.calendarId,
                   externalCalendarId: currentSource.externalCalendarId,
                   syncToken: ingestionState.syncToken,
-                  rateLimiter: resolveRateLimiter(currentSource.provider, currentSource.userId),
+                  rateLimiter,
                   signal,
                   plan: createSourceIngestionPlan(
                     ranges.historicRange,
@@ -981,26 +1082,30 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
                 if (!fetcher) {
                   return createSkippedIngestionResult(currentSource.userId);
                 }
-                const ingestionResult = await ingestSource({
-                  calendarId: source.calendarId,
-                  fetchEvents: () => fetcher.fetchEvents(),
-                  isCurrent,
-                  withPersistenceTransaction:
-                    createIngestionPersistenceTransaction(source.calendarId, signal, deadlineAt),
-                  onIngestEvent: recordIngestWideEvent,
-                });
-                return {
-                  eventsAdded: ingestionResult.eventsAdded,
-                  eventsRemoved: ingestionResult.eventsRemoved,
-                  reauthentication: {
-                    accountId: currentSource.accountId,
-                    demand: "authenticated" as const,
-                  },
-                  shouldPush: ingestionState.authorityChanged
-                    || ingestionResult.eventsAdded > 0
-                    || ingestionResult.eventsRemoved > 0,
-                  userId: currentSource.userId,
-                };
+                try {
+                  const ingestionResult = await ingestSource({
+                    calendarId: source.calendarId,
+                    fetchEvents: () => fetcher.fetchEvents(),
+                    isCurrent,
+                    withPersistenceTransaction:
+                      createIngestionPersistenceTransaction(source.calendarId, signal, deadlineAt),
+                    onIngestEvent: recordIngestWideEvent,
+                  });
+                  return {
+                    eventsAdded: ingestionResult.eventsAdded,
+                    eventsRemoved: ingestionResult.eventsRemoved,
+                    reauthentication: {
+                      accountId: currentSource.accountId,
+                      demand: "authenticated" as const,
+                    },
+                    shouldPush: ingestionState.authorityChanged
+                      || ingestionResult.eventsAdded > 0
+                      || ingestionResult.eventsRemoved > 0,
+                    userId: currentSource.userId,
+                  };
+                } finally {
+                  await rateLimiter?.dispose?.();
+                }
               }, shouldApplyOAuthIngestBackoff),
             );
             if (!result) {
@@ -1407,5 +1512,5 @@ export default withCronWideEvent({
   overrunProtection: false,
 }) satisfies CronOptions;
 
-export { ingestOAuthSources };
+export { ingestOAuthSources, resolveRateLimiter };
 export type { IngestionBatchResult };

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -610,7 +610,23 @@ const createIngestionPersistenceTransaction = (
       signal.throwIfAborted();
       ledger.callbackReturnedAt = performance.now();
       return result;
-    }), { deadlineAt })).finally(() => {
+    }), {
+      deadlineAt,
+      /*
+       * The persist-time currency probe is Redis I/O on the sync-lock client
+       * (10s commandTimeout). It must settle here — after the queue wait, but
+       * BEFORE flushDatabase.transaction opens — so a Redis brownout never
+       * parks the sole flush connection, the advisory lock, or the serial
+       * writer slot.
+       */
+      prepare: async (): Promise<IngestionResult | null> => {
+        const { preflight } = work;
+        if (!preflight) {
+          return null;
+        }
+        return await preflight();
+      },
+    })).finally(() => {
       /*
        * This is the one instrumentation site whose own failure could rewrite the
        * ingest's result: a throw here would reject a committed transaction, or

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -8,6 +8,7 @@ import {
   createMicrosoftTokenRefresher,
   createCoordinatedRefresher,
   createGoogleUserRateLimiter,
+  createSerialFlushWorker,
   createHostRateLimiter,
   createOutlookAccountSemaphore,
   ensureValidToken,
@@ -29,6 +30,7 @@ import {
   REAUTHENTICATION_SOURCE_INGEST,
 } from "@keeper.sh/constants";
 import type { SemaphoreLease } from "@keeper.sh/calendar";
+import type { IngestionResult } from "@keeper.sh/calendar";
 import type { CalendarBackoffState, IngestWideEventFields, IngestionFetchEventsResult, IngestionPersistenceWork, OutlookAccountSemaphore, RedisLeaseClient, RedisRateLimiter, RequiredSourceRanges, TokenState } from "@keeper.sh/calendar";
 import {
   createIcsSourceFetcher,
@@ -55,7 +57,7 @@ import {
 import { and, arrayContains, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
 import { withCronWideEvent } from "@/utils/with-wide-event";
 import { context, widelog } from "@/utils/logging";
-import { database, refreshLockRedis, refreshLockStore } from "@/context";
+import { database, flushDatabase, refreshLockRedis, refreshLockStore } from "@/context";
 import env from "@/env";
 import { safeFetchOptions } from "@/utils/safe-fetch-options";
 import {
@@ -315,6 +317,23 @@ const emitPersistenceLedger = (ledger: PersistenceLedger, requestedAt: number): 
   }
 };
 
+/*
+ * Collection is concurrent but writing is not: every source's persistence flush
+ * runs through this bounded serial worker onto the dedicated single-connection
+ * flushDatabase, so high fetch concurrency can never open concurrent write
+ * transactions against Postgres. The bound matters as much as the serialization:
+ * a bare promise chain would also serialize, but with nothing to stop an
+ * unbounded backlog of fetched payloads queueing behind a slow flush. A failed
+ * flush settles only its own source; a source aborted while parked frees its
+ * slot without ever running.
+ */
+const FLUSH_QUEUE_CAPACITY = 50;
+
+const ingestFlushWriter = createSerialFlushWorker(
+  (task: () => Promise<IngestionResult>) => task(),
+  { capacity: FLUSH_QUEUE_CAPACITY },
+);
+
 const createIngestionPersistenceTransaction = (
   calendarId: string,
   signal: AbortSignal,
@@ -323,7 +342,7 @@ const createIngestionPersistenceTransaction = (
   (work: IngestionPersistenceWork) => {
     const ledger = createPersistenceLedger();
     const requestedAt = performance.now();
-    return database.transaction(async (transaction) => {
+    return ingestFlushWriter.submit(() => flushDatabase.transaction(async (transaction) => {
     ledger.grantedAt = performance.now();
     const setRemainingStatementTimeout = async (): Promise<void> => {
       signal.throwIfAborted();
@@ -456,7 +475,7 @@ const createIngestionPersistenceTransaction = (
       signal.throwIfAborted();
       ledger.callbackReturnedAt = performance.now();
       return result;
-    }).finally(() => {
+    }), signal).finally(() => {
       /*
        * This is the one instrumentation site whose own failure could rewrite the
        * ingest's result: a throw here would reject a committed transaction, or

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -30,7 +30,7 @@ import {
   REAUTHENTICATION_SOURCE_INGEST,
 } from "@keeper.sh/constants";
 import type { SemaphoreLease } from "@keeper.sh/calendar";
-import type { IngestionResult } from "@keeper.sh/calendar";
+import type { FlushReservation, IngestionResult } from "@keeper.sh/calendar";
 import type { CalendarBackoffState, IngestWideEventFields, IngestionFetchEventsResult, IngestionPersistenceWork, OutlookAccountSemaphore, RedisLeaseClient, RedisRateLimiter, RequiredSourceRanges, TokenState } from "@keeper.sh/calendar";
 import {
   createIcsSourceFetcher,
@@ -54,7 +54,7 @@ import {
   sourceDestinationMappingsTable,
   userSubscriptionsTable,
 } from "@keeper.sh/database/schema";
-import { and, arrayContains, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
+import { and, arrayContains, count, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
 import { withCronWideEvent } from "@/utils/with-wide-event";
 import { context, widelog } from "@/utils/logging";
 import { database, flushDatabase, refreshLockRedis, refreshLockStore } from "@/context";
@@ -71,16 +71,26 @@ import { createSyncLock } from "@keeper.sh/sync";
 import { enqueueDestinationSyncsForUsers } from "@/utils/enqueue-destination-syncs";
 import { deleteEventStatesInChunks } from "@/utils/delete-event-states";
 import { selectIngestWideEventFields } from "@/utils/ingest-wide-event";
+import { WEIGHT_BUDGET, estimateIngestWeight } from "@/utils/ingest-weight";
 
 const SOURCE_TIMEOUT_MS = INGEST_SOURCE_TIMEOUT_MS;
 const SOURCE_TIMEOUT_DATABASE_GRACE_MS = 5000;
-const SOURCE_CONCURRENCY = 5;
+/*
+ * The real bounds are the weighted flush budget, the per-family provider
+ * limiters, and USER_CALENDAR_CONCURRENCY, so no global group throttle remains.
+ */
+const UNBOUNDED_USER_GROUPS = 1000;
 /*
  * A per-pass budget against Graph's documented MailboxConcurrency of four, not a
  * hard ceiling: webhook-driven syncs in the worker hit the same mailbox
  * independently, so combined traffic can still reach the provider limit.
  */
 const USER_CALENDAR_CONCURRENCY = 2;
+/*
+ * ICS keeps a small dedicated group budget: parsing is CPU-bound and starves
+ * the Bun event loop when run wide open — observed 2026-08-17.
+ */
+const ICS_PARSE_CONCURRENCY = 4;
 const SOURCE_INGEST_LOCK_KEY_PREFIX = "source-ingest:";
 
 /*
@@ -329,20 +339,59 @@ const emitPersistenceLedger = (ledger: PersistenceLedger, requestedAt: number): 
  */
 const FLUSH_QUEUE_CAPACITY = 50;
 
+/*
+ * The budget makes the bound memory-weighted rather than item-counted: a
+ * source must reserve its estimated payload weight BEFORE its provider fetch
+ * begins, so a full budget stops fetches from starting and blocked collectors
+ * hold no payloads.
+ */
 const ingestFlushWriter = createSerialFlushWorker(
   (task: () => Promise<IngestionResult>) => task(),
-  { capacity: FLUSH_QUEUE_CAPACITY },
+  { budget: WEIGHT_BUDGET, capacity: FLUSH_QUEUE_CAPACITY },
 );
+
+type IngestFlushReservation = FlushReservation<() => Promise<IngestionResult>, IngestionResult>;
+
+/*
+ * Acquires the weighted flush reservation for one source before its provider
+ * fetch is allowed to start. The wait is its own segment so "the budget was
+ * full" never masquerades as provider rate limiting.
+ */
+const reserveIngestFlushWeight = async (
+  calendarId: string,
+  hasEverIngested: boolean,
+  signal: AbortSignal,
+): Promise<IngestFlushReservation> => {
+  const weight = await estimateIngestWeight(
+    {
+      // The sizing read goes to the pooled database, never the flush writer.
+      countStoredEvents: async (targetCalendarId: string): Promise<number> => {
+        const rows = await database
+          .select({ count: count() })
+          .from(eventStatesTable)
+          .where(eq(eventStatesTable.calendarId, targetCalendarId));
+        return rows[0]?.count ?? 0;
+      },
+    },
+    calendarId,
+    hasEverIngested,
+  );
+  return await measureSegment(
+    "wait.flush_reserve_ms",
+    () => ingestFlushWriter.reserve(weight, signal),
+  );
+};
 
 const createIngestionPersistenceTransaction = (
   calendarId: string,
   signal: AbortSignal,
   deadlineAt: number,
+  reservation: IngestFlushReservation,
 ) =>
   (work: IngestionPersistenceWork) => {
     const ledger = createPersistenceLedger();
     const requestedAt = performance.now();
-    return ingestFlushWriter.submit(() => flushDatabase.transaction(async (transaction) => {
+    return reservation.submit(() => flushDatabase.transaction(async (transaction) => {
     ledger.grantedAt = performance.now();
     const setRemainingStatementTimeout = async (): Promise<void> => {
       signal.throwIfAborted();
@@ -475,7 +524,7 @@ const createIngestionPersistenceTransaction = (
       signal.throwIfAborted();
       ledger.callbackReturnedAt = performance.now();
       return result;
-    }), signal).finally(() => {
+    })).finally(() => {
       /*
        * This is the one instrumentation site whose own failure could rewrite the
        * ingest's result: a throw here would reject a committed transaction, or
@@ -1101,13 +1150,22 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
                 if (!fetcher) {
                   return createSkippedIngestionResult(currentSource.userId);
                 }
+                const reservation = await reserveIngestFlushWeight(
+                  source.calendarId,
+                  currentSource.ingestWindowRecordedAt !== null,
+                  signal,
+                );
                 try {
                   const ingestionResult = await ingestSource({
                     calendarId: source.calendarId,
                     fetchEvents: () => fetcher.fetchEvents(),
                     isCurrent,
-                    withPersistenceTransaction:
-                      createIngestionPersistenceTransaction(source.calendarId, signal, deadlineAt),
+                    withPersistenceTransaction: createIngestionPersistenceTransaction(
+                      source.calendarId,
+                      signal,
+                      deadlineAt,
+                      reservation,
+                    ),
                     onIngestEvent: recordIngestWideEvent,
                   });
                   return {
@@ -1123,6 +1181,8 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
                     userId: currentSource.userId,
                   };
                 } finally {
+                  /* A source that never submitted must not strand its weight. */
+                  reservation.release();
                   await rateLimiter?.dispose?.();
                 }
               }, shouldApplyOAuthIngestBackoff),
@@ -1172,7 +1232,7 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
       SOURCE_TIMEOUT_MS);
     }),
 oauthSources.map((source) => source.userId),
-    { groupConcurrency: SOURCE_CONCURRENCY, taskConcurrency: USER_CALENDAR_CONCURRENCY },
+    { groupConcurrency: UNBOUNDED_USER_GROUPS, taskConcurrency: USER_CALENDAR_CONCURRENCY },
   );
 
   return summariseIngestionSettlements(
@@ -1281,33 +1341,47 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
                     ranges.futureRange,
                   ),
                 });
-                const ingestionResult = await ingestSource({
-                  calendarId: source.calendarId,
-                  fetchEvents: async () => {
-                    const fetchResult = await fetcher.fetchEvents();
-                    recordSkippedResources(
-                      fetchResult.skippedResourceCount ?? 0,
-                      fetchResult.skippedResourceReasons ?? [],
-                    );
-                    return fetchResult;
-                  },
-                  isCurrent,
-                  withPersistenceTransaction:
-                    createIngestionPersistenceTransaction(source.calendarId, signal, deadlineAt),
-                  onIngestEvent: recordIngestWideEvent,
-                });
-                return {
-                  eventsAdded: ingestionResult.eventsAdded,
-                  eventsRemoved: ingestionResult.eventsRemoved,
-                  reauthentication: {
-                    accountId: source.accountId,
-                    demand: "authenticated" as const,
-                  },
-                  shouldPush: hasSourceAuthorityChanged(currentSource, ranges)
-                    || ingestionResult.eventsAdded > 0
-                    || ingestionResult.eventsRemoved > 0,
-                  userId: currentSource.userId,
-                };
+                const reservation = await reserveIngestFlushWeight(
+                  source.calendarId,
+                  currentSource.ingestWindowRecordedAt !== null,
+                  signal,
+                );
+                try {
+                  const ingestionResult = await ingestSource({
+                    calendarId: source.calendarId,
+                    fetchEvents: async () => {
+                      const fetchResult = await fetcher.fetchEvents();
+                      recordSkippedResources(
+                        fetchResult.skippedResourceCount ?? 0,
+                        fetchResult.skippedResourceReasons ?? [],
+                      );
+                      return fetchResult;
+                    },
+                    isCurrent,
+                    withPersistenceTransaction: createIngestionPersistenceTransaction(
+                      source.calendarId,
+                      signal,
+                      deadlineAt,
+                      reservation,
+                    ),
+                    onIngestEvent: recordIngestWideEvent,
+                  });
+                  return {
+                    eventsAdded: ingestionResult.eventsAdded,
+                    eventsRemoved: ingestionResult.eventsRemoved,
+                    reauthentication: {
+                      accountId: source.accountId,
+                      demand: "authenticated" as const,
+                    },
+                    shouldPush: hasSourceAuthorityChanged(currentSource, ranges)
+                      || ingestionResult.eventsAdded > 0
+                      || ingestionResult.eventsRemoved > 0,
+                    userId: currentSource.userId,
+                  };
+                } finally {
+                  /* A source that never submitted must not strand its weight. */
+                  reservation.release();
+                }
               }, (error) => !shouldTreatAsProviderAuthFailure(error)),
             );
             if (!result) {
@@ -1349,7 +1423,7 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
       SOURCE_TIMEOUT_MS);
     }),
 caldavSources.map((source) => source.userId),
-    { groupConcurrency: SOURCE_CONCURRENCY, taskConcurrency: USER_CALENDAR_CONCURRENCY },
+    { groupConcurrency: UNBOUNDED_USER_GROUPS, taskConcurrency: USER_CALENDAR_CONCURRENCY },
   );
 
   return summariseIngestionSettlements(
@@ -1433,30 +1507,44 @@ const ingestIcsSources = async (): Promise<IngestionBatchResult> => {
                     ranges.futureRange,
                   ),
                 });
-                const ingestionResult = await ingestSource({
-                  calendarId: source.calendarId,
-                  fetchEvents: () =>
-                    fetcher.fetchEvents({
-                      interpretEvents: (events, fetchContext) =>
-                        interpretFullDayTimedEventsAsAllDay(events, {
-                          calendarTimeZone: fetchContext.calendarTimeZone,
-                          enabled: currentSource.treatFullDayTimedEventsAsAllDay,
-                        }),
-                    }),
-                  isCurrent,
-                  withPersistenceTransaction:
-                    createIngestionPersistenceTransaction(source.calendarId, signal, deadlineAt),
-                  onIngestEvent: recordIngestWideEvent,
-                });
-                return {
-                  eventsAdded: ingestionResult.eventsAdded,
-                  eventsRemoved: ingestionResult.eventsRemoved,
-                  reauthentication: null,
-                  shouldPush: hasSourceAuthorityChanged(currentSource, ranges)
-                    || ingestionResult.eventsAdded > 0
-                    || ingestionResult.eventsRemoved > 0,
-                  userId: currentSource.userId,
-                };
+                const reservation = await reserveIngestFlushWeight(
+                  source.calendarId,
+                  currentSource.ingestWindowRecordedAt !== null,
+                  signal,
+                );
+                try {
+                  const ingestionResult = await ingestSource({
+                    calendarId: source.calendarId,
+                    fetchEvents: () =>
+                      fetcher.fetchEvents({
+                        interpretEvents: (events, fetchContext) =>
+                          interpretFullDayTimedEventsAsAllDay(events, {
+                            calendarTimeZone: fetchContext.calendarTimeZone,
+                            enabled: currentSource.treatFullDayTimedEventsAsAllDay,
+                          }),
+                      }),
+                    isCurrent,
+                    withPersistenceTransaction: createIngestionPersistenceTransaction(
+                      source.calendarId,
+                      signal,
+                      deadlineAt,
+                      reservation,
+                    ),
+                    onIngestEvent: recordIngestWideEvent,
+                  });
+                  return {
+                    eventsAdded: ingestionResult.eventsAdded,
+                    eventsRemoved: ingestionResult.eventsRemoved,
+                    reauthentication: null,
+                    shouldPush: hasSourceAuthorityChanged(currentSource, ranges)
+                      || ingestionResult.eventsAdded > 0
+                      || ingestionResult.eventsRemoved > 0,
+                    userId: currentSource.userId,
+                  };
+                } finally {
+                  /* A source that never submitted must not strand its weight. */
+                  reservation.release();
+                }
               }, () => true),
             );
             if (!result) {
@@ -1485,7 +1573,7 @@ const ingestIcsSources = async (): Promise<IngestionBatchResult> => {
       SOURCE_TIMEOUT_MS);
     }),
 icsSources.map((source) => source.userId),
-    { groupConcurrency: SOURCE_CONCURRENCY, taskConcurrency: USER_CALENDAR_CONCURRENCY },
+    { groupConcurrency: ICS_PARSE_CONCURRENCY, taskConcurrency: USER_CALENDAR_CONCURRENCY },
   );
 
   return summariseIngestionSettlements(

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -11,6 +11,7 @@ import {
   createSerialFlushWorker,
   createHostRateLimiter,
   createOutlookAccountSemaphore,
+  isCalDAVProvider,
   ensureValidToken,
   isTimeoutError,
   buildCalendarBackoffState,
@@ -58,13 +59,18 @@ import { and, arrayContains, count, desc, eq, inArray, isNull, ne, or, sql } fro
 import { withCronWideEvent } from "@/utils/with-wide-event";
 import { context, widelog } from "@/utils/logging";
 import { database, flushDatabase, refreshLockRedis, refreshLockStore } from "@/context";
+import { registerFlushDrain } from "@/utils/flush-drains";
 import env from "@/env";
 import { safeFetchOptions } from "@/utils/safe-fetch-options";
 import {
   resolveMissingCalendarFailure,
   shouldTreatAsProviderAuthFailure,
 } from "@/utils/provider-ingest-failure";
-import { hasErrorFlag, requiresReauthentication } from "@/utils/error-flags";
+import {
+  hasErrorFlag,
+  isIngestInfrastructureError,
+  requiresReauthentication,
+} from "@/utils/error-flags";
 import { resolveOAuthIngestionState } from "@/utils/oauth-ingestion-state";
 import { withAbortTimeout } from "@/utils/with-abort-timeout";
 import { createSyncLock } from "@keeper.sh/sync";
@@ -75,11 +81,23 @@ import { WEIGHT_BUDGET, estimateIngestWeight } from "@/utils/ingest-weight";
 
 const SOURCE_TIMEOUT_MS = INGEST_SOURCE_TIMEOUT_MS;
 const SOURCE_TIMEOUT_DATABASE_GRACE_MS = 5000;
+
 /*
- * The real bounds are the weighted flush budget, the per-family provider
- * limiters, and USER_CALENDAR_CONCURRENCY, so no global group throttle remains.
+ * Bound on how long a flush transaction may wait for its calendar's advisory
+ * lock while holding the single serial writer slot. The same (namespace,
+ * calendarId) lock is held minutes-scale by sync-user write-back and the API
+ * caldav persist, so a contended calendar must fail ITS flush quickly instead
+ * of parking every queued flush behind it until their deadlines expire.
  */
-const UNBOUNDED_USER_GROUPS = 1000;
+const ADVISORY_LOCK_WAIT_BOUND_MS = 5000;
+/*
+ * Sized to the shared cron pool (DATABASE_POOL_MAX 25 in deploy/compose.yaml):
+ * every launched source performs pooled reads before the weighted reserve() can
+ * park it, so this is the only bound on that pre-reserve read herd. Groups times
+ * USER_CALENDAR_CONCURRENCY must stay within the pool, leaving headroom for the
+ * other cron jobs sharing `database`.
+ */
+const USER_GROUP_CONCURRENCY = 12;
 /*
  * A per-pass budget against Graph's documented MailboxConcurrency of four, not a
  * hard ceiling: webhook-driven syncs in the worker hit the same mailbox
@@ -105,7 +123,18 @@ const instrumentedLockRedis = {
     measureRedisCommand(() => refreshLockRedis.get(key)),
 };
 
-const sourceIngestLock = createSyncLock(instrumentedLockRedis);
+/*
+ * Cron passes are serial (cronbake re-arms only after a pass completes), but a
+ * calendar's ingest can still be in flight when the next pass reaches it: a
+ * timeout-abandoned run keeps executing after withAbortTimeout frees its
+ * scheduler slot, and webhook-driven syncs contend for the same lock. That
+ * duplicate is a routine identical run, not a mapping mutation: it must acquire
+ * as "background" so IS_CURRENT stays true for the in-flight holder and its
+ * completed fetch persists. With the default "preempting" class every such
+ * overlap discarded the holder's finished work, and a source slower than its
+ * deadline never recorded its first ingest.
+ */
+const sourceIngestLock = createSyncLock(instrumentedLockRedis, "background");
 
 /*
  * The ioredis set overloads type expiry/condition tokens positionally, so the
@@ -350,6 +379,12 @@ const ingestFlushWriter = createSerialFlushWorker(
   { budget: WEIGHT_BUDGET, capacity: FLUSH_QUEUE_CAPACITY },
 );
 
+/*
+ * Shutdown must drain this writer before flushDatabase closes, or queued and
+ * in-flight flushes are stranded with their budget still reserved.
+ */
+registerFlushDrain(() => ingestFlushWriter.close());
+
 type IngestFlushReservation = FlushReservation<() => Promise<IngestionResult>, IngestionResult>;
 
 /*
@@ -408,7 +443,20 @@ const createIngestionPersistenceTransaction = (
       ${String(initialRemainingMs + SOURCE_TIMEOUT_DATABASE_GRACE_MS)},
       true
     )`);
-    await setRemainingStatementTimeout();
+    /*
+     * The advisory-lock wait runs under a small constant statement_timeout,
+     * never the source's full remaining deadline: the lock can be held
+     * minutes-scale elsewhere, and this transaction occupies the single
+     * serial writer slot while it waits.
+     */
+    const boundedLockWaitMs = Math.max(
+      1,
+      Math.min(ADVISORY_LOCK_WAIT_BOUND_MS, Math.ceil(deadlineAt - Date.now())),
+    );
+    signal.throwIfAborted();
+    await transaction.execute(
+      sql`select set_config('statement_timeout', ${String(boundedLockWaitMs)}, true)`,
+    );
     const advisoryLockRequestedAt = performance.now();
     try {
       await transaction.execute(
@@ -418,6 +466,8 @@ const createIngestionPersistenceTransaction = (
       ledger.advisoryLockMs += performance.now() - advisoryLockRequestedAt;
     }
     signal.throwIfAborted();
+    /* Restore the deadline-derived timeout for the persistence work itself. */
+    await setRemainingStatementTimeout();
 
     const result = await work({
       readExistingEvents: async () => {
@@ -630,7 +680,8 @@ const resolveRateLimiter = (
     );
   }
 
-  if (provider === "caldav") {
+  /* CalDAV sources may be stored as 'caldav', 'fastmail', or 'icloud'. */
+  if (isCalDAVProvider(provider)) {
     const host = resolveTargetHost(source.serverUrl ?? null);
     if (!host) {
       return;
@@ -1183,7 +1234,16 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
                 } finally {
                   /* A source that never submitted must not strand its weight. */
                   reservation.release();
-                  await rateLimiter?.dispose?.();
+                  /*
+                   * The lease TTL already reclaims the slot, so a failed release
+                   * must never clobber the ingest result with a rejection.
+                   */
+                  await rateLimiter?.dispose?.().catch((error: unknown) => {
+                    widelog.errorFields(error, {
+                      slug: "rate-limiter-dispose-failed",
+                      retriable: true,
+                    });
+                  });
                 }
               }, shouldApplyOAuthIngestBackoff),
             );
@@ -1232,7 +1292,7 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
       SOURCE_TIMEOUT_MS);
     }),
 oauthSources.map((source) => source.userId),
-    { groupConcurrency: UNBOUNDED_USER_GROUPS, taskConcurrency: USER_CALENDAR_CONCURRENCY },
+    { groupConcurrency: USER_GROUP_CONCURRENCY, taskConcurrency: USER_CALENDAR_CONCURRENCY },
   );
 
   return summariseIngestionSettlements(
@@ -1330,6 +1390,10 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
                   return createSkippedIngestionResult(source.userId);
                 }
                 const ranges = await getRequiredSourceRanges(source.calendarId);
+                const rateLimiter = resolveRateLimiter(currentSource.provider, {
+                  serverUrl: currentSource.serverUrl,
+                  userId: currentSource.userId,
+                });
                 const fetcher = createCalDAVSourceFetcher({
                   calendarUrl: currentSource.calendarUrl ?? currentSource.serverUrl,
                   serverUrl: currentSource.serverUrl,
@@ -1350,6 +1414,7 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
                   const ingestionResult = await ingestSource({
                     calendarId: source.calendarId,
                     fetchEvents: async () => {
+                      await rateLimiter?.acquire(1, signal);
                       const fetchResult = await fetcher.fetchEvents();
                       recordSkippedResources(
                         fetchResult.skippedResourceCount ?? 0,
@@ -1382,7 +1447,9 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
                   /* A source that never submitted must not strand its weight. */
                   reservation.release();
                 }
-              }, (error) => !shouldTreatAsProviderAuthFailure(error)),
+              }, (error) =>
+                !shouldTreatAsProviderAuthFailure(error)
+                && !isIngestInfrastructureError(error)),
             );
             if (!result) {
               widelog.set("outcome", "skipped");
@@ -1423,7 +1490,7 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
       SOURCE_TIMEOUT_MS);
     }),
 caldavSources.map((source) => source.userId),
-    { groupConcurrency: UNBOUNDED_USER_GROUPS, taskConcurrency: USER_CALENDAR_CONCURRENCY },
+    { groupConcurrency: USER_GROUP_CONCURRENCY, taskConcurrency: USER_CALENDAR_CONCURRENCY },
   );
 
   return summariseIngestionSettlements(
@@ -1497,6 +1564,10 @@ const ingestIcsSources = async (): Promise<IngestionBatchResult> => {
                   return createSkippedIngestionResult(source.userId);
                 }
                 const ranges = await getRequiredSourceRanges(source.calendarId);
+                const rateLimiter = resolveRateLimiter("ical", {
+                  url: currentSource.url,
+                  userId: currentSource.userId,
+                });
                 const fetcher = createIcsSourceFetcher({
                   calendarId: source.calendarId,
                   url: currentSource.url,
@@ -1515,14 +1586,16 @@ const ingestIcsSources = async (): Promise<IngestionBatchResult> => {
                 try {
                   const ingestionResult = await ingestSource({
                     calendarId: source.calendarId,
-                    fetchEvents: () =>
-                      fetcher.fetchEvents({
+                    fetchEvents: async () => {
+                      await rateLimiter?.acquire(1, signal);
+                      return await fetcher.fetchEvents({
                         interpretEvents: (events, fetchContext) =>
                           interpretFullDayTimedEventsAsAllDay(events, {
                             calendarTimeZone: fetchContext.calendarTimeZone,
                             enabled: currentSource.treatFullDayTimedEventsAsAllDay,
                           }),
-                      }),
+                      });
+                    },
                     isCurrent,
                     withPersistenceTransaction: createIngestionPersistenceTransaction(
                       source.calendarId,
@@ -1545,7 +1618,7 @@ const ingestIcsSources = async (): Promise<IngestionBatchResult> => {
                   /* A source that never submitted must not strand its weight. */
                   reservation.release();
                 }
-              }, () => true),
+              }, (error) => !isIngestInfrastructureError(error)),
             );
             if (!result) {
               widelog.set("outcome", "skipped");

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -642,6 +642,19 @@ interface IngestRateLimiter extends RedisRateLimiter {
   dispose?: () => Promise<void>;
 }
 
+const releaseOnceAcquired = async (
+  semaphore: OutlookAccountSemaphore,
+  lease: Promise<SemaphoreLease>,
+): Promise<void> => {
+  const acquired = await lease.then(
+    (held: SemaphoreLease) => held,
+    () => null,
+  );
+  if (acquired) {
+    await semaphore.release(acquired);
+  }
+};
+
 const createSemaphoreRateLimiterAdapter = (
   semaphore: OutlookAccountSemaphore,
 ): IngestRateLimiter => {
@@ -653,16 +666,14 @@ const createSemaphoreRateLimiterAdapter = (
       }
       await lease;
     },
+    /* A deadline can fire mid-acquire, so the lease is awaited here or its slot waits out the TTL. */
     dispose: async (): Promise<void> => {
       if (!lease) {
         return;
       }
-      /* Acquire() awaits this same promise, so a rejected lease already surfaced there. */
-      const held = await lease.catch(() => null);
+      const pending = lease;
       lease = null;
-      if (held) {
-        await semaphore.release(held);
-      }
+      await releaseOnceAcquired(semaphore, pending);
     },
   };
 };

--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -58,8 +58,13 @@ import {
 import { and, arrayContains, count, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
 import { withCronWideEvent } from "@/utils/with-wide-event";
 import { context, widelog } from "@/utils/logging";
-import { database, flushDatabase, refreshLockRedis, refreshLockStore } from "@/context";
-import { registerFlushDrain } from "@/utils/flush-drains";
+import {
+  database,
+  flushDatabase,
+  flushDrainRegistry,
+  refreshLockRedis,
+  refreshLockStore,
+} from "@/context";
 import env from "@/env";
 import { safeFetchOptions } from "@/utils/safe-fetch-options";
 import {
@@ -386,8 +391,7 @@ const ingestFlushWriter = createSerialFlushWorker(
   { budget: WEIGHT_BUDGET, capacity: FLUSH_QUEUE_CAPACITY },
 );
 
-/* Shutdown must drain this writer before flushDatabase closes, or flushes strand their budget. */
-registerFlushDrain(() => ingestFlushWriter.close());
+flushDrainRegistry.register(() => ingestFlushWriter.close());
 
 type IngestFlushReservation = FlushReservation<() => Promise<IngestionResult>, IngestionResult>;
 
@@ -653,6 +657,7 @@ const createSemaphoreRateLimiterAdapter = (
       if (!lease) {
         return;
       }
+      /* Acquire() awaits this same promise, so a rejected lease already surfaced there. */
       const held = await lease.catch(() => null);
       lease = null;
       if (held) {
@@ -1078,12 +1083,6 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
         ...buildOAuthSourceIdFilter(calendarIds),
       ),
     )
-  /*
-   * Null ingestWindowRecordedAt means exactly "never ingested": it is written by
-   * the first successful ingest of every family. The plan is coalesced because most
-   * free users have no subscription row at all, and a bare NULL would sort ahead of
-   * 'pro' under DESC.
-   */
     .orderBy(
       desc(isNull(calendarsTable.ingestWindowRecordedAt)),
       desc(sql`coalesce(${userSubscriptionsTable.plan}, 'free') = 'pro'`),
@@ -1230,9 +1229,7 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
                     userId: currentSource.userId,
                   };
                 } finally {
-                  /* A source that never submitted must not strand its weight. */
                   reservation.release();
-                  /* The lease TTL already reclaims the slot, so a failed release must not reject. */
                   await rateLimiter?.dispose?.().catch((error: unknown) => {
                     widelog.errorFields(error, {
                       slug: "rate-limiter-dispose-failed",
@@ -1391,10 +1388,6 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
                 });
                 const fetcher = createCalDAVSourceFetcher({
                   calendarUrl: currentSource.calendarUrl ?? currentSource.serverUrl,
-                  /*
-                   * The host budget meters requests per minute and a CalDAV fetch issues
-                   * discovery plus one REPORT per batch, so every origin request draws a permit.
-                   */
                   onBeforeRequest: async () => {
                     await rateLimiter?.acquire(1, signal);
                   },
@@ -1445,7 +1438,6 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
                     userId: currentSource.userId,
                   };
                 } finally {
-                  /* A source that never submitted must not strand its weight. */
                   reservation.release();
                 }
               }, (error) =>
@@ -1616,7 +1608,6 @@ const ingestIcsSources = async (): Promise<IngestionBatchResult> => {
                     userId: currentSource.userId,
                   };
                 } finally {
-                  /* A source that never submitted must not strand its weight. */
                   reservation.release();
                 }
               }, (error) => !isIngestInfrastructureError(error)),

--- a/services/cron/src/utils/enqueue-destination-syncs.ts
+++ b/services/cron/src/utils/enqueue-destination-syncs.ts
@@ -17,12 +17,9 @@ import {
 const REDIS_COMMAND_TIMEOUT_MS = 10_000;
 
 /*
- * The whole enqueue must settle within this bound: the ingest-sources cron
- * callback awaits it before completing, and cronbake re-arms the serial pass
- * only after the callback settles. BullMQ holds every command until ioredis
- * emits "ready", so a half-open Redis socket would otherwise park the pass
- * forever — commandTimeout alone never fires for a connection that is never
- * ready.
+ * Bounds the serial pass, which cronbake re-arms only after the callback settles. BullMQ
+ * holds every command until ioredis emits "ready", so a half-open socket would park the pass
+ * forever: commandTimeout never fires for a connection that is never ready.
  */
 const ENQUEUE_TIMEOUT_MS = 10_000;
 
@@ -86,14 +83,10 @@ const enqueueDestinationSyncsForUsers = async (
     );
   } finally {
     /*
-     * A timed-out run may still hold a queue on a connection that never became
-     * ready. BullMQ's disconnect() awaits the initializing promise first, which
-     * only settles on ioredis "ready"/"error"/"end", so against a black-hole
-     * socket it parks forever and the abandoned client keeps reconnecting.
-     * close() takes the status=="initializing" branch instead, disconnecting
-     * the raw client synchronously; disconnect() still covers the case where
-     * the connection did come up. Both are fire-and-forget, and each is a
-     * no-op in the other's scenario: nothing here may block the serial pass.
+     * BullMQ's disconnect() awaits an initializing promise that only settles on ioredis
+     * "ready"/"error"/"end", so against a black-hole socket it parks forever. close() takes
+     * the status=="initializing" branch and disconnects synchronously; disconnect() still
+     * covers a connection that did come up. Each is a no-op in the other's scenario.
      */
     for (const queue of openQueues) {
       queue.close().catch(() => null);

--- a/services/cron/src/utils/enqueue-destination-syncs.ts
+++ b/services/cron/src/utils/enqueue-destination-syncs.ts
@@ -6,6 +6,7 @@ import {
 } from "@keeper.sh/database/schema";
 import { and, arrayContains, eq, inArray } from "drizzle-orm";
 import env from "@/env";
+import { withAbortTimeout } from "@/utils/with-abort-timeout";
 
 import {
   runEnqueueDestinationSyncsForUsers,
@@ -13,13 +14,25 @@ import {
   type EnqueueDestinationSyncDependencies,
 } from "./enqueue-destination-syncs-core";
 
+const REDIS_COMMAND_TIMEOUT_MS = 10_000;
+
+/*
+ * The whole enqueue must settle within this bound: the ingest-sources cron
+ * callback awaits it before completing, and cronbake re-arms the serial pass
+ * only after the callback settles. BullMQ holds every command until ioredis
+ * emits "ready", so a half-open Redis socket would otherwise park the pass
+ * forever — commandTimeout alone never fires for a connection that is never
+ * ready.
+ */
+const ENQUEUE_TIMEOUT_MS = 10_000;
 
 const enqueueDestinationSyncsForUsers = async (
   candidateUserIds: Iterable<string>,
   trigger: PushSyncTrigger = "cron",
 ): Promise<number> => {
   const { database, premiumService } = await import("@/context");
-  return runEnqueueDestinationSyncsForUsers(candidateUserIds, {
+  const openQueues = new Set<ReturnType<typeof createPushSyncQueue>>();
+  const dependencies: EnqueueDestinationSyncDependencies = {
     acknowledgePendingRequests: async (requests) => {
       if (requests.length === 0) {
         return;
@@ -35,7 +48,15 @@ const enqueueDestinationSyncsForUsers = async (
         }
       });
     },
-    createQueue: () => createPushSyncQueue({ url: env.REDIS_URL, maxRetriesPerRequest: null }),
+    createQueue: () => {
+      const queue = createPushSyncQueue({
+        commandTimeout: REDIS_COMMAND_TIMEOUT_MS,
+        maxRetriesPerRequest: null,
+        url: env.REDIS_URL,
+      });
+      openQueues.add(queue);
+      return queue;
+    },
     enabled: env.WORKER_JOB_QUEUE_ENABLED !== false,
     generateCorrelationId: () => crypto.randomUUID(),
     getDestinations: (userIds) => database
@@ -57,7 +78,22 @@ const enqueueDestinationSyncsForUsers = async (
       })
       .from(userSyncRequestsTable),
     resolvePlan: (userId) => premiumService.getUserPlan(userId),
-  }, trigger);
+  };
+  try {
+    return await withAbortTimeout(
+      () => runEnqueueDestinationSyncsForUsers(candidateUserIds, dependencies, trigger),
+      ENQUEUE_TIMEOUT_MS,
+    );
+  } finally {
+    /*
+     * A timed-out run may still hold a queue whose close() itself hangs on the
+     * dead connection; force-disconnect so ioredis stops reconnecting forever.
+     * Fire-and-forget: nothing after the deadline may block the serial pass.
+     */
+    for (const queue of openQueues) {
+      queue.disconnect().catch(() => null);
+    }
+  }
 };
 
 export {

--- a/services/cron/src/utils/enqueue-destination-syncs.ts
+++ b/services/cron/src/utils/enqueue-destination-syncs.ts
@@ -86,11 +86,17 @@ const enqueueDestinationSyncsForUsers = async (
     );
   } finally {
     /*
-     * A timed-out run may still hold a queue whose close() itself hangs on the
-     * dead connection; force-disconnect so ioredis stops reconnecting forever.
-     * Fire-and-forget: nothing after the deadline may block the serial pass.
+     * A timed-out run may still hold a queue on a connection that never became
+     * ready. BullMQ's disconnect() awaits the initializing promise first, which
+     * only settles on ioredis "ready"/"error"/"end", so against a black-hole
+     * socket it parks forever and the abandoned client keeps reconnecting.
+     * close() takes the status=="initializing" branch instead, disconnecting
+     * the raw client synchronously; disconnect() still covers the case where
+     * the connection did come up. Both are fire-and-forget, and each is a
+     * no-op in the other's scenario: nothing here may block the serial pass.
      */
     for (const queue of openQueues) {
+      queue.close().catch(() => null);
       queue.disconnect().catch(() => null);
     }
   }

--- a/services/cron/src/utils/enqueue-destination-syncs.ts
+++ b/services/cron/src/utils/enqueue-destination-syncs.ts
@@ -6,6 +6,7 @@ import {
 } from "@keeper.sh/database/schema";
 import { and, arrayContains, eq, inArray } from "drizzle-orm";
 import env from "@/env";
+import { widelog } from "@/utils/logging";
 import { withAbortTimeout } from "@/utils/with-abort-timeout";
 
 import {
@@ -16,12 +17,14 @@ import {
 
 const REDIS_COMMAND_TIMEOUT_MS = 10_000;
 
-/*
- * Bounds the serial pass, which cronbake re-arms only after the callback settles. BullMQ
- * holds every command until ioredis emits "ready", so a half-open socket would park the pass
- * forever: commandTimeout never fires for a connection that is never ready.
- */
 const ENQUEUE_TIMEOUT_MS = 10_000;
+
+const logQueueTeardownFailure = (error: unknown): void => {
+  widelog.errorFields(error, {
+    slug: "push-sync-queue-teardown-failed",
+    retriable: false,
+  });
+};
 
 const enqueueDestinationSyncsForUsers = async (
   candidateUserIds: Iterable<string>,
@@ -89,8 +92,8 @@ const enqueueDestinationSyncsForUsers = async (
      * covers a connection that did come up. Each is a no-op in the other's scenario.
      */
     for (const queue of openQueues) {
-      queue.close().catch(() => null);
-      queue.disconnect().catch(() => null);
+      queue.close().catch(logQueueTeardownFailure);
+      queue.disconnect().catch(logQueueTeardownFailure);
     }
   }
 };

--- a/services/cron/src/utils/error-flags.ts
+++ b/services/cron/src/utils/error-flags.ts
@@ -13,26 +13,11 @@ const hasErrorFlag = (error: unknown, key: string): boolean =>
 
 const REAUTHENTICATION_FLAGS = ["authRequired", "oauthReauthRequired"];
 
-/*
- * Shutdown disconnects refreshLockRedis while the ingest pass is still running, so a
- * mid-flight round trip fails with this — keeper closed its own client, the provider was
- * never contacted. ioredis exposes no error class for it, only a bare Error with this message.
- */
 const REDIS_CONNECTION_CLOSED_MESSAGE = "Connection is closed.";
 
 const isRedisTeardownError = (error: unknown): boolean =>
   error instanceof Error && error.message === REDIS_CONNECTION_CLOSED_MESSAGE;
 
-/*
- * These never contacted the provider, so they must not accrue provider backoff. A Postgres
- * statement timeout (57014) belongs here because every statement_timeout keeper sets bounds
- * its own database — no provider is on the other side of that cancellation.
- *
- * A source-deadline OperationTimeoutError is NOT infrastructure by itself: withAbortTimeout
- * raises the same class when a slow provider overruns the deadline, which must accrue
- * backoff. Only a timeout observed while still parked on keeper's own pacing, ahead of the
- * request it gates, carries a park flag and stays exempt.
- */
 const SHUTDOWN_CLOSE_CONNECTION_SLUGS = new Set([
   "db-connection-terminated",
   "db-connection-unavailable",

--- a/services/cron/src/utils/error-flags.ts
+++ b/services/cron/src/utils/error-flags.ts
@@ -4,7 +4,7 @@ import {
   isSerialFlushRunDeadlineError,
   isSerialFlushWorkerClosedError,
 } from "@keeper.sh/calendar";
-import { resolveDatabaseErrorClassification } from "@keeper.sh/database";
+import { hasBoundedDatabaseCloseBegun, resolveDatabaseErrorClassification } from "@keeper.sh/database";
 
 const hasErrorFlag = (error: unknown, key: string): boolean =>
   error instanceof Error
@@ -47,8 +47,33 @@ const isRedisTeardownError = (error: unknown): boolean =>
  * limiter, or an account concurrency semaphore — carries a park flag and
  * stays exempt.
  */
+const SHUTDOWN_CLOSE_CONNECTION_SLUGS = new Set([
+  "db-connection-terminated",
+  "db-connection-unavailable",
+]);
+
+/*
+ * Connection-class errors are infrastructure only once shutdown's bounded
+ * close has begun, because from that point keeper is killing its own pool out
+ * from under in-flight and queued flushes. During normal operation the same
+ * slugs are genuine evidence of a failing provider pass and must keep
+ * accruing backoff (see tests/jobs/caldav-pool-backoff-convergence.test.ts),
+ * so this must never become a blanket slug exemption.
+ */
+const isShutdownForceCloseError = (error: unknown): boolean => {
+  if (!hasBoundedDatabaseCloseBegun()) {
+    return false;
+  }
+  const classification = resolveDatabaseErrorClassification(error);
+  if (classification === null) {
+    return false;
+  }
+  return SHUTDOWN_CLOSE_CONNECTION_SLUGS.has(classification.slug);
+};
+
 const isIngestInfrastructureError = (error: unknown): boolean =>
   isSerialFlushReserveAbortError(error)
+  || isShutdownForceCloseError(error)
   || isIngestPacingParkAbortError(error)
   || isSerialFlushWorkerClosedError(error)
   || isSerialFlushRunDeadlineError(error)

--- a/services/cron/src/utils/error-flags.ts
+++ b/services/cron/src/utils/error-flags.ts
@@ -1,3 +1,6 @@
+import { isSerialFlushWorkerClosedError } from "@keeper.sh/calendar";
+import { OperationTimeoutError } from "@/utils/with-abort-timeout";
+
 const hasErrorFlag = (error: unknown, key: string): boolean =>
   error instanceof Error
   && key in error
@@ -5,7 +8,23 @@ const hasErrorFlag = (error: unknown, key: string): boolean =>
 
 const REAUTHENTICATION_FLAGS = ["authRequired", "oauthReauthRequired"];
 
-const requiresReauthentication = (error: unknown): boolean =>
-  REAUTHENTICATION_FLAGS.some((flag) => hasErrorFlag(error, flag));
+/*
+ * Errors produced by ingest infrastructure — a reserve parked on the shared
+ * flush budget until the source deadline fired, or the flush writer rejecting
+ * parked reservers at shutdown — never contacted the calendar's provider, so
+ * they must not be treated as provider failures.
+ */
+const isIngestInfrastructureError = (error: unknown): boolean =>
+  error instanceof OperationTimeoutError || isSerialFlushWorkerClosedError(error);
 
-export { hasErrorFlag, requiresReauthentication };
+/*
+ * Every call site uses this predicate as an exemption gate for
+ * provider-failure handling (ingest backoff, missing-calendar
+ * classification). Infrastructure errors carry the same exemption as
+ * reauthentication errors: neither is evidence the provider misbehaved.
+ */
+const requiresReauthentication = (error: unknown): boolean =>
+  REAUTHENTICATION_FLAGS.some((flag) => hasErrorFlag(error, flag))
+  || isIngestInfrastructureError(error);
+
+export { hasErrorFlag, isIngestInfrastructureError, requiresReauthentication };

--- a/services/cron/src/utils/error-flags.ts
+++ b/services/cron/src/utils/error-flags.ts
@@ -1,5 +1,9 @@
-import { isSerialFlushRunDeadlineError, isSerialFlushWorkerClosedError } from "@keeper.sh/calendar";
-import { OperationTimeoutError } from "@/utils/with-abort-timeout";
+import {
+  isIngestPacingParkAbortError,
+  isSerialFlushReserveAbortError,
+  isSerialFlushRunDeadlineError,
+  isSerialFlushWorkerClosedError,
+} from "@keeper.sh/calendar";
 import { resolveDatabaseErrorClassification } from "@keeper.sh/database";
 
 const hasErrorFlag = (error: unknown, key: string): boolean =>
@@ -8,6 +12,19 @@ const hasErrorFlag = (error: unknown, key: string): boolean =>
   && (error as Error & Record<string, unknown>)[key] === true;
 
 const REAUTHENTICATION_FLAGS = ["authRequired", "oauthReauthRequired"];
+
+/*
+ * The exact rejection ioredis raises on every command once disconnect() has
+ * torn the client down. Shutdown (index.ts) disconnects refreshLockRedis
+ * while the in-flight ingest pass is still running, so a mid-flight task's
+ * next lock/limiter/lease round trip fails with this error — keeper closed
+ * its own client; the provider was never contacted. ioredis exposes no error
+ * class for this rejection, only a bare Error with this message.
+ */
+const REDIS_CONNECTION_CLOSED_MESSAGE = "Connection is closed.";
+
+const isRedisTeardownError = (error: unknown): boolean =>
+  error instanceof Error && error.message === REDIS_CONNECTION_CLOSED_MESSAGE;
 
 /*
  * Errors produced by ingest infrastructure — a reserve parked on the shared
@@ -20,11 +37,22 @@ const REAUTHENTICATION_FLAGS = ["authRequired", "oauthReauthRequired"];
  * persist) holds the same (namespace, calendarId) lock past the 5s bound,
  * and every statement_timeout keeper sets bounds its own database — a
  * provider is never on the other side of that cancellation.
+ *
+ * A source-deadline OperationTimeoutError is NOT infrastructure by itself:
+ * withAbortTimeout raises the same class when a hung or persistently slow
+ * provider overruns the 120s deadline, and that timeout must accrue ingest
+ * backoff. Only a timeout observed while still parked on keeper's own
+ * pacing, ahead of the provider request it gates — the flush worker's
+ * reserve (reserve-before-fetch), the shared per-host or per-user rate
+ * limiter, or an account concurrency semaphore — carries a park flag and
+ * stays exempt.
  */
 const isIngestInfrastructureError = (error: unknown): boolean =>
-  error instanceof OperationTimeoutError
+  isSerialFlushReserveAbortError(error)
+  || isIngestPacingParkAbortError(error)
   || isSerialFlushWorkerClosedError(error)
   || isSerialFlushRunDeadlineError(error)
+  || isRedisTeardownError(error)
   || resolveDatabaseErrorClassification(error)?.slug === "db-statement-timeout";
 
 /*

--- a/services/cron/src/utils/error-flags.ts
+++ b/services/cron/src/utils/error-flags.ts
@@ -1,5 +1,6 @@
-import { isSerialFlushWorkerClosedError } from "@keeper.sh/calendar";
+import { isSerialFlushRunDeadlineError, isSerialFlushWorkerClosedError } from "@keeper.sh/calendar";
 import { OperationTimeoutError } from "@/utils/with-abort-timeout";
+import { resolveDatabaseErrorClassification } from "@keeper.sh/database";
 
 const hasErrorFlag = (error: unknown, key: string): boolean =>
   error instanceof Error
@@ -10,12 +11,21 @@ const REAUTHENTICATION_FLAGS = ["authRequired", "oauthReauthRequired"];
 
 /*
  * Errors produced by ingest infrastructure — a reserve parked on the shared
- * flush budget until the source deadline fired, or the flush writer rejecting
- * parked reservers at shutdown — never contacted the calendar's provider, so
- * they must not be treated as provider failures.
+ * flush budget until the source deadline fired, the flush writer rejecting
+ * parked reservers at shutdown, or the pump's client-side run deadline firing
+ * on a wedged flush — never contacted the calendar's provider, so they must
+ * not be treated as provider failures. A Postgres statement timeout (57014)
+ * belongs here too: the bounded advisory-lock wait inside the flush
+ * transaction fires it when keeper's own write-back (sync-user, API caldav
+ * persist) holds the same (namespace, calendarId) lock past the 5s bound,
+ * and every statement_timeout keeper sets bounds its own database — a
+ * provider is never on the other side of that cancellation.
  */
 const isIngestInfrastructureError = (error: unknown): boolean =>
-  error instanceof OperationTimeoutError || isSerialFlushWorkerClosedError(error);
+  error instanceof OperationTimeoutError
+  || isSerialFlushWorkerClosedError(error)
+  || isSerialFlushRunDeadlineError(error)
+  || resolveDatabaseErrorClassification(error)?.slug === "db-statement-timeout";
 
 /*
  * Every call site uses this predicate as an exemption gate for

--- a/services/cron/src/utils/error-flags.ts
+++ b/services/cron/src/utils/error-flags.ts
@@ -14,12 +14,9 @@ const hasErrorFlag = (error: unknown, key: string): boolean =>
 const REAUTHENTICATION_FLAGS = ["authRequired", "oauthReauthRequired"];
 
 /*
- * The exact rejection ioredis raises on every command once disconnect() has
- * torn the client down. Shutdown (index.ts) disconnects refreshLockRedis
- * while the in-flight ingest pass is still running, so a mid-flight task's
- * next lock/limiter/lease round trip fails with this error — keeper closed
- * its own client; the provider was never contacted. ioredis exposes no error
- * class for this rejection, only a bare Error with this message.
+ * Shutdown disconnects refreshLockRedis while the ingest pass is still running, so a
+ * mid-flight round trip fails with this — keeper closed its own client, the provider was
+ * never contacted. ioredis exposes no error class for it, only a bare Error with this message.
  */
 const REDIS_CONNECTION_CLOSED_MESSAGE = "Connection is closed.";
 
@@ -27,25 +24,14 @@ const isRedisTeardownError = (error: unknown): boolean =>
   error instanceof Error && error.message === REDIS_CONNECTION_CLOSED_MESSAGE;
 
 /*
- * Errors produced by ingest infrastructure — a reserve parked on the shared
- * flush budget until the source deadline fired, the flush writer rejecting
- * parked reservers at shutdown, or the pump's client-side run deadline firing
- * on a wedged flush — never contacted the calendar's provider, so they must
- * not be treated as provider failures. A Postgres statement timeout (57014)
- * belongs here too: the bounded advisory-lock wait inside the flush
- * transaction fires it when keeper's own write-back (sync-user, API caldav
- * persist) holds the same (namespace, calendarId) lock past the 5s bound,
- * and every statement_timeout keeper sets bounds its own database — a
- * provider is never on the other side of that cancellation.
+ * These never contacted the provider, so they must not accrue provider backoff. A Postgres
+ * statement timeout (57014) belongs here because every statement_timeout keeper sets bounds
+ * its own database — no provider is on the other side of that cancellation.
  *
- * A source-deadline OperationTimeoutError is NOT infrastructure by itself:
- * withAbortTimeout raises the same class when a hung or persistently slow
- * provider overruns the 120s deadline, and that timeout must accrue ingest
- * backoff. Only a timeout observed while still parked on keeper's own
- * pacing, ahead of the provider request it gates — the flush worker's
- * reserve (reserve-before-fetch), the shared per-host or per-user rate
- * limiter, or an account concurrency semaphore — carries a park flag and
- * stays exempt.
+ * A source-deadline OperationTimeoutError is NOT infrastructure by itself: withAbortTimeout
+ * raises the same class when a slow provider overruns the deadline, which must accrue
+ * backoff. Only a timeout observed while still parked on keeper's own pacing, ahead of the
+ * request it gates, carries a park flag and stays exempt.
  */
 const SHUTDOWN_CLOSE_CONNECTION_SLUGS = new Set([
   "db-connection-terminated",
@@ -53,12 +39,9 @@ const SHUTDOWN_CLOSE_CONNECTION_SLUGS = new Set([
 ]);
 
 /*
- * Connection-class errors are infrastructure only once shutdown's bounded
- * close has begun, because from that point keeper is killing its own pool out
- * from under in-flight and queued flushes. During normal operation the same
- * slugs are genuine evidence of a failing provider pass and must keep
- * accruing backoff (see tests/jobs/caldav-pool-backoff-convergence.test.ts),
- * so this must never become a blanket slug exemption.
+ * Connection-class errors count as infrastructure only once shutdown's bounded close has
+ * begun and keeper is killing its own pool. During normal operation the same slugs are
+ * genuine evidence of a failing provider, so this must never become a blanket slug exemption.
  */
 const isShutdownForceCloseError = (error: unknown): boolean => {
   if (!hasBoundedDatabaseCloseBegun()) {
@@ -80,12 +63,6 @@ const isIngestInfrastructureError = (error: unknown): boolean =>
   || isRedisTeardownError(error)
   || resolveDatabaseErrorClassification(error)?.slug === "db-statement-timeout";
 
-/*
- * Every call site uses this predicate as an exemption gate for
- * provider-failure handling (ingest backoff, missing-calendar
- * classification). Infrastructure errors carry the same exemption as
- * reauthentication errors: neither is evidence the provider misbehaved.
- */
 const requiresReauthentication = (error: unknown): boolean =>
   REAUTHENTICATION_FLAGS.some((flag) => hasErrorFlag(error, flag))
   || isIngestInfrastructureError(error);

--- a/services/cron/src/utils/flush-drains.ts
+++ b/services/cron/src/utils/flush-drains.ts
@@ -1,0 +1,20 @@
+/*
+ * Writers parked on the dedicated single-connection flushDatabase register a
+ * drain here so shutdown can close them (letting queued and in-flight flushes
+ * settle) BEFORE that database is closed underneath them. The registry lives
+ * outside context.ts so job modules can register without widening the
+ * context surface.
+ */
+type FlushDrain = () => Promise<void>;
+
+const flushDrains: FlushDrain[] = [];
+
+const registerFlushDrain = (drain: FlushDrain): void => {
+  flushDrains.push(drain);
+};
+
+const drainFlushWriters = async (): Promise<void> => {
+  await Promise.all(flushDrains.map((drain) => drain()));
+};
+
+export { drainFlushWriters, registerFlushDrain };

--- a/services/cron/src/utils/flush-drains.ts
+++ b/services/cron/src/utils/flush-drains.ts
@@ -1,17 +1,21 @@
-/*
- * Writers register here so shutdown drains them BEFORE flushDatabase is closed underneath
- * them. Kept outside context.ts so job modules can register without widening that surface.
- */
 type FlushDrain = () => Promise<void>;
 
-const flushDrains: FlushDrain[] = [];
+interface FlushDrainRegistry {
+  drain: () => Promise<void>;
+  register: (drain: FlushDrain) => void;
+}
 
-const registerFlushDrain = (drain: FlushDrain): void => {
-  flushDrains.push(drain);
+const createFlushDrainRegistry = (): FlushDrainRegistry => {
+  const drains: FlushDrain[] = [];
+  return {
+    drain: async (): Promise<void> => {
+      await Promise.all(drains.map((flushDrain) => flushDrain()));
+    },
+    register: (flushDrain: FlushDrain): void => {
+      drains.push(flushDrain);
+    },
+  };
 };
 
-const drainFlushWriters = async (): Promise<void> => {
-  await Promise.all(flushDrains.map((drain) => drain()));
-};
-
-export { drainFlushWriters, registerFlushDrain };
+export { createFlushDrainRegistry };
+export type { FlushDrain, FlushDrainRegistry };

--- a/services/cron/src/utils/flush-drains.ts
+++ b/services/cron/src/utils/flush-drains.ts
@@ -1,9 +1,6 @@
 /*
- * Writers parked on the dedicated single-connection flushDatabase register a
- * drain here so shutdown can close them (letting queued and in-flight flushes
- * settle) BEFORE that database is closed underneath them. The registry lives
- * outside context.ts so job modules can register without widening the
- * context surface.
+ * Writers register here so shutdown drains them BEFORE flushDatabase is closed underneath
+ * them. Kept outside context.ts so job modules can register without widening that surface.
  */
 type FlushDrain = () => Promise<void>;
 

--- a/services/cron/src/utils/ingest-weight.ts
+++ b/services/cron/src/utils/ingest-weight.ts
@@ -1,16 +1,12 @@
 import { count, eq } from "drizzle-orm";
 import { eventStatesTable } from "@keeper.sh/database/schema";
+import { widelog } from "@/utils/logging";
 
-/*
- * Sized BEFORE the fetch begins, so the estimate comes from the previous ingest's stored
- * count. Payloads vary by two-plus orders of magnitude, so a byte-weight estimate bounds
- * memory where a count-based limit cannot.
- */
 const BYTES_PER_EVENT = 1024;
 const WEIGHT_FLOOR = 16_384;
 const WEIGHT_BUDGET = 64 * 1024 * 1024;
-/* No history to size from; an eighth of the budget self-limits a launch flood to ~8 fetches. */
-const NEVER_INGESTED_WEIGHT = WEIGHT_BUDGET / 8;
+const COLD_START_CONCURRENT_FETCH_ALLOWANCE = 8;
+const NEVER_INGESTED_WEIGHT = WEIGHT_BUDGET / COLD_START_CONCURRENT_FETCH_ALLOWANCE;
 
 interface IngestWeightDependencies {
   countStoredEvents: (calendarId: string) => Promise<number>;
@@ -30,7 +26,11 @@ const estimateIngestWeight = async (
       Math.max(storedCount * BYTES_PER_EVENT, WEIGHT_FLOOR),
       WEIGHT_BUDGET,
     );
-  } catch {
+  } catch (error) {
+    widelog.errorFields(error, {
+      slug: "ingest-weight-estimate-failed",
+      retriable: true,
+    });
     return NEVER_INGESTED_WEIGHT;
   }
 };

--- a/services/cron/src/utils/ingest-weight.ts
+++ b/services/cron/src/utils/ingest-weight.ts
@@ -1,0 +1,77 @@
+import { count, eq } from "drizzle-orm";
+import { eventStatesTable } from "@keeper.sh/database/schema";
+
+/*
+ * Weighted-permit sizing for provider ingests. The permit must be sized
+ * BEFORE the provider fetch begins, so the estimate comes from what we
+ * already know: the stored event count from the previous ingest. Items vary
+ * by two-plus orders of magnitude (a 12-event personal calendar vs a
+ * 3,000-event ICS feed), so a byte-weight estimate bounds memory where a
+ * count-based limit cannot.
+ */
+const BYTES_PER_EVENT = 1024;
+const WEIGHT_FLOOR = 16_384;
+// 64MB budget: 64 * 1024 * 1024 bytes.
+const WEIGHT_BUDGET = 67_108_864;
+/*
+ * A never-ingested calendar has no history to size from. Claiming an eighth
+ * of the budget self-limits a launch flood of unknown-size first ingests to
+ * roughly eight concurrent fetches.
+ */
+const NEVER_INGESTED_WEIGHT = WEIGHT_BUDGET / 8;
+
+interface IngestWeightDependencies {
+  countStoredEvents: (calendarId: string) => Promise<number>;
+}
+
+const estimateIngestWeight = async (
+  dependencies: IngestWeightDependencies,
+  calendarId: string,
+  hasEverIngested: boolean,
+): Promise<number> => {
+  if (!hasEverIngested) {
+    return NEVER_INGESTED_WEIGHT;
+  }
+  try {
+    const storedCount = await dependencies.countStoredEvents(calendarId);
+    return Math.min(
+      Math.max(storedCount * BYTES_PER_EVENT, WEIGHT_FLOOR),
+      WEIGHT_BUDGET,
+    );
+  } catch {
+    // A failed count read must not fail the ingest; size it like an unknown.
+    return NEVER_INGESTED_WEIGHT;
+  }
+};
+
+interface EventStateCountClient {
+  select: (fields: { count: ReturnType<typeof count> }) => {
+    from: (table: typeof eventStatesTable) => {
+      where: (
+        condition: ReturnType<typeof eq>,
+      ) => PromiseLike<{ count: number }[]>;
+    };
+  };
+}
+
+// Reads go against the pooled database, never through the flush writer.
+const countStoredEvents = async (
+  database: EventStateCountClient,
+  calendarId: string,
+): Promise<number> => {
+  const rows = await database
+    .select({ count: count() })
+    .from(eventStatesTable)
+    .where(eq(eventStatesTable.calendarId, calendarId));
+  return rows[0]?.count ?? 0;
+};
+
+export {
+  BYTES_PER_EVENT,
+  WEIGHT_BUDGET,
+  WEIGHT_FLOOR,
+  NEVER_INGESTED_WEIGHT,
+  countStoredEvents,
+  estimateIngestWeight,
+};
+export type { EventStateCountClient, IngestWeightDependencies };

--- a/services/cron/src/utils/ingest-weight.ts
+++ b/services/cron/src/utils/ingest-weight.ts
@@ -2,22 +2,14 @@ import { count, eq } from "drizzle-orm";
 import { eventStatesTable } from "@keeper.sh/database/schema";
 
 /*
- * Weighted-permit sizing for provider ingests. The permit must be sized
- * BEFORE the provider fetch begins, so the estimate comes from what we
- * already know: the stored event count from the previous ingest. Items vary
- * by two-plus orders of magnitude (a 12-event personal calendar vs a
- * 3,000-event ICS feed), so a byte-weight estimate bounds memory where a
- * count-based limit cannot.
+ * Sized BEFORE the fetch begins, so the estimate comes from the previous ingest's stored
+ * count. Payloads vary by two-plus orders of magnitude, so a byte-weight estimate bounds
+ * memory where a count-based limit cannot.
  */
 const BYTES_PER_EVENT = 1024;
 const WEIGHT_FLOOR = 16_384;
-// 64MB budget: 64 * 1024 * 1024 bytes.
-const WEIGHT_BUDGET = 67_108_864;
-/*
- * A never-ingested calendar has no history to size from. Claiming an eighth
- * of the budget self-limits a launch flood of unknown-size first ingests to
- * roughly eight concurrent fetches.
- */
+const WEIGHT_BUDGET = 64 * 1024 * 1024;
+/* No history to size from; an eighth of the budget self-limits a launch flood to ~8 fetches. */
 const NEVER_INGESTED_WEIGHT = WEIGHT_BUDGET / 8;
 
 interface IngestWeightDependencies {
@@ -39,7 +31,6 @@ const estimateIngestWeight = async (
       WEIGHT_BUDGET,
     );
   } catch {
-    // A failed count read must not fail the ingest; size it like an unknown.
     return NEVER_INGESTED_WEIGHT;
   }
 };
@@ -54,7 +45,6 @@ interface EventStateCountClient {
   };
 }
 
-// Reads go against the pooled database, never through the flush writer.
 const countStoredEvents = async (
   database: EventStateCountClient,
   calendarId: string,

--- a/services/cron/src/utils/with-abort-timeout.ts
+++ b/services/cron/src/utils/with-abort-timeout.ts
@@ -5,31 +5,6 @@ class OperationTimeoutError extends Error {
   }
 }
 
-const withAbortTimeout = async <TResult>(
-  operation: (signal: AbortSignal, deadlineAt: number) => Promise<TResult>,
-  timeoutMs: number,
-): Promise<TResult> => {
-  const controller = new AbortController();
-  const timeoutError = new OperationTimeoutError(timeoutMs);
-  const deadlineAt = Date.now() + timeoutMs;
-  const timeout = setTimeout(() => controller.abort(timeoutError), timeoutMs);
-
-  try {
-    const result = await operation(controller.signal, deadlineAt);
-    if (controller.signal.aborted) {
-      throw controller.signal.reason;
-    }
-    return result;
-  } catch (error) {
-    if (controller.signal.aborted) {
-      throw controller.signal.reason;
-    }
-    throw error;
-  } finally {
-    clearTimeout(timeout);
-  }
-};
-
 const raceAbortSignal = <TResult>(
   signal: AbortSignal,
   operation: Promise<TResult>,
@@ -48,6 +23,38 @@ const raceAbortSignal = <TResult>(
 
   return Promise.race([operation, aborted])
     .finally(() => listenerScope.abort());
+};
+
+const withAbortTimeout = async <TResult>(
+  operation: (signal: AbortSignal, deadlineAt: number) => Promise<TResult>,
+  timeoutMs: number,
+): Promise<TResult> => {
+  const controller = new AbortController();
+  const timeoutError = new OperationTimeoutError(timeoutMs);
+  const deadlineAt = Date.now() + timeoutMs;
+  const timeout = setTimeout(() => controller.abort(timeoutError), timeoutMs);
+
+  try {
+    /*
+     * Race the operation against the abort signal so a non-signal-aware hang
+     * still settles at the deadline instead of stranding the scheduler slot.
+     */
+    const result = await raceAbortSignal(
+      controller.signal,
+      operation(controller.signal, deadlineAt),
+    );
+    if (controller.signal.aborted) {
+      throw controller.signal.reason;
+    }
+    return result;
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw controller.signal.reason;
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
 };
 
 export { OperationTimeoutError, raceAbortSignal, withAbortTimeout };

--- a/services/cron/src/utils/with-abort-timeout.ts
+++ b/services/cron/src/utils/with-abort-timeout.ts
@@ -35,10 +35,6 @@ const withAbortTimeout = async <TResult>(
   const timeout = setTimeout(() => controller.abort(timeoutError), timeoutMs);
 
   try {
-    /*
-     * Race the operation against the abort signal so a non-signal-aware hang
-     * still settles at the deadline instead of stranding the scheduler slot.
-     */
     const result = await raceAbortSignal(
       controller.signal,
       operation(controller.signal, deadlineAt),

--- a/services/cron/tests/jobs/caldav-ics-infrastructure-backoff.test.ts
+++ b/services/cron/tests/jobs/caldav-ics-infrastructure-backoff.test.ts
@@ -10,19 +10,14 @@ import { isIngestInfrastructureError } from "../../src/utils/error-flags";
 import { shouldTreatAsProviderAuthFailure } from "../../src/utils/provider-ingest-failure";
 
 /*
- * Flush-budget starvation (an OperationTimeoutError from a reserve parked on
- * the exhausted shared 64MB budget) and writer shutdown never contacted the
- * provider, so no family's backoff gate may punish the calendar with provider
- * exponential backoff. The gates live as inline lambdas in ingest-sources.ts;
- * they are mirrored here for behavioral assertion, and a source-text pin below
- * fails this suite if the production lambdas stop matching the mirrors.
+ * Budget starvation and writer shutdown never contacted the provider, so
+ * neither may trigger provider exponential backoff. The production gates are
+ * inline lambdas, so they are mirrored here and pinned by source text below.
  */
 
-// Mirror of the CalDAV gate in ingest-sources.ts (pinned below).
 const shouldApplyCalDavIngestBackoff = (error: unknown): boolean =>
   !shouldTreatAsProviderAuthFailure(error) && !isIngestInfrastructureError(error);
 
-// Mirror of the ICS gate in ingest-sources.ts (pinned below).
 const shouldApplyIcsIngestBackoff = (error: unknown): boolean =>
   !isIngestInfrastructureError(error);
 
@@ -84,10 +79,7 @@ describe("backoff gate source pins", () => {
     );
 
     const gateOccurrences = source.match(/!isIngestInfrastructureError\(error\)/gu) ?? [];
-    /*
-     * CalDAV and ICS gates inline the exemption; OAuth routes through
-     * requiresReauthentication, which folds the same predicate in.
-     */
+    // OAuth's third gate folds the predicate into requiresReauthentication.
     expect(gateOccurrences.length).toBeGreaterThanOrEqual(2);
     expect(source).toContain(
       "!shouldTreatAsProviderAuthFailure(error)\n                && !isIngestInfrastructureError(error)",

--- a/services/cron/tests/jobs/caldav-ics-infrastructure-backoff.test.ts
+++ b/services/cron/tests/jobs/caldav-ics-infrastructure-backoff.test.ts
@@ -1,0 +1,127 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { createSerialFlushWorker } from "@keeper.sh/calendar";
+import {
+  NEVER_INGESTED_WEIGHT,
+  WEIGHT_BUDGET,
+} from "../../src/utils/ingest-weight";
+import { OperationTimeoutError, withAbortTimeout } from "../../src/utils/with-abort-timeout";
+import { isIngestInfrastructureError } from "../../src/utils/error-flags";
+import { shouldTreatAsProviderAuthFailure } from "../../src/utils/provider-ingest-failure";
+
+/*
+ * Flush-budget starvation (an OperationTimeoutError from a reserve parked on
+ * the exhausted shared 64MB budget) and writer shutdown never contacted the
+ * provider, so no family's backoff gate may punish the calendar with provider
+ * exponential backoff. The gates live as inline lambdas in ingest-sources.ts;
+ * they are mirrored here for behavioral assertion, and a source-text pin below
+ * fails this suite if the production lambdas stop matching the mirrors.
+ */
+
+// Mirror of the CalDAV gate in ingest-sources.ts (pinned below).
+const shouldApplyCalDavIngestBackoff = (error: unknown): boolean =>
+  !shouldTreatAsProviderAuthFailure(error) && !isIngestInfrastructureError(error);
+
+// Mirror of the ICS gate in ingest-sources.ts (pinned below).
+const shouldApplyIcsIngestBackoff = (error: unknown): boolean =>
+  !isIngestInfrastructureError(error);
+
+const COLD_START_SOURCES = 8;
+const SHORT_DEADLINE_MS = 50;
+
+const produceBudgetStarvationTimeout = async (): Promise<unknown> => {
+  const worker = createSerialFlushWorker(
+    (task: () => Promise<number>) => task(),
+    { budget: WEIGHT_BUDGET, capacity: 50 },
+  );
+  const holds = await Promise.all(
+    Array.from({ length: COLD_START_SOURCES }, () =>
+      worker.reserve(NEVER_INGESTED_WEIGHT)),
+  );
+  let caught: unknown = null;
+  try {
+    await withAbortTimeout(
+      (signal) => worker.reserve(NEVER_INGESTED_WEIGHT, signal),
+      SHORT_DEADLINE_MS,
+    );
+  } catch (error) {
+    caught = error;
+  }
+  for (const hold of holds) {
+    hold.release();
+  }
+  await worker.close();
+  return caught;
+};
+
+const produceShutdownRejection = async (): Promise<unknown> => {
+  const worker = createSerialFlushWorker(
+    (task: () => Promise<number>) => task(),
+    { budget: WEIGHT_BUDGET, capacity: 50 },
+  );
+  const holds = await Promise.all(
+    Array.from({ length: COLD_START_SOURCES }, () =>
+      worker.reserve(NEVER_INGESTED_WEIGHT)),
+  );
+  let caught: unknown = null;
+  const parked = worker.reserve(NEVER_INGESTED_WEIGHT).catch((error: unknown) => {
+    caught = error;
+    return null;
+  });
+  await worker.close();
+  await parked;
+  for (const hold of holds) {
+    hold.release();
+  }
+  return caught;
+};
+
+describe("backoff gate source pins", () => {
+  it("keeps every family's gate routed through the infrastructure exemption", () => {
+    const source = readFileSync(
+      new URL("../../src/jobs/ingest-sources.ts", import.meta.url),
+      "utf8",
+    );
+
+    const gateOccurrences = source.match(/!isIngestInfrastructureError\(error\)/gu) ?? [];
+    /*
+     * CalDAV and ICS gates inline the exemption; OAuth routes through
+     * requiresReauthentication, which folds the same predicate in.
+     */
+    expect(gateOccurrences.length).toBeGreaterThanOrEqual(2);
+    expect(source).toContain(
+      "!shouldTreatAsProviderAuthFailure(error)\n                && !isIngestInfrastructureError(error)",
+    );
+    expect(source).not.toContain("}, () => true)");
+  });
+});
+
+describe("CalDAV backoff gate versus ingest infrastructure errors", () => {
+  it("exempts a budget-starved reserve timeout from provider backoff", async () => {
+    const caught = await produceBudgetStarvationTimeout();
+    expect(caught).toBeInstanceOf(OperationTimeoutError);
+    expect(isIngestInfrastructureError(caught)).toBe(true);
+    expect(shouldApplyCalDavIngestBackoff(caught)).toBe(false);
+  });
+
+  it("exempts a shutdown-rejected parked reserve from provider backoff", async () => {
+    const caught = await produceShutdownRejection();
+    expect(isIngestInfrastructureError(caught)).toBe(true);
+    expect(shouldApplyCalDavIngestBackoff(caught)).toBe(false);
+  });
+});
+
+describe("ICS backoff gate versus ingest infrastructure errors", () => {
+  it("exempts a budget-starved reserve timeout from provider backoff", async () => {
+    const caught = await produceBudgetStarvationTimeout();
+    expect(caught).toBeInstanceOf(OperationTimeoutError);
+    expect(isIngestInfrastructureError(caught)).toBe(true);
+    expect(shouldApplyIcsIngestBackoff(caught)).toBe(false);
+  });
+
+  it("exempts a shutdown-rejected parked reserve from provider backoff", async () => {
+    const caught = await produceShutdownRejection();
+    expect(isIngestInfrastructureError(caught)).toBe(true);
+    expect(shouldApplyIcsIngestBackoff(caught)).toBe(false);
+  });
+});

--- a/services/cron/tests/jobs/caldav-ics-infrastructure-backoff.test.ts
+++ b/services/cron/tests/jobs/caldav-ics-infrastructure-backoff.test.ts
@@ -9,12 +9,6 @@ import { OperationTimeoutError, withAbortTimeout } from "../../src/utils/with-ab
 import { isIngestInfrastructureError } from "../../src/utils/error-flags";
 import { shouldTreatAsProviderAuthFailure } from "../../src/utils/provider-ingest-failure";
 
-/*
- * Budget starvation and writer shutdown never contacted the provider, so
- * neither may trigger provider exponential backoff. The production gates are
- * inline lambdas, so they are mirrored here and pinned by source text below.
- */
-
 const shouldApplyCalDavIngestBackoff = (error: unknown): boolean =>
   !shouldTreatAsProviderAuthFailure(error) && !isIngestInfrastructureError(error);
 

--- a/services/cron/tests/jobs/caldav-pool-backoff-convergence.test.ts
+++ b/services/cron/tests/jobs/caldav-pool-backoff-convergence.test.ts
@@ -138,6 +138,7 @@ const createUpdateQuery = (): unknown => {
 };
 
 vi.mock("@/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: {
     select: (projection: Record<string, unknown>) =>
       createQuery(() => resolveSelect(projection)),

--- a/services/cron/tests/jobs/caldav-pool-failure-labelling.test.ts
+++ b/services/cron/tests/jobs/caldav-pool-failure-labelling.test.ts
@@ -123,6 +123,7 @@ const createUpdateQuery = (): unknown => {
 };
 
 vi.mock("@/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: {
     select: (projection: Record<string, unknown>) =>
       createQuery(() => resolveSelect(projection)),

--- a/services/cron/tests/jobs/caldav-reauth-flag-convergence.test.ts
+++ b/services/cron/tests/jobs/caldav-reauth-flag-convergence.test.ts
@@ -142,6 +142,7 @@ const createUpdateQuery = (): unknown => {
 };
 
 vi.mock("@/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: {
     select: (projection: Record<string, unknown>) =>
       createQuery(() => resolveSelect(projection)),

--- a/services/cron/tests/jobs/delete-source-concurrency.test.ts
+++ b/services/cron/tests/jobs/delete-source-concurrency.test.ts
@@ -88,20 +88,21 @@ beforeEach(() => {
 describe("global source throttle removal", () => {
   /*
    * Provider protection, fairness, write pressure, and memory each have a
-   * dedicated mechanism now, so the group budget at the oauth and caldav call
-   * sites is effectively unlimited for the fleet (UNBOUNDED_USER_GROUPS =
-   * 1000), while the per-account Graph budget within a pass stays at
-   * USER_CALENDAR_CONCURRENCY = 2. ICS keeps a small dedicated group budget
-   * (ICS_PARSE_CONCURRENCY = 4) because parsing is CPU-bound and starves the
-   * Bun event loop.
+   * dedicated mechanism now, so the oauth and caldav call sites share the
+   * user-group budget (USER_GROUP_CONCURRENCY = 12, sized so groups times
+   * USER_CALENDAR_CONCURRENCY stays within the 25-connection cron pool: every
+   * source performs pooled reads before reserve() can park it), while the
+   * per-account Graph budget within a pass stays at USER_CALENDAR_CONCURRENCY
+   * = 2. ICS keeps a small dedicated group budget (ICS_PARSE_CONCURRENCY = 4)
+   * because parsing is CPU-bound and starves the Bun event loop.
    */
-  it("runs oauth and caldav effectively unbounded and ics at parse concurrency", async () => {
+  it("runs oauth and caldav at the pool-sized user-group budget and ics at parse concurrency", async () => {
     await job?.callback();
 
     expect(capturedOptions).toHaveLength(3);
 
     const unboundedSites = capturedOptions.filter(
-      (options) => options.groupConcurrency === 1000,
+      (options) => options.groupConcurrency === 12,
     );
     const icsSites = capturedOptions.filter(
       (options) => options.groupConcurrency === 4,
@@ -124,7 +125,7 @@ describe("global source throttle removal", () => {
     const source = readFileSync(jobSourcePath, "utf8");
 
     expect(source).not.toContain("SOURCE_CONCURRENCY");
-    expect(source).toContain("UNBOUNDED_USER_GROUPS");
+    expect(source).toContain("USER_GROUP_CONCURRENCY");
     expect(source).toContain("ICS_PARSE_CONCURRENCY");
   });
 });

--- a/services/cron/tests/jobs/delete-source-concurrency.test.ts
+++ b/services/cron/tests/jobs/delete-source-concurrency.test.ts
@@ -32,6 +32,7 @@ let job: typeof ingestSourcesJob | null = null;
 /* ENCRYPTION_KEY set so the CalDAV family does not early-return before its call site. */
 vi.mock("../../src/env", () => ({ default: { ENCRYPTION_KEY: "test-key" } }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: fakeDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },
   refreshLockRedis: { eval: () => Promise.resolve(null), get: () => Promise.resolve(null) },
@@ -78,12 +79,6 @@ beforeEach(() => {
 });
 
 describe("global source throttle removal", () => {
-  /*
-   * USER_GROUP_CONCURRENCY is 12 so groups times USER_CALENDAR_CONCURRENCY stays
-   * within the 25-connection cron pool; every source reads from the pool before
-   * reserve() can park it. ICS gets its own budget of 4 because parsing is
-   * CPU-bound and starves the Bun event loop.
-   */
   it("runs oauth and caldav at the pool-sized user-group budget and ics at parse concurrency", async () => {
     await job?.callback();
 

--- a/services/cron/tests/jobs/delete-source-concurrency.test.ts
+++ b/services/cron/tests/jobs/delete-source-concurrency.test.ts
@@ -3,17 +3,9 @@ import { fileURLToPath } from "node:url";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 
-/*
- * Every options argument handed to allSettledGroupedWithConcurrency across the
- * whole pass lands here, one record per call site, in call order.
- */
 const capturedOptions: Record<string, unknown>[] = [];
 
-/*
- * A real resolved promise carrying an orderBy method comes back from where():
- * the listing queries chain into orderBy(), while other selects in the same
- * job stop at where() or limit() and are awaited directly.
- */
+// Where() must be awaitable and chainable: listing queries add orderBy, others do not.
 const createQueryBuilder = () => {
   const builder: Record<string, unknown> = {};
   const chain = (): unknown => builder;
@@ -87,14 +79,10 @@ beforeEach(() => {
 
 describe("global source throttle removal", () => {
   /*
-   * Provider protection, fairness, write pressure, and memory each have a
-   * dedicated mechanism now, so the oauth and caldav call sites share the
-   * user-group budget (USER_GROUP_CONCURRENCY = 12, sized so groups times
-   * USER_CALENDAR_CONCURRENCY stays within the 25-connection cron pool: every
-   * source performs pooled reads before reserve() can park it), while the
-   * per-account Graph budget within a pass stays at USER_CALENDAR_CONCURRENCY
-   * = 2. ICS keeps a small dedicated group budget (ICS_PARSE_CONCURRENCY = 4)
-   * because parsing is CPU-bound and starves the Bun event loop.
+   * USER_GROUP_CONCURRENCY is 12 so groups times USER_CALENDAR_CONCURRENCY stays
+   * within the 25-connection cron pool; every source reads from the pool before
+   * reserve() can park it. ICS gets its own budget of 4 because parsing is
+   * CPU-bound and starves the Bun event loop.
    */
   it("runs oauth and caldav at the pool-sized user-group budget and ics at parse concurrency", async () => {
     await job?.callback();
@@ -116,11 +104,6 @@ describe("global source throttle removal", () => {
     }
   });
 
-  /*
-   * Grep-level pin: the global throttle constant is deleted outright, replaced
-   * by the named constants above. File-text assertion per repo precedent for
-   * existence pins.
-   */
   it("deletes SOURCE_CONCURRENCY from the job in favor of the named budgets", () => {
     const source = readFileSync(jobSourcePath, "utf8");
 

--- a/services/cron/tests/jobs/delete-source-concurrency.test.ts
+++ b/services/cron/tests/jobs/delete-source-concurrency.test.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type ingestSourcesJob from "../../src/jobs/ingest-sources";
+
+/*
+ * Every options argument handed to allSettledGroupedWithConcurrency across the
+ * whole pass lands here, one record per call site, in call order.
+ */
+const capturedOptions: Record<string, unknown>[] = [];
+
+/*
+ * A real resolved promise carrying an orderBy method comes back from where():
+ * the listing queries chain into orderBy(), while other selects in the same
+ * job stop at where() or limit() and are awaited directly.
+ */
+const createQueryBuilder = () => {
+  const builder: Record<string, unknown> = {};
+  const chain = (): unknown => builder;
+
+  builder.from = chain;
+  builder.innerJoin = chain;
+  builder.leftJoin = chain;
+  builder.limit = () => Promise.resolve([]);
+  builder.where = () =>
+    Object.assign(Promise.resolve([]), {
+      orderBy: () => Promise.resolve([]),
+    });
+
+  return builder;
+};
+
+const fakeDatabase = {
+  select: () => createQueryBuilder(),
+  update: () => ({ set: () => ({ where: () => Promise.resolve([]) }) }),
+};
+
+let job: typeof ingestSourcesJob | null = null;
+
+/* ENCRYPTION_KEY set so the CalDAV family does not early-return before its call site. */
+vi.mock("../../src/env", () => ({ default: { ENCRYPTION_KEY: "test-key" } }));
+vi.mock("../../src/context", () => ({
+  database: fakeDatabase,
+  premiumService: { getUserPlan: () => Promise.resolve("pro") },
+  refreshLockRedis: { eval: () => Promise.resolve(null), get: () => Promise.resolve(null) },
+  refreshLockStore: { release: () => Promise.resolve(), tryAcquire: () => Promise.resolve(true) },
+}));
+vi.mock("../../src/utils/logging", () => ({
+  context: (callback: () => unknown) => callback(),
+  widelog: {
+    append: () => null,
+    error: () => null,
+    errorFields: () => null,
+    flush: () => null,
+    set: () => null,
+    setFields: () => null,
+    time: { measure: (_key: string, callback: () => unknown) => callback() },
+  },
+}));
+vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: () => Promise.resolve(0),
+}));
+vi.mock("@keeper.sh/calendar", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const original = actual.allSettledGroupedWithConcurrency as (
+    ...callArguments: unknown[]
+  ) => unknown;
+  const spied = (...callArguments: unknown[]): unknown => {
+    capturedOptions.push({ ...(callArguments[2] as Record<string, unknown>) });
+    return original(...callArguments);
+  };
+  return { ...actual, allSettledGroupedWithConcurrency: spied };
+});
+
+const jobSourcePath = fileURLToPath(
+  new URL("../../src/jobs/ingest-sources.ts", import.meta.url),
+);
+
+beforeAll(async () => {
+  const module = await import("../../src/jobs/ingest-sources");
+  job = module.default;
+});
+
+beforeEach(() => {
+  capturedOptions.length = 0;
+});
+
+describe("global source throttle removal", () => {
+  /*
+   * Provider protection, fairness, write pressure, and memory each have a
+   * dedicated mechanism now, so the group budget at the oauth and caldav call
+   * sites is effectively unlimited for the fleet (UNBOUNDED_USER_GROUPS =
+   * 1000), while the per-account Graph budget within a pass stays at
+   * USER_CALENDAR_CONCURRENCY = 2. ICS keeps a small dedicated group budget
+   * (ICS_PARSE_CONCURRENCY = 4) because parsing is CPU-bound and starves the
+   * Bun event loop.
+   */
+  it("runs oauth and caldav effectively unbounded and ics at parse concurrency", async () => {
+    await job?.callback();
+
+    expect(capturedOptions).toHaveLength(3);
+
+    const unboundedSites = capturedOptions.filter(
+      (options) => options.groupConcurrency === 1000,
+    );
+    const icsSites = capturedOptions.filter(
+      (options) => options.groupConcurrency === 4,
+    );
+
+    expect(unboundedSites).toHaveLength(2);
+    expect(icsSites).toHaveLength(1);
+
+    for (const options of unboundedSites) {
+      expect(options.taskConcurrency).toBe(2);
+    }
+  });
+
+  /*
+   * Grep-level pin: the global throttle constant is deleted outright, replaced
+   * by the named constants above. File-text assertion per repo precedent for
+   * existence pins.
+   */
+  it("deletes SOURCE_CONCURRENCY from the job in favor of the named budgets", () => {
+    const source = readFileSync(jobSourcePath, "utf8");
+
+    expect(source).not.toContain("SOURCE_CONCURRENCY");
+    expect(source).toContain("UNBOUNDED_USER_GROUPS");
+    expect(source).toContain("ICS_PARSE_CONCURRENCY");
+  });
+});

--- a/services/cron/tests/jobs/drain-pending-ingest.test.ts
+++ b/services/cron/tests/jobs/drain-pending-ingest.test.ts
@@ -12,6 +12,7 @@ let drainJob: CronOptions = {
 
 vi.mock("../../src/env", () => ({ default: environment }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: { select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }) },
   premiumService: { getUserPlan: () => Promise.resolve("pro") },
   refreshLockRedis: {

--- a/services/cron/tests/jobs/drain-tick-gap.test.ts
+++ b/services/cron/tests/jobs/drain-tick-gap.test.ts
@@ -15,6 +15,7 @@ const lockControl = { acquires: true };
 const drainControl = { bodyDurationMs: 0 };
 
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: { select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }) },
   premiumService: { getUserPlan: () => Promise.resolve("pro") },
   refreshLockRedis: {

--- a/services/cron/tests/jobs/ingest-caldav-host-limiter-per-request.test.ts
+++ b/services/cron/tests/jobs/ingest-caldav-host-limiter-per-request.test.ts
@@ -1,0 +1,326 @@
+import { encryptPassword } from "@keeper.sh/database";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type ingestSourcesJob from "../../src/jobs/ingest-sources";
+
+/*
+ * Pins the host rate limiter to the unit it is defined over on the CalDAV
+ * family: the shared per-host budget meters requests per minute, so a CalDAV
+ * ingest must draw one permit for every request it sends to the origin. The
+ * real CalDAV fetcher issues one calendar-query REPORT plus one multiget
+ * REPORT per 250-object batch (on top of discovery), so a run over a large
+ * calendar that charges the limiter a single permit undercounts real origin
+ * traffic and lets an unthrottled request herd through.
+ *
+ * The real createCalDAVSourceFetcher and CalDAVClient run here (including the
+ * genuine 250-path batching); only tsdav is faked, so every fake client call
+ * marks exactly one origin HTTP request.
+ */
+const CALENDAR_URL = "https://caldav.example.net/calendars/user-1/personal/";
+
+const harness = vi.hoisted(() => {
+  interface CalDAVSourceRow {
+    accountId: string;
+    calendarId: string;
+    calendarUrl: string;
+    encryptedPassword: string;
+    ingestFutureRange: string;
+    ingestHistoricRange: string;
+    ingestWindowRecordedAt: Date | null;
+    provider: string;
+    reauthenticationSource: string | null;
+    serverUrl: string;
+    userId: string;
+  }
+
+  const state = {
+    acquiredPermits: [] as number[],
+    caldavRows: [] as CalDAVSourceRow[],
+    hostFactoryHosts: [] as string[],
+    providerRequests: [] as string[],
+  };
+
+  /* Grouped as properties so vi.hoisted can own capture-free helpers. */
+  const helpers = {
+    buildICalendarObject: (index: number): string => [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//keeper-test//EN",
+      "BEGIN:VEVENT",
+      `UID:event-${index}`,
+      "DTSTAMP:20260810T000000Z",
+      "DTSTART:20260820T100000Z",
+      "DTEND:20260820T110000Z",
+      "SUMMARY:Event",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n"),
+    renderStatementText: (statement: unknown): string => {
+      const collected: string[] = [];
+      const seen = new Set<object>();
+      const visit = (node: unknown): void => {
+        if (typeof node === "string") {
+          collected.push(node);
+          return;
+        }
+        if (!node || typeof node !== "object") {
+          return;
+        }
+        if (seen.has(node)) {
+          return;
+        }
+        seen.add(node);
+        for (const child of Object.values(node)) {
+          visit(child);
+        }
+      };
+      visit(statement);
+      return collected.join(" ");
+    },
+    resolveBare: (fields: Record<string, unknown>): unknown[] => {
+      if ("count" in fields) {
+        return [{ count: 10 }];
+      }
+      return [];
+    },
+    transactionRunner: async (
+      callback: (transaction: unknown) => Promise<unknown>,
+    ): Promise<unknown> => await callback({
+      execute: (): Promise<unknown[]> => Promise.resolve([]),
+    }),
+  };
+
+  const containsCalendarId = (node: unknown, calendarId: string): boolean =>
+    helpers.renderStatementText(node).includes(calendarId);
+
+  const resolveLimited = (fields: Record<string, unknown>, predicate: unknown): unknown[] => {
+    if ("failureCount" in fields) {
+      return [{ failureCount: 0, nextAttemptAt: null }];
+    }
+    if ("encryptedPassword" in fields) {
+      const row = state.caldavRows.find(
+        (candidate) => containsCalendarId(predicate, candidate.calendarId),
+      );
+      if (!row) {
+        return [];
+      }
+      return [row];
+    }
+    return [];
+  };
+
+  const resolveListing = (fields: Record<string, unknown>): unknown[] => {
+    if ("encryptedPassword" in fields) {
+      return state.caldavRows;
+    }
+    return [];
+  };
+
+  const createQueryBuilder = (fields: Record<string, unknown>) => {
+    const builder: Record<string, unknown> = {};
+    const chain = (): unknown => builder;
+    builder.from = chain;
+    builder.innerJoin = chain;
+    builder.leftJoin = chain;
+    builder.where = (predicate: unknown) =>
+      Object.assign(Promise.resolve(helpers.resolveBare(fields)), {
+        limit: () => Promise.resolve(resolveLimited(fields, predicate)),
+        orderBy: () => Promise.resolve(resolveListing(fields)),
+      });
+    return builder;
+  };
+
+  const updateBuilder = {
+    set: () => ({
+      where: () => Object.assign(Promise.resolve([]), {
+        returning: () => Promise.resolve([]),
+      }),
+    }),
+  };
+
+  const fakeDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: helpers.transactionRunner,
+    update: () => updateBuilder,
+  };
+
+  const createHostRateLimiter = vi.fn((_redis: unknown, host: string) => {
+    state.hostFactoryHosts.push(host);
+    return {
+      acquire: (weight: number): Promise<void> => {
+        state.acquiredPermits.push(weight);
+        return Promise.resolve();
+      },
+    };
+  });
+
+  interface FakeIngestSourceOptions {
+    calendarId: string;
+    fetchEvents: () => Promise<unknown>;
+    withPersistenceTransaction: (
+      work: (persistence: unknown) => Promise<{ eventsAdded: number; eventsRemoved: number }>,
+    ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
+  }
+
+  /*
+   * The engine is not under test: fetch, then route the result through the
+   * job-provided persistence transaction, exactly like the real ingestSource.
+   */
+  const ingestSource = vi.fn(async (
+    options: FakeIngestSourceOptions,
+  ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
+    await options.fetchEvents();
+    return await options.withPersistenceTransaction(
+      () => Promise.resolve({ eventsAdded: 0, eventsRemoved: 0 }),
+    );
+  });
+
+  const calendarUrl = "https://caldav.example.net/calendars/user-1/personal/";
+  const objectPaths = Array.from(
+    { length: 251 },
+    (_unused, index) => `/calendars/user-1/personal/event-${index}.ics`,
+  );
+
+  /* One fake tsdav client call per origin HTTP request. */
+  const fakeDAVClient = {
+    calendarQuery: (): Promise<{ href: string }[]> => {
+      state.providerRequests.push("calendar-query");
+      return Promise.resolve(objectPaths.map((path) => ({ href: path })));
+    },
+    fetchCalendarObjects: (params: { objectUrls: string[] }): Promise<unknown[]> => {
+      state.providerRequests.push(`multiget:${params.objectUrls.length}`);
+      return Promise.resolve(params.objectUrls.map((url, index) => ({
+        data: helpers.buildICalendarObject(index),
+        url,
+      })));
+    },
+    fetchCalendars: (): Promise<unknown[]> => {
+      state.providerRequests.push("propfind-calendars");
+      return Promise.resolve([{
+        components: ["VEVENT"],
+        ctag: "ctag-1",
+        displayName: "Personal",
+        url: calendarUrl,
+      }]);
+    },
+  };
+
+  return { createHostRateLimiter, fakeDatabase, fakeDAVClient, ingestSource, state };
+});
+
+vi.mock("tsdav", () => ({
+  DAVNamespaceShort: { DAV: "d" },
+  createDAVClient: () => Promise.resolve(harness.fakeDAVClient),
+}));
+
+vi.mock("@keeper.sh/calendar", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    createHostRateLimiter: harness.createHostRateLimiter,
+    ingestSource: harness.ingestSource,
+  };
+});
+
+vi.mock("@keeper.sh/sync", () => ({
+  createSyncLock: () => ({
+    acquire: () => Promise.resolve({
+      acquired: true,
+      handle: {
+        isCurrent: () => Promise.resolve(true),
+        release: () => Promise.resolve(),
+      },
+    }),
+  }),
+}));
+
+/* A real key so the job's decryptPassword round-trips the fixture password. */
+const ENCRYPTION_KEY = Buffer.alloc(32).toString("base64");
+
+vi.mock("../../src/env", () => ({
+  default: { ENCRYPTION_KEY: Buffer.alloc(32).toString("base64") },
+}));
+vi.mock("../../src/context", () => ({
+  database: harness.fakeDatabase,
+  flushDatabase: harness.fakeDatabase,
+  premiumService: { getUserPlan: () => Promise.resolve("pro") },
+  refreshLockRedis: { eval: () => Promise.resolve(null), get: () => Promise.resolve(null) },
+  refreshLockStore: { release: () => Promise.resolve(), tryAcquire: () => Promise.resolve(true) },
+}));
+vi.mock("../../src/utils/logging", () => ({
+  context: (callback: () => unknown) => callback(),
+  widelog: {
+    append: () => null,
+    count: () => null,
+    error: () => null,
+    errorFields: () => null,
+    flush: () => null,
+    max: () => null,
+    min: () => null,
+    set: () => null,
+    setFields: () => null,
+    time: { measure: (_key: string, callback: () => unknown) => callback() },
+  },
+}));
+vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: () => Promise.resolve(0),
+}));
+
+let job: typeof ingestSourcesJob | null = null;
+
+beforeAll(async () => {
+  const module = await import("../../src/jobs/ingest-sources");
+  job = module.default;
+});
+
+beforeEach(() => {
+  harness.state.acquiredPermits.length = 0;
+  harness.state.caldavRows.length = 0;
+  harness.state.hostFactoryHosts.length = 0;
+  harness.state.providerRequests.length = 0;
+  harness.createHostRateLimiter.mockClear();
+  harness.ingestSource.mockClear();
+});
+
+describe("CalDAV host limiter consumption", () => {
+  it("draws one host permit per origin request across a multi-batch fetch", async () => {
+    harness.state.caldavRows.push({
+      accountId: "account-caldav-1",
+      calendarId: "calendar-caldav-1",
+      calendarUrl: CALENDAR_URL,
+      encryptedPassword: encryptPassword("secret", ENCRYPTION_KEY),
+      ingestFutureRange: "6m",
+      ingestHistoricRange: "1m",
+      ingestWindowRecordedAt: new Date(),
+      provider: "fastmail",
+      reauthenticationSource: null,
+      serverUrl: "https://caldav.example.net",
+      userId: "user-1",
+    });
+
+    await job?.callback();
+
+    /* The ingest resolved the shared limiter keyed by the CalDAV host. */
+    expect(harness.state.hostFactoryHosts).toEqual(["caldav.example.net"]);
+
+    /*
+     * The real client listed 251 objects: one calendar-query REPORT plus
+     * ceil(251 / 250) = 2 multiget REPORTs, on top of one discovery PROPFIND.
+     */
+    expect(harness.state.providerRequests).toEqual([
+      "propfind-calendars",
+      "calendar-query",
+      "multiget:250",
+      "multiget:1",
+    ]);
+
+    /*
+     * The limiter budget is requests per minute per host, so the run must be
+     * charged at least one permit per request it actually sent to the origin.
+     */
+    let chargedPermits = 0;
+    for (const weight of harness.state.acquiredPermits) {
+      chargedPermits += weight;
+    }
+    expect(chargedPermits).toBeGreaterThanOrEqual(harness.state.providerRequests.length);
+  });
+});

--- a/services/cron/tests/jobs/ingest-caldav-host-limiter-per-request.test.ts
+++ b/services/cron/tests/jobs/ingest-caldav-host-limiter-per-request.test.ts
@@ -1,5 +1,5 @@
 import { encryptPassword } from "@keeper.sh/database";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 
 /*
@@ -12,8 +12,10 @@ import type ingestSourcesJob from "../../src/jobs/ingest-sources";
  * traffic and lets an unthrottled request herd through.
  *
  * The real createCalDAVSourceFetcher and CalDAVClient run here (including the
- * genuine 250-path batching); only tsdav is faked, so every fake client call
- * marks exactly one origin HTTP request.
+ * genuine 250-path batching); only tsdav is faked. The fake routes each
+ * operation through the fetch tsdav was constructed with, exactly as the real
+ * library does, because charging lives in that injected fetch — a fake that
+ * answered from its own state would bypass the charge and measure nothing.
  */
 const CALENDAR_URL = "https://caldav.example.net/calendars/user-1/personal/";
 
@@ -180,36 +182,46 @@ const harness = vi.hoisted(() => {
     (_unused, index) => `/calendars/user-1/personal/event-${index}.ics`,
   );
 
-  /* One fake tsdav client call per origin HTTP request. */
-  const fakeDAVClient = {
-    calendarQuery: (): Promise<{ href: string }[]> => {
-      state.providerRequests.push("calendar-query");
-      return Promise.resolve(objectPaths.map((path) => ({ href: path })));
+  /* One fake tsdav client call per origin HTTP request, each sent through the injected fetch. */
+  const buildFakeDAVClient = (
+    sendOriginRequest: (label: string) => Promise<void>,
+  ): Record<string, (params: never) => Promise<unknown>> => ({
+    calendarQuery: async (): Promise<{ href: string }[]> => {
+      await sendOriginRequest("calendar-query");
+      return objectPaths.map((path) => ({ href: path }));
     },
-    fetchCalendarObjects: (params: { objectUrls: string[] }): Promise<unknown[]> => {
-      state.providerRequests.push(`multiget:${params.objectUrls.length}`);
-      return Promise.resolve(params.objectUrls.map((url, index) => ({
+    fetchCalendarObjects: async (params: { objectUrls: string[] }): Promise<unknown[]> => {
+      await sendOriginRequest(`multiget:${params.objectUrls.length}`);
+      return params.objectUrls.map((url, index) => ({
         data: helpers.buildICalendarObject(index),
         url,
-      })));
+      }));
     },
-    fetchCalendars: (): Promise<unknown[]> => {
-      state.providerRequests.push("propfind-calendars");
-      return Promise.resolve([{
+    fetchCalendars: async (): Promise<unknown[]> => {
+      await sendOriginRequest("propfind-calendars");
+      return [{
         components: ["VEVENT"],
         ctag: "ctag-1",
         displayName: "Personal",
         url: calendarUrl,
-      }]);
+      }];
     },
-  };
+  }) as unknown as Record<string, (params: never) => Promise<unknown>>;
 
-  return { createHostRateLimiter, fakeDatabase, fakeDAVClient, ingestSource, state };
+  return { buildFakeDAVClient, createHostRateLimiter, fakeDatabase, ingestSource, state };
 });
 
 vi.mock("tsdav", () => ({
   DAVNamespaceShort: { DAV: "d" },
-  createDAVClient: () => Promise.resolve(harness.fakeDAVClient),
+  /*
+   * Real tsdav sends every operation through the fetch it was constructed
+   * with; the fake must too, because the host-limiter charge lives there.
+   */
+  createDAVClient: (options: { fetch: typeof globalThis.fetch }) =>
+    Promise.resolve(harness.buildFakeDAVClient(async (label: string) => {
+      harness.state.providerRequests.push(label);
+      await options.fetch(CALENDAR_URL, { method: "REPORT" });
+    })),
 }));
 
 vi.mock("@keeper.sh/calendar", async (importOriginal) => {
@@ -267,12 +279,22 @@ vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
 
 let job: typeof ingestSourcesJob | null = null;
 
+let originalFetch: typeof globalThis.fetch = globalThis.fetch;
+
 beforeAll(async () => {
   const module = await import("../../src/jobs/ingest-sources");
   job = module.default;
 });
 
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
 beforeEach(() => {
+  /* The fake tsdav client's requests must terminate here, never on the network. */
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = (() =>
+    Promise.resolve(new Response("", { status: 207 }))) as unknown as typeof globalThis.fetch;
   harness.state.acquiredPermits.length = 0;
   harness.state.caldavRows.length = 0;
   harness.state.hostFactoryHosts.length = 0;

--- a/services/cron/tests/jobs/ingest-caldav-host-limiter-per-request.test.ts
+++ b/services/cron/tests/jobs/ingest-caldav-host-limiter-per-request.test.ts
@@ -2,11 +2,6 @@ import { encryptPassword } from "@keeper.sh/database";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 
-/*
- * The shared per-host budget meters requests per minute, so a CalDAV ingest
- * must draw a permit per origin request. Charging once per run would undercount
- * a multi-batch fetch and let an unthrottled request herd through.
- */
 const CALENDAR_URL = "https://caldav.example.net/calendars/user-1/personal/";
 
 const harness = vi.hoisted(() => {
@@ -237,6 +232,7 @@ vi.mock("../../src/env", () => ({
   default: { ENCRYPTION_KEY: Buffer.alloc(32).toString("base64") },
 }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: harness.fakeDatabase,
   flushDatabase: harness.fakeDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },

--- a/services/cron/tests/jobs/ingest-caldav-host-limiter-per-request.test.ts
+++ b/services/cron/tests/jobs/ingest-caldav-host-limiter-per-request.test.ts
@@ -3,19 +3,9 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 
 /*
- * Pins the host rate limiter to the unit it is defined over on the CalDAV
- * family: the shared per-host budget meters requests per minute, so a CalDAV
- * ingest must draw one permit for every request it sends to the origin. The
- * real CalDAV fetcher issues one calendar-query REPORT plus one multiget
- * REPORT per 250-object batch (on top of discovery), so a run over a large
- * calendar that charges the limiter a single permit undercounts real origin
- * traffic and lets an unthrottled request herd through.
- *
- * The real createCalDAVSourceFetcher and CalDAVClient run here (including the
- * genuine 250-path batching); only tsdav is faked. The fake routes each
- * operation through the fetch tsdav was constructed with, exactly as the real
- * library does, because charging lives in that injected fetch — a fake that
- * answered from its own state would bypass the charge and measure nothing.
+ * The shared per-host budget meters requests per minute, so a CalDAV ingest
+ * must draw a permit per origin request. Charging once per run would undercount
+ * a multi-batch fetch and let an unthrottled request herd through.
  */
 const CALENDAR_URL = "https://caldav.example.net/calendars/user-1/personal/";
 
@@ -163,10 +153,6 @@ const harness = vi.hoisted(() => {
     ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
   }
 
-  /*
-   * The engine is not under test: fetch, then route the result through the
-   * job-provided persistence transaction, exactly like the real ingestSource.
-   */
   const ingestSource = vi.fn(async (
     options: FakeIngestSourceOptions,
   ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
@@ -182,7 +168,6 @@ const harness = vi.hoisted(() => {
     (_unused, index) => `/calendars/user-1/personal/event-${index}.ics`,
   );
 
-  /* One fake tsdav client call per origin HTTP request, each sent through the injected fetch. */
   const buildFakeDAVClient = (
     sendOriginRequest: (label: string) => Promise<void>,
   ): Record<string, (params: never) => Promise<unknown>> => ({
@@ -321,13 +306,9 @@ describe("CalDAV host limiter consumption", () => {
 
     await job?.callback();
 
-    /* The ingest resolved the shared limiter keyed by the CalDAV host. */
     expect(harness.state.hostFactoryHosts).toEqual(["caldav.example.net"]);
 
-    /*
-     * The real client listed 251 objects: one calendar-query REPORT plus
-     * ceil(251 / 250) = 2 multiget REPORTs, on top of one discovery PROPFIND.
-     */
+    // 251 objects: a discovery PROPFIND, a calendar-query, then ceil(251 / 250) multigets.
     expect(harness.state.providerRequests).toEqual([
       "propfind-calendars",
       "calendar-query",
@@ -335,10 +316,6 @@ describe("CalDAV host limiter consumption", () => {
       "multiget:1",
     ]);
 
-    /*
-     * The limiter budget is requests per minute per host, so the run must be
-     * charged at least one permit per request it actually sent to the origin.
-     */
     let chargedPermits = 0;
     for (const weight of harness.state.acquiredPermits) {
       chargedPermits += weight;

--- a/services/cron/tests/jobs/ingest-discard-telemetry-wiring.test.ts
+++ b/services/cron/tests/jobs/ingest-discard-telemetry-wiring.test.ts
@@ -99,6 +99,7 @@ const createQuery = (resolve: () => unknown): unknown =>
   });
 
 vi.mock("@/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: {
     select: (projection: Record<string, unknown>) =>
       createQuery(() => resolveSelect(projection)),

--- a/services/cron/tests/jobs/ingest-duration-attribution.test.ts
+++ b/services/cron/tests/jobs/ingest-duration-attribution.test.ts
@@ -45,10 +45,9 @@ const ADVISORY_LOCK_STATEMENT_INDEX = 3;
 const SECOND_POOL_WAIT_MS = 15;
 
 /*
- * Bun.sleep can return a fraction of a millisecond before the span measuring it elapses, so
- * an exact floor makes these assertions report timer granularity rather than attribution.
- * The slack is far smaller than any injected delay, so a segment charged to the wrong bucket
- * still fails.
+ * Bun.sleep can return a fraction of a millisecond early, so an exact floor would
+ * assert timer granularity. The slack stays far below every injected delay, so a
+ * segment charged to the wrong bucket still fails.
  */
 const TIMER_SLACK_MS = 5;
 
@@ -125,11 +124,6 @@ const createQuery = (resolve: () => unknown): unknown => {
   });
 };
 
-/*
- * The pool hands the callback over only after poolWaitMs, and the commit takes
- * commitMs after the callback returns — the two boundaries no in-callback timer
- * can see.
- */
 const nextPoolWaitMs = (): number => {
   if (stagedPoolWaits.length === 0) {
     return poolWaitMs;
@@ -213,10 +207,6 @@ vi.mock("@keeper.sh/database", async (importOriginal) => ({
   decryptPassword: () => "plaintext",
 }));
 
-/*
- * The real engine is replaced by one that drives the persistence transaction and
- * nothing else, so the only segments in play are the ones this file asserts.
- */
 vi.mock("@keeper.sh/calendar", async (importOriginal) => {
   const original = await importOriginal<Record<string, unknown>>();
   return {
@@ -370,11 +360,7 @@ describe("ingest duration decomposition", () => {
       .toSorted((first, second) => first - second);
 
     expect(events).toHaveLength(2);
-    /*
-     * The flush writer serialises persistence: the first source pays only its own
-     * connection wait, while the queued one is charged the peer's whole flush on
-     * top of its own smaller wait.
-     */
+    // The flush writer serialises persistence, so the queued source is also charged its peer's flush.
     expect(poolWaits[0]).toBeGreaterThanOrEqual(chargedAtLeast(POOL_WAIT_MS));
     expect(poolWaits[1]).toBeGreaterThanOrEqual(
       chargedAtLeast(POOL_WAIT_MS + SECOND_POOL_WAIT_MS),

--- a/services/cron/tests/jobs/ingest-duration-attribution.test.ts
+++ b/services/cron/tests/jobs/ingest-duration-attribution.test.ts
@@ -156,6 +156,7 @@ const runTransaction = async (work: (transaction: unknown) => Promise<unknown>):
 };
 
 vi.mock("@/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: {
     select: (projection: Record<string, unknown>) =>
       createQuery(() => resolveSelect(projection)),

--- a/services/cron/tests/jobs/ingest-duration-attribution.test.ts
+++ b/services/cron/tests/jobs/ingest-duration-attribution.test.ts
@@ -168,6 +168,12 @@ vi.mock("@/context", () => ({
     transaction: runTransaction,
     update: () => createQuery(() => []),
   },
+  flushDatabase: {
+    select: (projection: Record<string, unknown>) =>
+      createQuery(() => resolveSelect(projection)),
+    transaction: runTransaction,
+    update: () => createQuery(() => []),
+  },
   refreshLockRedis: {
     eval: async (): Promise<unknown> => {
       await Bun.sleep(redisCommandMs);
@@ -354,7 +360,7 @@ describe("ingest duration decomposition", () => {
     expect(event.work?.db_commit_ms).toBeUndefined();
   });
 
-  it("gives two concurrent ingests their own pool wait and neither the other's", async () => {
+  it("charges a queued source the writer wait it spends behind its peer's flush", async () => {
     sourceCount = 2;
     stagedPoolWaits = [POOL_WAIT_MS, SECOND_POOL_WAIT_MS];
 
@@ -364,9 +370,15 @@ describe("ingest duration decomposition", () => {
       .toSorted((first, second) => first - second);
 
     expect(events).toHaveLength(2);
-    expect(poolWaits[0]).toBeGreaterThanOrEqual(chargedAtLeast(SECOND_POOL_WAIT_MS));
-    expect(poolWaits[0]).toBeLessThan(POOL_WAIT_MS);
-    expect(poolWaits[1]).toBeGreaterThanOrEqual(chargedAtLeast(POOL_WAIT_MS));
+    /*
+     * The flush writer serialises persistence: the first source pays only its own
+     * connection wait, while the queued one is charged the peer's whole flush on
+     * top of its own smaller wait.
+     */
+    expect(poolWaits[0]).toBeGreaterThanOrEqual(chargedAtLeast(POOL_WAIT_MS));
+    expect(poolWaits[1]).toBeGreaterThanOrEqual(
+      chargedAtLeast(POOL_WAIT_MS + SECOND_POOL_WAIT_MS),
+    );
     for (const event of events) {
       expect(event.accounted_ms ?? 0).toBeLessThanOrEqual(event.duration_ms ?? 0);
     }

--- a/services/cron/tests/jobs/ingest-flush-item-deadline-wiring.test.ts
+++ b/services/cron/tests/jobs/ingest-flush-item-deadline-wiring.test.ts
@@ -201,6 +201,7 @@ vi.mock("@keeper.sh/sync", () => ({
 /* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
 vi.mock("../../src/env", () => ({ default: {} }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: harness.pooledDatabase,
   flushDatabase: harness.flushDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },

--- a/services/cron/tests/jobs/ingest-flush-item-deadline-wiring.test.ts
+++ b/services/cron/tests/jobs/ingest-flush-item-deadline-wiring.test.ts
@@ -1,0 +1,290 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type ingestSourcesJob from "../../src/jobs/ingest-sources";
+
+/*
+ * Pins the item-carried run deadline wiring the serial flush worker documents:
+ * its resolveRunDeadlineMs probe states "the production ingest caller submits
+ * `() => task()` functions with a `deadlineAt` attached", so every thunk the
+ * ingest job hands to reservation.submit must carry a finite numeric
+ * `deadlineAt`. Without it, a wedged production flush is bounded only by the
+ * generic ten-minute fallback instead of the source's own deadline.
+ */
+const harness = vi.hoisted(() => {
+  interface IcsSourceRow {
+    calendarId: string;
+    ingestFutureRange: string;
+    ingestHistoricRange: string;
+    ingestWindowRecordedAt: Date;
+    treatFullDayTimedEventsAsAllDay: boolean;
+    url: string;
+    userId: string;
+  }
+
+  const state = {
+    icsRows: [] as IcsSourceRow[],
+    submittedItems: [] as unknown[],
+  };
+
+  /*
+   * Drizzle SQL objects carry their bound parameters (calendar ids among them)
+   * as nested values, so a deep string sweep is enough to identify a statement.
+   */
+  // eslint-disable-next-line @eslint-plugin-unicorn/consistent-function-scoping -- The vi.hoisted callback runs before module initialization, so this helper cannot live at module scope.
+  const renderStatementText = (statement: unknown): string => {
+    const collected: string[] = [];
+    const seen = new Set<object>();
+    const visit = (node: unknown): void => {
+      if (typeof node === "string") {
+        collected.push(node);
+        return;
+      }
+      if (!node || typeof node !== "object") {
+        return;
+      }
+      if (seen.has(node)) {
+        return;
+      }
+      seen.add(node);
+      for (const child of Object.values(node)) {
+        visit(child);
+      }
+    };
+    visit(statement);
+    return collected.join(" ");
+  };
+
+  const containsCalendarId = (node: unknown, calendarId: string): boolean =>
+    renderStatementText(node).includes(calendarId);
+
+  const resolveLimited = (fields: Record<string, unknown>, predicate: unknown): unknown[] => {
+    if ("failureCount" in fields) {
+      return [{ failureCount: 0, nextAttemptAt: null }];
+    }
+    if ("url" in fields) {
+      const row = state.icsRows.find(
+        (candidate) => containsCalendarId(predicate, candidate.calendarId),
+      );
+      if (!row) {
+        return [];
+      }
+      return [row];
+    }
+    return [];
+  };
+
+  const resolveListing = (fields: Record<string, unknown>): unknown[] => {
+    if ("treatFullDayTimedEventsAsAllDay" in fields) {
+      return state.icsRows;
+    }
+    return [];
+  };
+
+  const createQueryBuilder = (fields: Record<string, unknown>) => {
+    const builder: Record<string, unknown> = {};
+    const chain = (): unknown => builder;
+    builder.from = chain;
+    builder.innerJoin = chain;
+    builder.leftJoin = chain;
+    builder.where = (predicate: unknown) => Object.assign(Promise.resolve([]), {
+      limit: () => Promise.resolve(resolveLimited(fields, predicate)),
+      orderBy: () => Promise.resolve(resolveListing(fields)),
+    });
+    return builder;
+  };
+
+  const updateBuilder = {
+    set: () => ({
+      where: () => Object.assign(Promise.resolve([]), {
+        returning: () => Promise.resolve([]),
+      }),
+    }),
+  };
+
+  // eslint-disable-next-line @eslint-plugin-unicorn/consistent-function-scoping -- The vi.hoisted callback runs before module initialization, so this helper cannot live at module scope.
+  const transactionRunner = async (
+    callback: (transaction: unknown) => Promise<unknown>,
+  ): Promise<unknown> => await callback({
+    execute: (): Promise<unknown[]> => Promise.resolve([]),
+  });
+
+  const pooledDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: transactionRunner,
+    update: () => updateBuilder,
+  };
+
+  const flushDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: transactionRunner,
+    update: () => updateBuilder,
+  };
+
+  interface FakeIngestSourceOptions {
+    calendarId: string;
+    fetchEvents: () => Promise<unknown>;
+    withPersistenceTransaction: (
+      work: (persistence: unknown) => Promise<{ eventsAdded: number; eventsRemoved: number }>,
+    ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
+  }
+
+  /*
+   * The engine is not under test here: fetch, then route the result through
+   * the job-provided persistence transaction, exactly like the real
+   * ingestSource, so the job's reservation.submit call site runs for real.
+   */
+  const ingestSource = vi.fn(async (
+    options: FakeIngestSourceOptions,
+  ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
+    await options.fetchEvents();
+    return await options.withPersistenceTransaction(
+      () => Promise.resolve({ eventsAdded: 1, eventsRemoved: 0 }),
+    );
+  });
+
+  return {
+    flushDatabase,
+    ingestSource,
+    pooledDatabase,
+    state,
+  };
+});
+
+vi.mock("@keeper.sh/calendar", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  interface Reservation {
+    release: () => void;
+    submit: (item: unknown) => Promise<unknown>;
+  }
+  interface Worker {
+    close: () => Promise<void>;
+    reserve: (weight: number, signal?: AbortSignal) => Promise<Reservation>;
+    submit: (item: unknown, signal?: AbortSignal) => Promise<unknown>;
+  }
+  const actualCreate = actual.createSerialFlushWorker as (
+    run: (item: unknown) => Promise<unknown>,
+    options?: unknown,
+  ) => Worker;
+  /*
+   * Pass-through interception: the real worker runs unchanged, but every item
+   * production hands to reservation.submit is recorded for inspection.
+   */
+  const createSerialFlushWorker = (
+    run: (item: unknown) => Promise<unknown>,
+    options?: unknown,
+  ): Worker => {
+    const worker = actualCreate(run, options);
+    return {
+      close: () => worker.close(),
+      reserve: async (weight: number, signal?: AbortSignal): Promise<Reservation> => {
+        const reservation = await worker.reserve(weight, signal);
+        return {
+          release: () => { reservation.release(); },
+          submit: (item: unknown): Promise<unknown> => {
+            harness.state.submittedItems.push(item);
+            return reservation.submit(item);
+          },
+        };
+      },
+      submit: (item: unknown, signal?: AbortSignal): Promise<unknown> => {
+        harness.state.submittedItems.push(item);
+        return worker.submit(item, signal);
+      },
+    };
+  };
+  return { ...actual, createSerialFlushWorker, ingestSource: harness.ingestSource };
+});
+
+vi.mock("@keeper.sh/calendar/ics", () => ({
+  createIcsSourceFetcher: () => ({
+    fetchEvents: () => Promise.resolve({ events: [] }),
+  }),
+  interpretFullDayTimedEventsAsAllDay: (events: unknown) => events,
+  persistCalendarSnapshot: () => Promise.resolve(),
+}));
+
+vi.mock("@keeper.sh/sync", () => ({
+  createSyncLock: () => ({
+    acquire: () => Promise.resolve({
+      acquired: true,
+      handle: {
+        isCurrent: () => Promise.resolve(true),
+        release: () => Promise.resolve(),
+      },
+    }),
+  }),
+}));
+
+/* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
+vi.mock("../../src/env", () => ({ default: {} }));
+vi.mock("../../src/context", () => ({
+  database: harness.pooledDatabase,
+  flushDatabase: harness.flushDatabase,
+  premiumService: { getUserPlan: () => Promise.resolve("pro") },
+  /* The host limiter's acquire script expects [waitTimeMs, occupancy]; 0 wait grants. */
+  refreshLockRedis: { eval: () => Promise.resolve([0, 0]), get: () => Promise.resolve(null) },
+  refreshLockStore: { release: () => Promise.resolve(), tryAcquire: () => Promise.resolve(true) },
+}));
+vi.mock("../../src/utils/logging", () => ({
+  context: (callback: () => unknown) => callback(),
+  widelog: {
+    append: () => null,
+    count: () => null,
+    error: () => null,
+    errorFields: () => null,
+    flush: () => null,
+    max: () => null,
+    min: () => null,
+    set: () => null,
+    setFields: () => null,
+    time: { measure: (_key: string, callback: () => unknown) => callback() },
+  },
+}));
+vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: (_userIds: Set<string>) => Promise.resolve(0),
+}));
+
+const createIcsRow = (calendarId: string, userId: string) => ({
+  calendarId,
+  ingestFutureRange: "6m",
+  ingestHistoricRange: "1m",
+  ingestWindowRecordedAt: new Date(),
+  treatFullDayTimedEventsAsAllDay: false,
+  url: `https://feeds.example.net/${calendarId}.ics`,
+  userId,
+});
+
+let job: typeof ingestSourcesJob | null = null;
+
+beforeAll(async () => {
+  const module = await import("../../src/jobs/ingest-sources");
+  job = module.default;
+});
+
+beforeEach(() => {
+  harness.state.icsRows.length = 0;
+  harness.state.submittedItems.length = 0;
+  harness.ingestSource.mockClear();
+});
+
+describe("ingest flush item-carried deadline wiring", () => {
+  it("attaches a finite deadlineAt to every thunk submitted to the flush writer", async () => {
+    harness.state.icsRows.push(createIcsRow("calendar-alpha", "user-alpha"));
+
+    await job?.callback();
+
+    /* The source's flush went through reservation.submit for real. */
+    expect(harness.state.submittedItems.length).toBeGreaterThan(0);
+
+    /*
+     * The worker's resolveRunDeadlineMs probe documents that production thunks
+     * carry `deadlineAt`; a bare thunk silently falls back to the generic
+     * ten-minute run deadline instead of the source's own deadline.
+     */
+    for (const item of harness.state.submittedItems) {
+      expect(item).toHaveProperty("deadlineAt");
+      const { deadlineAt } = item as { deadlineAt: unknown };
+      expect(typeof deadlineAt).toBe("number");
+      expect(Number.isFinite(deadlineAt)).toBe(true);
+    }
+  });
+});

--- a/services/cron/tests/jobs/ingest-flush-item-deadline-wiring.test.ts
+++ b/services/cron/tests/jobs/ingest-flush-item-deadline-wiring.test.ts
@@ -2,12 +2,9 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 
 /*
- * Pins the item-carried run deadline wiring the serial flush worker documents:
- * its resolveRunDeadlineMs probe states "the production ingest caller submits
- * `() => task()` functions with a `deadlineAt` attached", so every thunk the
- * ingest job hands to reservation.submit must carry a finite numeric
- * `deadlineAt`. Without it, a wedged production flush is bounded only by the
- * generic ten-minute fallback instead of the source's own deadline.
+ * Every thunk handed to reservation.submit must carry a finite deadlineAt: the
+ * worker's resolveRunDeadlineMs otherwise falls back to a generic ten minutes,
+ * silently unbounding a wedged flush from its source's own deadline.
  */
 const harness = vi.hoisted(() => {
   interface IcsSourceRow {
@@ -25,10 +22,6 @@ const harness = vi.hoisted(() => {
     submittedItems: [] as unknown[],
   };
 
-  /*
-   * Drizzle SQL objects carry their bound parameters (calendar ids among them)
-   * as nested values, so a deep string sweep is enough to identify a statement.
-   */
   // eslint-disable-next-line @eslint-plugin-unicorn/consistent-function-scoping -- The vi.hoisted callback runs before module initialization, so this helper cannot live at module scope.
   const renderStatementText = (statement: unknown): string => {
     const collected: string[] = [];
@@ -127,11 +120,6 @@ const harness = vi.hoisted(() => {
     ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
   }
 
-  /*
-   * The engine is not under test here: fetch, then route the result through
-   * the job-provided persistence transaction, exactly like the real
-   * ingestSource, so the job's reservation.submit call site runs for real.
-   */
   const ingestSource = vi.fn(async (
     options: FakeIngestSourceOptions,
   ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
@@ -164,10 +152,6 @@ vi.mock("@keeper.sh/calendar", async (importOriginal) => {
     run: (item: unknown) => Promise<unknown>,
     options?: unknown,
   ) => Worker;
-  /*
-   * Pass-through interception: the real worker runs unchanged, but every item
-   * production hands to reservation.submit is recorded for inspection.
-   */
   const createSerialFlushWorker = (
     run: (item: unknown) => Promise<unknown>,
     options?: unknown,
@@ -272,14 +256,8 @@ describe("ingest flush item-carried deadline wiring", () => {
 
     await job?.callback();
 
-    /* The source's flush went through reservation.submit for real. */
     expect(harness.state.submittedItems.length).toBeGreaterThan(0);
 
-    /*
-     * The worker's resolveRunDeadlineMs probe documents that production thunks
-     * carry `deadlineAt`; a bare thunk silently falls back to the generic
-     * ten-minute run deadline instead of the source's own deadline.
-     */
     for (const item of harness.state.submittedItems) {
       expect(item).toHaveProperty("deadlineAt");
       const { deadlineAt } = item as { deadlineAt: unknown };

--- a/services/cron/tests/jobs/ingest-flush-lock-bound.test.ts
+++ b/services/cron/tests/jobs/ingest-flush-lock-bound.test.ts
@@ -2,10 +2,19 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 
 /*
- * Pins the flush-writer routing: every source's persistence transaction must run
- * against the dedicated flushDatabase, one at a time, while fetches stay
- * concurrent — and each source's settlement must await its own flush.
+ * Pins the head-of-line bound on the flush writer's advisory-lock wait. The
+ * flush transaction takes pg_advisory_xact_lock(9003, calendarId) while holding
+ * the single serial writer slot, and the same lock is held minutes-scale by
+ * sync-user write-back and the API caldav persist. The wait on that lock must
+ * therefore be bounded by a small constant statement_timeout (a few seconds),
+ * not by the source's remaining 120s ingest deadline: one contended calendar
+ * must fail ITS flush quickly so parked peers still flush inside their own
+ * deadlines. The mock flushDatabase honours statement_timeout exactly like
+ * Postgres does — a held lock rejects only when the in-effect timeout fires.
  */
+const ADVISORY_LOCK_WAIT_BOUND_MS = 10_000;
+const SIMULATED_CONTENTION_CAP_MS = 20_000;
+
 const harness = vi.hoisted(() => {
   interface IcsSourceRow {
     calendarId: string;
@@ -17,25 +26,20 @@ const harness = vi.hoisted(() => {
     userId: string;
   }
 
-  interface StatementRecord {
-    label: "flush" | "pooled";
-    text: string;
-  }
-
   const state = {
-    activeTransactionCount: 0,
-    failingCalendarIds: new Set<string>(),
+    contendedCalendarIds: new Set<string>(),
+    contentionCapMs: 20_000,
     icsRows: [] as IcsSourceRow[],
-    maxActiveTransactionCount: 0,
-    statements: [] as StatementRecord[],
-    transactionCounts: { flush: 0, pooled: 0 },
+    lockStatementTimeoutMs: new Map<string, number>(),
+    lockStatementsSeen: [] as string[],
   };
 
   const statementTextSeparator = " ";
 
   /*
-   * Drizzle SQL objects carry their bound parameters (calendar ids among them) as
-   * nested values, so a deep string sweep is enough to identify a statement.
+   * Drizzle SQL objects carry their bound parameters (calendar ids and the
+   * set_config values among them) as nested values, so a deep string sweep is
+   * enough to identify a statement and read its parameters.
    */
   const renderStatementText = (statement: unknown): string => {
     const collected: string[] = [];
@@ -62,7 +66,6 @@ const harness = vi.hoisted(() => {
 
   const containsCalendarId = (node: unknown, calendarId: string): boolean =>
     renderStatementText(node).includes(calendarId);
-
 
   const resolveLimited = (fields: Record<string, unknown>, predicate: unknown): unknown[] => {
     if ("failureCount" in fields) {
@@ -108,47 +111,67 @@ const harness = vi.hoisted(() => {
     }),
   };
 
-  const createTransactionRunner = (label: "flush" | "pooled") =>
-    async (callback: (transaction: unknown) => Promise<unknown>): Promise<unknown> => {
-      state.transactionCounts[label] += 1;
-      state.activeTransactionCount += 1;
-      state.maxActiveTransactionCount = Math.max(
-        state.maxActiveTransactionCount,
-        state.activeTransactionCount,
-      );
-      try {
-        /*
-         * Hold the transaction open across a macrotask so a concurrently started
-         * peer transaction is observable as overlap.
-         */
-        await new Promise((resolve) => { setTimeout(resolve, 25); });
-        return await callback({
-          execute: (statement: unknown): Promise<unknown[]> => {
-            const text = renderStatementText(statement);
-            state.statements.push({ label, text });
-            const failing = [...state.failingCalendarIds].find(
-              (calendarId) => text.includes(calendarId),
-            );
-            if (failing) {
-              return Promise.reject(new Error(`flush transaction rejected for ${failing}`));
-            }
-            return Promise.resolve([]);
-          },
-        });
-      } finally {
-        state.activeTransactionCount -= 1;
+  const resolveLockedCalendarId = (text: string): string | null => {
+    for (const row of state.icsRows) {
+      if (text.includes(row.calendarId)) {
+        return row.calendarId;
       }
-    };
+    }
+    return null;
+  };
+
+  /*
+   * The flush transaction runner models Postgres semantics for the one thing
+   * under test: set_config('statement_timeout', …) changes the in-effect
+   * timeout, and a pg_advisory_xact_lock held by another session (a contended
+   * calendar) blocks until that in-effect timeout cancels the statement. The
+   * cap keeps the simulated contention finite so an unbounded wait fails the
+   * test instead of hanging the runner for the full 120s deadline.
+   */
+  const flushTransaction = async (
+    callback: (transaction: unknown) => Promise<unknown>,
+  ): Promise<unknown> => {
+    let inEffectStatementTimeoutMs = 0;
+    return await callback({
+      execute: (statement: unknown): Promise<unknown[]> => {
+        const text = renderStatementText(statement);
+        if (text.includes("set_config") && text.includes("statement_timeout")
+          && !text.includes("idle_in_transaction_session_timeout")) {
+          const match = /\b(\d{1,9})\b/.exec(text);
+          inEffectStatementTimeoutMs = Number(match?.[1] ?? 0);
+          return Promise.resolve([]);
+        }
+        if (text.includes("pg_advisory_xact_lock")) {
+          const calendarId = resolveLockedCalendarId(text);
+          if (calendarId) {
+            state.lockStatementsSeen.push(calendarId);
+            state.lockStatementTimeoutMs.set(calendarId, inEffectStatementTimeoutMs);
+            if (state.contendedCalendarIds.has(calendarId)) {
+              const waitMs = Math.min(inEffectStatementTimeoutMs, state.contentionCapMs);
+              return new Promise((_resolve, reject) => {
+                const timer = setTimeout(
+                  () => reject(new Error("canceling statement due to statement timeout")),
+                  waitMs,
+                );
+                (timer as { unref?: () => void }).unref?.();
+              });
+            }
+          }
+        }
+        return Promise.resolve([]);
+      },
+    });
+  };
 
   const pooledDatabase = {
     select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
-    transaction: createTransactionRunner("pooled"),
+    transaction: flushTransaction,
     update: () => updateBuilder,
   };
 
   const flushDatabase = {
     select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
-    transaction: createTransactionRunner("flush"),
+    transaction: flushTransaction,
     update: () => updateBuilder,
   };
 
@@ -165,9 +188,8 @@ const harness = vi.hoisted(() => {
   }
 
   /*
-   * The engine is not under test here: fetch, then route the result through the
+   * The engine is not under test: fetch, then route the result through the
    * job-provided persistence transaction, exactly like the real ingestSource.
-   * A non-zero eventsAdded makes each successful source visible via shouldPush.
    */
   const ingestSource = vi.fn(async (
     options: FakeIngestSourceOptions,
@@ -259,68 +281,44 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
-  harness.state.activeTransactionCount = 0;
-  harness.state.failingCalendarIds.clear();
+  harness.state.contendedCalendarIds.clear();
+  harness.state.contentionCapMs = SIMULATED_CONTENTION_CAP_MS;
   harness.state.icsRows.length = 0;
-  harness.state.maxActiveTransactionCount = 0;
-  harness.state.statements.length = 0;
-  harness.state.transactionCounts.flush = 0;
-  harness.state.transactionCounts.pooled = 0;
+  harness.state.lockStatementTimeoutMs.clear();
+  harness.state.lockStatementsSeen.length = 0;
   harness.enqueueDestinationSyncsForUsers.mockClear();
 });
 
-describe("ingest flush writer", () => {
-  it("never overlaps the persistence transactions of concurrently ingesting sources", async () => {
-    harness.state.icsRows.push(
-      createIcsRow("calendar-alpha", "user-alpha"),
-      createIcsRow("calendar-beta", "user-beta"),
-    );
+describe("ingest flush advisory-lock wait bound", () => {
+  it("caps the statement_timeout in effect at pg_advisory_xact_lock to a small constant", async () => {
+    harness.state.icsRows.push(createIcsRow("calendar-alpha", "user-alpha"));
 
     await job?.callback();
 
-    const totalTransactionCount = harness.state.transactionCounts.flush
-      + harness.state.transactionCounts.pooled;
-    expect(totalTransactionCount).toBe(2);
-    expect(harness.state.maxActiveTransactionCount).toBe(1);
+    const lockTimeoutMs = harness.state.lockStatementTimeoutMs.get("calendar-alpha");
+    /*
+     * The lock statement must run under a bounded wait, not the source's full
+     * remaining deadline: 120s here means one calendar contended by sync-user
+     * write-back parks the single flush writer for two minutes.
+     */
+    expect(lockTimeoutMs).toBeDefined();
+    expect(lockTimeoutMs ?? 0).toBeGreaterThan(0);
+    expect(lockTimeoutMs ?? 0).toBeLessThanOrEqual(ADVISORY_LOCK_WAIT_BOUND_MS);
   });
 
-  it("runs persistence against the flush database with timeouts and advisory locks inside", async () => {
+  it("fails a contended calendar's flush quickly so a parked peer still flushes", async () => {
     harness.state.icsRows.push(
-      createIcsRow("calendar-alpha", "user-alpha"),
-      createIcsRow("calendar-beta", "user-beta"),
+      createIcsRow("calendar-contended", "user-contended"),
+      createIcsRow("calendar-peer", "user-peer"),
     );
+    harness.state.contendedCalendarIds.add("calendar-contended");
 
-    await job?.callback();
-
-    expect(harness.state.transactionCounts.flush).toBe(2);
-    expect(harness.state.transactionCounts.pooled).toBe(0);
-
-    const flushStatements = harness.state.statements
-      .filter(({ label }) => label === "flush")
-      .map(({ text }) => text);
-    expect(flushStatements.some((text) => text.includes("statement_timeout"))).toBe(true);
-    expect(flushStatements.some((text) =>
-      text.includes("pg_advisory_xact_lock") && text.includes("calendar-alpha"))).toBe(true);
-    expect(flushStatements.some((text) =>
-      text.includes("pg_advisory_xact_lock") && text.includes("calendar-beta"))).toBe(true);
-  });
-
-  it("settles a source as an error when its own flush rejects, without touching its peer", async () => {
-    harness.state.icsRows.push(
-      createIcsRow("calendar-healthy", "user-healthy"),
-      createIcsRow("calendar-doomed", "user-doomed"),
-    );
-    harness.state.failingCalendarIds.add("calendar-doomed");
-
+    /* The contended source settles as its own error; the pass reports it. */
     await expect(job?.callback()).rejects.toThrow(
       "Calendar source ingestion completed with failures",
     );
 
-    /* The writer survives one source's flush failure: both transactions ran on it. */
-    expect(harness.state.transactionCounts.flush).toBe(2);
-
-    expect(harness.enqueueDestinationSyncsForUsers).toHaveBeenCalledTimes(1);
-    const [affectedUserIds] = harness.enqueueDestinationSyncsForUsers.mock.calls[0] ?? [];
-    expect([...affectedUserIds ?? []]).toEqual(["user-healthy"]);
-  });
+    /* The peer parked behind the contended flush must still have flushed. */
+    expect(harness.state.lockStatementsSeen).toContain("calendar-peer");
+  }, 15_000);
 });

--- a/services/cron/tests/jobs/ingest-flush-lock-bound.test.ts
+++ b/services/cron/tests/jobs/ingest-flush-lock-bound.test.ts
@@ -220,6 +220,7 @@ vi.mock("@keeper.sh/sync", () => ({
 /* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
 vi.mock("../../src/env", () => ({ default: {} }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: harness.pooledDatabase,
   flushDatabase: harness.flushDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },

--- a/services/cron/tests/jobs/ingest-flush-lock-bound.test.ts
+++ b/services/cron/tests/jobs/ingest-flush-lock-bound.test.ts
@@ -2,15 +2,10 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 
 /*
- * Pins the head-of-line bound on the flush writer's advisory-lock wait. The
- * flush transaction takes pg_advisory_xact_lock(9003, calendarId) while holding
- * the single serial writer slot, and the same lock is held minutes-scale by
- * sync-user write-back and the API caldav persist. The wait on that lock must
- * therefore be bounded by a small constant statement_timeout (a few seconds),
- * not by the source's remaining 120s ingest deadline: one contended calendar
- * must fail ITS flush quickly so parked peers still flush inside their own
- * deadlines. The mock flushDatabase honours statement_timeout exactly like
- * Postgres does — a held lock rejects only when the in-effect timeout fires.
+ * The flush takes pg_advisory_xact_lock(9003, calendarId) while holding the single
+ * serial writer slot, and sync-user write-back holds that same lock minutes-scale.
+ * The wait must therefore be a small constant statement_timeout, not the source's
+ * remaining 120s deadline, or one contended calendar parks every peer behind it.
  */
 const ADVISORY_LOCK_WAIT_BOUND_MS = 10_000;
 const SIMULATED_CONTENTION_CAP_MS = 20_000;
@@ -36,11 +31,6 @@ const harness = vi.hoisted(() => {
 
   const statementTextSeparator = " ";
 
-  /*
-   * Drizzle SQL objects carry their bound parameters (calendar ids and the
-   * set_config values among them) as nested values, so a deep string sweep is
-   * enough to identify a statement and read its parameters.
-   */
   const renderStatementText = (statement: unknown): string => {
     const collected: string[] = [];
     const seen = new Set<object>();
@@ -121,12 +111,9 @@ const harness = vi.hoisted(() => {
   };
 
   /*
-   * The flush transaction runner models Postgres semantics for the one thing
-   * under test: set_config('statement_timeout', …) changes the in-effect
-   * timeout, and a pg_advisory_xact_lock held by another session (a contended
-   * calendar) blocks until that in-effect timeout cancels the statement. The
-   * cap keeps the simulated contention finite so an unbounded wait fails the
-   * test instead of hanging the runner for the full 120s deadline.
+   * Postgres semantics for the statement under test: a lock held by another
+   * session blocks until the in-effect statement_timeout cancels it. The cap
+   * keeps an unbounded wait failing fast instead of hanging for the full deadline.
    */
   const flushTransaction = async (
     callback: (transaction: unknown) => Promise<unknown>,
@@ -187,10 +174,6 @@ const harness = vi.hoisted(() => {
     ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
   }
 
-  /*
-   * The engine is not under test: fetch, then route the result through the
-   * job-provided persistence transaction, exactly like the real ingestSource.
-   */
   const ingestSource = vi.fn(async (
     options: FakeIngestSourceOptions,
   ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
@@ -296,11 +279,6 @@ describe("ingest flush advisory-lock wait bound", () => {
     await job?.callback();
 
     const lockTimeoutMs = harness.state.lockStatementTimeoutMs.get("calendar-alpha");
-    /*
-     * The lock statement must run under a bounded wait, not the source's full
-     * remaining deadline: 120s here means one calendar contended by sync-user
-     * write-back parks the single flush writer for two minutes.
-     */
     expect(lockTimeoutMs).toBeDefined();
     expect(lockTimeoutMs ?? 0).toBeGreaterThan(0);
     expect(lockTimeoutMs ?? 0).toBeLessThanOrEqual(ADVISORY_LOCK_WAIT_BOUND_MS);
@@ -313,12 +291,10 @@ describe("ingest flush advisory-lock wait bound", () => {
     );
     harness.state.contendedCalendarIds.add("calendar-contended");
 
-    /* The contended source settles as its own error; the pass reports it. */
     await expect(job?.callback()).rejects.toThrow(
       "Calendar source ingestion completed with failures",
     );
 
-    /* The peer parked behind the contended flush must still have flushed. */
     expect(harness.state.lockStatementsSeen).toContain("calendar-peer");
   }, 15_000);
 });

--- a/services/cron/tests/jobs/ingest-flush-lock-timeout-no-backoff.test.ts
+++ b/services/cron/tests/jobs/ingest-flush-lock-timeout-no-backoff.test.ts
@@ -2,14 +2,10 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 
 /*
- * When the bounded 5s statement_timeout fires on pg_advisory_xact_lock inside
- * the flush transaction, Postgres raises SQLSTATE 57014. That contention is
- * keeper's own write-back (sync-user, API caldav persist) holding the same
- * (namespace, calendarId) lock — the provider fetch already succeeded — so it
- * must be exempt from ingest backoff exactly like the other infrastructure
- * failures (reserve starvation, writer shutdown, pump deadline). This test
- * pins that exemption: a contended calendar whose flush loses the advisory
- * lock race must not have its ingestFailureCount escalated.
+ * A flush that loses the advisory-lock race lost it to keeper's own write-back,
+ * not to the provider, whose fetch already succeeded. Escalating
+ * ingestFailureCount there would push a healthy calendar's next attempt
+ * exponentially out, so the bounded lock timeout must be exempt from backoff.
  */
 
 const harness = vi.hoisted(() => {
@@ -31,11 +27,6 @@ const harness = vi.hoisted(() => {
 
   const statementTextSeparator = " ";
 
-  /*
-   * Drizzle SQL objects carry their bound parameters (calendar ids among
-   * them) as nested values, so a deep string sweep is enough to identify a
-   * statement and read its parameters.
-   */
   const renderStatementText = (statement: unknown): string => {
     const collected: string[] = [];
     const seen = new Set<object>();
@@ -98,7 +89,6 @@ const harness = vi.hoisted(() => {
     return builder;
   };
 
-  /* Every update's set payload is captured so backoff writes are observable. */
   const updateStub = () => ({
     set: (payload: Record<string, unknown>) => {
       state.backoffWrites.push(payload);
@@ -120,10 +110,8 @@ const harness = vi.hoisted(() => {
   };
 
   /*
-   * The one Postgres semantic under test: pg_advisory_xact_lock on a lock
-   * held by another session (sync-user write-back) is cancelled by the
-   * in-effect statement_timeout, raised to the client as SQLSTATE 57014 —
-   * the exact shape Bun's driver produces (errno carries the SQLSTATE).
+   * A statement_timeout cancellation reaches the client as SQLSTATE 57014, and
+   * Bun's Postgres driver carries that SQLSTATE in errno rather than in code.
    */
   const flushTransaction = async (
     callback: (transaction: unknown) => Promise<unknown>,
@@ -168,11 +156,6 @@ const harness = vi.hoisted(() => {
     ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
   }
 
-  /*
-   * The engine is not under test: fetch succeeds (the provider is healthy),
-   * then the result routes through the job-provided persistence transaction,
-   * exactly like the real ingestSource.
-   */
   const ingestSource = vi.fn(async (
     options: FakeIngestSourceOptions,
   ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
@@ -274,16 +257,10 @@ describe("ingest flush advisory-lock statement timeout", () => {
     harness.state.icsRows.push(createIcsRow("calendar-wedged", "user-wedged"));
     harness.state.contendedCalendarIds.add("calendar-wedged");
 
-    /* The source still fails its pass; the pass reports the failure. */
     await expect(job?.callback()).rejects.toThrow(
       "Calendar source ingestion completed with failures",
     );
 
-    /*
-     * The provider fetch succeeded; only keeper's own write-back held the
-     * advisory lock past the 5s bound. Escalating ingestFailureCount here
-     * pushes ingestNextAttemptAt exponentially out for a healthy calendar.
-     */
     const escalations = harness.state.backoffWrites.filter(
       (payload) => typeof payload.ingestFailureCount === "number"
         && payload.ingestFailureCount >= 1,

--- a/services/cron/tests/jobs/ingest-flush-lock-timeout-no-backoff.test.ts
+++ b/services/cron/tests/jobs/ingest-flush-lock-timeout-no-backoff.test.ts
@@ -202,6 +202,7 @@ vi.mock("@keeper.sh/sync", () => ({
 /* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
 vi.mock("../../src/env", () => ({ default: {} }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: harness.pooledDatabase,
   flushDatabase: harness.flushDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },

--- a/services/cron/tests/jobs/ingest-flush-lock-timeout-no-backoff.test.ts
+++ b/services/cron/tests/jobs/ingest-flush-lock-timeout-no-backoff.test.ts
@@ -1,0 +1,293 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type ingestSourcesJob from "../../src/jobs/ingest-sources";
+
+/*
+ * When the bounded 5s statement_timeout fires on pg_advisory_xact_lock inside
+ * the flush transaction, Postgres raises SQLSTATE 57014. That contention is
+ * keeper's own write-back (sync-user, API caldav persist) holding the same
+ * (namespace, calendarId) lock — the provider fetch already succeeded — so it
+ * must be exempt from ingest backoff exactly like the other infrastructure
+ * failures (reserve starvation, writer shutdown, pump deadline). This test
+ * pins that exemption: a contended calendar whose flush loses the advisory
+ * lock race must not have its ingestFailureCount escalated.
+ */
+
+const harness = vi.hoisted(() => {
+  interface IcsSourceRow {
+    calendarId: string;
+    ingestFutureRange: string;
+    ingestHistoricRange: string;
+    ingestWindowRecordedAt: Date;
+    treatFullDayTimedEventsAsAllDay: boolean;
+    url: string;
+    userId: string;
+  }
+
+  const state = {
+    backoffWrites: [] as Record<string, unknown>[],
+    contendedCalendarIds: new Set<string>(),
+    icsRows: [] as IcsSourceRow[],
+  };
+
+  const statementTextSeparator = " ";
+
+  /*
+   * Drizzle SQL objects carry their bound parameters (calendar ids among
+   * them) as nested values, so a deep string sweep is enough to identify a
+   * statement and read its parameters.
+   */
+  const renderStatementText = (statement: unknown): string => {
+    const collected: string[] = [];
+    const seen = new Set<object>();
+    const visit = (node: unknown): void => {
+      if (typeof node === "string") {
+        collected.push(node);
+        return;
+      }
+      if (!node || typeof node !== "object") {
+        return;
+      }
+      if (seen.has(node)) {
+        return;
+      }
+      seen.add(node);
+      for (const child of Object.values(node)) {
+        visit(child);
+      }
+    };
+    visit(statement);
+    return collected.join(statementTextSeparator);
+  };
+
+  const containsCalendarId = (node: unknown, calendarId: string): boolean =>
+    renderStatementText(node).includes(calendarId);
+
+  const resolveLimited = (fields: Record<string, unknown>, predicate: unknown): unknown[] => {
+    if ("failureCount" in fields) {
+      return [{ failureCount: 0, nextAttemptAt: null }];
+    }
+    if ("url" in fields) {
+      const row = state.icsRows.find(
+        (candidate) => containsCalendarId(predicate, candidate.calendarId),
+      );
+      if (!row) {
+        return [];
+      }
+      return [row];
+    }
+    return [];
+  };
+
+  const resolveListing = (fields: Record<string, unknown>): unknown[] => {
+    if ("treatFullDayTimedEventsAsAllDay" in fields) {
+      return state.icsRows;
+    }
+    return [];
+  };
+
+  const createQueryBuilder = (fields: Record<string, unknown>) => {
+    const builder: Record<string, unknown> = {};
+    const chain = (): unknown => builder;
+    builder.from = chain;
+    builder.innerJoin = chain;
+    builder.leftJoin = chain;
+    builder.where = (predicate: unknown) => Object.assign(Promise.resolve([]), {
+      limit: () => Promise.resolve(resolveLimited(fields, predicate)),
+      orderBy: () => Promise.resolve(resolveListing(fields)),
+    });
+    return builder;
+  };
+
+  /* Every update's set payload is captured so backoff writes are observable. */
+  const updateStub = () => ({
+    set: (payload: Record<string, unknown>) => {
+      state.backoffWrites.push(payload);
+      return {
+        where: () => Object.assign(Promise.resolve([]), {
+          returning: () => Promise.resolve([]),
+        }),
+      };
+    },
+  });
+
+  const resolveLockedCalendarId = (text: string): string | null => {
+    for (const row of state.icsRows) {
+      if (text.includes(row.calendarId)) {
+        return row.calendarId;
+      }
+    }
+    return null;
+  };
+
+  /*
+   * The one Postgres semantic under test: pg_advisory_xact_lock on a lock
+   * held by another session (sync-user write-back) is cancelled by the
+   * in-effect statement_timeout, raised to the client as SQLSTATE 57014 —
+   * the exact shape Bun's driver produces (errno carries the SQLSTATE).
+   */
+  const flushTransaction = async (
+    callback: (transaction: unknown) => Promise<unknown>,
+  ): Promise<unknown> => await callback({
+    execute: (statement: unknown): Promise<unknown[]> => {
+      const text = renderStatementText(statement);
+      if (text.includes("pg_advisory_xact_lock")) {
+        const calendarId = resolveLockedCalendarId(text);
+        if (calendarId && state.contendedCalendarIds.has(calendarId)) {
+          const statementTimeout = Object.assign(
+            new Error("canceling statement due to statement timeout"),
+            { code: "ERR_POSTGRES_SERVER_ERROR", errno: "57014" },
+          );
+          return Promise.reject(statementTimeout);
+        }
+      }
+      return Promise.resolve([]);
+    },
+  });
+
+  const pooledDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: flushTransaction,
+    update: updateStub,
+  };
+
+  const flushDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: flushTransaction,
+    update: updateStub,
+  };
+
+  const enqueueDestinationSyncsForUsers = vi.fn(
+    (_userIds: Set<string>) => Promise.resolve(0),
+  );
+
+  interface FakeIngestSourceOptions {
+    calendarId: string;
+    fetchEvents: () => Promise<unknown>;
+    withPersistenceTransaction: (
+      work: (persistence: unknown) => Promise<{ eventsAdded: number; eventsRemoved: number }>,
+    ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
+  }
+
+  /*
+   * The engine is not under test: fetch succeeds (the provider is healthy),
+   * then the result routes through the job-provided persistence transaction,
+   * exactly like the real ingestSource.
+   */
+  const ingestSource = vi.fn(async (
+    options: FakeIngestSourceOptions,
+  ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
+    await options.fetchEvents();
+    return await options.withPersistenceTransaction(
+      () => Promise.resolve({ eventsAdded: 1, eventsRemoved: 0 }),
+    );
+  });
+
+  return {
+    enqueueDestinationSyncsForUsers,
+    flushDatabase,
+    ingestSource,
+    pooledDatabase,
+    state,
+  };
+});
+
+vi.mock("@keeper.sh/calendar", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, ingestSource: harness.ingestSource };
+});
+
+vi.mock("@keeper.sh/calendar/ics", () => ({
+  createIcsSourceFetcher: () => ({
+    fetchEvents: () => Promise.resolve({ events: [] }),
+  }),
+  interpretFullDayTimedEventsAsAllDay: (events: unknown) => events,
+  persistCalendarSnapshot: () => Promise.resolve(),
+}));
+
+vi.mock("@keeper.sh/sync", () => ({
+  createSyncLock: () => ({
+    acquire: () => Promise.resolve({
+      acquired: true,
+      handle: {
+        isCurrent: () => Promise.resolve(true),
+        release: () => Promise.resolve(),
+      },
+    }),
+  }),
+}));
+
+/* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
+vi.mock("../../src/env", () => ({ default: {} }));
+vi.mock("../../src/context", () => ({
+  database: harness.pooledDatabase,
+  flushDatabase: harness.flushDatabase,
+  premiumService: { getUserPlan: () => Promise.resolve("pro") },
+  /* The host limiter's acquire script expects [waitTimeMs, occupancy]; 0 wait grants. */
+  refreshLockRedis: { eval: () => Promise.resolve([0, 0]), get: () => Promise.resolve(null) },
+  refreshLockStore: { release: () => Promise.resolve(), tryAcquire: () => Promise.resolve(true) },
+}));
+vi.mock("../../src/utils/logging", () => ({
+  context: (callback: () => unknown) => callback(),
+  widelog: {
+    append: () => null,
+    count: () => null,
+    error: () => null,
+    errorFields: () => null,
+    flush: () => null,
+    max: () => null,
+    min: () => null,
+    set: () => null,
+    setFields: () => null,
+    time: { measure: (_key: string, callback: () => unknown) => callback() },
+  },
+}));
+vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: harness.enqueueDestinationSyncsForUsers,
+}));
+
+const createIcsRow = (calendarId: string, userId: string) => ({
+  calendarId,
+  ingestFutureRange: "6m",
+  ingestHistoricRange: "1m",
+  ingestWindowRecordedAt: new Date(),
+  treatFullDayTimedEventsAsAllDay: false,
+  url: `https://feeds.example.net/${calendarId}.ics`,
+  userId,
+});
+
+let job: typeof ingestSourcesJob | null = null;
+
+beforeAll(async () => {
+  const module = await import("../../src/jobs/ingest-sources");
+  job = module.default;
+});
+
+beforeEach(() => {
+  harness.state.backoffWrites.length = 0;
+  harness.state.contendedCalendarIds.clear();
+  harness.state.icsRows.length = 0;
+  harness.enqueueDestinationSyncsForUsers.mockClear();
+});
+
+describe("ingest flush advisory-lock statement timeout", () => {
+  it("does not apply provider backoff when the bounded lock wait times out (57014)", async () => {
+    harness.state.icsRows.push(createIcsRow("calendar-wedged", "user-wedged"));
+    harness.state.contendedCalendarIds.add("calendar-wedged");
+
+    /* The source still fails its pass; the pass reports the failure. */
+    await expect(job?.callback()).rejects.toThrow(
+      "Calendar source ingestion completed with failures",
+    );
+
+    /*
+     * The provider fetch succeeded; only keeper's own write-back held the
+     * advisory lock past the 5s bound. Escalating ingestFailureCount here
+     * pushes ingestNextAttemptAt exponentially out for a healthy calendar.
+     */
+    const escalations = harness.state.backoffWrites.filter(
+      (payload) => typeof payload.ingestFailureCount === "number"
+        && payload.ingestFailureCount >= 1,
+    );
+    expect(escalations).toEqual([]);
+  });
+});

--- a/services/cron/tests/jobs/ingest-flush-shutdown-drain.test.ts
+++ b/services/cron/tests/jobs/ingest-flush-shutdown-drain.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from "vitest";
+
+/*
+ * Pins the shutdown ordering for the ingest flush writer: when the process
+ * shuts down while a flush is queued on the serial writer, the writer must be
+ * closed (draining its queue) BEFORE the dedicated single-connection
+ * flushDatabase is closed. Closing the database first strands every queued or
+ * in-flight flush: fetched payloads that already reserved budget are dropped
+ * on deploy restarts.
+ */
+const harness = vi.hoisted(() => {
+  const events: string[] = [];
+  const pooledInstance = { name: "pooled-database" };
+  const flushInstance = { name: "flush-database" };
+  const instances = [pooledInstance, flushInstance];
+  let callIndex = 0;
+  const createDatabase = vi.fn(() => {
+    const instance = instances[callIndex] ?? { name: "unexpected-extra-database" };
+    callIndex += 1;
+    return Promise.resolve(instance);
+  });
+  const closeDatabase = vi.fn((instance: { name: string }) => {
+    events.push(`close-db:${instance.name}`);
+  });
+  interface CapturedWorker {
+    close(): Promise<void>;
+    reserve(weight: number): Promise<{
+      release(): void;
+      submit(item: () => Promise<unknown>): Promise<unknown>;
+    }>;
+  }
+  const workers: CapturedWorker[] = [];
+  return { closeDatabase, createDatabase, events, flushInstance, pooledInstance, workers };
+});
+
+vi.mock("@keeper.sh/database", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    closeDatabase: harness.closeDatabase,
+    createDatabase: harness.createDatabase,
+  };
+});
+
+vi.mock("@keeper.sh/calendar", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  type WorkerFactory = (...args: unknown[]) => {
+    close(): Promise<void>;
+    reserve(weight: number): Promise<unknown>;
+    submit(item: unknown): Promise<unknown>;
+  };
+  const actualCreateSerialFlushWorker = actual.createSerialFlushWorker as WorkerFactory;
+  return {
+    ...actual,
+    createSerialFlushWorker: (...args: unknown[]) => {
+      const worker = actualCreateSerialFlushWorker(...args);
+      const realClose = worker.close.bind(worker);
+      worker.close = async (): Promise<void> => {
+        harness.events.push("writer-close");
+        await realClose();
+        harness.events.push("writer-drained");
+      };
+      harness.workers.push(worker as never);
+      return worker;
+    },
+    resolveWebhookConfig: () => null,
+  };
+});
+
+vi.mock("ioredis", () => ({
+  // The flag gives disconnect a `this` use so oxlint accepts the stub.
+  default: class FakeRedis {
+    public connected = true;
+
+    public disconnect(): void {
+      this.connected = false;
+    }
+  },
+}));
+
+vi.mock("@keeper.sh/premium", () => ({
+  createPremiumService: () => ({}),
+}));
+
+vi.mock("@polar-sh/sdk", () => ({
+  // The member keeps oxlint's no-extraneous-class satisfied on this stub.
+  Polar: class FakePolar {
+    public readonly mocked = true;
+  },
+}));
+
+vi.mock("@keeper.sh/sync", () => ({
+  createSyncLock: () => ({
+    acquire: () => Promise.resolve({
+      acquired: true,
+      handle: {
+        isCurrent: () => Promise.resolve(true),
+        release: () => Promise.resolve(),
+      },
+    }),
+  }),
+}));
+
+vi.mock("../../src/env", () => ({
+  default: {
+    COMMERCIAL_MODE: false,
+    DATABASE_POOL_MAX: 10,
+    DATABASE_URL: "postgres://cron-test/keeper",
+    REDIS_URL: "redis://cron-test:6379",
+  },
+}));
+
+vi.mock("../../src/utils/logging", () => ({
+  context: (callback: () => unknown) => callback(),
+  destroy: () => null,
+  widelog: {
+    append: () => null,
+    count: () => null,
+    error: () => null,
+    errorFields: () => null,
+    flush: () => null,
+    max: () => null,
+    min: () => null,
+    set: () => null,
+    setFields: () => null,
+    time: { measure: (_key: string, callback: () => unknown) => callback() },
+  },
+}));
+
+vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: () => Promise.resolve(0),
+}));
+
+describe("ingest flush writer shutdown drain", () => {
+  it("closes and drains the flush writer before closing flushDatabase", async () => {
+    /* Loading the job module creates the module-level ingest flush writer. */
+    await import("../../src/jobs/ingest-sources");
+    const { shutdownDatabases } = await import("../../src/context");
+
+    const [worker] = harness.workers;
+    expect(worker).toBeDefined();
+    if (!worker) {
+      return;
+    }
+
+    /*
+     * Park one flush exactly as a live source would at deploy time: weight
+     * reserved, payload fetched, flush submitted and still in flight.
+     */
+    let releaseFlush = (): void => { harness.events.push("flush-release-unwired"); };
+    const reservation = await worker.reserve(1024);
+    const inFlightFlush = reservation.submit(() => new Promise((resolve) => {
+      harness.events.push("flush-started");
+      releaseFlush = (): void => {
+        harness.events.push("flush-settled");
+        resolve("flushed");
+      };
+    }));
+
+    /* Let the writer's pump pick the flush up before shutdown begins. */
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+    expect(harness.events).toContain("flush-started");
+
+    const shutdownResult = (shutdownDatabases as () => Promise<void> | void)();
+    /* A draining shutdown completes once the in-flight flush settles. */
+    releaseFlush();
+    await shutdownResult;
+    await inFlightFlush;
+
+    const writerCloseIndex = harness.events.indexOf("writer-close");
+    const flushDatabaseCloseIndex = harness.events.indexOf("close-db:flush-database");
+    expect(flushDatabaseCloseIndex).toBeGreaterThanOrEqual(0);
+    /*
+     * The writer must be closed, and drained of its in-flight flush, before
+     * the single-connection flush database goes away underneath it.
+     */
+    expect(writerCloseIndex).toBeGreaterThanOrEqual(0);
+    expect(writerCloseIndex).toBeLessThan(flushDatabaseCloseIndex);
+    expect(harness.events.indexOf("flush-settled")).toBeLessThan(flushDatabaseCloseIndex);
+  });
+});

--- a/services/cron/tests/jobs/ingest-flush-shutdown-drain.test.ts
+++ b/services/cron/tests/jobs/ingest-flush-shutdown-drain.test.ts
@@ -1,12 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
 /*
- * Pins the shutdown ordering for the ingest flush writer: when the process
- * shuts down while a flush is queued on the serial writer, the writer must be
- * closed (draining its queue) BEFORE the dedicated single-connection
- * flushDatabase is closed. Closing the database first strands every queued or
- * in-flight flush: fetched payloads that already reserved budget are dropped
- * on deploy restarts.
+ * The flush writer must be closed and drained before the single-connection
+ * flushDatabase it writes through. Closing the database first strands every
+ * queued flush, dropping already-fetched payloads on every deploy restart.
  */
 const harness = vi.hoisted(() => {
   const events: string[] = [];
@@ -131,9 +128,12 @@ vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
   enqueueDestinationSyncsForUsers: () => Promise.resolve(0),
 }));
 
+const yieldToWriterPump = async (): Promise<void> => {
+  await new Promise((resolve) => { setTimeout(resolve, 0); });
+};
+
 describe("ingest flush writer shutdown drain", () => {
   it("closes and drains the flush writer before closing flushDatabase", async () => {
-    /* Loading the job module creates the module-level ingest flush writer. */
     await import("../../src/jobs/ingest-sources");
     const { shutdownDatabases } = await import("../../src/context");
 
@@ -143,10 +143,6 @@ describe("ingest flush writer shutdown drain", () => {
       return;
     }
 
-    /*
-     * Park one flush exactly as a live source would at deploy time: weight
-     * reserved, payload fetched, flush submitted and still in flight.
-     */
     let releaseFlush = (): void => { harness.events.push("flush-release-unwired"); };
     const reservation = await worker.reserve(1024);
     const inFlightFlush = reservation.submit(() => new Promise((resolve) => {
@@ -157,12 +153,10 @@ describe("ingest flush writer shutdown drain", () => {
       };
     }));
 
-    /* Let the writer's pump pick the flush up before shutdown begins. */
-    await new Promise((resolve) => { setTimeout(resolve, 0); });
+    await yieldToWriterPump();
     expect(harness.events).toContain("flush-started");
 
     const shutdownResult = (shutdownDatabases as () => Promise<void> | void)();
-    /* A draining shutdown completes once the in-flight flush settles. */
     releaseFlush();
     await shutdownResult;
     await inFlightFlush;
@@ -170,10 +164,6 @@ describe("ingest flush writer shutdown drain", () => {
     const writerCloseIndex = harness.events.indexOf("writer-close");
     const flushDatabaseCloseIndex = harness.events.indexOf("close-db:flush-database");
     expect(flushDatabaseCloseIndex).toBeGreaterThanOrEqual(0);
-    /*
-     * The writer must be closed, and drained of its in-flight flush, before
-     * the single-connection flush database goes away underneath it.
-     */
     expect(writerCloseIndex).toBeGreaterThanOrEqual(0);
     expect(writerCloseIndex).toBeLessThan(flushDatabaseCloseIndex);
     expect(harness.events.indexOf("flush-settled")).toBeLessThan(flushDatabaseCloseIndex);

--- a/services/cron/tests/jobs/ingest-flush-writer.test.ts
+++ b/services/cron/tests/jobs/ingest-flush-writer.test.ts
@@ -1,0 +1,325 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type ingestSourcesJob from "../../src/jobs/ingest-sources";
+
+/*
+ * Pins the flush-writer routing: every source's persistence transaction must run
+ * against the dedicated flushDatabase, one at a time, while fetches stay
+ * concurrent — and each source's settlement must await its own flush.
+ */
+const harness = vi.hoisted(() => {
+  interface IcsSourceRow {
+    calendarId: string;
+    ingestFutureRange: string;
+    ingestHistoricRange: string;
+    ingestWindowRecordedAt: Date;
+    treatFullDayTimedEventsAsAllDay: boolean;
+    url: string;
+    userId: string;
+  }
+
+  interface StatementRecord {
+    label: "flush" | "pooled";
+    text: string;
+  }
+
+  const state = {
+    activeTransactionCount: 0,
+    failingCalendarIds: new Set<string>(),
+    icsRows: [] as IcsSourceRow[],
+    maxActiveTransactionCount: 0,
+    statements: [] as StatementRecord[],
+    transactionCounts: { flush: 0, pooled: 0 },
+  };
+
+  const statementTextSeparator = " ";
+
+  /*
+   * Drizzle SQL objects carry their bound parameters (calendar ids among them) as
+   * nested values, so a deep string sweep is enough to identify a statement.
+   */
+  const renderStatementText = (statement: unknown): string => {
+    const collected: string[] = [];
+    const seen = new Set<object>();
+    const visit = (node: unknown): void => {
+      if (typeof node === "string") {
+        collected.push(node);
+        return;
+      }
+      if (!node || typeof node !== "object") {
+        return;
+      }
+      if (seen.has(node)) {
+        return;
+      }
+      seen.add(node);
+      for (const child of Object.values(node)) {
+        visit(child);
+      }
+    };
+    visit(statement);
+    return collected.join(statementTextSeparator);
+  };
+
+  const containsCalendarId = (node: unknown, calendarId: string): boolean =>
+    renderStatementText(node).includes(calendarId);
+
+
+  const resolveLimited = (fields: Record<string, unknown>, predicate: unknown): unknown[] => {
+    if ("failureCount" in fields) {
+      return [{ failureCount: 0, nextAttemptAt: null }];
+    }
+    if ("url" in fields) {
+      const row = state.icsRows.find(
+        (candidate) => containsCalendarId(predicate, candidate.calendarId),
+      );
+      if (!row) {
+        return [];
+      }
+      return [row];
+    }
+    return [];
+  };
+
+  const resolveListing = (fields: Record<string, unknown>): unknown[] => {
+    if ("treatFullDayTimedEventsAsAllDay" in fields) {
+      return state.icsRows;
+    }
+    return [];
+  };
+
+  const createQueryBuilder = (fields: Record<string, unknown>) => {
+    const builder: Record<string, unknown> = {};
+    const chain = (): unknown => builder;
+    builder.from = chain;
+    builder.innerJoin = chain;
+    builder.leftJoin = chain;
+    builder.where = (predicate: unknown) => Object.assign(Promise.resolve([]), {
+      limit: () => Promise.resolve(resolveLimited(fields, predicate)),
+      orderBy: () => Promise.resolve(resolveListing(fields)),
+    });
+    return builder;
+  };
+
+  const updateBuilder = {
+    set: () => ({
+      where: () => Object.assign(Promise.resolve([]), {
+        returning: () => Promise.resolve([]),
+      }),
+    }),
+  };
+
+  const createTransactionRunner = (label: "flush" | "pooled") =>
+    async (callback: (transaction: unknown) => Promise<unknown>): Promise<unknown> => {
+      state.transactionCounts[label] += 1;
+      state.activeTransactionCount += 1;
+      state.maxActiveTransactionCount = Math.max(
+        state.maxActiveTransactionCount,
+        state.activeTransactionCount,
+      );
+      try {
+        /*
+         * Hold the transaction open across a macrotask so a concurrently started
+         * peer transaction is observable as overlap.
+         */
+        await new Promise((resolve) => { setTimeout(resolve, 25); });
+        return await callback({
+          execute: (statement: unknown): Promise<unknown[]> => {
+            const text = renderStatementText(statement);
+            state.statements.push({ label, text });
+            const failing = [...state.failingCalendarIds].find(
+              (calendarId) => text.includes(calendarId),
+            );
+            if (failing) {
+              return Promise.reject(new Error(`flush transaction rejected for ${failing}`));
+            }
+            return Promise.resolve([]);
+          },
+        });
+      } finally {
+        state.activeTransactionCount -= 1;
+      }
+    };
+
+  const pooledDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: createTransactionRunner("pooled"),
+    update: () => updateBuilder,
+  };
+
+  const flushDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: createTransactionRunner("flush"),
+    update: () => updateBuilder,
+  };
+
+  const enqueueDestinationSyncsForUsers = vi.fn(
+    (_userIds: Set<string>) => Promise.resolve(0),
+  );
+
+  interface FakeIngestSourceOptions {
+    calendarId: string;
+    fetchEvents: () => Promise<unknown>;
+    withPersistenceTransaction: (
+      work: (persistence: unknown) => Promise<{ eventsAdded: number; eventsRemoved: number }>,
+    ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
+  }
+
+  /*
+   * The engine is not under test here: fetch, then route the result through the
+   * job-provided persistence transaction, exactly like the real ingestSource.
+   * A non-zero eventsAdded makes each successful source visible via shouldPush.
+   */
+  const ingestSource = vi.fn(async (
+    options: FakeIngestSourceOptions,
+  ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
+    await options.fetchEvents();
+    return await options.withPersistenceTransaction(
+      () => Promise.resolve({ eventsAdded: 1, eventsRemoved: 0 }),
+    );
+  });
+
+  return {
+    enqueueDestinationSyncsForUsers,
+    flushDatabase,
+    ingestSource,
+    pooledDatabase,
+    state,
+  };
+});
+
+vi.mock("@keeper.sh/calendar", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, ingestSource: harness.ingestSource };
+});
+
+vi.mock("@keeper.sh/calendar/ics", () => ({
+  createIcsSourceFetcher: () => ({
+    fetchEvents: () => Promise.resolve({ events: [] }),
+  }),
+  interpretFullDayTimedEventsAsAllDay: (events: unknown) => events,
+  persistCalendarSnapshot: () => Promise.resolve(),
+}));
+
+vi.mock("@keeper.sh/sync", () => ({
+  createSyncLock: () => ({
+    acquire: () => Promise.resolve({
+      acquired: true,
+      handle: {
+        isCurrent: () => Promise.resolve(true),
+        release: () => Promise.resolve(),
+      },
+    }),
+  }),
+}));
+
+/* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
+vi.mock("../../src/env", () => ({ default: {} }));
+vi.mock("../../src/context", () => ({
+  database: harness.pooledDatabase,
+  flushDatabase: harness.flushDatabase,
+  premiumService: { getUserPlan: () => Promise.resolve("pro") },
+  refreshLockRedis: { eval: () => Promise.resolve(null), get: () => Promise.resolve(null) },
+  refreshLockStore: { release: () => Promise.resolve(), tryAcquire: () => Promise.resolve(true) },
+}));
+vi.mock("../../src/utils/logging", () => ({
+  context: (callback: () => unknown) => callback(),
+  widelog: {
+    append: () => null,
+    count: () => null,
+    error: () => null,
+    errorFields: () => null,
+    flush: () => null,
+    max: () => null,
+    min: () => null,
+    set: () => null,
+    setFields: () => null,
+    time: { measure: (_key: string, callback: () => unknown) => callback() },
+  },
+}));
+vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: harness.enqueueDestinationSyncsForUsers,
+}));
+
+const createIcsRow = (calendarId: string, userId: string) => ({
+  calendarId,
+  ingestFutureRange: "6m",
+  ingestHistoricRange: "1m",
+  ingestWindowRecordedAt: new Date(),
+  treatFullDayTimedEventsAsAllDay: false,
+  url: `https://feeds.example.net/${calendarId}.ics`,
+  userId,
+});
+
+let job: typeof ingestSourcesJob | null = null;
+
+beforeAll(async () => {
+  const module = await import("../../src/jobs/ingest-sources");
+  job = module.default;
+});
+
+beforeEach(() => {
+  harness.state.activeTransactionCount = 0;
+  harness.state.failingCalendarIds.clear();
+  harness.state.icsRows.length = 0;
+  harness.state.maxActiveTransactionCount = 0;
+  harness.state.statements.length = 0;
+  harness.state.transactionCounts.flush = 0;
+  harness.state.transactionCounts.pooled = 0;
+  harness.enqueueDestinationSyncsForUsers.mockClear();
+});
+
+describe("ingest flush writer", () => {
+  it("never overlaps the persistence transactions of concurrently ingesting sources", async () => {
+    harness.state.icsRows.push(
+      createIcsRow("calendar-alpha", "user-alpha"),
+      createIcsRow("calendar-beta", "user-beta"),
+    );
+
+    await job?.callback();
+
+    const totalTransactionCount = harness.state.transactionCounts.flush
+      + harness.state.transactionCounts.pooled;
+    expect(totalTransactionCount).toBe(2);
+    expect(harness.state.maxActiveTransactionCount).toBe(1);
+  });
+
+  it("runs persistence against the flush database with timeouts and advisory locks inside", async () => {
+    harness.state.icsRows.push(
+      createIcsRow("calendar-alpha", "user-alpha"),
+      createIcsRow("calendar-beta", "user-beta"),
+    );
+
+    await job?.callback();
+
+    expect(harness.state.transactionCounts.flush).toBe(2);
+    expect(harness.state.transactionCounts.pooled).toBe(0);
+
+    const flushStatements = harness.state.statements
+      .filter(({ label }) => label === "flush")
+      .map(({ text }) => text);
+    expect(flushStatements.some((text) => text.includes("statement_timeout"))).toBe(true);
+    expect(flushStatements.some((text) =>
+      text.includes("pg_advisory_xact_lock") && text.includes("calendar-alpha"))).toBe(true);
+    expect(flushStatements.some((text) =>
+      text.includes("pg_advisory_xact_lock") && text.includes("calendar-beta"))).toBe(true);
+  });
+
+  it("settles a source as an error when its own flush rejects, without touching its peer", async () => {
+    harness.state.icsRows.push(
+      createIcsRow("calendar-healthy", "user-healthy"),
+      createIcsRow("calendar-doomed", "user-doomed"),
+    );
+    harness.state.failingCalendarIds.add("calendar-doomed");
+
+    await expect(job?.callback()).rejects.toThrow(
+      "Calendar source ingestion completed with failures",
+    );
+
+    /* The writer survives one source's flush failure: both transactions ran on it. */
+    expect(harness.state.transactionCounts.flush).toBe(2);
+
+    expect(harness.enqueueDestinationSyncsForUsers).toHaveBeenCalledTimes(1);
+    const [affectedUserIds] = harness.enqueueDestinationSyncsForUsers.mock.calls[0] ?? [];
+    expect([...affectedUserIds ?? []]).toEqual(["user-healthy"]);
+  });
+});

--- a/services/cron/tests/jobs/ingest-flush-writer.test.ts
+++ b/services/cron/tests/jobs/ingest-flush-writer.test.ts
@@ -205,6 +205,7 @@ vi.mock("@keeper.sh/sync", () => ({
 /* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
 vi.mock("../../src/env", () => ({ default: {} }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: harness.pooledDatabase,
   flushDatabase: harness.flushDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },

--- a/services/cron/tests/jobs/ingest-flush-writer.test.ts
+++ b/services/cron/tests/jobs/ingest-flush-writer.test.ts
@@ -2,9 +2,8 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 
 /*
- * Pins the flush-writer routing: every source's persistence transaction must run
- * against the dedicated flushDatabase, one at a time, while fetches stay
- * concurrent — and each source's settlement must await its own flush.
+ * Persistence must run one transaction at a time on the dedicated flushDatabase
+ * while fetches stay concurrent, and each source must await its own flush.
  */
 const harness = vi.hoisted(() => {
   interface IcsSourceRow {
@@ -33,10 +32,6 @@ const harness = vi.hoisted(() => {
 
   const statementTextSeparator = " ";
 
-  /*
-   * Drizzle SQL objects carry their bound parameters (calendar ids among them) as
-   * nested values, so a deep string sweep is enough to identify a statement.
-   */
   const renderStatementText = (statement: unknown): string => {
     const collected: string[] = [];
     const seen = new Set<object>();
@@ -108,6 +103,8 @@ const harness = vi.hoisted(() => {
     }),
   };
 
+  const HOLD_OPEN_FOR_OVERLAP_OBSERVATION_MS = 25;
+
   const createTransactionRunner = (label: "flush" | "pooled") =>
     async (callback: (transaction: unknown) => Promise<unknown>): Promise<unknown> => {
       state.transactionCounts[label] += 1;
@@ -117,11 +114,9 @@ const harness = vi.hoisted(() => {
         state.activeTransactionCount,
       );
       try {
-        /*
-         * Hold the transaction open across a macrotask so a concurrently started
-         * peer transaction is observable as overlap.
-         */
-        await new Promise((resolve) => { setTimeout(resolve, 25); });
+        await new Promise((resolve) => {
+          setTimeout(resolve, HOLD_OPEN_FOR_OVERLAP_OBSERVATION_MS);
+        });
         return await callback({
           execute: (statement: unknown): Promise<unknown[]> => {
             const text = renderStatementText(statement);
@@ -164,11 +159,6 @@ const harness = vi.hoisted(() => {
     ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
   }
 
-  /*
-   * The engine is not under test here: fetch, then route the result through the
-   * job-provided persistence transaction, exactly like the real ingestSource.
-   * A non-zero eventsAdded makes each successful source visible via shouldPush.
-   */
   const ingestSource = vi.fn(async (
     options: FakeIngestSourceOptions,
   ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
@@ -316,7 +306,6 @@ describe("ingest flush writer", () => {
       "Calendar source ingestion completed with failures",
     );
 
-    /* The writer survives one source's flush failure: both transactions ran on it. */
     expect(harness.state.transactionCounts.flush).toBe(2);
 
     expect(harness.enqueueDestinationSyncsForUsers).toHaveBeenCalledTimes(1);

--- a/services/cron/tests/jobs/ingest-ics-host-limiter-consumption.test.ts
+++ b/services/cron/tests/jobs/ingest-ics-host-limiter-consumption.test.ts
@@ -1,0 +1,254 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type ingestSourcesJob from "../../src/jobs/ingest-sources";
+
+/*
+ * Pins the host rate limiter to its consumption point on the ICS family: an ICS
+ * ingest must resolve the per-host limiter and acquire it before the feed's
+ * HTTP fetch begins. resolveRateLimiter having a working "ical" branch is not
+ * enough — the limiter has to be threaded into the actual ingest path.
+ */
+const harness = vi.hoisted(() => {
+  interface IcsSourceRow {
+    calendarId: string;
+    ingestFutureRange: string;
+    ingestHistoricRange: string;
+    ingestWindowRecordedAt: Date | null;
+    treatFullDayTimedEventsAsAllDay: boolean;
+    url: string;
+    userId: string;
+  }
+
+  const state = {
+    hostFactoryHosts: [] as string[],
+    icsRows: [] as IcsSourceRow[],
+    /* Interleaving log: "acquire:<host>" and "fetch:<calendarId>" entries in order. */
+    orderedEvents: [] as string[],
+  };
+
+  /* Grouped as properties so vi.hoisted can own capture-free helpers. */
+  const helpers = {
+    renderStatementText: (statement: unknown): string => {
+      const collected: string[] = [];
+      const seen = new Set<object>();
+      const visit = (node: unknown): void => {
+        if (typeof node === "string") {
+          collected.push(node);
+          return;
+        }
+        if (!node || typeof node !== "object") {
+          return;
+        }
+        if (seen.has(node)) {
+          return;
+        }
+        seen.add(node);
+        for (const child of Object.values(node)) {
+          visit(child);
+        }
+      };
+      visit(statement);
+      return collected.join(" ");
+    },
+    resolveBare: (fields: Record<string, unknown>): unknown[] => {
+      if ("count" in fields) {
+        return [{ count: 10 }];
+      }
+      return [];
+    },
+    transactionRunner: async (
+      callback: (transaction: unknown) => Promise<unknown>,
+    ): Promise<unknown> => await callback({
+      execute: (): Promise<unknown[]> => Promise.resolve([]),
+    }),
+  };
+
+  const containsCalendarId = (node: unknown, calendarId: string): boolean =>
+    helpers.renderStatementText(node).includes(calendarId);
+
+  const resolveLimited = (fields: Record<string, unknown>, predicate: unknown): unknown[] => {
+    if ("failureCount" in fields) {
+      return [{ failureCount: 0, nextAttemptAt: null }];
+    }
+    if ("url" in fields) {
+      const row = state.icsRows.find(
+        (candidate) => containsCalendarId(predicate, candidate.calendarId),
+      );
+      if (!row) {
+        return [];
+      }
+      return [row];
+    }
+    return [];
+  };
+
+  const resolveListing = (fields: Record<string, unknown>): unknown[] => {
+    if ("treatFullDayTimedEventsAsAllDay" in fields) {
+      return state.icsRows;
+    }
+    return [];
+  };
+
+  const createQueryBuilder = (fields: Record<string, unknown>) => {
+    const builder: Record<string, unknown> = {};
+    const chain = (): unknown => builder;
+    builder.from = chain;
+    builder.innerJoin = chain;
+    builder.leftJoin = chain;
+    builder.where = (predicate: unknown) =>
+      Object.assign(Promise.resolve(helpers.resolveBare(fields)), {
+        limit: () => Promise.resolve(resolveLimited(fields, predicate)),
+        orderBy: () => Promise.resolve(resolveListing(fields)),
+      });
+    return builder;
+  };
+
+  const updateBuilder = {
+    set: () => ({
+      where: () => Object.assign(Promise.resolve([]), {
+        returning: () => Promise.resolve([]),
+      }),
+    }),
+  };
+
+  const fakeDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: helpers.transactionRunner,
+    update: () => updateBuilder,
+  };
+
+  const createHostRateLimiter = vi.fn((_redis: unknown, host: string) => {
+    state.hostFactoryHosts.push(host);
+    return {
+      acquire: (): Promise<void> => {
+        state.orderedEvents.push(`acquire:${host}`);
+        return Promise.resolve();
+      },
+    };
+  });
+
+  interface FakeIngestSourceOptions {
+    calendarId: string;
+    fetchEvents: () => Promise<unknown>;
+    withPersistenceTransaction: (
+      work: (persistence: unknown) => Promise<{ eventsAdded: number; eventsRemoved: number }>,
+    ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
+  }
+
+  /*
+   * The engine is not under test: fetch, then route the result through the
+   * job-provided persistence transaction, exactly like the real ingestSource.
+   */
+  const ingestSource = vi.fn(async (
+    options: FakeIngestSourceOptions,
+  ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
+    await options.fetchEvents();
+    return await options.withPersistenceTransaction(
+      () => Promise.resolve({ eventsAdded: 0, eventsRemoved: 0 }),
+    );
+  });
+
+  return { createHostRateLimiter, fakeDatabase, ingestSource, state };
+});
+
+vi.mock("@keeper.sh/calendar", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    createHostRateLimiter: harness.createHostRateLimiter,
+    ingestSource: harness.ingestSource,
+  };
+});
+
+vi.mock("@keeper.sh/calendar/ics", () => ({
+  createIcsSourceFetcher: (options: { calendarId: string }) => ({
+    fetchEvents: (): Promise<unknown> => {
+      harness.state.orderedEvents.push(`fetch:${options.calendarId}`);
+      return Promise.resolve({ events: [] });
+    },
+  }),
+  interpretFullDayTimedEventsAsAllDay: (events: unknown) => events,
+  persistCalendarSnapshot: () => Promise.resolve(),
+}));
+
+vi.mock("@keeper.sh/sync", () => ({
+  createSyncLock: () => ({
+    acquire: () => Promise.resolve({
+      acquired: true,
+      handle: {
+        isCurrent: () => Promise.resolve(true),
+        release: () => Promise.resolve(),
+      },
+    }),
+  }),
+}));
+
+/* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
+vi.mock("../../src/env", () => ({ default: {} }));
+vi.mock("../../src/context", () => ({
+  database: harness.fakeDatabase,
+  flushDatabase: harness.fakeDatabase,
+  premiumService: { getUserPlan: () => Promise.resolve("pro") },
+  refreshLockRedis: { eval: () => Promise.resolve(null), get: () => Promise.resolve(null) },
+  refreshLockStore: { release: () => Promise.resolve(), tryAcquire: () => Promise.resolve(true) },
+}));
+vi.mock("../../src/utils/logging", () => ({
+  context: (callback: () => unknown) => callback(),
+  widelog: {
+    append: () => null,
+    count: () => null,
+    error: () => null,
+    errorFields: () => null,
+    flush: () => null,
+    max: () => null,
+    min: () => null,
+    set: () => null,
+    setFields: () => null,
+    time: { measure: (_key: string, callback: () => unknown) => callback() },
+  },
+}));
+vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: () => Promise.resolve(0),
+}));
+
+let job: typeof ingestSourcesJob | null = null;
+
+beforeAll(async () => {
+  const module = await import("../../src/jobs/ingest-sources");
+  job = module.default;
+});
+
+beforeEach(() => {
+  harness.state.hostFactoryHosts.length = 0;
+  harness.state.icsRows.length = 0;
+  harness.state.orderedEvents.length = 0;
+  harness.createHostRateLimiter.mockClear();
+  harness.ingestSource.mockClear();
+});
+
+describe("ICS host limiter consumption", () => {
+  it("acquires the feed host's limiter before the ICS HTTP fetch begins", async () => {
+    harness.state.icsRows.push({
+      calendarId: "calendar-ics-1",
+      ingestFutureRange: "6m",
+      ingestHistoricRange: "1m",
+      ingestWindowRecordedAt: new Date(),
+      treatFullDayTimedEventsAsAllDay: false,
+      url: "https://feeds.example.net/team.ics",
+      userId: "user-1",
+    });
+
+    await job?.callback();
+
+    /* The ingest actually ran and fetched the feed. */
+    expect(harness.state.orderedEvents).toContain("fetch:calendar-ics-1");
+
+    /* The ICS family resolved a limiter keyed by the feed host... */
+    expect(harness.state.hostFactoryHosts).toEqual(["feeds.example.net"]);
+
+    /* ...and acquired it before the HTTP request. */
+    expect(harness.state.orderedEvents).toEqual([
+      "acquire:feeds.example.net",
+      "fetch:calendar-ics-1",
+    ]);
+  });
+});

--- a/services/cron/tests/jobs/ingest-ics-host-limiter-consumption.test.ts
+++ b/services/cron/tests/jobs/ingest-ics-host-limiter-consumption.test.ts
@@ -2,10 +2,9 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 
 /*
- * Pins the host rate limiter to its consumption point on the ICS family: an ICS
- * ingest must resolve the per-host limiter and acquire it before the feed's
- * HTTP fetch begins. resolveRateLimiter having a working "ical" branch is not
- * enough — the limiter has to be threaded into the actual ingest path.
+ * An ICS ingest must acquire the per-host limiter before its feed fetch begins:
+ * a working "ical" branch in resolveRateLimiter proves nothing unless the
+ * limiter is threaded into the ingest path itself.
  */
 const harness = vi.hoisted(() => {
   interface IcsSourceRow {
@@ -21,7 +20,6 @@ const harness = vi.hoisted(() => {
   const state = {
     hostFactoryHosts: [] as string[],
     icsRows: [] as IcsSourceRow[],
-    /* Interleaving log: "acquire:<host>" and "fetch:<calendarId>" entries in order. */
     orderedEvents: [] as string[],
   };
 
@@ -134,10 +132,6 @@ const harness = vi.hoisted(() => {
     ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
   }
 
-  /*
-   * The engine is not under test: fetch, then route the result through the
-   * job-provided persistence transaction, exactly like the real ingestSource.
-   */
   const ingestSource = vi.fn(async (
     options: FakeIngestSourceOptions,
   ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
@@ -239,13 +233,8 @@ describe("ICS host limiter consumption", () => {
 
     await job?.callback();
 
-    /* The ingest actually ran and fetched the feed. */
     expect(harness.state.orderedEvents).toContain("fetch:calendar-ics-1");
-
-    /* The ICS family resolved a limiter keyed by the feed host... */
     expect(harness.state.hostFactoryHosts).toEqual(["feeds.example.net"]);
-
-    /* ...and acquired it before the HTTP request. */
     expect(harness.state.orderedEvents).toEqual([
       "acquire:feeds.example.net",
       "fetch:calendar-ics-1",

--- a/services/cron/tests/jobs/ingest-ics-host-limiter-consumption.test.ts
+++ b/services/cron/tests/jobs/ingest-ics-host-limiter-consumption.test.ts
@@ -179,6 +179,7 @@ vi.mock("@keeper.sh/sync", () => ({
 /* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
 vi.mock("../../src/env", () => ({ default: {} }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: harness.fakeDatabase,
   flushDatabase: harness.fakeDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },

--- a/services/cron/tests/jobs/ingest-lock-release-flake.test.ts
+++ b/services/cron/tests/jobs/ingest-lock-release-flake.test.ts
@@ -189,6 +189,7 @@ vi.mock("@keeper.sh/calendar/ics", () => ({
 /* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
 vi.mock("../../src/env", () => ({ default: {} }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: harness.pooledDatabase,
   flushDatabase: harness.flushDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },

--- a/services/cron/tests/jobs/ingest-lock-release-flake.test.ts
+++ b/services/cron/tests/jobs/ingest-lock-release-flake.test.ts
@@ -1,0 +1,273 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type ingestSourcesJob from "../../src/jobs/ingest-sources";
+
+/*
+ * Pins the invariant already stated at the rateLimiter dispose site in
+ * ingest-sources.ts: a failed release must never clobber the ingest result.
+ * runSourceIngest ends with `finally { await lockResult.handle.release(); }`,
+ * and the sync lock's release is a bare redis.eval. A transient Redis failure
+ * at release time therefore replaces a successful ingest with a rejection:
+ * the settlement lands as outcome error, shouldPush is lost, and the user's
+ * destination syncs are never enqueued despite persisted changes. This test
+ * runs one ICS source through a fully successful ingest while the RELEASE
+ * script alone flakes, and requires the pass to still settle as a success
+ * with the destination sync enqueued.
+ */
+const harness = vi.hoisted(() => {
+  interface IcsSourceRow {
+    calendarId: string;
+    ingestFutureRange: string;
+    ingestHistoricRange: string;
+    ingestWindowRecordedAt: Date;
+    treatFullDayTimedEventsAsAllDay: boolean;
+    url: string;
+    userId: string;
+  }
+
+  const state = {
+    icsRows: [] as IcsSourceRow[],
+    releaseRejections: 0,
+  };
+
+  const statementTextSeparator = " ";
+  const emptyResultRows: unknown[] = [];
+
+  const containsCalendarId = (node: unknown, calendarId: string): boolean => {
+    const collected: string[] = [];
+    const seen = new Set<object>();
+    const visit = (candidate: unknown): void => {
+      if (typeof candidate === "string") {
+        collected.push(candidate);
+        return;
+      }
+      if (!candidate || typeof candidate !== "object") {
+        return;
+      }
+      if (seen.has(candidate)) {
+        return;
+      }
+      seen.add(candidate);
+      for (const child of Object.values(candidate)) {
+        visit(child);
+      }
+    };
+    visit(node);
+    return collected.join(statementTextSeparator).includes(calendarId);
+  };
+
+  const resolveLimited = (fields: Record<string, unknown>, predicate: unknown): unknown[] => {
+    if ("failureCount" in fields) {
+      return [{ failureCount: 0, nextAttemptAt: null }];
+    }
+    if ("url" in fields) {
+      const row = state.icsRows.find(
+        (candidate) => containsCalendarId(predicate, candidate.calendarId),
+      );
+      if (!row) {
+        return [];
+      }
+      return [row];
+    }
+    return [];
+  };
+
+  const resolveListing = (fields: Record<string, unknown>): unknown[] => {
+    if ("treatFullDayTimedEventsAsAllDay" in fields) {
+      return state.icsRows;
+    }
+    return [];
+  };
+
+  const createQueryBuilder = (fields: Record<string, unknown>) => {
+    const builder: Record<string, unknown> = {};
+    const chain = (): unknown => builder;
+    builder.from = chain;
+    builder.innerJoin = chain;
+    builder.leftJoin = chain;
+    builder.where = (predicate: unknown) => Object.assign(Promise.resolve([]), {
+      limit: () => Promise.resolve(resolveLimited(fields, predicate)),
+      orderBy: () => Promise.resolve(resolveListing(fields)),
+    });
+    return builder;
+  };
+
+  const updateBuilder = {
+    set: () => ({
+      where: () => Object.assign(Promise.resolve([]), {
+        returning: () => Promise.resolve([]),
+      }),
+    }),
+  };
+
+  /* The flush transaction is not under test: every statement succeeds. */
+  const flushTransaction = async (
+    callback: (transaction: unknown) => Promise<unknown>,
+  ): Promise<unknown> => await callback({
+    execute: (): Promise<unknown[]> => Promise.resolve(emptyResultRows),
+  });
+
+  const pooledDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: flushTransaction,
+    update: () => updateBuilder,
+  };
+
+  const flushDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: flushTransaction,
+    update: () => updateBuilder,
+  };
+
+  const enqueueDestinationSyncsForUsers = vi.fn(
+    (_userIds: Set<string>) => Promise.resolve(0),
+  );
+
+  interface FakeIngestSourceOptions {
+    calendarId: string;
+    fetchEvents: () => Promise<unknown>;
+    withPersistenceTransaction: (
+      work: (persistence: unknown) => Promise<{ eventsAdded: number; eventsRemoved: number }>,
+    ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
+  }
+
+  /*
+   * The engine is not under test: fetch, then route the result through the
+   * job-provided persistence transaction, exactly like the real ingestSource.
+   * One event added makes shouldPush true, so a correct pass must enqueue.
+   */
+  const ingestSource = vi.fn(async (
+    options: FakeIngestSourceOptions,
+  ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
+    await options.fetchEvents();
+    return await options.withPersistenceTransaction(
+      () => Promise.resolve({ eventsAdded: 1, eventsRemoved: 0 }),
+    );
+  });
+
+  /*
+   * Real @keeper.sh/sync lock semantics over a script-aware Redis stand-in.
+   * Every sync-lock script succeeds except RELEASE, which flakes exactly the
+   * way a transient ioredis failure surfaces: a rejected eval. The scripts are
+   * recognised by distinctive command tokens; PEXPIRE belongs only to the host
+   * rate limiter's acquire script, whose reply shape is [waitTimeMs, occupancy].
+   */
+  const redisEval = (script: string): Promise<unknown> => {
+    if (script.includes("PEXPIRE")) {
+      return Promise.resolve([0, 0]);
+    }
+    if (script.includes("LPUSH")) {
+      return Promise.resolve("acquired");
+    }
+    if (script.includes("LRANGE")) {
+      return Promise.resolve(1);
+    }
+    if (script.includes("LINDEX") && script.includes("signal ==")) {
+      return Promise.resolve(1);
+    }
+    if (script.includes("LINDEX")) {
+      return Promise.resolve("");
+    }
+    if (script.includes("EXPIRE")) {
+      return Promise.resolve(1);
+    }
+    if (script.includes("DEL")) {
+      state.releaseRejections += 1;
+      return Promise.reject(new Error("Connection is closed."));
+    }
+    return Promise.resolve([0, 0]);
+  };
+
+  return {
+    enqueueDestinationSyncsForUsers,
+    flushDatabase,
+    ingestSource,
+    pooledDatabase,
+    redisEval,
+    state,
+  };
+});
+
+vi.mock("@keeper.sh/calendar", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, ingestSource: harness.ingestSource };
+});
+
+vi.mock("@keeper.sh/calendar/ics", () => ({
+  createIcsSourceFetcher: () => ({
+    fetchEvents: () => Promise.resolve({ events: [] }),
+  }),
+  interpretFullDayTimedEventsAsAllDay: (events: unknown) => events,
+  persistCalendarSnapshot: () => Promise.resolve(),
+}));
+
+/* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
+vi.mock("../../src/env", () => ({ default: {} }));
+vi.mock("../../src/context", () => ({
+  database: harness.pooledDatabase,
+  flushDatabase: harness.flushDatabase,
+  premiumService: { getUserPlan: () => Promise.resolve("pro") },
+  refreshLockRedis: {
+    eval: (script: string) => harness.redisEval(script),
+    get: () => Promise.resolve(null),
+  },
+  refreshLockStore: { release: () => Promise.resolve(), tryAcquire: () => Promise.resolve(true) },
+}));
+vi.mock("../../src/utils/logging", () => ({
+  context: (callback: () => unknown) => callback(),
+  widelog: {
+    append: () => null,
+    count: () => null,
+    error: () => null,
+    errorFields: () => null,
+    flush: () => null,
+    max: () => null,
+    min: () => null,
+    set: () => null,
+    setFields: () => null,
+    time: { measure: (_key: string, callback: () => unknown) => callback() },
+  },
+}));
+vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: harness.enqueueDestinationSyncsForUsers,
+}));
+
+let job: typeof ingestSourcesJob | null = null;
+
+beforeAll(async () => {
+  const module = await import("../../src/jobs/ingest-sources");
+  job = module.default;
+});
+
+beforeEach(() => {
+  harness.state.icsRows.length = 0;
+  harness.state.releaseRejections = 0;
+  harness.enqueueDestinationSyncsForUsers.mockClear();
+});
+
+describe("sync-lock release flake after a successful ingest", () => {
+  it("keeps the successful result and still enqueues destination syncs", async () => {
+    harness.state.icsRows.push({
+      calendarId: "calendar-alpha",
+      ingestFutureRange: "6m",
+      ingestHistoricRange: "1m",
+      ingestWindowRecordedAt: new Date(),
+      treatFullDayTimedEventsAsAllDay: false,
+      url: "https://feeds.example.net/calendar-alpha.ics",
+      userId: "user-alpha",
+    });
+
+    /*
+     * The ingest itself succeeded and its changes are persisted; only the
+     * post-work lock release flaked. The pass must not report a failure.
+     */
+    await job?.callback();
+
+    /* The flake must actually have fired for this run to prove anything. */
+    expect(harness.state.releaseRejections).toBeGreaterThan(0);
+
+    /* ShouldPush survived, so the user's destination syncs were enqueued. */
+    expect(harness.enqueueDestinationSyncsForUsers).toHaveBeenCalledTimes(1);
+    const [enqueuedUsers] = harness.enqueueDestinationSyncsForUsers.mock.calls[0] ?? [];
+    expect([...enqueuedUsers ?? []]).toContain("user-alpha");
+  });
+});

--- a/services/cron/tests/jobs/ingest-lock-release-flake.test.ts
+++ b/services/cron/tests/jobs/ingest-lock-release-flake.test.ts
@@ -2,16 +2,9 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 
 /*
- * Pins the invariant already stated at the rateLimiter dispose site in
- * ingest-sources.ts: a failed release must never clobber the ingest result.
- * runSourceIngest ends with `finally { await lockResult.handle.release(); }`,
- * and the sync lock's release is a bare redis.eval. A transient Redis failure
- * at release time therefore replaces a successful ingest with a rejection:
- * the settlement lands as outcome error, shouldPush is lost, and the user's
- * destination syncs are never enqueued despite persisted changes. This test
- * runs one ICS source through a fully successful ingest while the RELEASE
- * script alone flakes, and requires the pass to still settle as a success
- * with the destination sync enqueued.
+ * A failed lock release must never clobber the ingest result. The release runs
+ * in a finally as a bare redis.eval, so a transient Redis failure would settle a
+ * fully persisted ingest as an error and drop the user's destination syncs.
  */
 const harness = vi.hoisted(() => {
   interface IcsSourceRow {
@@ -99,7 +92,6 @@ const harness = vi.hoisted(() => {
     }),
   };
 
-  /* The flush transaction is not under test: every statement succeeds. */
   const flushTransaction = async (
     callback: (transaction: unknown) => Promise<unknown>,
   ): Promise<unknown> => await callback({
@@ -130,11 +122,7 @@ const harness = vi.hoisted(() => {
     ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
   }
 
-  /*
-   * The engine is not under test: fetch, then route the result through the
-   * job-provided persistence transaction, exactly like the real ingestSource.
-   * One event added makes shouldPush true, so a correct pass must enqueue.
-   */
+  // One event added makes shouldPush true, so a correct pass must enqueue.
   const ingestSource = vi.fn(async (
     options: FakeIngestSourceOptions,
   ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
@@ -145,11 +133,9 @@ const harness = vi.hoisted(() => {
   });
 
   /*
-   * Real @keeper.sh/sync lock semantics over a script-aware Redis stand-in.
-   * Every sync-lock script succeeds except RELEASE, which flakes exactly the
-   * way a transient ioredis failure surfaces: a rejected eval. The scripts are
-   * recognised by distinctive command tokens; PEXPIRE belongs only to the host
-   * rate limiter's acquire script, whose reply shape is [waitTimeMs, occupancy].
+   * Scripts are told apart by distinctive command tokens: PEXPIRE belongs only
+   * to the host limiter's acquire, whose reply is [waitTimeMs, occupancy], and
+   * DEL only to RELEASE, which flakes here as a transient ioredis rejection.
    */
   const redisEval = (script: string): Promise<unknown> => {
     if (script.includes("PEXPIRE")) {
@@ -256,16 +242,11 @@ describe("sync-lock release flake after a successful ingest", () => {
       userId: "user-alpha",
     });
 
-    /*
-     * The ingest itself succeeded and its changes are persisted; only the
-     * post-work lock release flaked. The pass must not report a failure.
-     */
     await job?.callback();
 
-    /* The flake must actually have fired for this run to prove anything. */
+    // The flake must actually have fired for this run to prove anything.
     expect(harness.state.releaseRejections).toBeGreaterThan(0);
 
-    /* ShouldPush survived, so the user's destination syncs were enqueued. */
     expect(harness.enqueueDestinationSyncsForUsers).toHaveBeenCalledTimes(1);
     const [enqueuedUsers] = harness.enqueueDestinationSyncsForUsers.mock.calls[0] ?? [];
     expect([...enqueuedUsers ?? []]).toContain("user-alpha");

--- a/services/cron/tests/jobs/ingest-overlap-preemption.test.ts
+++ b/services/cron/tests/jobs/ingest-overlap-preemption.test.ts
@@ -2,18 +2,11 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 
 /*
- * Proves the cron self-preemption livelock. runSourceIngest builds its
- * per-calendar lock with createSyncLock(instrumentedLockRedis) and no second
- * argument, so every cron pass acquires with the default "preempting" class.
- * Cron passes are serial, but a timeout-abandoned run keeps executing after
- * withAbortTimeout frees its scheduler slot, so the next pass's task for a
- * calendar whose ingest is still in flight becomes a queued preempting waiter
- * instead of a skip. IS_CURRENT then reads 0 for the
- * in-flight holder, and ingest.ts discards the completed fetch before
- * persistence ("superseded"). A source slower than the cadence therefore
- * never flushes: this test interleaves two passes over one calendar through
- * the REAL sync lock and the REAL ingestSource engine and asserts the first
- * pass's finished fetch still persists.
+ * Cron passes take the per-calendar lock in the default preempting class, and a
+ * timeout-abandoned run keeps executing after its scheduler slot is freed. The
+ * next pass therefore queues as a preempting waiter, IS_CURRENT reads 0 for the
+ * in-flight holder, and its finished fetch is discarded as superseded — so a
+ * source slower than the cron cadence would never flush at all.
  */
 const harness = vi.hoisted(() => {
   interface IcsSourceRow {
@@ -35,12 +28,6 @@ const harness = vi.hoisted(() => {
     transactionCounts: { flush: 0, pooled: 0 },
   };
 
-  /*
-   * In-memory Redis implementing the sync-lock Lua scripts' semantics, so the
-   * real createSyncLock from @keeper.sh/sync runs unmodified. Dispatch mirrors
-   * packages/sync/tests/sync-lock.test.ts. Non-sync keys (the ICS host rate
-   * limiter) are granted immediately with [waitTimeMs, occupancy] = [0, 0].
-   */
   const strings = new Map<string, string>();
   const lists = new Map<string, string[]>();
   const BACKGROUND_HOLDER_PREFIX = "background:";
@@ -180,7 +167,6 @@ const harness = vi.hoisted(() => {
     get: (key: string): Promise<string | null> => Promise.resolve(readValue(key)),
   };
 
-  /* Minimal drizzle stand-ins, in the shape of ingest-reserve-before-fetch.test.ts. */
   const helpers = {
     resolveBare: (fields: Record<string, unknown>): unknown[] => {
       if ("count" in fields) {
@@ -195,7 +181,6 @@ const harness = vi.hoisted(() => {
       return [{ failureCount: 0, nextAttemptAt: null }];
     }
     if ("url" in fields) {
-      /* Drizzle predicates carry bound parameters as nested (cyclic) values. */
       const collected: string[] = [];
       const seen = new Set<object>();
       const visit = (node: unknown): void => {
@@ -279,11 +264,6 @@ const harness = vi.hoisted(() => {
   return { flushDatabase, lockRedis, pooledDatabase, state };
 });
 
-/*
- * The provider fetch is gated per call so the test controls how long each
- * pass's in-lock time lasts — the stand-in for a source slower than the 60s
- * cron cadence. Everything downstream of the fetch is the real engine.
- */
 vi.mock("@keeper.sh/calendar/ics", () => ({
   createIcsSourceFetcher: (options: { calendarId: string }) => ({
     fetchEvents: async (): Promise<unknown> => {
@@ -366,28 +346,20 @@ describe("overlapping cron passes on one calendar", () => {
     const secondFetchGate = Promise.withResolvers<null>();
     harness.state.fetchGates.push(firstFetchGate.promise, secondFetchGate.promise);
 
-    /* Pass 1 acquires the lock and parks inside its provider fetch. */
     const firstPass = Promise.resolve(job?.callback()).catch(() => null);
     await vi.waitFor(() => {
       expect(harness.state.fetchStarts).toHaveLength(1);
     }, { timeout: 5000 });
 
-    /* Pass 2 arrives on the 60s cadence while pass 1 is still fetching. */
     const secondPass = Promise.resolve(job?.callback()).catch(() => null);
     await vi.waitFor(() => {
       expect(harness.state.lockAcquireAttempts).toBeGreaterThanOrEqual(2);
     }, { timeout: 5000 });
 
     try {
-      /* The slow fetch completes while the next pass is present. */
       firstFetchGate.resolve(null);
       await firstPass;
 
-      /*
-       * The pass that did the work must persist it: an overlapping pass for the
-       * same calendar must not discard a completed fetch, or a source slower
-       * than the cadence never records its first ingest.
-       */
       expect(harness.state.transactionCounts.flush).toBe(1);
       expect(harness.state.snapshotPersistCount).toBe(1);
     } finally {

--- a/services/cron/tests/jobs/ingest-overlap-preemption.test.ts
+++ b/services/cron/tests/jobs/ingest-overlap-preemption.test.ts
@@ -288,6 +288,7 @@ vi.mock("@keeper.sh/calendar/ics", () => ({
 /* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
 vi.mock("../../src/env", () => ({ default: {} }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: harness.pooledDatabase,
   flushDatabase: harness.flushDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },

--- a/services/cron/tests/jobs/ingest-overlap-preemption.test.ts
+++ b/services/cron/tests/jobs/ingest-overlap-preemption.test.ts
@@ -1,0 +1,398 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type ingestSourcesJob from "../../src/jobs/ingest-sources";
+
+/*
+ * Proves the cron self-preemption livelock. runSourceIngest builds its
+ * per-calendar lock with createSyncLock(instrumentedLockRedis) and no second
+ * argument, so every cron pass acquires with the default "preempting" class.
+ * Cron passes are serial, but a timeout-abandoned run keeps executing after
+ * withAbortTimeout frees its scheduler slot, so the next pass's task for a
+ * calendar whose ingest is still in flight becomes a queued preempting waiter
+ * instead of a skip. IS_CURRENT then reads 0 for the
+ * in-flight holder, and ingest.ts discards the completed fetch before
+ * persistence ("superseded"). A source slower than the cadence therefore
+ * never flushes: this test interleaves two passes over one calendar through
+ * the REAL sync lock and the REAL ingestSource engine and asserts the first
+ * pass's finished fetch still persists.
+ */
+const harness = vi.hoisted(() => {
+  interface IcsSourceRow {
+    calendarId: string;
+    ingestFutureRange: string;
+    ingestHistoricRange: string;
+    ingestWindowRecordedAt: Date | null;
+    treatFullDayTimedEventsAsAllDay: boolean;
+    url: string;
+    userId: string;
+  }
+
+  const state = {
+    fetchGates: [] as Promise<null>[],
+    fetchStarts: [] as string[],
+    icsRows: [] as IcsSourceRow[],
+    lockAcquireAttempts: 0,
+    snapshotPersistCount: 0,
+    transactionCounts: { flush: 0, pooled: 0 },
+  };
+
+  /*
+   * In-memory Redis implementing the sync-lock Lua scripts' semantics, so the
+   * real createSyncLock from @keeper.sh/sync runs unmodified. Dispatch mirrors
+   * packages/sync/tests/sync-lock.test.ts. Non-sync keys (the ICS host rate
+   * limiter) are granted immediately with [waitTimeMs, occupancy] = [0, 0].
+   */
+  const strings = new Map<string, string>();
+  const lists = new Map<string, string[]>();
+  const BACKGROUND_HOLDER_PREFIX = "background:";
+
+  const readValue = (key: string): string | null => strings.get(key) ?? null;
+
+  const runAcquireOrSignal = (args: string[]): unknown => {
+    state.lockAcquireAttempts += 1;
+    const lockKey = args[0] ?? "";
+    const signalKey = args[1] ?? "";
+    const blockerLockKey = args[2] ?? "";
+    const waiterKey = args[3] ?? "";
+    const holderId = args[4] ?? "";
+    const checkBlocker = args[7] === "1";
+    if (checkBlocker && readValue(blockerLockKey) !== null) {
+      return "blocked";
+    }
+    const existing = readValue(signalKey);
+    const waiters = (lists.get(waiterKey) ?? []).filter((waiter) => waiter !== holderId);
+    waiters.unshift(holderId);
+    lists.set(waiterKey, waiters);
+    strings.set(signalKey, holderId);
+    if (readValue(lockKey) === null) {
+      strings.set(lockKey, holderId);
+      return "acquired";
+    }
+    if (existing === null) {
+      return "queued";
+    }
+    return "replaced";
+  };
+
+  const runCancelWaiter = (args: string[]): unknown => {
+    const signalKey = args[0] ?? "";
+    const waiterKey = args[1] ?? "";
+    const lockKey = args[2] ?? "";
+    const holderId = args[3] ?? "";
+    if (readValue(lockKey) === holderId) {
+      strings.delete(lockKey);
+    }
+    const waiters = (lists.get(waiterKey) ?? []).filter((waiter) => waiter !== holderId);
+    const [nextWaiter] = waiters;
+    if (nextWaiter) {
+      lists.set(waiterKey, waiters);
+      strings.set(signalKey, nextWaiter);
+      return nextWaiter;
+    }
+    lists.delete(waiterKey);
+    strings.delete(signalKey);
+    return "";
+  };
+
+  const runConfirmAcquisition = (args: string[]): unknown => {
+    const lockKey = args[0] ?? "";
+    const signalKey = args[1] ?? "";
+    const waiterKey = args[2] ?? "";
+    const holderId = args[3] ?? "";
+    const [currentWaiter] = lists.get(waiterKey) ?? [];
+    if (
+      readValue(lockKey) !== holderId
+      || readValue(signalKey) !== holderId
+      || currentWaiter !== holderId
+    ) {
+      return 0;
+    }
+    strings.delete(signalKey);
+    lists.delete(waiterKey);
+    return 1;
+  };
+
+  const runIsCurrent = (args: string[]): unknown => {
+    const lockKey = args[0] ?? "";
+    const waiterKey = args[1] ?? "";
+    const holderId = args[2] ?? "";
+    if (readValue(lockKey) !== holderId) {
+      return 0;
+    }
+    const waiters = lists.get(waiterKey) ?? [];
+    const preempted = waiters.some((waiter) =>
+      waiter !== holderId && !waiter.startsWith(BACKGROUND_HOLDER_PREFIX));
+    if (preempted) {
+      return 0;
+    }
+    return 1;
+  };
+
+  const runRenew = (args: string[]): unknown => {
+    const lockKey = args[0] ?? "";
+    const holderId = args[1] ?? "";
+    if (readValue(lockKey) === holderId) {
+      return 1;
+    }
+    return 0;
+  };
+
+  const runRelease = (args: string[]): unknown => {
+    const lockKey = args[0] ?? "";
+    const holderId = args[1] ?? "";
+    if (readValue(lockKey) === holderId) {
+      strings.delete(lockKey);
+      return 1;
+    }
+    return 0;
+  };
+
+  const lockRedis = {
+    call: (): Promise<string> => Promise.resolve("OK"),
+    del: (): Promise<number> => Promise.resolve(0),
+    eval: (script: string, keyCount: number, ...args: string[]): Promise<unknown> => {
+      const firstKey = args[0] ?? "";
+      if (!firstKey.startsWith("sync:")) {
+        /* The host limiter's acquire script expects [waitTimeMs, occupancy]. */
+        return Promise.resolve([0, 0]);
+      }
+      if (script.includes("LRANGE")) {
+        return Promise.resolve(runIsCurrent(args));
+      }
+      if (keyCount === 4 && args.length === 8) {
+        return Promise.resolve(runAcquireOrSignal(args));
+      }
+      if (keyCount === 3 && args.length === 5) {
+        return Promise.resolve(runCancelWaiter(args));
+      }
+      if (keyCount === 3 && args.length === 4) {
+        return Promise.resolve(runConfirmAcquisition(args));
+      }
+      if (keyCount === 1 && args.length === 3) {
+        return Promise.resolve(runRenew(args));
+      }
+      if (keyCount === 1 && args.length === 2) {
+        return Promise.resolve(runRelease(args));
+      }
+      return Promise.reject(
+        new Error(`Unexpected EVAL with ${keyCount} keys and ${args.length} args`),
+      );
+    },
+    get: (key: string): Promise<string | null> => Promise.resolve(readValue(key)),
+  };
+
+  /* Minimal drizzle stand-ins, in the shape of ingest-reserve-before-fetch.test.ts. */
+  const helpers = {
+    resolveBare: (fields: Record<string, unknown>): unknown[] => {
+      if ("count" in fields) {
+        return [{ count: 0 }];
+      }
+      return [];
+    },
+  };
+
+  const resolveLimited = (fields: Record<string, unknown>, predicate: unknown): unknown[] => {
+    if ("failureCount" in fields) {
+      return [{ failureCount: 0, nextAttemptAt: null }];
+    }
+    if ("url" in fields) {
+      /* Drizzle predicates carry bound parameters as nested (cyclic) values. */
+      const collected: string[] = [];
+      const seen = new Set<object>();
+      const visit = (node: unknown): void => {
+        if (typeof node === "string") {
+          collected.push(node);
+          return;
+        }
+        if (!node || typeof node !== "object") {
+          return;
+        }
+        if (seen.has(node)) {
+          return;
+        }
+        seen.add(node);
+        for (const child of Object.values(node)) {
+          visit(child);
+        }
+      };
+      visit(predicate);
+      const text = collected.join(" ");
+      const row = state.icsRows.find((candidate) => text.includes(candidate.calendarId));
+      if (!row) {
+        return [];
+      }
+      return [row];
+    }
+    return [];
+  };
+
+  const resolveListing = (fields: Record<string, unknown>): unknown[] => {
+    if ("treatFullDayTimedEventsAsAllDay" in fields) {
+      return state.icsRows;
+    }
+    return [];
+  };
+
+  const createQueryBuilder = (fields: Record<string, unknown>) => {
+    const builder: Record<string, unknown> = {};
+    const chain = (): unknown => builder;
+    builder.from = chain;
+    builder.innerJoin = chain;
+    builder.leftJoin = chain;
+    builder.where = (predicate: unknown) =>
+      Object.assign(Promise.resolve(helpers.resolveBare(fields)), {
+        limit: () => Promise.resolve(resolveLimited(fields, predicate)),
+        orderBy: () => Promise.resolve(resolveListing(fields)),
+      });
+    return builder;
+  };
+
+  const updateBuilder = {
+    set: () => ({
+      where: () => Object.assign(Promise.resolve([]), {
+        returning: () => Promise.resolve([]),
+      }),
+    }),
+  };
+
+  const createTransactionRunner = (label: "flush" | "pooled") =>
+    async (callback: (transaction: unknown) => Promise<unknown>): Promise<unknown> => {
+      state.transactionCounts[label] += 1;
+      return await callback({
+        execute: (): Promise<unknown[]> => Promise.resolve([]),
+        select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+        update: () => updateBuilder,
+      });
+    };
+
+  const pooledDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: createTransactionRunner("pooled"),
+    update: () => updateBuilder,
+  };
+
+  const flushDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: createTransactionRunner("flush"),
+    update: () => updateBuilder,
+  };
+
+  return { flushDatabase, lockRedis, pooledDatabase, state };
+});
+
+/*
+ * The provider fetch is gated per call so the test controls how long each
+ * pass's in-lock time lasts — the stand-in for a source slower than the 60s
+ * cron cadence. Everything downstream of the fetch is the real engine.
+ */
+vi.mock("@keeper.sh/calendar/ics", () => ({
+  createIcsSourceFetcher: (options: { calendarId: string }) => ({
+    fetchEvents: async (): Promise<unknown> => {
+      harness.state.fetchStarts.push(options.calendarId);
+      const gate = harness.state.fetchGates.shift();
+      if (gate) {
+        await gate;
+      }
+      return {
+        events: [],
+        snapshot: { contentHash: "hash-1", ical: "BEGIN:VCALENDAR" },
+      };
+    },
+  }),
+  interpretFullDayTimedEventsAsAllDay: (events: unknown) => events,
+  persistCalendarSnapshot: (): Promise<void> => {
+    harness.state.snapshotPersistCount += 1;
+    return Promise.resolve();
+  },
+}));
+
+/* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
+vi.mock("../../src/env", () => ({ default: {} }));
+vi.mock("../../src/context", () => ({
+  database: harness.pooledDatabase,
+  flushDatabase: harness.flushDatabase,
+  premiumService: { getUserPlan: () => Promise.resolve("pro") },
+  refreshLockRedis: harness.lockRedis,
+  refreshLockStore: { release: () => Promise.resolve(), tryAcquire: () => Promise.resolve(true) },
+}));
+vi.mock("../../src/utils/logging", () => ({
+  context: (callback: () => unknown) => callback(),
+  widelog: {
+    append: () => null,
+    count: () => null,
+    error: () => null,
+    errorFields: () => null,
+    flush: () => null,
+    max: () => null,
+    min: () => null,
+    set: () => null,
+    setFields: () => null,
+    time: { measure: (_key: string, callback: () => unknown) => callback() },
+  },
+}));
+vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: () => Promise.resolve(0),
+}));
+
+let job: typeof ingestSourcesJob | null = null;
+
+beforeAll(async () => {
+  const module = await import("../../src/jobs/ingest-sources");
+  job = module.default;
+});
+
+beforeEach(() => {
+  harness.state.fetchGates.length = 0;
+  harness.state.fetchStarts.length = 0;
+  harness.state.icsRows.length = 0;
+  harness.state.lockAcquireAttempts = 0;
+  harness.state.snapshotPersistCount = 0;
+  harness.state.transactionCounts.flush = 0;
+  harness.state.transactionCounts.pooled = 0;
+});
+
+describe("overlapping cron passes on one calendar", () => {
+  it("persists the in-flight pass's completed fetch despite the next pass arriving", async () => {
+    harness.state.icsRows.push({
+      calendarId: "calendar-slow",
+      ingestFutureRange: "6m",
+      ingestHistoricRange: "1m",
+      ingestWindowRecordedAt: new Date(),
+      treatFullDayTimedEventsAsAllDay: false,
+      url: "https://feeds.example.net/calendar-slow.ics",
+      userId: "user-slow",
+    });
+
+    const firstFetchGate = Promise.withResolvers<null>();
+    const secondFetchGate = Promise.withResolvers<null>();
+    harness.state.fetchGates.push(firstFetchGate.promise, secondFetchGate.promise);
+
+    /* Pass 1 acquires the lock and parks inside its provider fetch. */
+    const firstPass = Promise.resolve(job?.callback()).catch(() => null);
+    await vi.waitFor(() => {
+      expect(harness.state.fetchStarts).toHaveLength(1);
+    }, { timeout: 5000 });
+
+    /* Pass 2 arrives on the 60s cadence while pass 1 is still fetching. */
+    const secondPass = Promise.resolve(job?.callback()).catch(() => null);
+    await vi.waitFor(() => {
+      expect(harness.state.lockAcquireAttempts).toBeGreaterThanOrEqual(2);
+    }, { timeout: 5000 });
+
+    try {
+      /* The slow fetch completes while the next pass is present. */
+      firstFetchGate.resolve(null);
+      await firstPass;
+
+      /*
+       * The pass that did the work must persist it: an overlapping pass for the
+       * same calendar must not discard a completed fetch, or a source slower
+       * than the cadence never records its first ingest.
+       */
+      expect(harness.state.transactionCounts.flush).toBe(1);
+      expect(harness.state.snapshotPersistCount).toBe(1);
+    } finally {
+      secondFetchGate.resolve(null);
+      await secondPass;
+    }
+  });
+});

--- a/services/cron/tests/jobs/ingest-persist-probe-writer-slot.test.ts
+++ b/services/cron/tests/jobs/ingest-persist-probe-writer-slot.test.ts
@@ -1,0 +1,282 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type ingestSourcesJob from "../../src/jobs/ingest-sources";
+
+/*
+ * Pins where the persist-time currency probe's Redis I/O runs relative to the
+ * flush writer's critical section. The probe is a Redis command on the
+ * sync-lock client (commandTimeout 10s); if it is awaited after
+ * flushDatabase.transaction has opened and pg_advisory_xact_lock has been
+ * taken, a Redis brownout parks the sole flushDatabase connection, the
+ * advisory lock, and the single serial writer slot for up to 10s per flush,
+ * head-of-line stalling every family's persistence. The probe must therefore
+ * settle before the flush transaction opens — the same hazard the dedicated
+ * ADVISORY_LOCK_WAIT_BOUND_MS exists for on the pg side.
+ */
+const harness = vi.hoisted(() => {
+  interface IcsSourceRow {
+    calendarId: string;
+    ingestFutureRange: string;
+    ingestHistoricRange: string;
+    ingestWindowRecordedAt: Date;
+    treatFullDayTimedEventsAsAllDay: boolean;
+    url: string;
+    userId: string;
+  }
+
+  interface ProbeObservation {
+    advisoryLocksHeld: number;
+    openFlushTransactions: number;
+  }
+
+  const state = {
+    advisoryLocksHeld: 0,
+    icsRows: [] as IcsSourceRow[],
+    openFlushTransactions: 0,
+    probeObservations: [] as ProbeObservation[],
+  };
+
+  const statementTextSeparator = " ";
+
+  /*
+   * Drizzle SQL objects carry their bound parameters as nested values, so a
+   * deep string sweep is enough to identify a statement.
+   */
+  const renderStatementText = (statement: unknown): string => {
+    const collected: string[] = [];
+    const seen = new Set<object>();
+    const visit = (node: unknown): void => {
+      if (typeof node === "string") {
+        collected.push(node);
+        return;
+      }
+      if (!node || typeof node !== "object") {
+        return;
+      }
+      if (seen.has(node)) {
+        return;
+      }
+      seen.add(node);
+      for (const child of Object.values(node)) {
+        visit(child);
+      }
+    };
+    visit(statement);
+    return collected.join(statementTextSeparator);
+  };
+
+  const containsCalendarId = (node: unknown, calendarId: string): boolean =>
+    renderStatementText(node).includes(calendarId);
+
+  const resolveLimited = (fields: Record<string, unknown>, predicate: unknown): unknown[] => {
+    if ("failureCount" in fields) {
+      return [{ failureCount: 0, nextAttemptAt: null }];
+    }
+    if ("url" in fields) {
+      const row = state.icsRows.find(
+        (candidate) => containsCalendarId(predicate, candidate.calendarId),
+      );
+      if (!row) {
+        return [];
+      }
+      return [row];
+    }
+    return [];
+  };
+
+  const resolveListing = (fields: Record<string, unknown>): unknown[] => {
+    if ("treatFullDayTimedEventsAsAllDay" in fields) {
+      return state.icsRows;
+    }
+    return [];
+  };
+
+  const createQueryBuilder = (fields: Record<string, unknown>) => {
+    const builder: Record<string, unknown> = {};
+    const chain = (): unknown => builder;
+    builder.from = chain;
+    builder.innerJoin = chain;
+    builder.leftJoin = chain;
+    builder.where = (predicate: unknown) => Object.assign(Promise.resolve([]), {
+      limit: () => Promise.resolve(resolveLimited(fields, predicate)),
+      orderBy: () => Promise.resolve(resolveListing(fields)),
+    });
+    return builder;
+  };
+
+  const updateBuilder = {
+    set: () => ({
+      where: () => Object.assign(Promise.resolve([]), {
+        returning: () => Promise.resolve([]),
+      }),
+    }),
+  };
+
+  /*
+   * The flush transaction runner tracks the critical section: while the
+   * callback is pending the sole flushDatabase connection is occupied, and
+   * once pg_advisory_xact_lock has executed the per-calendar advisory lock is
+   * held until settlement.
+   */
+  const flushTransaction = async (
+    callback: (transaction: unknown) => Promise<unknown>,
+  ): Promise<unknown> => {
+    state.openFlushTransactions += 1;
+    let lockTakenByThisTransaction = false;
+    try {
+      return await callback({
+        execute: (statement: unknown): Promise<unknown[]> => {
+          const text = renderStatementText(statement);
+          if (text.includes("pg_advisory_xact_lock")) {
+            lockTakenByThisTransaction = true;
+            state.advisoryLocksHeld += 1;
+          }
+          return Promise.resolve([]);
+        },
+        select: () => ({
+          from: () => ({
+            where: () => Promise.resolve([]),
+          }),
+        }),
+      });
+    } finally {
+      state.openFlushTransactions -= 1;
+      if (lockTakenByThisTransaction) {
+        state.advisoryLocksHeld -= 1;
+      }
+    }
+  };
+
+  const pooledDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    update: () => updateBuilder,
+  };
+
+  const flushDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: flushTransaction,
+    update: () => updateBuilder,
+  };
+
+  const enqueueDestinationSyncsForUsers = vi.fn(
+    (_userIds: Set<string>) => Promise.resolve(0),
+  );
+
+  /* The lock handle's isCurrent is the Redis probe; record where it runs. */
+  const isCurrent = vi.fn((): Promise<boolean> => {
+    state.probeObservations.push({
+      advisoryLocksHeld: state.advisoryLocksHeld,
+      openFlushTransactions: state.openFlushTransactions,
+    });
+    return Promise.resolve(true);
+  });
+
+  return {
+    enqueueDestinationSyncsForUsers,
+    flushDatabase,
+    isCurrent,
+    pooledDatabase,
+    state,
+  };
+});
+
+vi.mock("@keeper.sh/calendar/ics", () => ({
+  createIcsSourceFetcher: () => ({
+    fetchEvents: () => Promise.resolve({ events: [] }),
+  }),
+  interpretFullDayTimedEventsAsAllDay: (events: unknown) => events,
+  persistCalendarSnapshot: () => Promise.resolve(),
+}));
+
+vi.mock("@keeper.sh/sync", () => ({
+  createSyncLock: () => ({
+    acquire: () => Promise.resolve({
+      acquired: true,
+      handle: {
+        isCurrent: harness.isCurrent,
+        release: () => Promise.resolve(),
+      },
+    }),
+  }),
+}));
+
+/* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
+vi.mock("../../src/env", () => ({ default: {} }));
+vi.mock("../../src/context", () => ({
+  database: harness.pooledDatabase,
+  flushDatabase: harness.flushDatabase,
+  premiumService: { getUserPlan: () => Promise.resolve("pro") },
+  /* The host limiter's acquire script expects [waitTimeMs, occupancy]; 0 wait grants. */
+  refreshLockRedis: { eval: () => Promise.resolve([0, 0]), get: () => Promise.resolve(null) },
+  refreshLockStore: { release: () => Promise.resolve(), tryAcquire: () => Promise.resolve(true) },
+}));
+vi.mock("../../src/utils/logging", () => ({
+  context: (callback: () => unknown) => callback(),
+  widelog: {
+    append: () => null,
+    count: () => null,
+    error: () => null,
+    errorFields: () => null,
+    flush: () => null,
+    max: () => null,
+    min: () => null,
+    set: () => null,
+    setFields: () => null,
+    time: { measure: (_key: string, callback: () => unknown) => callback() },
+  },
+}));
+vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: harness.enqueueDestinationSyncsForUsers,
+}));
+
+const createIcsRow = (calendarId: string, userId: string) => ({
+  calendarId,
+  ingestFutureRange: "6m",
+  ingestHistoricRange: "1m",
+  ingestWindowRecordedAt: new Date(),
+  treatFullDayTimedEventsAsAllDay: false,
+  url: `https://feeds.example.net/${calendarId}.ics`,
+  userId,
+});
+
+let job: typeof ingestSourcesJob | null = null;
+
+beforeAll(async () => {
+  const module = await import("../../src/jobs/ingest-sources");
+  job = module.default;
+});
+
+beforeEach(() => {
+  harness.state.advisoryLocksHeld = 0;
+  harness.state.icsRows.length = 0;
+  harness.state.openFlushTransactions = 0;
+  harness.state.probeObservations.length = 0;
+  harness.enqueueDestinationSyncsForUsers.mockClear();
+  harness.isCurrent.mockClear();
+});
+
+describe("persist-time currency probe placement", () => {
+  it("never awaits the Redis currency probe inside the open flush transaction", async () => {
+    harness.state.icsRows.push(createIcsRow("calendar-alpha", "user-alpha"));
+
+    await job?.callback();
+
+    /*
+     * Sanity: the source ran both probes — pre-enqueue and persist-time. If
+     * this drops below 2 the persist-time re-probe was removed, which is a
+     * different regression (stale flushes), not a pass.
+     */
+    expect(harness.isCurrent.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    /*
+     * The probe is a Redis command with a 10s commandTimeout. Awaiting it
+     * while the flush transaction is open (sole flushDatabase connection,
+     * pg_advisory_xact_lock held, serial writer slot occupied) lets a Redis
+     * brownout head-of-line stall every family's persistence at up to ~10s
+     * per flush. Every probe must observe zero open flush transactions.
+     */
+    const probesInsideCriticalSection = harness.state.probeObservations.filter(
+      (observation) => observation.openFlushTransactions > 0,
+    );
+    expect(probesInsideCriticalSection).toEqual([]);
+  });
+});

--- a/services/cron/tests/jobs/ingest-persist-probe-writer-slot.test.ts
+++ b/services/cron/tests/jobs/ingest-persist-probe-writer-slot.test.ts
@@ -2,15 +2,10 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 
 /*
- * Pins where the persist-time currency probe's Redis I/O runs relative to the
- * flush writer's critical section. The probe is a Redis command on the
- * sync-lock client (commandTimeout 10s); if it is awaited after
- * flushDatabase.transaction has opened and pg_advisory_xact_lock has been
- * taken, a Redis brownout parks the sole flushDatabase connection, the
- * advisory lock, and the single serial writer slot for up to 10s per flush,
- * head-of-line stalling every family's persistence. The probe must therefore
- * settle before the flush transaction opens — the same hazard the dedicated
- * ADVISORY_LOCK_WAIT_BOUND_MS exists for on the pg side.
+ * The currency probe is a Redis command with a 10s commandTimeout, so awaiting
+ * it inside the open flush transaction would let a Redis brownout hold the sole
+ * flushDatabase connection, the advisory lock, and the serial writer slot for
+ * 10s per flush. It must settle before the transaction opens.
  */
 const harness = vi.hoisted(() => {
   interface IcsSourceRow {
@@ -37,10 +32,6 @@ const harness = vi.hoisted(() => {
 
   const statementTextSeparator = " ";
 
-  /*
-   * Drizzle SQL objects carry their bound parameters as nested values, so a
-   * deep string sweep is enough to identify a statement.
-   */
   const renderStatementText = (statement: unknown): string => {
     const collected: string[] = [];
     const seen = new Set<object>();
@@ -111,12 +102,6 @@ const harness = vi.hoisted(() => {
     }),
   };
 
-  /*
-   * The flush transaction runner tracks the critical section: while the
-   * callback is pending the sole flushDatabase connection is occupied, and
-   * once pg_advisory_xact_lock has executed the per-calendar advisory lock is
-   * held until settlement.
-   */
   const flushTransaction = async (
     callback: (transaction: unknown) => Promise<unknown>,
   ): Promise<unknown> => {
@@ -161,7 +146,6 @@ const harness = vi.hoisted(() => {
     (_userIds: Set<string>) => Promise.resolve(0),
   );
 
-  /* The lock handle's isCurrent is the Redis probe; record where it runs. */
   const isCurrent = vi.fn((): Promise<boolean> => {
     state.probeObservations.push({
       advisoryLocksHeld: state.advisoryLocksHeld,
@@ -260,20 +244,9 @@ describe("persist-time currency probe placement", () => {
 
     await job?.callback();
 
-    /*
-     * Sanity: the source ran both probes — pre-enqueue and persist-time. If
-     * this drops below 2 the persist-time re-probe was removed, which is a
-     * different regression (stale flushes), not a pass.
-     */
+    // Below 2 the persist-time re-probe is gone, which is a stale-flush regression, not a pass.
     expect(harness.isCurrent.mock.calls.length).toBeGreaterThanOrEqual(2);
 
-    /*
-     * The probe is a Redis command with a 10s commandTimeout. Awaiting it
-     * while the flush transaction is open (sole flushDatabase connection,
-     * pg_advisory_xact_lock held, serial writer slot occupied) lets a Redis
-     * brownout head-of-line stall every family's persistence at up to ~10s
-     * per flush. Every probe must observe zero open flush transactions.
-     */
     const probesInsideCriticalSection = harness.state.probeObservations.filter(
       (observation) => observation.openFlushTransactions > 0,
     );

--- a/services/cron/tests/jobs/ingest-persist-probe-writer-slot.test.ts
+++ b/services/cron/tests/jobs/ingest-persist-probe-writer-slot.test.ts
@@ -186,6 +186,7 @@ vi.mock("@keeper.sh/sync", () => ({
 /* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
 vi.mock("../../src/env", () => ({ default: {} }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: harness.pooledDatabase,
   flushDatabase: harness.flushDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },

--- a/services/cron/tests/jobs/ingest-preflight-serial-slot.test.ts
+++ b/services/cron/tests/jobs/ingest-preflight-serial-slot.test.ts
@@ -1,0 +1,297 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type ingestSourcesJob from "../../src/jobs/ingest-sources";
+
+/*
+ * Pins the claim the persist-preflight comment in ingest-sources.ts makes: the
+ * persist-time currency probe (Redis I/O on the sync-lock client, 10s
+ * commandTimeout) "must settle here — after the queue wait, but BEFORE
+ * flushDatabase.transaction opens — so a Redis brownout never parks the sole
+ * flush connection, the advisory lock, or the serial writer slot".
+ *
+ * If that claim holds, a brownout-slow preflight on one source must not delay
+ * another source's flush: the serial writer slot stays free while the probe
+ * waits on Redis. This test drives two sources through the job's real
+ * reservation.submit wiring and the real serial flush worker, makes source
+ * alpha's preflight slow, and asserts source bravo's flush enters before
+ * alpha's preflight settles.
+ */
+const harness = vi.hoisted(() => {
+  interface IcsSourceRow {
+    calendarId: string;
+    ingestFutureRange: string;
+    ingestHistoricRange: string;
+    ingestWindowRecordedAt: Date;
+    treatFullDayTimedEventsAsAllDay: boolean;
+    url: string;
+    userId: string;
+  }
+
+  const alphaPreflightGate = Promise.withResolvers<null>();
+  const alphaPreflightStarted = alphaPreflightGate.promise;
+  const signalAlphaPreflightStarted = (): void => {
+    alphaPreflightGate.resolve(null);
+  };
+
+  const state = {
+    alphaPreflightStarted,
+    icsRows: [] as IcsSourceRow[],
+    signalAlphaPreflightStarted,
+    timeline: [] as string[],
+  };
+
+  /*
+   * Drizzle SQL objects carry their bound parameters (calendar ids among them)
+   * as nested values, so a deep string sweep is enough to identify a statement.
+   */
+  // eslint-disable-next-line @eslint-plugin-unicorn/consistent-function-scoping -- The vi.hoisted callback runs before module initialization, so this helper cannot live at module scope.
+  const renderStatementText = (statement: unknown): string => {
+    const collected: string[] = [];
+    const seen = new Set<object>();
+    const visit = (node: unknown): void => {
+      if (typeof node === "string") {
+        collected.push(node);
+        return;
+      }
+      if (!node || typeof node !== "object") {
+        return;
+      }
+      if (seen.has(node)) {
+        return;
+      }
+      seen.add(node);
+      for (const child of Object.values(node)) {
+        visit(child);
+      }
+    };
+    visit(statement);
+    return collected.join(" ");
+  };
+
+  const containsCalendarId = (node: unknown, calendarId: string): boolean =>
+    renderStatementText(node).includes(calendarId);
+
+  const resolveLimited = (fields: Record<string, unknown>, predicate: unknown): unknown[] => {
+    if ("failureCount" in fields) {
+      return [{ failureCount: 0, nextAttemptAt: null }];
+    }
+    if ("url" in fields) {
+      const row = state.icsRows.find(
+        (candidate) => containsCalendarId(predicate, candidate.calendarId),
+      );
+      if (!row) {
+        return [];
+      }
+      return [row];
+    }
+    return [];
+  };
+
+  const resolveListing = (fields: Record<string, unknown>): unknown[] => {
+    if ("treatFullDayTimedEventsAsAllDay" in fields) {
+      return state.icsRows;
+    }
+    return [];
+  };
+
+  const createQueryBuilder = (fields: Record<string, unknown>) => {
+    const builder: Record<string, unknown> = {};
+    const chain = (): unknown => builder;
+    builder.from = chain;
+    builder.innerJoin = chain;
+    builder.leftJoin = chain;
+    builder.where = (predicate: unknown) => Object.assign(Promise.resolve([]), {
+      limit: () => Promise.resolve(resolveLimited(fields, predicate)),
+      orderBy: () => Promise.resolve(resolveListing(fields)),
+    });
+    return builder;
+  };
+
+  const updateBuilder = {
+    set: () => ({
+      where: () => Object.assign(Promise.resolve([]), {
+        returning: () => Promise.resolve([]),
+      }),
+    }),
+  };
+
+  // eslint-disable-next-line @eslint-plugin-unicorn/consistent-function-scoping -- The vi.hoisted callback runs before module initialization, so this helper cannot live at module scope.
+  const transactionRunner = async (
+    callback: (transaction: unknown) => Promise<unknown>,
+  ): Promise<unknown> => await callback({
+    execute: (): Promise<unknown[]> => Promise.resolve([]),
+  });
+
+  const pooledDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: transactionRunner,
+    update: () => updateBuilder,
+  };
+
+  const flushDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: transactionRunner,
+    update: () => updateBuilder,
+  };
+
+  // eslint-disable-next-line @eslint-plugin-unicorn/consistent-function-scoping -- The vi.hoisted callback runs before module initialization, so this helper cannot live at module scope.
+  const sleep = (durationMs: number): Promise<void> =>
+    new Promise((resolve) => {
+      setTimeout(resolve, durationMs);
+    });
+
+  interface FakeIngestSourceOptions {
+    calendarId: string;
+    fetchEvents: () => Promise<unknown>;
+    withPersistenceTransaction: (
+      work: ((persistence: unknown) => Promise<{ eventsAdded: number; eventsRemoved: number }>)
+        & { preflight?: () => Promise<{ eventsAdded: number; eventsRemoved: number } | null> },
+    ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
+  }
+
+  /*
+   * The engine is not under test here: fetch, then route the result through
+   * the job-provided persistence transaction — carrying a persist-time
+   * preflight exactly like the real ingestSource does — so the job's
+   * reservation.submit call site and the real serial flush worker run for
+   * real. Alpha's preflight simulates a Redis brownout (a slow sync-lock
+   * isCurrent probe); bravo submits only after alpha's preflight has started,
+   * so the ordering between the two thunks is deterministic.
+   */
+  const ingestSource = vi.fn(async (
+    options: FakeIngestSourceOptions,
+  ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
+    await options.fetchEvents();
+    if (options.calendarId === "calendar-bravo") {
+      await state.alphaPreflightStarted;
+    }
+    const runFlush = (): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
+      state.timeline.push(`flush-entered:${options.calendarId}`);
+      return Promise.resolve({ eventsAdded: 1, eventsRemoved: 0 });
+    };
+    const preflight = async (): Promise<null> => {
+      state.timeline.push(`preflight-started:${options.calendarId}`);
+      if (options.calendarId === "calendar-alpha") {
+        state.signalAlphaPreflightStarted();
+        /* Simulated Redis brownout on the persist-time currency probe. */
+        await sleep(1000);
+      }
+      state.timeline.push(`preflight-settled:${options.calendarId}`);
+      return null;
+    };
+    return await options.withPersistenceTransaction(Object.assign(runFlush, { preflight }));
+  });
+
+  return {
+    flushDatabase,
+    ingestSource,
+    pooledDatabase,
+    state,
+  };
+});
+
+vi.mock("@keeper.sh/calendar", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, ingestSource: harness.ingestSource };
+});
+
+vi.mock("@keeper.sh/calendar/ics", () => ({
+  createIcsSourceFetcher: () => ({
+    fetchEvents: () => Promise.resolve({ events: [] }),
+  }),
+  interpretFullDayTimedEventsAsAllDay: (events: unknown) => events,
+  persistCalendarSnapshot: () => Promise.resolve(),
+}));
+
+vi.mock("@keeper.sh/sync", () => ({
+  createSyncLock: () => ({
+    acquire: () => Promise.resolve({
+      acquired: true,
+      handle: {
+        isCurrent: () => Promise.resolve(true),
+        release: () => Promise.resolve(),
+      },
+    }),
+  }),
+}));
+
+/* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
+vi.mock("../../src/env", () => ({ default: {} }));
+vi.mock("../../src/context", () => ({
+  database: harness.pooledDatabase,
+  flushDatabase: harness.flushDatabase,
+  premiumService: { getUserPlan: () => Promise.resolve("pro") },
+  /* The host limiter's acquire script expects [waitTimeMs, occupancy]; 0 wait grants. */
+  refreshLockRedis: { eval: () => Promise.resolve([0, 0]), get: () => Promise.resolve(null) },
+  refreshLockStore: { release: () => Promise.resolve(), tryAcquire: () => Promise.resolve(true) },
+}));
+vi.mock("../../src/utils/logging", () => ({
+  context: (callback: () => unknown) => callback(),
+  widelog: {
+    append: () => null,
+    count: () => null,
+    error: () => null,
+    errorFields: () => null,
+    flush: () => null,
+    max: () => null,
+    min: () => null,
+    set: () => null,
+    setFields: () => null,
+    time: { measure: (_key: string, callback: () => unknown) => callback() },
+  },
+}));
+vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: (_userIds: Set<string>) => Promise.resolve(0),
+}));
+
+const createIcsRow = (calendarId: string, userId: string) => ({
+  calendarId,
+  ingestFutureRange: "6m",
+  ingestHistoricRange: "1m",
+  ingestWindowRecordedAt: new Date(),
+  treatFullDayTimedEventsAsAllDay: false,
+  url: `https://feeds.example.net/${calendarId}.ics`,
+  userId,
+});
+
+let job: typeof ingestSourcesJob | null = null;
+
+beforeAll(async () => {
+  const module = await import("../../src/jobs/ingest-sources");
+  job = module.default;
+});
+
+beforeEach(() => {
+  harness.state.icsRows.length = 0;
+  harness.state.timeline.length = 0;
+  harness.ingestSource.mockClear();
+});
+
+describe("persist-time preflight and the serial writer slot", () => {
+  it("lets another source's flush proceed while one source's preflight waits on Redis", async () => {
+    /* Two different users, so grouped per-user scheduling runs them concurrently. */
+    harness.state.icsRows.push(createIcsRow("calendar-alpha", "user-alpha"));
+    harness.state.icsRows.push(createIcsRow("calendar-bravo", "user-bravo"));
+
+    await job?.callback();
+
+    const { timeline } = harness.state;
+    /* Both sources reached persistence for real. */
+    expect(timeline).toContain("flush-entered:calendar-alpha");
+    expect(timeline).toContain("flush-entered:calendar-bravo");
+
+    /*
+     * The comment above the preflight in ingest-sources.ts promises the probe
+     * "never parks the sole flush connection, the advisory lock, or the
+     * serial writer slot". If the serial writer slot really stays free while
+     * alpha's probe waits on Redis, bravo's flush — submitted after alpha's
+     * preflight began — must enter before that probe settles, instead of
+     * queueing head-of-line behind the full brownout.
+     */
+    const bravoFlushIndex = timeline.indexOf("flush-entered:calendar-bravo");
+    const alphaPreflightSettledIndex = timeline.indexOf("preflight-settled:calendar-alpha");
+    expect(
+      bravoFlushIndex,
+      `bravo's flush was parked behind alpha's preflight; timeline: ${timeline.join(" -> ")}`,
+    ).toBeLessThan(alphaPreflightSettledIndex);
+  });
+});

--- a/services/cron/tests/jobs/ingest-preflight-serial-slot.test.ts
+++ b/services/cron/tests/jobs/ingest-preflight-serial-slot.test.ts
@@ -197,6 +197,7 @@ vi.mock("@keeper.sh/sync", () => ({
 /* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
 vi.mock("../../src/env", () => ({ default: {} }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: harness.pooledDatabase,
   flushDatabase: harness.flushDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },

--- a/services/cron/tests/jobs/ingest-preflight-serial-slot.test.ts
+++ b/services/cron/tests/jobs/ingest-preflight-serial-slot.test.ts
@@ -2,18 +2,9 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 
 /*
- * Pins the claim the persist-preflight comment in ingest-sources.ts makes: the
- * persist-time currency probe (Redis I/O on the sync-lock client, 10s
- * commandTimeout) "must settle here — after the queue wait, but BEFORE
- * flushDatabase.transaction opens — so a Redis brownout never parks the sole
- * flush connection, the advisory lock, or the serial writer slot".
- *
- * If that claim holds, a brownout-slow preflight on one source must not delay
- * another source's flush: the serial writer slot stays free while the probe
- * waits on Redis. This test drives two sources through the job's real
- * reservation.submit wiring and the real serial flush worker, makes source
- * alpha's preflight slow, and asserts source bravo's flush enters before
- * alpha's preflight settles.
+ * The persist-time currency probe runs after the queue wait but before the flush
+ * transaction opens, so the serial writer slot must stay free while it waits on
+ * Redis: a brownout on one source's probe may not delay another source's flush.
  */
 const harness = vi.hoisted(() => {
   interface IcsSourceRow {
@@ -39,10 +30,6 @@ const harness = vi.hoisted(() => {
     timeline: [] as string[],
   };
 
-  /*
-   * Drizzle SQL objects carry their bound parameters (calendar ids among them)
-   * as nested values, so a deep string sweep is enough to identify a statement.
-   */
   // eslint-disable-next-line @eslint-plugin-unicorn/consistent-function-scoping -- The vi.hoisted callback runs before module initialization, so this helper cannot live at module scope.
   const renderStatementText = (statement: unknown): string => {
     const collected: string[] = [];
@@ -148,15 +135,9 @@ const harness = vi.hoisted(() => {
     ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
   }
 
-  /*
-   * The engine is not under test here: fetch, then route the result through
-   * the job-provided persistence transaction — carrying a persist-time
-   * preflight exactly like the real ingestSource does — so the job's
-   * reservation.submit call site and the real serial flush worker run for
-   * real. Alpha's preflight simulates a Redis brownout (a slow sync-lock
-   * isCurrent probe); bravo submits only after alpha's preflight has started,
-   * so the ordering between the two thunks is deterministic.
-   */
+  const SIMULATED_REDIS_BROWNOUT_MS = 1000;
+
+  // Bravo submits only once alpha's preflight has started, so the order is deterministic.
   const ingestSource = vi.fn(async (
     options: FakeIngestSourceOptions,
   ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
@@ -172,8 +153,7 @@ const harness = vi.hoisted(() => {
       state.timeline.push(`preflight-started:${options.calendarId}`);
       if (options.calendarId === "calendar-alpha") {
         state.signalAlphaPreflightStarted();
-        /* Simulated Redis brownout on the persist-time currency probe. */
-        await sleep(1000);
+        await sleep(SIMULATED_REDIS_BROWNOUT_MS);
       }
       state.timeline.push(`preflight-settled:${options.calendarId}`);
       return null;
@@ -275,18 +255,9 @@ describe("persist-time preflight and the serial writer slot", () => {
     await job?.callback();
 
     const { timeline } = harness.state;
-    /* Both sources reached persistence for real. */
     expect(timeline).toContain("flush-entered:calendar-alpha");
     expect(timeline).toContain("flush-entered:calendar-bravo");
 
-    /*
-     * The comment above the preflight in ingest-sources.ts promises the probe
-     * "never parks the sole flush connection, the advisory lock, or the
-     * serial writer slot". If the serial writer slot really stays free while
-     * alpha's probe waits on Redis, bravo's flush — submitted after alpha's
-     * preflight began — must enter before that probe settles, instead of
-     * queueing head-of-line behind the full brownout.
-     */
     const bravoFlushIndex = timeline.indexOf("flush-entered:calendar-bravo");
     const alphaPreflightSettledIndex = timeline.indexOf("preflight-settled:calendar-alpha");
     expect(

--- a/services/cron/tests/jobs/ingest-reserve-before-fetch.test.ts
+++ b/services/cron/tests/jobs/ingest-reserve-before-fetch.test.ts
@@ -3,11 +3,9 @@ import type ingestSourcesJob from "../../src/jobs/ingest-sources";
 import { NEVER_INGESTED_WEIGHT, WEIGHT_BUDGET } from "../../src/utils/ingest-weight";
 
 /*
- * Pins the reserve-before-fetch wiring: the flush writer is constructed with a
- * weight budget, every source acquires a weighted reservation BEFORE its
- * provider fetch begins (measured as wait.flush_reserve_ms), the persistence
- * transaction is submitted through that reservation, and a source that fails
- * between reserve and submit releases its weight so the next source proceeds.
+ * Every source must take its weighted reservation before its provider fetch
+ * begins, and a source that fails between reserve and submit must release its
+ * weight, or one failure parks the budget and no later source ever fetches.
  */
 const harness = vi.hoisted(() => {
   interface IcsSourceRow {
@@ -44,10 +42,6 @@ const harness = vi.hoisted(() => {
 
   const statementTextSeparator = " ";
 
-  /*
-   * Drizzle SQL objects carry their bound parameters (calendar ids among them)
-   * as nested values, so a deep string sweep is enough to identify a statement.
-   */
   const renderStatementText = (statement: unknown): string => {
     const collected: string[] = [];
     const seen = new Set<object>();
@@ -74,7 +68,6 @@ const harness = vi.hoisted(() => {
   const containsCalendarId = (node: unknown, calendarId: string): boolean =>
     renderStatementText(node).includes(calendarId);
 
-  /* Queries awaited straight off .where() — the stored-event count read among them. */
   const resolveBare = (fields: Record<string, unknown>, predicate: unknown): unknown[] => {
     if ("count" in fields) {
       const entry = [...state.storedEventCounts.entries()].find(
@@ -142,7 +135,6 @@ const harness = vi.hoisted(() => {
         state.activeTransactionCount,
       );
       try {
-        /* A queued gate holds this flush open so the test controls interleaving. */
         const gate = state.flushGates.shift();
         if (gate) {
           await gate;
@@ -202,10 +194,6 @@ const harness = vi.hoisted(() => {
     },
   });
 
-  /*
-   * The real primitive does the work; this wrapper only records how the job
-   * constructs and drives it, so the pins stay at the wiring level.
-   */
   const wrapWorkerFactory = (factory: WorkerFactory): WorkerFactory =>
     (run, options) => {
       state.workerOptionsLog.push(options ?? null);
@@ -229,10 +217,6 @@ const harness = vi.hoisted(() => {
     ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
   }
 
-  /*
-   * The engine is not under test here: fetch, then route the result through the
-   * job-provided persistence transaction, exactly like the real ingestSource.
-   */
   const ingestSource = vi.fn(async (
     options: FakeIngestSourceOptions,
   ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
@@ -372,7 +356,7 @@ beforeEach(() => {
 
 describe("reserve-before-fetch wiring", () => {
   it("constructs the flush writer with the weight budget", () => {
-    /* The worker is built at module load, so the log survives beforeEach resets. */
+    // The worker is built at module load, so the log survives beforeEach resets.
     const budgeted = harness.state.workerOptionsLog.some(
       (options) => options !== null && options.budget === WEIGHT_BUDGET,
     );
@@ -396,10 +380,6 @@ describe("reserve-before-fetch wiring", () => {
       await vi.waitFor(() => {
         expect(harness.state.transactionCounts.flush).toBeGreaterThan(0);
       });
-      /*
-       * The first source is mid-flush and still holds its full-budget weight,
-       * so the second source's reservation is parked and its fetch has not begun.
-       */
       expect(harness.state.fetchStarts).toHaveLength(1);
     } finally {
       gate.resolve(null);
@@ -408,7 +388,6 @@ describe("reserve-before-fetch wiring", () => {
 
     expect(harness.state.fetchStarts).toHaveLength(2);
     expect(harness.state.reserveRequests).toEqual([WEIGHT_BUDGET, WEIGHT_BUDGET]);
-    /* Both persistence transactions went through reservations, on the flush database. */
     expect(harness.state.reservationSubmitCount).toBe(2);
     expect(harness.state.transactionCounts.flush).toBe(2);
     expect(harness.state.transactionCounts.pooled).toBe(0);
@@ -425,11 +404,7 @@ describe("reserve-before-fetch wiring", () => {
     harness.state.storedEventCounts.set("calendar-healthy", WHALE_EVENT_COUNT);
     harness.state.failingFetchCalendarIds.add("calendar-doomed");
 
-    /*
-     * Each source reserves the whole budget, so the second reservation can only
-     * be granted if the failed source released its weight in a finally. Without
-     * the release this callback never settles.
-     */
+    // Both sources reserve the whole budget, so without the release this never settles.
     await expect(job?.callback()).rejects.toThrow(
       "Calendar source ingestion completed with failures",
     );
@@ -437,7 +412,6 @@ describe("reserve-before-fetch wiring", () => {
     expect(harness.state.fetchStarts).toContain("calendar-doomed");
     expect(harness.state.fetchStarts).toContain("calendar-healthy");
     expect(harness.state.reserveRequests).toEqual([WEIGHT_BUDGET, WEIGHT_BUDGET]);
-    /* Only the healthy source flushed; the doomed one released without submitting. */
     expect(harness.state.transactionCounts.flush).toBe(1);
     expect(harness.state.releaseCallCount).toBeGreaterThanOrEqual(1);
 
@@ -450,7 +424,7 @@ describe("reserve-before-fetch wiring", () => {
     harness.state.icsRows.push(
       createIcsRow("calendar-fresh", "user-fresh", null),
     );
-    /* A stale stored count must not shrink a first ingest's reservation. */
+    // A stale stored count must not shrink a first ingest's reservation.
     harness.state.storedEventCounts.set("calendar-fresh", 1);
 
     await job?.callback();

--- a/services/cron/tests/jobs/ingest-reserve-before-fetch.test.ts
+++ b/services/cron/tests/jobs/ingest-reserve-before-fetch.test.ts
@@ -305,7 +305,8 @@ vi.mock("../../src/context", () => ({
   database: harness.pooledDatabase,
   flushDatabase: harness.flushDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },
-  refreshLockRedis: { eval: () => Promise.resolve(null), get: () => Promise.resolve(null) },
+  /* The host limiter's acquire script expects [waitTimeMs, occupancy]; 0 wait grants. */
+  refreshLockRedis: { eval: () => Promise.resolve([0, 0]), get: () => Promise.resolve(null) },
   refreshLockStore: { release: () => Promise.resolve(), tryAcquire: () => Promise.resolve(true) },
 }));
 vi.mock("../../src/utils/logging", () => ({

--- a/services/cron/tests/jobs/ingest-reserve-before-fetch.test.ts
+++ b/services/cron/tests/jobs/ingest-reserve-before-fetch.test.ts
@@ -1,0 +1,460 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type ingestSourcesJob from "../../src/jobs/ingest-sources";
+import { NEVER_INGESTED_WEIGHT, WEIGHT_BUDGET } from "../../src/utils/ingest-weight";
+
+/*
+ * Pins the reserve-before-fetch wiring: the flush writer is constructed with a
+ * weight budget, every source acquires a weighted reservation BEFORE its
+ * provider fetch begins (measured as wait.flush_reserve_ms), the persistence
+ * transaction is submitted through that reservation, and a source that fails
+ * between reserve and submit releases its weight so the next source proceeds.
+ */
+const harness = vi.hoisted(() => {
+  interface IcsSourceRow {
+    calendarId: string;
+    ingestFutureRange: string;
+    ingestHistoricRange: string;
+    ingestWindowRecordedAt: Date | null;
+    treatFullDayTimedEventsAsAllDay: boolean;
+    url: string;
+    userId: string;
+  }
+
+  interface StatementRecord {
+    label: "flush" | "pooled";
+    text: string;
+  }
+
+  const state = {
+    activeTransactionCount: 0,
+    failingFetchCalendarIds: new Set<string>(),
+    fetchStarts: [] as string[],
+    flushGates: [] as Promise<null>[],
+    icsRows: [] as IcsSourceRow[],
+    maxActiveTransactionCount: 0,
+    releaseCallCount: 0,
+    reservationSubmitCount: 0,
+    reserveRequests: [] as number[],
+    segmentNames: [] as string[],
+    statements: [] as StatementRecord[],
+    storedEventCounts: new Map<string, number>(),
+    transactionCounts: { flush: 0, pooled: 0 },
+    workerOptionsLog: [] as (Record<string, unknown> | null)[],
+  };
+
+  const statementTextSeparator = " ";
+
+  /*
+   * Drizzle SQL objects carry their bound parameters (calendar ids among them)
+   * as nested values, so a deep string sweep is enough to identify a statement.
+   */
+  const renderStatementText = (statement: unknown): string => {
+    const collected: string[] = [];
+    const seen = new Set<object>();
+    const visit = (node: unknown): void => {
+      if (typeof node === "string") {
+        collected.push(node);
+        return;
+      }
+      if (!node || typeof node !== "object") {
+        return;
+      }
+      if (seen.has(node)) {
+        return;
+      }
+      seen.add(node);
+      for (const child of Object.values(node)) {
+        visit(child);
+      }
+    };
+    visit(statement);
+    return collected.join(statementTextSeparator);
+  };
+
+  const containsCalendarId = (node: unknown, calendarId: string): boolean =>
+    renderStatementText(node).includes(calendarId);
+
+  /* Queries awaited straight off .where() — the stored-event count read among them. */
+  const resolveBare = (fields: Record<string, unknown>, predicate: unknown): unknown[] => {
+    if ("count" in fields) {
+      const entry = [...state.storedEventCounts.entries()].find(
+        ([calendarId]) => containsCalendarId(predicate, calendarId),
+      );
+      if (!entry) {
+        return [{ count: 0 }];
+      }
+      return [{ count: entry[1] }];
+    }
+    return [];
+  };
+
+  const resolveLimited = (fields: Record<string, unknown>, predicate: unknown): unknown[] => {
+    if ("failureCount" in fields) {
+      return [{ failureCount: 0, nextAttemptAt: null }];
+    }
+    if ("url" in fields) {
+      const row = state.icsRows.find(
+        (candidate) => containsCalendarId(predicate, candidate.calendarId),
+      );
+      if (!row) {
+        return [];
+      }
+      return [row];
+    }
+    return [];
+  };
+
+  const resolveListing = (fields: Record<string, unknown>): unknown[] => {
+    if ("treatFullDayTimedEventsAsAllDay" in fields) {
+      return state.icsRows;
+    }
+    return [];
+  };
+
+  const createQueryBuilder = (fields: Record<string, unknown>) => {
+    const builder: Record<string, unknown> = {};
+    const chain = (): unknown => builder;
+    builder.from = chain;
+    builder.innerJoin = chain;
+    builder.leftJoin = chain;
+    builder.where = (predicate: unknown) =>
+      Object.assign(Promise.resolve(resolveBare(fields, predicate)), {
+        limit: () => Promise.resolve(resolveLimited(fields, predicate)),
+        orderBy: () => Promise.resolve(resolveListing(fields)),
+      });
+    return builder;
+  };
+
+  const updateBuilder = {
+    set: () => ({
+      where: () => Object.assign(Promise.resolve([]), {
+        returning: () => Promise.resolve([]),
+      }),
+    }),
+  };
+
+  const createTransactionRunner = (label: "flush" | "pooled") =>
+    async (callback: (transaction: unknown) => Promise<unknown>): Promise<unknown> => {
+      state.transactionCounts[label] += 1;
+      state.activeTransactionCount += 1;
+      state.maxActiveTransactionCount = Math.max(
+        state.maxActiveTransactionCount,
+        state.activeTransactionCount,
+      );
+      try {
+        /* A queued gate holds this flush open so the test controls interleaving. */
+        const gate = state.flushGates.shift();
+        if (gate) {
+          await gate;
+        }
+        await new Promise((resolve) => { setTimeout(resolve, 5); });
+        return await callback({
+          execute: (statement: unknown): Promise<unknown[]> => {
+            state.statements.push({ label, text: renderStatementText(statement) });
+            return Promise.resolve([]);
+          },
+        });
+      } finally {
+        state.activeTransactionCount -= 1;
+      }
+    };
+
+  const pooledDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: createTransactionRunner("pooled"),
+    update: () => updateBuilder,
+  };
+
+  const flushDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: createTransactionRunner("flush"),
+    update: () => updateBuilder,
+  };
+
+  const enqueueDestinationSyncsForUsers = vi.fn(
+    (_userIds: Set<string>) => Promise.resolve(0),
+  );
+
+  interface ReservationLike {
+    release: () => void;
+    submit: (item: unknown) => Promise<unknown>;
+  }
+
+  interface WorkerLike {
+    close: () => Promise<void>;
+    reserve: (weight: number, signal?: AbortSignal) => Promise<ReservationLike>;
+    submit: (item: unknown, signal?: AbortSignal) => Promise<unknown>;
+  }
+
+  type WorkerFactory = (
+    run: (item: unknown) => Promise<unknown>,
+    options?: Record<string, unknown>,
+  ) => WorkerLike;
+
+  const wrapReservation = (reservation: ReservationLike): ReservationLike => ({
+    release: (): void => {
+      state.releaseCallCount += 1;
+      reservation.release();
+    },
+    submit: (item: unknown): Promise<unknown> => {
+      state.reservationSubmitCount += 1;
+      return reservation.submit(item);
+    },
+  });
+
+  /*
+   * The real primitive does the work; this wrapper only records how the job
+   * constructs and drives it, so the pins stay at the wiring level.
+   */
+  const wrapWorkerFactory = (factory: WorkerFactory): WorkerFactory =>
+    (run, options) => {
+      state.workerOptionsLog.push(options ?? null);
+      const worker = factory(run, options);
+      return {
+        close: worker.close,
+        reserve: async (weight: number, signal?: AbortSignal): Promise<ReservationLike> => {
+          state.reserveRequests.push(weight);
+          const reservation = await worker.reserve(weight, signal);
+          return wrapReservation(reservation);
+        },
+        submit: worker.submit,
+      };
+    };
+
+  interface FakeIngestSourceOptions {
+    calendarId: string;
+    fetchEvents: () => Promise<unknown>;
+    withPersistenceTransaction: (
+      work: (persistence: unknown) => Promise<{ eventsAdded: number; eventsRemoved: number }>,
+    ) => Promise<{ eventsAdded: number; eventsRemoved: number }>;
+  }
+
+  /*
+   * The engine is not under test here: fetch, then route the result through the
+   * job-provided persistence transaction, exactly like the real ingestSource.
+   */
+  const ingestSource = vi.fn(async (
+    options: FakeIngestSourceOptions,
+  ): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
+    await options.fetchEvents();
+    return await options.withPersistenceTransaction(
+      () => Promise.resolve({ eventsAdded: 1, eventsRemoved: 0 }),
+    );
+  });
+
+  return {
+    enqueueDestinationSyncsForUsers,
+    flushDatabase,
+    ingestSource,
+    pooledDatabase,
+    state,
+    wrapWorkerFactory,
+  };
+});
+
+vi.mock("@keeper.sh/calendar", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  type MeasureSegment = <TResult>(
+    name: string,
+    run: () => Promise<TResult>,
+  ) => Promise<TResult>;
+  const actualMeasureSegment = actual.measureSegment as MeasureSegment;
+  const wrappedMeasureSegment: MeasureSegment = (name, run) => {
+    harness.state.segmentNames.push(name);
+    return actualMeasureSegment(name, run);
+  };
+  return {
+    ...actual,
+    createSerialFlushWorker: harness.wrapWorkerFactory(
+      actual.createSerialFlushWorker as Parameters<typeof harness.wrapWorkerFactory>[0],
+    ),
+    ingestSource: harness.ingestSource,
+    measureSegment: wrappedMeasureSegment,
+  };
+});
+
+vi.mock("@keeper.sh/calendar/ics", () => ({
+  createIcsSourceFetcher: (options: { calendarId: string }) => ({
+    fetchEvents: (): Promise<unknown> => {
+      harness.state.fetchStarts.push(options.calendarId);
+      if (harness.state.failingFetchCalendarIds.has(options.calendarId)) {
+        return Promise.reject(new Error(`provider fetch failed for ${options.calendarId}`));
+      }
+      return Promise.resolve({ events: [] });
+    },
+  }),
+  interpretFullDayTimedEventsAsAllDay: (events: unknown) => events,
+  persistCalendarSnapshot: () => Promise.resolve(),
+}));
+
+vi.mock("@keeper.sh/sync", () => ({
+  createSyncLock: () => ({
+    acquire: () => Promise.resolve({
+      acquired: true,
+      handle: {
+        isCurrent: () => Promise.resolve(true),
+        release: () => Promise.resolve(),
+      },
+    }),
+  }),
+}));
+
+/* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
+vi.mock("../../src/env", () => ({ default: {} }));
+vi.mock("../../src/context", () => ({
+  database: harness.pooledDatabase,
+  flushDatabase: harness.flushDatabase,
+  premiumService: { getUserPlan: () => Promise.resolve("pro") },
+  refreshLockRedis: { eval: () => Promise.resolve(null), get: () => Promise.resolve(null) },
+  refreshLockStore: { release: () => Promise.resolve(), tryAcquire: () => Promise.resolve(true) },
+}));
+vi.mock("../../src/utils/logging", () => ({
+  context: (callback: () => unknown) => callback(),
+  widelog: {
+    append: () => null,
+    count: () => null,
+    error: () => null,
+    errorFields: () => null,
+    flush: () => null,
+    max: () => null,
+    min: () => null,
+    set: () => null,
+    setFields: () => null,
+    time: { measure: (_key: string, callback: () => unknown) => callback() },
+  },
+}));
+vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: harness.enqueueDestinationSyncsForUsers,
+}));
+
+const createIcsRow = (
+  calendarId: string,
+  userId: string,
+  ingestWindowRecordedAt: Date | null,
+) => ({
+  calendarId,
+  ingestFutureRange: "6m",
+  ingestHistoricRange: "1m",
+  ingestWindowRecordedAt,
+  treatFullDayTimedEventsAsAllDay: false,
+  url: `https://feeds.example.net/${calendarId}.ics`,
+  userId,
+});
+
+/* Enough stored events that the estimated weight clamps to the whole budget. */
+const WHALE_EVENT_COUNT = 200_000;
+
+let job: typeof ingestSourcesJob | null = null;
+
+beforeAll(async () => {
+  const module = await import("../../src/jobs/ingest-sources");
+  job = module.default;
+});
+
+beforeEach(() => {
+  harness.state.activeTransactionCount = 0;
+  harness.state.failingFetchCalendarIds.clear();
+  harness.state.fetchStarts.length = 0;
+  harness.state.flushGates.length = 0;
+  harness.state.icsRows.length = 0;
+  harness.state.maxActiveTransactionCount = 0;
+  harness.state.releaseCallCount = 0;
+  harness.state.reservationSubmitCount = 0;
+  harness.state.reserveRequests.length = 0;
+  harness.state.segmentNames.length = 0;
+  harness.state.statements.length = 0;
+  harness.state.storedEventCounts.clear();
+  harness.state.transactionCounts.flush = 0;
+  harness.state.transactionCounts.pooled = 0;
+  harness.enqueueDestinationSyncsForUsers.mockClear();
+});
+
+describe("reserve-before-fetch wiring", () => {
+  it("constructs the flush writer with the weight budget", () => {
+    /* The worker is built at module load, so the log survives beforeEach resets. */
+    const budgeted = harness.state.workerOptionsLog.some(
+      (options) => options !== null && options.budget === WEIGHT_BUDGET,
+    );
+    expect(budgeted).toBe(true);
+  });
+
+  it("does not start a second fetch while one source holds the whole budget", async () => {
+    harness.state.icsRows.push(
+      createIcsRow("calendar-first", "user-one", new Date()),
+      createIcsRow("calendar-second", "user-two", new Date()),
+    );
+    harness.state.storedEventCounts.set("calendar-first", WHALE_EVENT_COUNT);
+    harness.state.storedEventCounts.set("calendar-second", WHALE_EVENT_COUNT);
+
+    const gate = Promise.withResolvers<null>();
+    harness.state.flushGates.push(gate.promise);
+
+    const jobRun = job?.callback() ?? Promise.resolve();
+    const settled = jobRun.catch(() => null);
+    try {
+      await vi.waitFor(() => {
+        expect(harness.state.transactionCounts.flush).toBeGreaterThan(0);
+      });
+      /*
+       * The first source is mid-flush and still holds its full-budget weight,
+       * so the second source's reservation is parked and its fetch has not begun.
+       */
+      expect(harness.state.fetchStarts).toHaveLength(1);
+    } finally {
+      gate.resolve(null);
+      await settled;
+    }
+
+    expect(harness.state.fetchStarts).toHaveLength(2);
+    expect(harness.state.reserveRequests).toEqual([WEIGHT_BUDGET, WEIGHT_BUDGET]);
+    /* Both persistence transactions went through reservations, on the flush database. */
+    expect(harness.state.reservationSubmitCount).toBe(2);
+    expect(harness.state.transactionCounts.flush).toBe(2);
+    expect(harness.state.transactionCounts.pooled).toBe(0);
+    expect(harness.state.maxActiveTransactionCount).toBe(1);
+    expect(harness.state.segmentNames).toContain("wait.flush_reserve_ms");
+  });
+
+  it("releases a failed source's weight so the next full-budget reserve proceeds", async () => {
+    harness.state.icsRows.push(
+      createIcsRow("calendar-doomed", "user-doomed", new Date()),
+      createIcsRow("calendar-healthy", "user-healthy", new Date()),
+    );
+    harness.state.storedEventCounts.set("calendar-doomed", WHALE_EVENT_COUNT);
+    harness.state.storedEventCounts.set("calendar-healthy", WHALE_EVENT_COUNT);
+    harness.state.failingFetchCalendarIds.add("calendar-doomed");
+
+    /*
+     * Each source reserves the whole budget, so the second reservation can only
+     * be granted if the failed source released its weight in a finally. Without
+     * the release this callback never settles.
+     */
+    await expect(job?.callback()).rejects.toThrow(
+      "Calendar source ingestion completed with failures",
+    );
+
+    expect(harness.state.fetchStarts).toContain("calendar-doomed");
+    expect(harness.state.fetchStarts).toContain("calendar-healthy");
+    expect(harness.state.reserveRequests).toEqual([WEIGHT_BUDGET, WEIGHT_BUDGET]);
+    /* Only the healthy source flushed; the doomed one released without submitting. */
+    expect(harness.state.transactionCounts.flush).toBe(1);
+    expect(harness.state.releaseCallCount).toBeGreaterThanOrEqual(1);
+
+    expect(harness.enqueueDestinationSyncsForUsers).toHaveBeenCalledTimes(1);
+    const [affectedUserIds] = harness.enqueueDestinationSyncsForUsers.mock.calls[0] ?? [];
+    expect([...affectedUserIds ?? []]).toEqual(["user-healthy"]);
+  });
+
+  it("reserves the heavy default weight for a never-ingested source", async () => {
+    harness.state.icsRows.push(
+      createIcsRow("calendar-fresh", "user-fresh", null),
+    );
+    /* A stale stored count must not shrink a first ingest's reservation. */
+    harness.state.storedEventCounts.set("calendar-fresh", 1);
+
+    await job?.callback();
+
+    expect(harness.state.reserveRequests).toEqual([NEVER_INGESTED_WEIGHT]);
+    expect(harness.state.transactionCounts.flush).toBe(1);
+  });
+});

--- a/services/cron/tests/jobs/ingest-reserve-before-fetch.test.ts
+++ b/services/cron/tests/jobs/ingest-reserve-before-fetch.test.ts
@@ -286,6 +286,7 @@ vi.mock("@keeper.sh/sync", () => ({
 /* No ENCRYPTION_KEY, so the CalDAV family early-returns and only ICS sources run. */
 vi.mock("../../src/env", () => ({ default: {} }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: harness.pooledDatabase,
   flushDatabase: harness.flushDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },

--- a/services/cron/tests/jobs/ingest-sources-rate-limiter.test.ts
+++ b/services/cron/tests/jobs/ingest-sources-rate-limiter.test.ts
@@ -118,6 +118,23 @@ describe("resolveRateLimiter", () => {
     expect(factorySpies.host.mock.calls[0]?.[1]).toBe("caldav.example.com");
   });
 
+  /*
+   * CalDAV sources are stored with provider 'caldav', 'fastmail', or 'icloud'
+   * (createCalDAVSourceSchema) — the branded variants must not fall through
+   * the family branch and lose their host politeness budget.
+   */
+  it("keys the branded caldav variants by server host like plain caldav", () => {
+    for (const provider of ["fastmail", "icloud"]) {
+      const limiter = resolveRateLimiter(provider, sourceContext);
+
+      expect(limiter).toBeDefined();
+      expect(typeof limiter?.acquire).toBe("function");
+    }
+    expect(factorySpies.host).toHaveBeenCalledTimes(2);
+    expect(factorySpies.host.mock.calls[0]?.[1]).toBe("caldav.example.com");
+    expect(factorySpies.host.mock.calls[1]?.[1]).toBe("caldav.example.com");
+  });
+
   it("returns a host limiter keyed by the ics feed host", () => {
     const limiter = resolveRateLimiter("ical", sourceContext);
 

--- a/services/cron/tests/jobs/ingest-sources-rate-limiter.test.ts
+++ b/services/cron/tests/jobs/ingest-sources-rate-limiter.test.ts
@@ -39,6 +39,7 @@ vi.mock("@keeper.sh/calendar", async (importOriginal) => {
 
 vi.mock("../../src/env", () => ({ default: { ENCRYPTION_KEY: "test-key" } }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: { select: () => ({}), update: () => ({}) },
   premiumService: { getUserPlan: () => Promise.resolve("pro") },
   refreshLockRedis: { eval: () => Promise.resolve(null), get: () => Promise.resolve(null) },

--- a/services/cron/tests/jobs/ingest-sources-rate-limiter.test.ts
+++ b/services/cron/tests/jobs/ingest-sources-rate-limiter.test.ts
@@ -17,11 +17,6 @@ type ResolveRateLimiter = (
   source: RateLimiterSourceContext,
 ) => FakeLimiter | undefined;
 
-/*
- * The factories are spied at the package boundary so each family's keying can be
- * asserted through the factory arguments: google by userId, outlook by accountId,
- * caldav/ical by target host.
- */
 const factorySpies = vi.hoisted(() => ({
   google: vi.fn((..._factoryArgs: unknown[]) => ({ acquire: () => Promise.resolve() })),
   host: vi.fn((..._factoryArgs: unknown[]) => ({ acquire: () => Promise.resolve() })),
@@ -118,11 +113,7 @@ describe("resolveRateLimiter", () => {
     expect(factorySpies.host.mock.calls[0]?.[1]).toBe("caldav.example.com");
   });
 
-  /*
-   * CalDAV sources are stored with provider 'caldav', 'fastmail', or 'icloud'
-   * (createCalDAVSourceSchema) — the branded variants must not fall through
-   * the family branch and lose their host politeness budget.
-   */
+  // CalDAV sources are stored as 'caldav', 'fastmail', or 'icloud', so all three need the host budget.
   it("keys the branded caldav variants by server host like plain caldav", () => {
     for (const provider of ["fastmail", "icloud"]) {
       const limiter = resolveRateLimiter(provider, sourceContext);
@@ -145,9 +136,8 @@ describe("resolveRateLimiter", () => {
   });
 
   /*
-   * The lease must be freed when the source finishes, not left to its 150s TTL:
-   * an account's fourth calendar in one pass would otherwise wait out a TTL that
-   * is longer than its own 120s ingest deadline.
+   * The lease's 150s TTL outlives a source's own 120s ingest deadline, so a
+   * lease left to expire would strand an account's next calendar in the pass.
    */
   it("releases the outlook lease on dispose", async () => {
     const limiter = resolveRateLimiter("outlook", sourceContext);

--- a/services/cron/tests/jobs/ingest-sources-rate-limiter.test.ts
+++ b/services/cron/tests/jobs/ingest-sources-rate-limiter.test.ts
@@ -1,0 +1,161 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FakeLimiter {
+  acquire(count: number, signal?: AbortSignal): Promise<void>;
+  dispose?(): Promise<void>;
+}
+
+interface RateLimiterSourceContext {
+  accountId: string;
+  serverUrl: string;
+  url: string;
+  userId: string;
+}
+
+type ResolveRateLimiter = (
+  provider: string,
+  source: RateLimiterSourceContext,
+) => FakeLimiter | undefined;
+
+/*
+ * The factories are spied at the package boundary so each family's keying can be
+ * asserted through the factory arguments: google by userId, outlook by accountId,
+ * caldav/ical by target host.
+ */
+const factorySpies = vi.hoisted(() => ({
+  google: vi.fn((..._factoryArgs: unknown[]) => ({ acquire: () => Promise.resolve() })),
+  host: vi.fn((..._factoryArgs: unknown[]) => ({ acquire: () => Promise.resolve() })),
+  outlookRelease: vi.fn((_lease: unknown) => Promise.resolve()),
+  outlook: vi.fn((..._factoryArgs: unknown[]) => ({
+    acquireLease: () => Promise.resolve({ key: "lease", token: "token" }),
+    release: factorySpies.outlookRelease,
+  })),
+}));
+
+vi.mock("@keeper.sh/calendar", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    createGoogleUserRateLimiter: factorySpies.google,
+    createHostRateLimiter: factorySpies.host,
+    createOutlookAccountSemaphore: factorySpies.outlook,
+  };
+});
+
+vi.mock("../../src/env", () => ({ default: { ENCRYPTION_KEY: "test-key" } }));
+vi.mock("../../src/context", () => ({
+  database: { select: () => ({}), update: () => ({}) },
+  premiumService: { getUserPlan: () => Promise.resolve("pro") },
+  refreshLockRedis: { eval: () => Promise.resolve(null), get: () => Promise.resolve(null) },
+  refreshLockStore: { release: () => Promise.resolve(), tryAcquire: () => Promise.resolve(true) },
+}));
+vi.mock("../../src/utils/logging", () => ({
+  context: (callback: () => unknown) => callback(),
+  widelog: {
+    append: () => null,
+    error: () => null,
+    errorFields: () => null,
+    flush: () => null,
+    set: () => null,
+    setFields: () => null,
+    time: { measure: (_key: string, callback: () => unknown) => callback() },
+  },
+}));
+vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: () => Promise.resolve(0),
+}));
+
+let resolveRateLimiter: ResolveRateLimiter = () => {
+  throw new Error("Module not loaded");
+};
+
+const sourceContext: RateLimiterSourceContext = {
+  accountId: "account-7",
+  serverUrl: "https://caldav.example.com/dav/rida/",
+  url: "https://feeds.example.net/team.ics",
+  userId: "user-1",
+};
+
+beforeAll(async () => {
+  const module = await import("../../src/jobs/ingest-sources") as unknown as Record<string, unknown>;
+  expect(typeof module.resolveRateLimiter).toBe("function");
+  resolveRateLimiter = module.resolveRateLimiter as ResolveRateLimiter;
+});
+
+beforeEach(() => {
+  factorySpies.google.mockClear();
+  factorySpies.host.mockClear();
+  factorySpies.outlook.mockClear();
+  factorySpies.outlookRelease.mockClear();
+});
+
+describe("resolveRateLimiter", () => {
+  it("returns the per-user google limiter on the ingest lane", () => {
+    const limiter = resolveRateLimiter("google", sourceContext);
+
+    expect(limiter).toBeDefined();
+    expect(typeof limiter?.acquire).toBe("function");
+    expect(factorySpies.google).toHaveBeenCalledTimes(1);
+    expect(factorySpies.google.mock.calls[0]?.[1]).toBe("user-1");
+    expect(factorySpies.google.mock.calls[0]?.[2]).toBe("ingest");
+  });
+
+  it("returns a limiter-shaped adapter over the outlook semaphore keyed by accountId", () => {
+    const limiter = resolveRateLimiter("outlook", sourceContext);
+
+    expect(limiter).toBeDefined();
+    expect(typeof limiter?.acquire).toBe("function");
+    expect(factorySpies.outlook).toHaveBeenCalledTimes(1);
+    expect(factorySpies.outlook.mock.calls[0]?.[1]).toBe("account-7");
+  });
+
+  it("returns a host limiter keyed by the caldav credential server host", () => {
+    const limiter = resolveRateLimiter("caldav", sourceContext);
+
+    expect(limiter).toBeDefined();
+    expect(typeof limiter?.acquire).toBe("function");
+    expect(factorySpies.host).toHaveBeenCalledTimes(1);
+    expect(factorySpies.host.mock.calls[0]?.[1]).toBe("caldav.example.com");
+  });
+
+  it("returns a host limiter keyed by the ics feed host", () => {
+    const limiter = resolveRateLimiter("ical", sourceContext);
+
+    expect(limiter).toBeDefined();
+    expect(typeof limiter?.acquire).toBe("function");
+    expect(factorySpies.host).toHaveBeenCalledTimes(1);
+    expect(factorySpies.host.mock.calls[0]?.[1]).toBe("feeds.example.net");
+  });
+
+  /*
+   * The lease must be freed when the source finishes, not left to its 150s TTL:
+   * an account's fourth calendar in one pass would otherwise wait out a TTL that
+   * is longer than its own 120s ingest deadline.
+   */
+  it("releases the outlook lease on dispose", async () => {
+    const limiter = resolveRateLimiter("outlook", sourceContext);
+
+    await limiter?.acquire(1);
+    await limiter?.dispose?.();
+
+    expect(factorySpies.outlookRelease).toHaveBeenCalledTimes(1);
+    expect(factorySpies.outlookRelease.mock.calls[0]?.[0]).toEqual({ key: "lease", token: "token" });
+  });
+
+  it("dispose without a prior acquire releases nothing", async () => {
+    const limiter = resolveRateLimiter("outlook", sourceContext);
+
+    await limiter?.dispose?.();
+
+    expect(factorySpies.outlookRelease).not.toHaveBeenCalled();
+  });
+
+  it("returns no limiter for an unrecognised provider", () => {
+    const limiter = resolveRateLimiter("exchange-ews", sourceContext);
+
+    expect(limiter).toBeUndefined();
+    expect(factorySpies.google).not.toHaveBeenCalled();
+    expect(factorySpies.host).not.toHaveBeenCalled();
+    expect(factorySpies.outlook).not.toHaveBeenCalled();
+  });
+});

--- a/services/cron/tests/jobs/ingest-sources-selection.test.ts
+++ b/services/cron/tests/jobs/ingest-sources-selection.test.ts
@@ -46,6 +46,7 @@ let job: typeof ingestSourcesJob | null = null;
 /* ENCRYPTION_KEY set so the CalDAV family does not early-return before its listing. */
 vi.mock("../../src/env", () => ({ default: { ENCRYPTION_KEY: "test-key" } }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: fakeDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },
   refreshLockRedis: { eval: () => Promise.resolve(null), get: () => Promise.resolve(null) },

--- a/services/cron/tests/jobs/iscurrent-flake-clobbers-success.test.ts
+++ b/services/cron/tests/jobs/iscurrent-flake-clobbers-success.test.ts
@@ -1,13 +1,9 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 /*
- * Pins the outcome of a source whose ingest SUCCEEDS (flush committed, work()
- * returned) but whose post-work isCurrent() probe rejects — a renewal-tick
- * blip latched into SyncLockRenewalError, or a raw redis.eval failure. The
- * probe only gates the optional resetIngestBackoff write; its rejection
- * carries no information about the committed ingest, so it must not replace
- * the successful result with a failure, and it must never feed the provider
- * backoff escalator.
+ * The post-work isCurrent probe only gates the optional resetIngestBackoff
+ * write, so its rejection says nothing about the already-committed ingest and
+ * must never turn that success into a failure feeding the backoff escalator.
  */
 const harness = vi.hoisted(() => {
   const state = {
@@ -40,10 +36,7 @@ const harness = vi.hoisted(() => {
 
   const resolveLimited = (fields: Record<string, unknown>): unknown[] => {
     if ("failureCount" in fields) {
-      /*
-       * A prior pass failed once, so the success path wants to clear the
-       * backoff row — which routes it through the isCurrent() probe.
-       */
+      // A non-zero count is what routes the success path through the probe.
       return [{ failureCount: 1, nextAttemptAt: null }];
     }
     if ("accessToken" in fields) {
@@ -65,10 +58,6 @@ const harness = vi.hoisted(() => {
     builder.from = chain;
     builder.innerJoin = chain;
     builder.leftJoin = chain;
-    /*
-     * Bare awaits are the stored-event count and the destination-mapping read;
-     * zero rows mean weight from defaults and default required ranges.
-     */
     const resolveBare = (): unknown[] => {
       if ("count" in fields) {
         return [{ count: 0 }];
@@ -125,13 +114,7 @@ const harness = vi.hoisted(() => {
     return Promise.resolve({ eventsAdded: 3, eventsRemoved: 1 });
   });
 
-  /*
-   * The lock acquires and releases normally, but every isCurrent probe hits a
-   * Redis failure — the renewal-error latch and the eval-backed probe both
-   * surface exactly this way after a transient blip. The mocked ingestSource
-   * never consults isCurrent mid-run, so the ONLY caller is the success path's
-   * own post-commit probe at ingest-sources.ts line 232.
-   */
+  // The mocked engine never probes mid-run, so the post-commit probe is the only caller.
   const isCurrent = (): Promise<boolean> => {
     state.isCurrentCallCount += 1;
     return Promise.reject(new Error("redis eval timed out during isCurrent"));
@@ -232,15 +215,10 @@ describe("isCurrent rejection after a successful ingest with a prior failure", (
   it("keeps the successful result and applies no backoff", async () => {
     const result = await ingestOAuthSources();
 
-    /* The ingest itself ran to completion and the probe was actually hit. */
     expect(harness.state.fetchCallCount).toBe(1);
     expect(harness.state.ingestCallCount).toBe(1);
     expect(harness.state.isCurrentCallCount).toBeGreaterThan(0);
 
-    /*
-     * The rejected probe must not clobber the committed ingest: the source
-     * counts as a success with its events, and no backoff row is escalated.
-     */
     expect(result.errors).toBe(0);
     expect(result.added).toBe(3);
     expect(result.removed).toBe(1);

--- a/services/cron/tests/jobs/iscurrent-flake-clobbers-success.test.ts
+++ b/services/cron/tests/jobs/iscurrent-flake-clobbers-success.test.ts
@@ -162,6 +162,7 @@ vi.mock("@keeper.sh/sync", () => ({
 /* No client secrets, so the token-refresh branch is skipped entirely. */
 vi.mock("../../src/env", () => ({ default: {} }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: harness.database,
   flushDatabase: harness.flushDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },

--- a/services/cron/tests/jobs/iscurrent-flake-clobbers-success.test.ts
+++ b/services/cron/tests/jobs/iscurrent-flake-clobbers-success.test.ts
@@ -1,0 +1,250 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+/*
+ * Pins the outcome of a source whose ingest SUCCEEDS (flush committed, work()
+ * returned) but whose post-work isCurrent() probe rejects — a renewal-tick
+ * blip latched into SyncLockRenewalError, or a raw redis.eval failure. The
+ * probe only gates the optional resetIngestBackoff write; its rejection
+ * carries no information about the committed ingest, so it must not replace
+ * the successful result with a failure, and it must never feed the provider
+ * backoff escalator.
+ */
+const harness = vi.hoisted(() => {
+  const state = {
+    backoffWriteCount: 0,
+    fetchCallCount: 0,
+    ingestCallCount: 0,
+    isCurrentCallCount: 0,
+  };
+
+  const FUTURE_EXPIRY_MS = 3_600_000;
+
+  const sourceRow = {
+    accountId: "account-1",
+    accessToken: "access-token",
+    calendarId: "calendar-1",
+    expiresAt: new Date(Date.now() + FUTURE_EXPIRY_MS),
+    externalCalendarId: "external-calendar-1",
+    ingestFutureRange: "6m",
+    ingestHistoricRange: "1m",
+    ingestWindowEnd: null,
+    ingestWindowRecordedAt: null,
+    ingestWindowStart: null,
+    oauthCredentialId: "credential-1",
+    provider: "outlook",
+    reauthenticationSource: null,
+    refreshToken: "refresh-token",
+    syncToken: null,
+    userId: "user-1",
+  };
+
+  const resolveLimited = (fields: Record<string, unknown>): unknown[] => {
+    if ("failureCount" in fields) {
+      /*
+       * A prior pass failed once, so the success path wants to clear the
+       * backoff row — which routes it through the isCurrent() probe.
+       */
+      return [{ failureCount: 1, nextAttemptAt: null }];
+    }
+    if ("accessToken" in fields) {
+      return [sourceRow];
+    }
+    return [];
+  };
+
+  const resolveListing = (fields: Record<string, unknown>): unknown[] => {
+    if ("reauthenticationSource" in fields) {
+      return [sourceRow];
+    }
+    return [];
+  };
+
+  const createQueryBuilder = (fields: Record<string, unknown>) => {
+    const builder: Record<string, unknown> = {};
+    const chain = (): unknown => builder;
+    builder.from = chain;
+    builder.innerJoin = chain;
+    builder.leftJoin = chain;
+    /*
+     * Bare awaits are the stored-event count and the destination-mapping read;
+     * zero rows mean weight from defaults and default required ranges.
+     */
+    const resolveBare = (): unknown[] => {
+      if ("count" in fields) {
+        return [{ count: 0 }];
+      }
+      return [];
+    };
+    builder.where = () =>
+      Object.assign(Promise.resolve(resolveBare()), {
+        limit: () => Promise.resolve(resolveLimited(fields)),
+        orderBy: () => Promise.resolve(resolveListing(fields)),
+      });
+    return builder;
+  };
+
+  const updateBuilder = {
+    set: (values: Record<string, unknown>) => ({
+      where: () => {
+        if ("ingestFailureCount" in values && values.ingestFailureCount !== 0) {
+          state.backoffWriteCount += 1;
+        }
+        return Object.assign(Promise.resolve([]), {
+          returning: () => Promise.resolve([]),
+        });
+      },
+    }),
+  };
+
+  const database = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    update: () => updateBuilder,
+  };
+
+  const flushDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: (callback: (transaction: unknown) => Promise<unknown>) =>
+      callback({ execute: () => Promise.resolve([]) }),
+    update: () => updateBuilder,
+  };
+
+  const createOutlookAccountSemaphore = vi.fn(() => ({
+    acquireLease: () => Promise.resolve({ key: "lease-key", token: "lease-token" }),
+    release: (): Promise<void> => Promise.resolve(),
+  }));
+
+  const createOutlookSourceFetcher = () => ({
+    fetchEvents: (): Promise<unknown> => {
+      state.fetchCallCount += 1;
+      return Promise.resolve({ events: [] });
+    },
+  });
+
+  const ingestSource = vi.fn((): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
+    state.ingestCallCount += 1;
+    return Promise.resolve({ eventsAdded: 3, eventsRemoved: 1 });
+  });
+
+  /*
+   * The lock acquires and releases normally, but every isCurrent probe hits a
+   * Redis failure — the renewal-error latch and the eval-backed probe both
+   * surface exactly this way after a transient blip. The mocked ingestSource
+   * never consults isCurrent mid-run, so the ONLY caller is the success path's
+   * own post-commit probe at ingest-sources.ts line 232.
+   */
+  const isCurrent = (): Promise<boolean> => {
+    state.isCurrentCallCount += 1;
+    return Promise.reject(new Error("redis eval timed out during isCurrent"));
+  };
+
+  return {
+    createOutlookAccountSemaphore,
+    createOutlookSourceFetcher,
+    database,
+    flushDatabase,
+    ingestSource,
+    isCurrent,
+    state,
+  };
+});
+
+vi.mock("@keeper.sh/calendar", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    createOutlookAccountSemaphore: harness.createOutlookAccountSemaphore,
+    ingestSource: async (options: { fetchEvents: () => Promise<unknown> }) => {
+      await options.fetchEvents();
+      return await harness.ingestSource();
+    },
+  };
+});
+
+vi.mock("@keeper.sh/calendar/outlook", () => ({
+  createOutlookSourceFetcher: harness.createOutlookSourceFetcher,
+}));
+
+vi.mock("@keeper.sh/sync", () => ({
+  createSyncLock: () => ({
+    acquire: () => Promise.resolve({
+      acquired: true,
+      handle: {
+        isCurrent: harness.isCurrent,
+        release: () => Promise.resolve(),
+      },
+    }),
+  }),
+}));
+
+/* No client secrets, so the token-refresh branch is skipped entirely. */
+vi.mock("../../src/env", () => ({ default: {} }));
+vi.mock("../../src/context", () => ({
+  database: harness.database,
+  flushDatabase: harness.flushDatabase,
+  premiumService: { getUserPlan: () => Promise.resolve("pro") },
+  refreshLockRedis: {
+    call: () => Promise.resolve("OK"),
+    del: () => Promise.resolve(1),
+    eval: () => Promise.resolve([0, 0]),
+    get: () => Promise.resolve(null),
+  },
+  refreshLockStore: { release: () => Promise.resolve(), tryAcquire: () => Promise.resolve(true) },
+}));
+vi.mock("../../src/utils/logging", () => ({
+  context: (callback: () => unknown) => callback(),
+  widelog: {
+    append: () => null,
+    count: () => null,
+    error: () => null,
+    errorFields: () => null,
+    flush: () => null,
+    max: () => null,
+    min: () => null,
+    set: () => null,
+    setFields: () => null,
+    time: { measure: (_key: string, callback: () => unknown) => callback() },
+  },
+}));
+vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: () => Promise.resolve(0),
+}));
+
+interface IngestionBatchResult {
+  added: number;
+  affectedUserIds: string[];
+  errors: number;
+  removed: number;
+}
+
+type IngestOAuthSources = (calendarIds?: string[]) => Promise<IngestionBatchResult>;
+
+let ingestOAuthSources: IngestOAuthSources = () => {
+  throw new Error("Module not loaded");
+};
+
+beforeAll(async () => {
+  const module = await import("../../src/jobs/ingest-sources") as unknown as Record<string, unknown>;
+  expect(typeof module.ingestOAuthSources).toBe("function");
+  ingestOAuthSources = module.ingestOAuthSources as IngestOAuthSources;
+});
+
+describe("isCurrent rejection after a successful ingest with a prior failure", () => {
+  it("keeps the successful result and applies no backoff", async () => {
+    const result = await ingestOAuthSources();
+
+    /* The ingest itself ran to completion and the probe was actually hit. */
+    expect(harness.state.fetchCallCount).toBe(1);
+    expect(harness.state.ingestCallCount).toBe(1);
+    expect(harness.state.isCurrentCallCount).toBeGreaterThan(0);
+
+    /*
+     * The rejected probe must not clobber the committed ingest: the source
+     * counts as a success with its events, and no backoff row is escalated.
+     */
+    expect(result.errors).toBe(0);
+    expect(result.added).toBe(3);
+    expect(result.removed).toBe(1);
+    expect(result.affectedUserIds).toEqual(["user-1"]);
+    expect(harness.state.backoffWriteCount).toBe(0);
+  });
+});

--- a/services/cron/tests/jobs/oauth-auth-failure-not-found-substring.test.ts
+++ b/services/cron/tests/jobs/oauth-auth-failure-not-found-substring.test.ts
@@ -169,6 +169,7 @@ const createUpdateQuery = (pending?: Record<string, unknown>): unknown => {
 };
 
 vi.mock("@/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: {
     select: (projection: Record<string, unknown>) =>
       createQuery(() => resolveSelect(projection)),

--- a/services/cron/tests/jobs/oauth-dispose-rejection-clobbers-success.test.ts
+++ b/services/cron/tests/jobs/oauth-dispose-rejection-clobbers-success.test.ts
@@ -1,0 +1,244 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+/*
+ * Pins the outcome of a source whose ingest SUCCEEDS but whose rate-limiter
+ * dispose() rejects in the finally (outlook lease release hitting a Redis
+ * error). The lease TTL already guarantees slot recovery, so a failed release
+ * must not replace the successful result with a failure: the settlement should
+ * stay fulfilled, count its events, and never feed the ingest backoff.
+ */
+const harness = vi.hoisted(() => {
+  const state = {
+    backoffWriteCount: 0,
+    disposeCallCount: 0,
+    fetchCallCount: 0,
+    ingestCallCount: 0,
+    releaseCallCount: 0,
+  };
+
+  const FUTURE_EXPIRY_MS = 3_600_000;
+
+  const sourceRow = {
+    accountId: "account-1",
+    accessToken: "access-token",
+    calendarId: "calendar-1",
+    expiresAt: new Date(Date.now() + FUTURE_EXPIRY_MS),
+    externalCalendarId: "external-calendar-1",
+    ingestFutureRange: "6m",
+    ingestHistoricRange: "1m",
+    ingestWindowEnd: null,
+    ingestWindowRecordedAt: null,
+    ingestWindowStart: null,
+    oauthCredentialId: "credential-1",
+    provider: "outlook",
+    reauthenticationSource: null,
+    refreshToken: "refresh-token",
+    syncToken: null,
+    userId: "user-1",
+  };
+
+  const resolveLimited = (fields: Record<string, unknown>): unknown[] => {
+    if ("failureCount" in fields) {
+      return [{ failureCount: 0, nextAttemptAt: null }];
+    }
+    if ("accessToken" in fields) {
+      return [sourceRow];
+    }
+    return [];
+  };
+
+  const resolveListing = (fields: Record<string, unknown>): unknown[] => {
+    if ("reauthenticationSource" in fields) {
+      return [sourceRow];
+    }
+    return [];
+  };
+
+  const createQueryBuilder = (fields: Record<string, unknown>) => {
+    const builder: Record<string, unknown> = {};
+    const chain = (): unknown => builder;
+    builder.from = chain;
+    builder.innerJoin = chain;
+    builder.leftJoin = chain;
+    /*
+     * Bare awaits are the stored-event count and the destination-mapping read;
+     * zero rows mean weight from defaults and default required ranges.
+     */
+    const resolveBare = (): unknown[] => {
+      if ("count" in fields) {
+        return [{ count: 0 }];
+      }
+      return [];
+    };
+    builder.where = () =>
+      Object.assign(Promise.resolve(resolveBare()), {
+        limit: () => Promise.resolve(resolveLimited(fields)),
+        orderBy: () => Promise.resolve(resolveListing(fields)),
+      });
+    return builder;
+  };
+
+  const updateBuilder = {
+    set: (values: Record<string, unknown>) => ({
+      where: () => {
+        if ("ingestFailureCount" in values) {
+          state.backoffWriteCount += 1;
+        }
+        return Object.assign(Promise.resolve([]), {
+          returning: () => Promise.resolve([]),
+        });
+      },
+    }),
+  };
+
+  const database = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    update: () => updateBuilder,
+  };
+
+  const flushDatabase = {
+    select: (fields: Record<string, unknown>) => createQueryBuilder(fields),
+    transaction: (callback: (transaction: unknown) => Promise<unknown>) =>
+      callback({ execute: () => Promise.resolve([]) }),
+    update: () => updateBuilder,
+  };
+
+  /*
+   * The semaphore's lease is granted normally, but the explicit release hits a
+   * Redis failure. The TTL still reclaims the slot, so this rejection carries
+   * no information the run needs to act on.
+   */
+  const createOutlookAccountSemaphore = vi.fn(() => ({
+    acquireLease: () => Promise.resolve({ key: "lease-key", token: "lease-token" }),
+    release: (): Promise<void> => {
+      state.releaseCallCount += 1;
+      return Promise.reject(new Error("redis connection reset during lease release"));
+    },
+  }));
+
+  const createOutlookSourceFetcher = (
+    params: { rateLimiter?: { acquire: (count: number) => Promise<void> } },
+  ) => ({
+    fetchEvents: async (): Promise<unknown> => {
+      state.fetchCallCount += 1;
+      /* Pagination goes through the limiter, so the lease is genuinely held. */
+      await params.rateLimiter?.acquire(1);
+      return { events: [] };
+    },
+  });
+
+  const ingestSource = vi.fn((): Promise<{ eventsAdded: number; eventsRemoved: number }> => {
+    state.ingestCallCount += 1;
+    return Promise.resolve({ eventsAdded: 3, eventsRemoved: 1 });
+  });
+
+  return {
+    createOutlookAccountSemaphore,
+    createOutlookSourceFetcher,
+    database,
+    flushDatabase,
+    ingestSource,
+    state,
+  };
+});
+
+vi.mock("@keeper.sh/calendar", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    createOutlookAccountSemaphore: harness.createOutlookAccountSemaphore,
+    ingestSource: async (options: { fetchEvents: () => Promise<unknown> }) => {
+      await options.fetchEvents();
+      return await harness.ingestSource();
+    },
+  };
+});
+
+vi.mock("@keeper.sh/calendar/outlook", () => ({
+  createOutlookSourceFetcher: harness.createOutlookSourceFetcher,
+}));
+
+vi.mock("@keeper.sh/sync", () => ({
+  createSyncLock: () => ({
+    acquire: () => Promise.resolve({
+      acquired: true,
+      handle: {
+        isCurrent: () => Promise.resolve(true),
+        release: () => Promise.resolve(),
+      },
+    }),
+  }),
+}));
+
+/* No client secrets, so the token-refresh branch is skipped entirely. */
+vi.mock("../../src/env", () => ({ default: {} }));
+vi.mock("../../src/context", () => ({
+  database: harness.database,
+  flushDatabase: harness.flushDatabase,
+  premiumService: { getUserPlan: () => Promise.resolve("pro") },
+  refreshLockRedis: {
+    call: () => Promise.resolve("OK"),
+    del: () => Promise.resolve(1),
+    eval: () => Promise.resolve([0, 0]),
+    get: () => Promise.resolve(null),
+  },
+  refreshLockStore: { release: () => Promise.resolve(), tryAcquire: () => Promise.resolve(true) },
+}));
+vi.mock("../../src/utils/logging", () => ({
+  context: (callback: () => unknown) => callback(),
+  widelog: {
+    append: () => null,
+    count: () => null,
+    error: () => null,
+    errorFields: () => null,
+    flush: () => null,
+    max: () => null,
+    min: () => null,
+    set: () => null,
+    setFields: () => null,
+    time: { measure: (_key: string, callback: () => unknown) => callback() },
+  },
+}));
+vi.mock("../../src/utils/enqueue-destination-syncs", () => ({
+  enqueueDestinationSyncsForUsers: () => Promise.resolve(0),
+}));
+
+interface IngestionBatchResult {
+  added: number;
+  affectedUserIds: string[];
+  errors: number;
+  removed: number;
+}
+
+type IngestOAuthSources = (calendarIds?: string[]) => Promise<IngestionBatchResult>;
+
+let ingestOAuthSources: IngestOAuthSources = () => {
+  throw new Error("Module not loaded");
+};
+
+beforeAll(async () => {
+  const module = await import("../../src/jobs/ingest-sources") as unknown as Record<string, unknown>;
+  expect(typeof module.ingestOAuthSources).toBe("function");
+  ingestOAuthSources = module.ingestOAuthSources as IngestOAuthSources;
+});
+
+describe("rate limiter dispose rejection after a successful ingest", () => {
+  it("keeps the successful result and applies no backoff", async () => {
+    const result = await ingestOAuthSources();
+
+    /* The ingest itself ran to completion and the lease release was attempted. */
+    expect(harness.state.fetchCallCount).toBe(1);
+    expect(harness.state.ingestCallCount).toBe(1);
+    expect(harness.state.releaseCallCount).toBe(1);
+
+    /*
+     * The rejected dispose must not clobber the fulfilled ingest: the source
+     * counts as a success with its events, not as an error feeding backoff.
+     */
+    expect(result.errors).toBe(0);
+    expect(result.added).toBe(3);
+    expect(result.removed).toBe(1);
+    expect(result.affectedUserIds).toEqual(["user-1"]);
+    expect(harness.state.backoffWriteCount).toBe(0);
+  });
+});

--- a/services/cron/tests/jobs/oauth-dispose-rejection-clobbers-success.test.ts
+++ b/services/cron/tests/jobs/oauth-dispose-rejection-clobbers-success.test.ts
@@ -162,6 +162,7 @@ vi.mock("@keeper.sh/sync", () => ({
 /* No client secrets, so the token-refresh branch is skipped entirely. */
 vi.mock("../../src/env", () => ({ default: {} }));
 vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: harness.database,
   flushDatabase: harness.flushDatabase,
   premiumService: { getUserPlan: () => Promise.resolve("pro") },

--- a/services/cron/tests/jobs/oauth-dispose-rejection-clobbers-success.test.ts
+++ b/services/cron/tests/jobs/oauth-dispose-rejection-clobbers-success.test.ts
@@ -1,11 +1,9 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 /*
- * Pins the outcome of a source whose ingest SUCCEEDS but whose rate-limiter
- * dispose() rejects in the finally (outlook lease release hitting a Redis
- * error). The lease TTL already guarantees slot recovery, so a failed release
- * must not replace the successful result with a failure: the settlement should
- * stay fulfilled, count its events, and never feed the ingest backoff.
+ * The lease TTL already guarantees slot recovery, so a dispose() that rejects in
+ * the finally carries no information the run needs and must never turn a
+ * successful ingest into a failure feeding the backoff.
  */
 const harness = vi.hoisted(() => {
   const state = {
@@ -60,10 +58,6 @@ const harness = vi.hoisted(() => {
     builder.from = chain;
     builder.innerJoin = chain;
     builder.leftJoin = chain;
-    /*
-     * Bare awaits are the stored-event count and the destination-mapping read;
-     * zero rows mean weight from defaults and default required ranges.
-     */
     const resolveBare = (): unknown[] => {
       if ("count" in fields) {
         return [{ count: 0 }];
@@ -103,11 +97,6 @@ const harness = vi.hoisted(() => {
     update: () => updateBuilder,
   };
 
-  /*
-   * The semaphore's lease is granted normally, but the explicit release hits a
-   * Redis failure. The TTL still reclaims the slot, so this rejection carries
-   * no information the run needs to act on.
-   */
   const createOutlookAccountSemaphore = vi.fn(() => ({
     acquireLease: () => Promise.resolve({ key: "lease-key", token: "lease-token" }),
     release: (): Promise<void> => {
@@ -121,7 +110,7 @@ const harness = vi.hoisted(() => {
   ) => ({
     fetchEvents: async (): Promise<unknown> => {
       state.fetchCallCount += 1;
-      /* Pagination goes through the limiter, so the lease is genuinely held. */
+      // Pagination goes through the limiter, so the lease is genuinely held.
       await params.rateLimiter?.acquire(1);
       return { events: [] };
     },
@@ -226,15 +215,10 @@ describe("rate limiter dispose rejection after a successful ingest", () => {
   it("keeps the successful result and applies no backoff", async () => {
     const result = await ingestOAuthSources();
 
-    /* The ingest itself ran to completion and the lease release was attempted. */
     expect(harness.state.fetchCallCount).toBe(1);
     expect(harness.state.ingestCallCount).toBe(1);
     expect(harness.state.releaseCallCount).toBe(1);
 
-    /*
-     * The rejected dispose must not clobber the fulfilled ingest: the source
-     * counts as a success with its events, not as an error feeding backoff.
-     */
     expect(result.errors).toBe(0);
     expect(result.added).toBe(3);
     expect(result.removed).toBe(1);

--- a/services/cron/tests/jobs/reauth-clear-write-failure.test.ts
+++ b/services/cron/tests/jobs/reauth-clear-write-failure.test.ts
@@ -177,6 +177,7 @@ const createUpdateQuery = (pending?: Record<string, unknown>): unknown => {
 };
 
 vi.mock("@/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: {
     select: (projection: Record<string, unknown>) =>
       createQuery(() => resolveSelect(projection)),

--- a/services/cron/tests/jobs/reauth-demand-absent-vote.test.ts
+++ b/services/cron/tests/jobs/reauth-demand-absent-vote.test.ts
@@ -152,6 +152,7 @@ const createUpdateQuery = (pending?: Record<string, unknown>): unknown => {
 };
 
 vi.mock("@/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: {
     select: (projection: Record<string, unknown>) =>
       createQuery(() => resolveSelect(projection)),

--- a/services/cron/tests/jobs/reauth-demand-log-emission.test.ts
+++ b/services/cron/tests/jobs/reauth-demand-log-emission.test.ts
@@ -119,6 +119,7 @@ const createUpdateQuery = (pending?: Record<string, unknown>): unknown => {
 };
 
 vi.mock("@/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: {
     select: (projection: Record<string, unknown>) =>
       createQuery(() => resolveSelect(projection)),

--- a/services/cron/tests/jobs/reauth-demand-provenance.test.ts
+++ b/services/cron/tests/jobs/reauth-demand-provenance.test.ts
@@ -147,6 +147,7 @@ const createUpdateQuery = (pending?: Record<string, unknown>): unknown => {
 };
 
 vi.mock("@/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: {
     select: (projection: Record<string, unknown>) =>
       createQuery(() => resolveSelect(projection)),

--- a/services/cron/tests/jobs/reauth-demand-recovery.test.ts
+++ b/services/cron/tests/jobs/reauth-demand-recovery.test.ts
@@ -211,6 +211,7 @@ const createUpdateQuery = (): unknown => {
 };
 
 vi.mock("@/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: {
     select: (projection: Record<string, unknown>) =>
       createRecordingQuery((calls) => resolveSelect(projection, calls)),

--- a/services/cron/tests/jobs/reauth-demand-telemetry.test.ts
+++ b/services/cron/tests/jobs/reauth-demand-telemetry.test.ts
@@ -169,6 +169,7 @@ const createUpdateQuery = (pending?: Record<string, unknown>): unknown => {
 };
 
 vi.mock("@/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: {
     select: (projection: Record<string, unknown>) =>
       createQuery(() => resolveSelect(projection)),

--- a/services/cron/tests/jobs/reauth-demand-write-isolation.test.ts
+++ b/services/cron/tests/jobs/reauth-demand-write-isolation.test.ts
@@ -157,6 +157,7 @@ const createUpdateQuery = (pending?: Record<string, unknown>): unknown => {
 };
 
 vi.mock("@/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: {
     select: (projection: Record<string, unknown>) =>
       createQuery(() => resolveSelect(projection)),

--- a/services/cron/tests/jobs/reauth-flag-account-churn.test.ts
+++ b/services/cron/tests/jobs/reauth-flag-account-churn.test.ts
@@ -144,6 +144,7 @@ const createUpdateQuery = (pending?: Record<string, unknown>): unknown => {
 };
 
 vi.mock("@/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: {
     select: (projection: Record<string, unknown>) =>
       createQuery(() => resolveSelect(projection)),

--- a/services/cron/tests/jobs/unclassified-database-ingest-labelling.test.ts
+++ b/services/cron/tests/jobs/unclassified-database-ingest-labelling.test.ts
@@ -123,6 +123,7 @@ const createUpdateQuery = (): unknown => {
 };
 
 vi.mock("@/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
   database: {
     select: (projection: Record<string, unknown>) =>
       createQuery(() => resolveSelect(projection)),

--- a/services/cron/tests/scheduler-shutdown.test.ts
+++ b/services/cron/tests/scheduler-shutdown.test.ts
@@ -1,0 +1,104 @@
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+/*
+ * Entrykit registers the cleanup returned by src/index.ts main() via
+ * process.once("SIGTERM", cleanup) and never calls process.exit, so the only
+ * way the cron service exits gracefully is for cleanup to leave the event
+ * loop empty. Cronbake arms bare setTimeout/setInterval timers (never
+ * unref'd), so cleanup must stop the baker: otherwise the armed schedulers
+ * keep the process alive until the supervisor SIGKILLs it, and jobs whose
+ * status is still "running" keep launching full ingest passes against the
+ * already-closed flush writer, database pools, and disconnected Redis. This
+ * test drives the real registerJobs/baker through index.ts with everything
+ * else stubbed, invokes the captured cleanup, and pins that the scheduler is
+ * stopped and fires no further ticks afterwards.
+ */
+
+interface HarnessState {
+  cleanup: (() => Promise<void>) | null;
+  tickCount: number;
+}
+
+const harness = vi.hoisted((): HarnessState => ({
+  cleanup: null,
+  tickCount: 0,
+}));
+
+vi.mock("entrykit", () => ({
+  entry: async (options: { main: () => Promise<() => Promise<void>> }): Promise<void> => {
+    harness.cleanup = await options.main();
+  },
+}));
+
+vi.mock("../src/env", () => ({
+  default: { WORKER_JOB_QUEUE_ENABLED: true },
+}));
+
+vi.mock("../src/migration-check", () => ({
+  checkWorkerMigrationStatus: (): void => {
+    // The real check may process.exit(1); the stub keeps the test alive.
+  },
+}));
+
+vi.mock("../src/context", () => ({
+  database: { name: "fake-database" },
+  shutdownDatabases: (): Promise<void> => Promise.resolve(),
+  shutdownRefreshLockRedis: (): void => {
+    // Redis is out of scope here; the stub records nothing.
+  },
+}));
+
+vi.mock("@keeper.sh/database", () => ({
+  createMigrationReadinessDatabase: (): object => ({}),
+  waitForDatabaseMigrations: (): Promise<void> => Promise.resolve(),
+}));
+
+vi.mock("../src/utils/logging", () => ({
+  destroy: (): void => {
+    // Logging teardown is out of scope here.
+  },
+}));
+
+vi.mock("../src/utils/get-jobs", () => ({
+  getAllJobs: (): Promise<unknown[]> =>
+    Promise.resolve([
+      {
+        callback: (): void => {
+          harness.tickCount += 1;
+        },
+        cron: "@every_second",
+        name: "shutdown-probe",
+      },
+    ]),
+}));
+
+describe("SIGTERM cleanup and the cronbake scheduler", () => {
+  afterAll(async () => {
+    // Disarm any timers the test left behind so the runner can exit.
+    const { baker } = await import("../src/utils/baker");
+    baker.destroyAll();
+  });
+
+  it("stops the scheduler so no new passes launch against torn-down resources", async () => {
+    await import("../src/index");
+    const { baker } = await import("../src/utils/baker");
+
+    expect(harness.cleanup).not.toBeNull();
+    expect(baker.getStatus("shutdown-probe")).toBe("running");
+
+    await harness.cleanup?.();
+
+    /*
+     * After cleanup the scheduler must be stopped: a "running" job means
+     * armed timers pin the event loop open forever (cronbake never unrefs)
+     * and keep firing ingest passes against closed pools.
+     */
+    expect(baker.getStatus("shutdown-probe")).toBe("stopped");
+
+    const ticksAtCleanup = harness.tickCount;
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1500);
+    });
+    expect(harness.tickCount).toBe(ticksAtCleanup);
+  });
+});

--- a/services/cron/tests/scheduler-shutdown.test.ts
+++ b/services/cron/tests/scheduler-shutdown.test.ts
@@ -1,17 +1,9 @@
 import { afterAll, describe, expect, it, vi } from "vitest";
 
 /*
- * Entrykit registers the cleanup returned by src/index.ts main() via
- * process.once("SIGTERM", cleanup) and never calls process.exit, so the only
- * way the cron service exits gracefully is for cleanup to leave the event
- * loop empty. Cronbake arms bare setTimeout/setInterval timers (never
- * unref'd), so cleanup must stop the baker: otherwise the armed schedulers
- * keep the process alive until the supervisor SIGKILLs it, and jobs whose
- * status is still "running" keep launching full ingest passes against the
- * already-closed flush writer, database pools, and disconnected Redis. This
- * test drives the real registerJobs/baker through index.ts with everything
- * else stubbed, invokes the captured cleanup, and pins that the scheduler is
- * stopped and fires no further ticks afterwards.
+ * Cleanup must stop the baker: cronbake's timers are never unref'd, so a
+ * still-"running" job both pins the event loop open and keeps launching
+ * ingest passes against closed pools and disconnected Redis.
  */
 
 interface HarnessState {
@@ -36,7 +28,7 @@ vi.mock("../src/env", () => ({
 
 vi.mock("../src/migration-check", () => ({
   checkWorkerMigrationStatus: (): void => {
-    // The real check may process.exit(1); the stub keeps the test alive.
+    // The real check may process.exit(1).
   },
 }));
 
@@ -44,7 +36,7 @@ vi.mock("../src/context", () => ({
   database: { name: "fake-database" },
   shutdownDatabases: (): Promise<void> => Promise.resolve(),
   shutdownRefreshLockRedis: (): void => {
-    // Redis is out of scope here; the stub records nothing.
+    // Intentionally empty.
   },
 }));
 
@@ -55,7 +47,7 @@ vi.mock("@keeper.sh/database", () => ({
 
 vi.mock("../src/utils/logging", () => ({
   destroy: (): void => {
-    // Logging teardown is out of scope here.
+    // Intentionally empty.
   },
 }));
 
@@ -74,7 +66,6 @@ vi.mock("../src/utils/get-jobs", () => ({
 
 describe("SIGTERM cleanup and the cronbake scheduler", () => {
   afterAll(async () => {
-    // Disarm any timers the test left behind so the runner can exit.
     const { baker } = await import("../src/utils/baker");
     baker.destroyAll();
   });
@@ -88,11 +79,6 @@ describe("SIGTERM cleanup and the cronbake scheduler", () => {
 
     await harness.cleanup?.();
 
-    /*
-     * After cleanup the scheduler must be stopped: a "running" job means
-     * armed timers pin the event loop open forever (cronbake never unrefs)
-     * and keep firing ingest passes against closed pools.
-     */
     expect(baker.getStatus("shutdown-probe")).toBe("stopped");
 
     const ticksAtCleanup = harness.tickCount;

--- a/services/cron/tests/shutdown-drain-redis-order.test.ts
+++ b/services/cron/tests/shutdown-drain-redis-order.test.ts
@@ -1,24 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
 /*
- * Pins the OTHER half of the shutdown ordering. The flush drain
- * (context.ts:29-45) exists so "queued and in-flight flushes settle before
- * the dedicated single-connection flushDatabase is closed" — but a drained
- * flush only commits if its persist-time currency re-probe
- * (packages/calendar/src/core/sync-engine/ingest.ts:308-313) answers
- * "current". That probe is a redis.eval on the sync-lock handle backed by
- * refreshLockRedis (packages/sync/src/sync-lock.ts:224-236,
- * ingest-sources.ts:125-143). The cleanup in src/index.ts runs
- * shutdownRefreshLockRedis() BEFORE await shutdownDatabases(), so by the
- * time the drain pumps a queued flush the client rejects every command,
- * probeCurrency (ingest.ts:203-210) reports "currency-unconfirmed", and the
- * flush returns EMPTY_RESULT without flushing: the drain "succeeds" while
- * every payload it was built to persist is silently discarded. This test
- * drives the REAL src/index.ts cleanup, the REAL context/flush-drain
- * machinery, and the REAL ingestSource persist-time probe; only the
- * process-boundary pieces (entrykit, env, databases, ioredis, polar,
- * premium) are stubbed. On current code the parked flush is discarded as
- * currency-unconfirmed, so this test FAILS, proving the issue.
+ * A drained flush only commits if its persist-time currency re-probe answers
+ * "current", and that probe is a redis.eval on refreshLockRedis. Disconnect
+ * that client before the drain and the drain still "succeeds" while every
+ * payload it was built to persist is silently discarded.
  */
 
 interface HarnessState {
@@ -47,24 +33,23 @@ vi.mock("../src/env", () => ({
 
 vi.mock("../src/migration-check", () => ({
   checkWorkerMigrationStatus: (): void => {
-    // The real check may process.exit(1); the stub keeps the test alive.
+    // The real check may process.exit(1).
   },
 }));
 
 vi.mock("../src/utils/logging", () => ({
   destroy: (): void => {
-    // Logging teardown is out of scope here.
+    // Intentionally empty.
   },
 }));
 
 vi.mock("../src/utils/get-jobs", () => ({
-  // No scheduled jobs: the parked flush is injected through the drain registry.
   getAllJobs: (): Promise<unknown[]> => Promise.resolve([]),
 }));
 
 vi.mock("@keeper.sh/database", () => ({
   closeDatabase: (): void => {
-    // Pool teardown is out of scope here.
+    // Intentionally empty.
   },
   createDatabase: (): Promise<object> => Promise.resolve({}),
   createMigrationReadinessDatabase: (): object => ({}),
@@ -82,11 +67,7 @@ vi.mock("@polar-sh/sdk", () => ({
   },
 }));
 
-/*
- * Mirror of ioredis teardown semantics: after disconnect() the client
- * rejects every command with the bare "Connection is closed." Error — the
- * exact rejection the persist-time probe sees during shutdown.
- */
+/* Mirrors ioredis: after disconnect() every command rejects "Connection is closed." */
 vi.mock("ioredis", () => ({
   default: class FakeRedis {
     public closed = false;
@@ -113,11 +94,6 @@ describe("SIGTERM cleanup and the flush drain's currency probe", () => {
 
     expect(harness.cleanup).not.toBeNull();
 
-    /*
-     * Mirror of the sourceIngestLock handle's isCurrent
-     * (packages/sync/src/sync-lock.ts:224-236): a redis.eval round trip on
-     * the very client shutdownRefreshLockRedis disconnects.
-     */
     const isCurrent = async (): Promise<boolean> => {
       const current = await (refreshLockRedis as {
         eval: (...args: unknown[]) => Promise<unknown>;
@@ -125,11 +101,6 @@ describe("SIGTERM cleanup and the flush drain's currency probe", () => {
       return current === 1;
     };
 
-    /*
-     * Park one flush exactly as a live source would at deploy time: payload
-     * fully fetched, pre-enqueue probe passed, transaction thunk waiting in
-     * the serial flush queue for the drain to pump it.
-     */
     const queuedThunks: (() => void)[] = [];
     let flushCommitted = false;
     let recordedOutcome = "";
@@ -157,7 +128,6 @@ describe("SIGTERM cleanup and the flush drain's currency probe", () => {
       }),
     });
 
-    /* Let the fetch and the pre-enqueue probe settle so the thunk parks. */
     await new Promise((resolve) => { setTimeout(resolve, 0); });
     expect(queuedThunks).toHaveLength(1);
 
@@ -172,15 +142,9 @@ describe("SIGTERM cleanup and the flush drain's currency probe", () => {
 
     await harness.cleanup?.();
 
-    /* The drain itself completes either way — that is what masks the loss. */
+    /* The drain completes either way — that is what masks the loss. */
     expect(drained).toBe(true);
 
-    /*
-     * The whole point of draining before closing the flush database is that
-     * the queued flush PERSISTS. If refreshLockRedis was disconnected first,
-     * the persist-time probe answers "currency-unconfirmed" and the payload
-     * is silently discarded.
-     */
     expect(recordedOutcome).not.toBe("currency-unconfirmed");
     expect(flushCommitted).toBe(true);
   });

--- a/services/cron/tests/shutdown-drain-redis-order.test.ts
+++ b/services/cron/tests/shutdown-drain-redis-order.test.ts
@@ -88,8 +88,7 @@ vi.mock("ioredis", () => ({
 describe("SIGTERM cleanup and the flush drain's currency probe", () => {
   it("keeps refreshLockRedis alive until drained flushes have committed", async () => {
     await import("../src/index");
-    const { refreshLockRedis } = await import("../src/context");
-    const { registerFlushDrain } = await import("../src/utils/flush-drains");
+    const { flushDrainRegistry, refreshLockRedis } = await import("../src/context");
     const { ingestSource } = await import("@keeper.sh/calendar");
 
     expect(harness.cleanup).not.toBeNull();
@@ -132,7 +131,7 @@ describe("SIGTERM cleanup and the flush drain's currency probe", () => {
     expect(queuedThunks).toHaveLength(1);
 
     let drained = false;
-    registerFlushDrain(async () => {
+    flushDrainRegistry.register(async () => {
       for (const runThunk of queuedThunks.splice(0)) {
         runThunk();
       }

--- a/services/cron/tests/shutdown-drain-redis-order.test.ts
+++ b/services/cron/tests/shutdown-drain-redis-order.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+
+/*
+ * Pins the OTHER half of the shutdown ordering. The flush drain
+ * (context.ts:29-45) exists so "queued and in-flight flushes settle before
+ * the dedicated single-connection flushDatabase is closed" — but a drained
+ * flush only commits if its persist-time currency re-probe
+ * (packages/calendar/src/core/sync-engine/ingest.ts:308-313) answers
+ * "current". That probe is a redis.eval on the sync-lock handle backed by
+ * refreshLockRedis (packages/sync/src/sync-lock.ts:224-236,
+ * ingest-sources.ts:125-143). The cleanup in src/index.ts runs
+ * shutdownRefreshLockRedis() BEFORE await shutdownDatabases(), so by the
+ * time the drain pumps a queued flush the client rejects every command,
+ * probeCurrency (ingest.ts:203-210) reports "currency-unconfirmed", and the
+ * flush returns EMPTY_RESULT without flushing: the drain "succeeds" while
+ * every payload it was built to persist is silently discarded. This test
+ * drives the REAL src/index.ts cleanup, the REAL context/flush-drain
+ * machinery, and the REAL ingestSource persist-time probe; only the
+ * process-boundary pieces (entrykit, env, databases, ioredis, polar,
+ * premium) are stubbed. On current code the parked flush is discarded as
+ * currency-unconfirmed, so this test FAILS, proving the issue.
+ */
+
+interface HarnessState {
+  cleanup: (() => Promise<void>) | null;
+}
+
+const harness = vi.hoisted((): HarnessState => ({
+  cleanup: null,
+}));
+
+vi.mock("entrykit", () => ({
+  entry: async (options: { main: () => Promise<() => Promise<void>> }): Promise<void> => {
+    harness.cleanup = await options.main();
+  },
+}));
+
+vi.mock("../src/env", () => ({
+  default: {
+    COMMERCIAL_MODE: false,
+    DATABASE_POOL_MAX: 10,
+    DATABASE_URL: "postgres://cron-test/keeper",
+    REDIS_URL: "redis://cron-test:6379",
+    WORKER_JOB_QUEUE_ENABLED: false,
+  },
+}));
+
+vi.mock("../src/migration-check", () => ({
+  checkWorkerMigrationStatus: (): void => {
+    // The real check may process.exit(1); the stub keeps the test alive.
+  },
+}));
+
+vi.mock("../src/utils/logging", () => ({
+  destroy: (): void => {
+    // Logging teardown is out of scope here.
+  },
+}));
+
+vi.mock("../src/utils/get-jobs", () => ({
+  // No scheduled jobs: the parked flush is injected through the drain registry.
+  getAllJobs: (): Promise<unknown[]> => Promise.resolve([]),
+}));
+
+vi.mock("@keeper.sh/database", () => ({
+  closeDatabase: (): void => {
+    // Pool teardown is out of scope here.
+  },
+  createDatabase: (): Promise<object> => Promise.resolve({}),
+  createMigrationReadinessDatabase: (): object => ({}),
+  waitForDatabaseMigrations: (): Promise<void> => Promise.resolve(),
+}));
+
+vi.mock("@keeper.sh/premium", () => ({
+  createPremiumService: (): object => ({}),
+}));
+
+vi.mock("@polar-sh/sdk", () => ({
+  // The member keeps oxlint's no-extraneous-class satisfied on this stub.
+  Polar: class FakePolar {
+    public readonly mocked = true;
+  },
+}));
+
+/*
+ * Mirror of ioredis teardown semantics: after disconnect() the client
+ * rejects every command with the bare "Connection is closed." Error — the
+ * exact rejection the persist-time probe sees during shutdown.
+ */
+vi.mock("ioredis", () => ({
+  default: class FakeRedis {
+    public closed = false;
+
+    public disconnect(): void {
+      this.closed = true;
+    }
+
+    public eval(): Promise<number> {
+      if (this.closed) {
+        return Promise.reject(new Error("Connection is closed."));
+      }
+      return Promise.resolve(1);
+    }
+  },
+}));
+
+describe("SIGTERM cleanup and the flush drain's currency probe", () => {
+  it("keeps refreshLockRedis alive until drained flushes have committed", async () => {
+    await import("../src/index");
+    const { refreshLockRedis } = await import("../src/context");
+    const { registerFlushDrain } = await import("../src/utils/flush-drains");
+    const { ingestSource } = await import("@keeper.sh/calendar");
+
+    expect(harness.cleanup).not.toBeNull();
+
+    /*
+     * Mirror of the sourceIngestLock handle's isCurrent
+     * (packages/sync/src/sync-lock.ts:224-236): a redis.eval round trip on
+     * the very client shutdownRefreshLockRedis disconnects.
+     */
+    const isCurrent = async (): Promise<boolean> => {
+      const current = await (refreshLockRedis as {
+        eval: (...args: unknown[]) => Promise<unknown>;
+      }).eval("is-current-script", 2, "lock:calendar-1", "waiter:calendar-1", "holder-1");
+      return current === 1;
+    };
+
+    /*
+     * Park one flush exactly as a live source would at deploy time: payload
+     * fully fetched, pre-enqueue probe passed, transaction thunk waiting in
+     * the serial flush queue for the drain to pump it.
+     */
+    const queuedThunks: (() => void)[] = [];
+    let flushCommitted = false;
+    let recordedOutcome = "";
+
+    const ingestRun = ingestSource({
+      calendarId: "calendar-1",
+      fetchEvents: () => Promise.resolve({
+        events: [],
+        nextSyncToken: "sync-token-after-fetch",
+      }),
+      isCurrent,
+      onIngestEvent: (event) => {
+        recordedOutcome = String(event["outcome"]);
+      },
+      withPersistenceTransaction: (work) => new Promise((resolve) => {
+        queuedThunks.push(() => {
+          resolve(work({
+            flush: (): Promise<void> => {
+              flushCommitted = true;
+              return Promise.resolve();
+            },
+            readExistingEvents: () => Promise.resolve([]),
+          }));
+        });
+      }),
+    });
+
+    /* Let the fetch and the pre-enqueue probe settle so the thunk parks. */
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+    expect(queuedThunks).toHaveLength(1);
+
+    let drained = false;
+    registerFlushDrain(async () => {
+      for (const runThunk of queuedThunks.splice(0)) {
+        runThunk();
+      }
+      await ingestRun;
+      drained = true;
+    });
+
+    await harness.cleanup?.();
+
+    /* The drain itself completes either way — that is what masks the loss. */
+    expect(drained).toBe(true);
+
+    /*
+     * The whole point of draining before closing the flush database is that
+     * the queued flush PERSISTS. If refreshLockRedis was disconnected first,
+     * the persist-time probe answers "currency-unconfirmed" and the payload
+     * is silently discarded.
+     */
+    expect(recordedOutcome).not.toBe("currency-unconfirmed");
+    expect(flushCommitted).toBe(true);
+  });
+});

--- a/services/cron/tests/utils/enqueue-destination-syncs-force-disconnect.test.ts
+++ b/services/cron/tests/utils/enqueue-destination-syncs-force-disconnect.test.ts
@@ -4,17 +4,11 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { createPushSyncQueue } from "@keeper.sh/queue";
 
 /*
- * The enqueue's finally block fire-and-forgets queue.disconnect() so that a
- * timed-out run "force-disconnects" the ioredis connection and it "stops
- * reconnecting forever". But BullMQ's RedisConnection.disconnect() begins with
- * `const client = await this.client`, and `client` is the `initializing`
- * promise that only resolves once ioredis emits "ready". Against a Redis
- * endpoint that accepts TCP and never answers — exactly the scenario the 10s
- * enqueue timeout exists for — "ready" never fires, so the disconnect parks
- * forever before reaching client.disconnect(), and the abandoned ioredis
- * client keeps its reconnect loop alive. This suite drives the real enqueue
- * wiring at such an endpoint and requires the underlying ioredis client to
- * actually reach "end" shortly after the enqueue settles.
+ * BullMQ's RedisConnection.disconnect() starts with `await this.client`, a
+ * promise that only settles once ioredis emits "ready". Against an endpoint
+ * that accepts TCP and never answers — the case the enqueue timeout exists
+ * for — the disconnect parks before it ever closes the socket, leaving the
+ * abandoned client's reconnect loop running.
  */
 
 const testState = vi.hoisted(() => ({
@@ -40,11 +34,7 @@ vi.mock("@/utils/logging", () => ({
 vi.mock("@/context", () => ({
   database: {
     select: () => ({
-      /*
-       * A real promise (awaited directly by getPendingRequests: no pending
-       * requests) augmented with `where` (chained by getDestinations: one
-       * push-capable pro destination).
-       */
+      /* Awaited directly by getPendingRequests, chained with `where` by getDestinations. */
       from: () =>
         Object.assign(Promise.resolve([]), {
           where: () => Promise.resolve([{ calendarId: "cal-1", userId: "user-1" }]),
@@ -97,7 +87,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  // Abandon the leaked clients so vitest can exit even while the bug stands.
+  // Close leaked clients by hand, or vitest cannot exit while the bug stands.
   for (const queue of testState.createdQueues) {
     const client = (queue as QueueInternals).connection._client;
     (client as unknown as { disconnect?: () => void })?.disconnect?.();
@@ -127,11 +117,6 @@ describe("enqueue force-disconnect against an unresponsive Redis", () => {
 
     expect(testState.createdQueues.length).toBeGreaterThan(0);
 
-    /*
-     * The finally block has already fired queue.disconnect() by now. Give the
-     * teardown a generous grace window, then require every abandoned client to
-     * have actually left the connect/reconnect cycle.
-     */
     const deadline = Date.now() + 5000;
     let statuses: string[] = [];
     while (Date.now() < deadline) {

--- a/services/cron/tests/utils/enqueue-destination-syncs-force-disconnect.test.ts
+++ b/services/cron/tests/utils/enqueue-destination-syncs-force-disconnect.test.ts
@@ -1,0 +1,153 @@
+import { createServer } from "node:net";
+import type { Server, Socket } from "node:net";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { createPushSyncQueue } from "@keeper.sh/queue";
+
+/*
+ * The enqueue's finally block fire-and-forgets queue.disconnect() so that a
+ * timed-out run "force-disconnects" the ioredis connection and it "stops
+ * reconnecting forever". But BullMQ's RedisConnection.disconnect() begins with
+ * `const client = await this.client`, and `client` is the `initializing`
+ * promise that only resolves once ioredis emits "ready". Against a Redis
+ * endpoint that accepts TCP and never answers — exactly the scenario the 10s
+ * enqueue timeout exists for — "ready" never fires, so the disconnect parks
+ * forever before reaching client.disconnect(), and the abandoned ioredis
+ * client keeps its reconnect loop alive. This suite drives the real enqueue
+ * wiring at such an endpoint and requires the underlying ioredis client to
+ * actually reach "end" shortly after the enqueue settles.
+ */
+
+const testState = vi.hoisted(() => ({
+  createdQueues: [] as object[],
+  redisUrl: "",
+}));
+
+vi.mock("@/env", () => ({
+  default: {
+    get REDIS_URL(): string {
+      return testState.redisUrl;
+    },
+    WORKER_JOB_QUEUE_ENABLED: true,
+  },
+}));
+
+vi.mock("@/utils/logging", () => ({
+  widelog: {
+    set: () => null,
+  },
+}));
+
+vi.mock("@/context", () => ({
+  database: {
+    select: () => ({
+      /*
+       * A real promise (awaited directly by getPendingRequests: no pending
+       * requests) augmented with `where` (chained by getDestinations: one
+       * push-capable pro destination).
+       */
+      from: () =>
+        Object.assign(Promise.resolve([]), {
+          where: () => Promise.resolve([{ calendarId: "cal-1", userId: "user-1" }]),
+        }),
+    }),
+    transaction: (work: (transaction: unknown) => Promise<unknown>) => work({}),
+  },
+  premiumService: {
+    getUserPlan: () => Promise.resolve("pro"),
+  },
+}));
+
+vi.mock("@keeper.sh/queue", async (importOriginal) => {
+  const actual = await importOriginal<{ createPushSyncQueue: typeof createPushSyncQueue }>();
+  const wrappedCreatePushSyncQueue: typeof createPushSyncQueue = (connection) => {
+    const queue = actual.createPushSyncQueue(connection);
+    testState.createdQueues.push(queue);
+    return queue;
+  };
+  return {
+    ...actual,
+    createPushSyncQueue: wrappedCreatePushSyncQueue,
+  };
+});
+
+interface QueueInternals {
+  connection: {
+    _client?: {
+      status: string;
+    };
+  };
+}
+
+const sockets: Socket[] = [];
+let blackHoleServer: Server | null = null;
+
+beforeAll(async () => {
+  // A Redis endpoint that accepts connections and then never sends a byte.
+  blackHoleServer = createServer((socket) => {
+    sockets.push(socket);
+  });
+  await new Promise<void>((resolve) => {
+    blackHoleServer?.listen(0, "127.0.0.1", resolve);
+  });
+  const address = blackHoleServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Black-hole server has no port");
+  }
+  testState.redisUrl = `redis://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  // Abandon the leaked clients so vitest can exit even while the bug stands.
+  for (const queue of testState.createdQueues) {
+    const client = (queue as QueueInternals).connection._client;
+    (client as unknown as { disconnect?: () => void })?.disconnect?.();
+  }
+  for (const socket of sockets) {
+    socket.destroy();
+  }
+  await new Promise<void>((resolve) => {
+    if (!blackHoleServer) {
+      resolve();
+      return;
+    }
+    blackHoleServer.close(() => resolve());
+  });
+});
+
+const sleep = (durationMs: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, durationMs);
+  });
+
+describe("enqueue force-disconnect against an unresponsive Redis", () => {
+  it("tears down the ioredis client after the enqueue timeout", async () => {
+    const { enqueueDestinationSyncsForUsers } = await import("@/utils/enqueue-destination-syncs");
+
+    await enqueueDestinationSyncsForUsers(["user-1"]).catch(() => null);
+
+    expect(testState.createdQueues.length).toBeGreaterThan(0);
+
+    /*
+     * The finally block has already fired queue.disconnect() by now. Give the
+     * teardown a generous grace window, then require every abandoned client to
+     * have actually left the connect/reconnect cycle.
+     */
+    const deadline = Date.now() + 5000;
+    let statuses: string[] = [];
+    while (Date.now() < deadline) {
+      statuses = testState.createdQueues.map((queue) => {
+        const client = (queue as QueueInternals).connection._client;
+        if (!client) {
+          return "no-client";
+        }
+        return client.status;
+      });
+      if (statuses.every((status) => status === "end" || status === "close")) {
+        break;
+      }
+      await sleep(100);
+    }
+
+    expect(statuses).toEqual(statuses.map(() => "end"));
+  }, 30_000);
+});

--- a/services/cron/tests/utils/enqueue-destination-syncs-force-disconnect.test.ts
+++ b/services/cron/tests/utils/enqueue-destination-syncs-force-disconnect.test.ts
@@ -27,6 +27,7 @@ vi.mock("@/env", () => ({
 
 vi.mock("@/utils/logging", () => ({
   widelog: {
+    errorFields: () => null,
     set: () => null,
   },
 }));

--- a/services/cron/tests/utils/enqueue-destination-syncs-unbounded-redis.test.ts
+++ b/services/cron/tests/utils/enqueue-destination-syncs-unbounded-redis.test.ts
@@ -3,16 +3,11 @@ import type { Server, Socket } from "node:net";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 /*
- * The ingest-sources cron callback awaits enqueueDestinationSyncsForUsers before
- * it returns, and cronbake re-arms the job only after the callback settles. The
- * production wiring opens a BullMQ queue with maxRetriesPerRequest: null and no
- * commandTimeout, so a Redis endpoint that accepts the TCP connection but never
- * answers (a half-open socket, or an outage behind a load balancer) leaves
- * queue.getJob / queue.addBulk pending forever — parking the serial ingest pass
- * with no bound. This suite points the real wiring at exactly such an endpoint
- * and requires the enqueue to settle (resolve OR reject) within a generous
- * bound far above the 10s commandTimeout every other Redis client in this
- * service already carries.
+ * Cronbake re-arms the ingest job only after its callback settles, so the
+ * enqueue must be bounded: with BullMQ's maxRetriesPerRequest: null and no
+ * commandTimeout, a Redis endpoint that accepts TCP but never answers parks
+ * the serial ingest pass forever. The 15s bound sits far above the 10s
+ * commandTimeout every other Redis client in this service carries.
  */
 
 const testState = vi.hoisted(() => ({ redisUrl: "" }));
@@ -35,11 +30,7 @@ vi.mock("@/utils/logging", () => ({
 vi.mock("@/context", () => ({
   database: {
     select: () => ({
-      /*
-       * A real promise (awaited directly by getPendingRequests: no pending
-       * requests) augmented with `where` (chained by getDestinations: one
-       * push-capable pro destination).
-       */
+      /* Awaited directly by getPendingRequests, chained with `where` by getDestinations. */
       from: () =>
         Object.assign(Promise.resolve([]), {
           where: () => Promise.resolve([{ calendarId: "cal-1", userId: "user-1" }]),

--- a/services/cron/tests/utils/enqueue-destination-syncs-unbounded-redis.test.ts
+++ b/services/cron/tests/utils/enqueue-destination-syncs-unbounded-redis.test.ts
@@ -1,0 +1,103 @@
+import { createServer } from "node:net";
+import type { Server, Socket } from "node:net";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+/*
+ * The ingest-sources cron callback awaits enqueueDestinationSyncsForUsers before
+ * it returns, and cronbake re-arms the job only after the callback settles. The
+ * production wiring opens a BullMQ queue with maxRetriesPerRequest: null and no
+ * commandTimeout, so a Redis endpoint that accepts the TCP connection but never
+ * answers (a half-open socket, or an outage behind a load balancer) leaves
+ * queue.getJob / queue.addBulk pending forever — parking the serial ingest pass
+ * with no bound. This suite points the real wiring at exactly such an endpoint
+ * and requires the enqueue to settle (resolve OR reject) within a generous
+ * bound far above the 10s commandTimeout every other Redis client in this
+ * service already carries.
+ */
+
+const testState = vi.hoisted(() => ({ redisUrl: "" }));
+
+vi.mock("@/env", () => ({
+  default: {
+    get REDIS_URL(): string {
+      return testState.redisUrl;
+    },
+    WORKER_JOB_QUEUE_ENABLED: true,
+  },
+}));
+
+vi.mock("@/utils/logging", () => ({
+  widelog: {
+    set: () => null,
+  },
+}));
+
+vi.mock("@/context", () => ({
+  database: {
+    select: () => ({
+      /*
+       * A real promise (awaited directly by getPendingRequests: no pending
+       * requests) augmented with `where` (chained by getDestinations: one
+       * push-capable pro destination).
+       */
+      from: () =>
+        Object.assign(Promise.resolve([]), {
+          where: () => Promise.resolve([{ calendarId: "cal-1", userId: "user-1" }]),
+        }),
+    }),
+    transaction: (work: (transaction: unknown) => Promise<unknown>) => work({}),
+  },
+  premiumService: {
+    getUserPlan: () => Promise.resolve("pro"),
+  },
+}));
+
+const sockets: Socket[] = [];
+let blackHoleServer: Server | null = null;
+
+beforeAll(async () => {
+  // A Redis endpoint that accepts connections and then never sends a byte.
+  blackHoleServer = createServer((socket) => {
+    sockets.push(socket);
+  });
+  await new Promise<void>((resolve) => {
+    blackHoleServer?.listen(0, "127.0.0.1", resolve);
+  });
+  const address = blackHoleServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Black-hole server has no port");
+  }
+  testState.redisUrl = `redis://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  for (const socket of sockets) {
+    socket.destroy();
+  }
+  await new Promise<void>((resolve) => {
+    if (!blackHoleServer) {
+      resolve();
+      return;
+    }
+    blackHoleServer.close(() => resolve());
+  });
+});
+
+describe("enqueueDestinationSyncsForUsers against an unresponsive Redis", () => {
+  it("settles within a bound instead of parking the serial ingest pass forever", async () => {
+    const { enqueueDestinationSyncsForUsers } = await import("@/utils/enqueue-destination-syncs");
+
+    const outcome = await Promise.race([
+      enqueueDestinationSyncsForUsers(["user-1"]).then(
+        () => "settled",
+        () => "settled",
+      ),
+      new Promise<string>((resolve) => {
+        const timer = setTimeout(() => resolve("still pending after 15s"), 15_000);
+        timer.unref?.();
+      }),
+    ]);
+
+    expect(outcome).toBe("settled");
+  }, 30_000);
+});

--- a/services/cron/tests/utils/enqueue-destination-syncs-unbounded-redis.test.ts
+++ b/services/cron/tests/utils/enqueue-destination-syncs-unbounded-redis.test.ts
@@ -23,6 +23,7 @@ vi.mock("@/env", () => ({
 
 vi.mock("@/utils/logging", () => ({
   widelog: {
+    errorFields: () => null,
     set: () => null,
   },
 }));

--- a/services/cron/tests/utils/flush-database-context.test.ts
+++ b/services/cron/tests/utils/flush-database-context.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+
+/*
+ * The flush writer must persist through a dedicated single-connection database
+ * so that high fetch concurrency can never open concurrent write transactions
+ * against Postgres. This pins that the cron context constructs a second
+ * database instance with { maxConnections: 1 } and that shutting the context
+ * down closes both instances.
+ */
+
+const TEST_DATABASE_URL = "postgres://cron-test/keeper";
+
+const mocks = vi.hoisted(() => {
+  const pooledInstance = { name: "pooled-database" };
+  const flushInstance = { name: "flush-database" };
+  const instances = [pooledInstance, flushInstance];
+  let callIndex = 0;
+  const createDatabase = vi.fn(() => {
+    const instance = instances[callIndex] ?? { name: "unexpected-extra-database" };
+    callIndex += 1;
+    return Promise.resolve(instance);
+  });
+  const closeDatabase = vi.fn();
+  return { closeDatabase, createDatabase, flushInstance, pooledInstance };
+});
+
+vi.mock("../../src/env", () => ({
+  default: {
+    COMMERCIAL_MODE: false,
+    DATABASE_POOL_MAX: 10,
+    DATABASE_URL: TEST_DATABASE_URL,
+    REDIS_URL: "redis://cron-test:6379",
+  },
+}));
+
+vi.mock("@keeper.sh/database", () => ({
+  closeDatabase: mocks.closeDatabase,
+  createDatabase: mocks.createDatabase,
+}));
+
+vi.mock("ioredis", () => ({
+  // The flag gives disconnect a `this` use so oxlint accepts the stub.
+  default: class FakeRedis {
+    public connected = true;
+
+    public disconnect(): void {
+      this.connected = false;
+    }
+  },
+}));
+
+vi.mock("@keeper.sh/premium", () => ({
+  createPremiumService: () => ({}),
+}));
+
+vi.mock("@keeper.sh/calendar", () => ({
+  resolveWebhookConfig: () => null,
+}));
+
+vi.mock("@polar-sh/sdk", () => ({
+  // The member keeps oxlint's no-extraneous-class satisfied on this stub.
+  Polar: class FakePolar {
+    public readonly mocked = true;
+  },
+}));
+
+describe("cron context flush database", () => {
+  it("creates a dedicated single-connection flush database alongside the pooled one", async () => {
+    const context = await import("../../src/context");
+
+    expect(mocks.createDatabase).toHaveBeenCalledTimes(2);
+    expect(mocks.createDatabase).toHaveBeenNthCalledWith(1, TEST_DATABASE_URL, {
+      maxConnections: 10,
+    });
+    expect(mocks.createDatabase).toHaveBeenNthCalledWith(2, TEST_DATABASE_URL, {
+      maxConnections: 1,
+    });
+
+    const exported = context as Record<string, unknown>;
+    expect(exported.database).toBe(mocks.pooledInstance);
+    expect(exported.flushDatabase).toBe(mocks.flushInstance);
+  });
+
+  it("closes both database instances on context shutdown", async () => {
+    const context = await import("../../src/context");
+    const exported = context as Record<string, unknown>;
+    const { shutdownDatabases } = exported;
+
+    expect(typeof shutdownDatabases).toBe("function");
+    await (shutdownDatabases as () => Promise<void> | void)();
+
+    expect(mocks.closeDatabase).toHaveBeenCalledWith(mocks.pooledInstance);
+    expect(mocks.closeDatabase).toHaveBeenCalledWith(mocks.flushInstance);
+  });
+});

--- a/services/cron/tests/utils/flush-database-context.test.ts
+++ b/services/cron/tests/utils/flush-database-context.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
 /*
- * The flush writer must persist through a dedicated single-connection database
- * so that high fetch concurrency can never open concurrent write transactions
- * against Postgres. This pins that the cron context constructs a second
- * database instance with { maxConnections: 1 } and that shutting the context
- * down closes both instances.
+ * The flush writer gets its own single-connection database so high fetch
+ * concurrency can never open concurrent write transactions against Postgres.
  */
 
 const TEST_DATABASE_URL = "postgres://cron-test/keeper";
@@ -90,9 +87,8 @@ describe("cron context flush database", () => {
     await (shutdownDatabases as () => Promise<void> | void)();
 
     /*
-     * Cron bounds its own teardown so one wedged flush cannot hold a pool
-     * socket past the drain deadline and turn SIGTERM into a hang; every
-     * other service closes unbounded and keeps its in-flight transactions.
+     * Cron alone bounds its close: one wedged flush must not hold a pool
+     * socket past the drain deadline and turn SIGTERM into a hang.
      */
     const boundedClose = { graceSeconds: 2 };
     expect(mocks.closeDatabase).toHaveBeenCalledWith(mocks.pooledInstance, boundedClose);

--- a/services/cron/tests/utils/flush-database-context.test.ts
+++ b/services/cron/tests/utils/flush-database-context.test.ts
@@ -89,7 +89,13 @@ describe("cron context flush database", () => {
     expect(typeof shutdownDatabases).toBe("function");
     await (shutdownDatabases as () => Promise<void> | void)();
 
-    expect(mocks.closeDatabase).toHaveBeenCalledWith(mocks.pooledInstance);
-    expect(mocks.closeDatabase).toHaveBeenCalledWith(mocks.flushInstance);
+    /*
+     * Cron bounds its own teardown so one wedged flush cannot hold a pool
+     * socket past the drain deadline and turn SIGTERM into a hang; every
+     * other service closes unbounded and keeps its in-flight transactions.
+     */
+    const boundedClose = { graceSeconds: 2 };
+    expect(mocks.closeDatabase).toHaveBeenCalledWith(mocks.pooledInstance, boundedClose);
+    expect(mocks.closeDatabase).toHaveBeenCalledWith(mocks.flushInstance, boundedClose);
   });
 });

--- a/services/cron/tests/utils/flush-deadline-backoff-exemption.test.ts
+++ b/services/cron/tests/utils/flush-deadline-backoff-exemption.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { createSerialFlushWorker } from "@keeper.sh/calendar";
+import { isIngestInfrastructureError, requiresReauthentication } from "../../src/utils/error-flags";
+
+interface DeadlineItem {
+  deadlineAt: number;
+}
+
+/*
+ * A wedged flush (half-open connection) makes the pump's client-side run
+ * deadline fire. That rejection never contacted the calendar's provider, so
+ * it must carry the same infrastructure exemption as OperationTimeoutError
+ * and SerialFlushWorkerClosedError — otherwise runSourceIngest applies
+ * provider backoff to an innocent calendar and labels it provider-api-error.
+ */
+describe("pump deadline rejection", () => {
+  it("is classified as ingest infrastructure, exempt from provider backoff", async () => {
+    const wedged = Promise.withResolvers<never>();
+    const worker = createSerialFlushWorker<DeadlineItem, never>(() => wedged.promise);
+
+    let caught: unknown = null;
+    try {
+      await worker.submit({ deadlineAt: Date.now() + 20 });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("deadline");
+    // The abandoned run's error must be exempt exactly like the other two infrastructure errors.
+    expect(isIngestInfrastructureError(caught)).toBe(true);
+    expect(requiresReauthentication(caught)).toBe(true);
+
+    // Let the abandoned run settle so the worker can close cleanly.
+    wedged.reject(new Error("release wedged run"));
+    await worker.close();
+  });
+});

--- a/services/cron/tests/utils/flush-deadline-backoff-exemption.test.ts
+++ b/services/cron/tests/utils/flush-deadline-backoff-exemption.test.ts
@@ -7,11 +7,10 @@ interface DeadlineItem {
 }
 
 /*
- * A wedged flush (half-open connection) makes the pump's client-side run
- * deadline fire. That rejection never contacted the calendar's provider, so
- * it must carry the same infrastructure exemption as OperationTimeoutError
- * and SerialFlushWorkerClosedError — otherwise runSourceIngest applies
- * provider backoff to an innocent calendar and labels it provider-api-error.
+ * A pump deadline rejection never contacted the provider, so it must carry the
+ * same infrastructure exemption as OperationTimeoutError and
+ * SerialFlushWorkerClosedError — otherwise runSourceIngest applies provider
+ * backoff to an innocent calendar and labels it provider-api-error.
  */
 describe("pump deadline rejection", () => {
   it("is classified as ingest infrastructure, exempt from provider backoff", async () => {
@@ -27,11 +26,9 @@ describe("pump deadline rejection", () => {
 
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toContain("deadline");
-    // The abandoned run's error must be exempt exactly like the other two infrastructure errors.
     expect(isIngestInfrastructureError(caught)).toBe(true);
     expect(requiresReauthentication(caught)).toBe(true);
 
-    // Let the abandoned run settle so the worker can close cleanly.
     wedged.reject(new Error("release wedged run"));
     await worker.close();
   });

--- a/services/cron/tests/utils/ingest-precontact-park-backoff.test.ts
+++ b/services/cron/tests/utils/ingest-precontact-park-backoff.test.ts
@@ -1,0 +1,108 @@
+import {
+  createHostRateLimiter,
+  createOutlookAccountSemaphore,
+} from "@keeper.sh/calendar";
+import { describe, expect, it } from "vitest";
+import {
+  isIngestInfrastructureError,
+  requiresReauthentication,
+} from "../../src/utils/error-flags";
+import { OperationTimeoutError, withAbortTimeout } from "../../src/utils/with-abort-timeout";
+
+/*
+ * Reserve-before-fetch is not the only keeper-internal park that precedes any
+ * provider contact. Two more sit on the same side of the first provider
+ * request:
+ *
+ * - The shared per-host CalDAV/ICS budget: acquire(1, signal) is awaited at
+ *   ingest-sources.ts:1643 (and in every onBeforeRequest at :1450-1452)
+ *   BEFORE the corresponding origin request is sent. When the 30rpm window is
+ *   full, waitForRetry (redis-rate-limiter.ts:98-117) parks and, on deadline,
+ *   rejects with the bare signal.reason — an unflagged OperationTimeoutError.
+ * - The Outlook account semaphore: the adapter at ingest-sources.ts:689-694
+ *   awaits semaphore.acquireLease(signal); with all 3 slots leased,
+ *   sleepWithSignal (leased-semaphore.ts:29-47) parks the retry loop and on
+ *   deadline likewise rejects with the bare unflagged signal.reason.
+ *
+ * The serialFlushReserveAborted flag is stamped only inside the flush
+ * worker's reserve() (serial-flush-worker.ts fast path and parked onAbort),
+ * so these two pre-contact parks reach isIngestInfrastructureError unflagged,
+ * the predicate returns false, and every family's gate —
+ * shouldApplyOAuthIngestBackoff at ingest-sources.ts:278-279, CalDAV at
+ * :1503-1505, ICS at :1674 — applies exponential provider backoff to a
+ * calendar whose provider was never contacted. These expectations assert the
+ * stated invariant ("the provider was never contacted yet ... stays exempt")
+ * and FAIL on current code.
+ */
+
+// Exact mirror of ingest-sources.ts:278-279 (the predicate is not exported).
+const shouldApplyOAuthIngestBackoff = (error: unknown): boolean =>
+  !requiresReauthentication(error);
+
+// Exact mirror of the ICS gate at ingest-sources.ts:1674 (CalDAV at
+// :1503-1505 adds only an auth-failure clause that a timeout never trips).
+const shouldApplyHostFamilyBackoff = (error: unknown): boolean =>
+  !isIngestInfrastructureError(error);
+
+const SHORT_DEADLINE_MS = 60;
+// Occupancy at the 30rpm host cap: the window is full, so retry in 500ms.
+const FULL_WINDOW_DECISION = [500, 30];
+
+// A shared-host window that is always full: every charged acquire must park.
+const fullWindowRedis = {
+  eval: (): Promise<unknown> => Promise.resolve(FULL_WINDOW_DECISION),
+};
+
+// An account whose 3 slots are all leased: every SET NX comes back unclaimed.
+const exhaustedLeaseRedis = {
+  del: (): Promise<number> => Promise.resolve(0),
+  set: (): Promise<string | null> => Promise.resolve(null),
+};
+
+describe("pre-contact parks versus provider ingest backoff", () => {
+  it("exempts a host-limiter park that timed out before any provider request", async () => {
+    const limiter = createHostRateLimiter(fullWindowRedis, "caldav.icloud.com");
+    let caught: unknown = null;
+    try {
+      // Mirror of ingest-sources.ts:1643 — permit precedes the origin request.
+      await withAbortTimeout(async (signal) => {
+        await limiter.acquire(1, signal);
+      }, SHORT_DEADLINE_MS);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(OperationTimeoutError);
+
+    /*
+     * The deadline burned out while parked on keeper's own shared-host
+     * pacing; no request ever left for the provider, so per the invariant
+     * this must be infrastructure and must not accrue provider backoff.
+     */
+    expect(isIngestInfrastructureError(caught)).toBe(true);
+    expect(shouldApplyHostFamilyBackoff(caught)).toBe(false);
+    expect(shouldApplyOAuthIngestBackoff(caught)).toBe(false);
+  });
+
+  it("exempts an Outlook semaphore park that timed out before any provider request", async () => {
+    const semaphore = createOutlookAccountSemaphore(exhaustedLeaseRedis, "account-1");
+    let caught: unknown = null;
+    try {
+      // Mirror of the adapter at ingest-sources.ts:689-694.
+      await withAbortTimeout(async (signal) => {
+        await semaphore.acquireLease(signal);
+      }, SHORT_DEADLINE_MS);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(OperationTimeoutError);
+
+    /*
+     * The 4th concurrent calendar of an account parked on keeper's own
+     * 3-slot concurrency cap; Graph was never contacted, so punishing the
+     * calendar with exponential backoff misattributes keeper's cap to the
+     * provider.
+     */
+    expect(isIngestInfrastructureError(caught)).toBe(true);
+    expect(shouldApplyOAuthIngestBackoff(caught)).toBe(false);
+  });
+});

--- a/services/cron/tests/utils/ingest-precontact-park-backoff.test.ts
+++ b/services/cron/tests/utils/ingest-precontact-park-backoff.test.ts
@@ -10,52 +10,31 @@ import {
 import { OperationTimeoutError, withAbortTimeout } from "../../src/utils/with-abort-timeout";
 
 /*
- * Reserve-before-fetch is not the only keeper-internal park that precedes any
- * provider contact. Two more sit on the same side of the first provider
- * request:
- *
- * - The shared per-host CalDAV/ICS budget: acquire(1, signal) is awaited at
- *   ingest-sources.ts:1643 (and in every onBeforeRequest at :1450-1452)
- *   BEFORE the corresponding origin request is sent. When the 30rpm window is
- *   full, waitForRetry (redis-rate-limiter.ts:98-117) parks and, on deadline,
- *   rejects with the bare signal.reason — an unflagged OperationTimeoutError.
- * - The Outlook account semaphore: the adapter at ingest-sources.ts:689-694
- *   awaits semaphore.acquireLease(signal); with all 3 slots leased,
- *   sleepWithSignal (leased-semaphore.ts:29-47) parks the retry loop and on
- *   deadline likewise rejects with the bare unflagged signal.reason.
- *
- * The serialFlushReserveAborted flag is stamped only inside the flush
- * worker's reserve() (serial-flush-worker.ts fast path and parked onAbort),
- * so these two pre-contact parks reach isIngestInfrastructureError unflagged,
- * the predicate returns false, and every family's gate —
- * shouldApplyOAuthIngestBackoff at ingest-sources.ts:278-279, CalDAV at
- * :1503-1505, ICS at :1674 — applies exponential provider backoff to a
- * calendar whose provider was never contacted. These expectations assert the
- * stated invariant ("the provider was never contacted yet ... stays exempt")
- * and FAIL on current code.
+ * The shared per-host budget and the Outlook account semaphore both park
+ * BEFORE the first provider request, and on deadline reject with a bare
+ * unflagged signal.reason (only the flush worker's reserve() stamps the
+ * infrastructure flag). Unflagged, every family's backoff gate punishes a
+ * calendar whose provider was never contacted.
  */
 
-// Exact mirror of ingest-sources.ts:278-279 (the predicate is not exported).
+/* Mirrors of the production gates, which are not exported. */
 const shouldApplyOAuthIngestBackoff = (error: unknown): boolean =>
   !requiresReauthentication(error);
 
-// Exact mirror of the ICS gate at ingest-sources.ts:1674 (CalDAV at
-// :1503-1505 adds only an auth-failure clause that a timeout never trips).
 const shouldApplyHostFamilyBackoff = (error: unknown): boolean =>
   !isIngestInfrastructureError(error);
 
 const SHORT_DEADLINE_MS = 60;
-// Occupancy at the 30rpm host cap: the window is full, so retry in 500ms.
+/* Occupancy at the 30rpm host cap: the window is full, so retry in 500ms. */
 const FULL_WINDOW_DECISION = [500, 30];
 
-// A shared-host window that is always full: every charged acquire must park.
 const fullWindowRedis = {
   eval: (): Promise<unknown> => Promise.resolve(FULL_WINDOW_DECISION),
 };
 
-// An account whose 3 slots are all leased: every SET NX comes back unclaimed.
 const exhaustedLeaseRedis = {
   del: (): Promise<number> => Promise.resolve(0),
+  // SET NX answers null while all of the account's leases are held.
   set: (): Promise<string | null> => Promise.resolve(null),
 };
 
@@ -64,7 +43,6 @@ describe("pre-contact parks versus provider ingest backoff", () => {
     const limiter = createHostRateLimiter(fullWindowRedis, "caldav.icloud.com");
     let caught: unknown = null;
     try {
-      // Mirror of ingest-sources.ts:1643 — permit precedes the origin request.
       await withAbortTimeout(async (signal) => {
         await limiter.acquire(1, signal);
       }, SHORT_DEADLINE_MS);
@@ -73,11 +51,6 @@ describe("pre-contact parks versus provider ingest backoff", () => {
     }
     expect(caught).toBeInstanceOf(OperationTimeoutError);
 
-    /*
-     * The deadline burned out while parked on keeper's own shared-host
-     * pacing; no request ever left for the provider, so per the invariant
-     * this must be infrastructure and must not accrue provider backoff.
-     */
     expect(isIngestInfrastructureError(caught)).toBe(true);
     expect(shouldApplyHostFamilyBackoff(caught)).toBe(false);
     expect(shouldApplyOAuthIngestBackoff(caught)).toBe(false);
@@ -87,7 +60,6 @@ describe("pre-contact parks versus provider ingest backoff", () => {
     const semaphore = createOutlookAccountSemaphore(exhaustedLeaseRedis, "account-1");
     let caught: unknown = null;
     try {
-      // Mirror of the adapter at ingest-sources.ts:689-694.
       await withAbortTimeout(async (signal) => {
         await semaphore.acquireLease(signal);
       }, SHORT_DEADLINE_MS);
@@ -96,12 +68,6 @@ describe("pre-contact parks versus provider ingest backoff", () => {
     }
     expect(caught).toBeInstanceOf(OperationTimeoutError);
 
-    /*
-     * The 4th concurrent calendar of an account parked on keeper's own
-     * 3-slot concurrency cap; Graph was never contacted, so punishing the
-     * calendar with exponential backoff misattributes keeper's cap to the
-     * provider.
-     */
     expect(isIngestInfrastructureError(caught)).toBe(true);
     expect(shouldApplyOAuthIngestBackoff(caught)).toBe(false);
   });

--- a/services/cron/tests/utils/ingest-reserve-backoff-misclassification.test.ts
+++ b/services/cron/tests/utils/ingest-reserve-backoff-misclassification.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { createSerialFlushWorker } from "@keeper.sh/calendar";
+import {
+  NEVER_INGESTED_WEIGHT,
+  WEIGHT_BUDGET,
+} from "../../src/utils/ingest-weight";
+import { OperationTimeoutError, withAbortTimeout } from "../../src/utils/with-abort-timeout";
+import { requiresReauthentication } from "../../src/utils/error-flags";
+
+/*
+ * The reserveIngestFlushWeight call is awaited INSIDE runSourceIngest's work callback
+ * (ingest-sources.ts:1196-1200, 1400-1404, 1571-1575) under the source's
+ * 120s abort signal. When the shared 64MB budget is pinned (eight
+ * NEVER_INGESTED_WEIGHT holds of budget/8 while their fetches sleep in
+ * provider throttles), a parked reserve() rejects with the source's
+ * OperationTimeoutError at its deadline; on shutdown, close() rejects every
+ * parked reserver with "serial flush worker is closed". Neither error ever
+ * touched the calendar's provider.
+ *
+ * Both rejections propagate to runSourceIngest's catch (lines 219-223),
+ * where shouldApplyOAuthIngestBackoff (line 230: !requiresReauthentication)
+ * classifies EVERY non-reauth error as a provider failure and applies
+ * exponential ingest backoff (5min doubling to a 6h cap) to the calendar.
+ *
+ * Desired property asserted here: an error produced purely by flush-budget
+ * starvation or writer shutdown must NOT qualify a calendar for provider
+ * backoff. On current code the classifier returns true for both, so these
+ * tests FAIL, proving the misclassification.
+ */
+
+// Exact mirror of ingest-sources.ts:230-231 (the predicate is not exported).
+const shouldApplyOAuthIngestBackoff = (error: unknown): boolean =>
+  !requiresReauthentication(error);
+
+const COLD_START_SOURCES = 8;
+const SHORT_DEADLINE_MS = 50;
+
+describe("flush-budget infrastructure errors versus provider backoff", () => {
+  it("does not qualify a budget-starved reserve timeout for provider backoff", async () => {
+    const worker = createSerialFlushWorker(
+      (task: () => Promise<number>) => task(),
+      { budget: WEIGHT_BUDGET, capacity: 50 },
+    );
+    // Pin the budget exactly as eight concurrent cold-start sources do.
+    const holds = await Promise.all(
+      Array.from({ length: COLD_START_SOURCES }, () =>
+        worker.reserve(NEVER_INGESTED_WEIGHT)),
+    );
+    expect(COLD_START_SOURCES * NEVER_INGESTED_WEIGHT).toBe(WEIGHT_BUDGET);
+
+    /*
+     * A ninth cold source parks in reserve()'s FIFO (budget/8 is far above
+     * the budget/64 express-lane ceiling) and hits its source deadline, the
+     * same withAbortTimeout mechanism that arms the production 120s signal.
+     */
+    let caught: unknown = null;
+    try {
+      await withAbortTimeout(
+        (signal) => worker.reserve(NEVER_INGESTED_WEIGHT, signal),
+        SHORT_DEADLINE_MS,
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(OperationTimeoutError);
+
+    /*
+     * The calendar's provider was never contacted. runSourceIngest's catch
+     * must not hand this error to applyIngestBackoff — yet the production
+     * classifier exempts only reauthentication errors, so this expect fails
+     * with true on current code.
+     */
+    expect(shouldApplyOAuthIngestBackoff(caught)).toBe(false);
+
+    for (const hold of holds) {
+      hold.release();
+    }
+    await worker.close();
+  });
+
+  it("does not qualify a shutdown-rejected parked reserve for provider backoff", async () => {
+    const worker = createSerialFlushWorker(
+      (task: () => Promise<number>) => task(),
+      { budget: WEIGHT_BUDGET, capacity: 50 },
+    );
+    const holds = await Promise.all(
+      Array.from({ length: COLD_START_SOURCES }, () =>
+        worker.reserve(NEVER_INGESTED_WEIGHT)),
+    );
+
+    // A parked reserver caught by shutdown: close() rejects it outright.
+    let caught: unknown = null;
+    const parked = worker.reserve(NEVER_INGESTED_WEIGHT).catch((error: unknown) => {
+      caught = error;
+      return null;
+    });
+    await worker.close();
+    await parked;
+    for (const hold of holds) {
+      hold.release();
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toBe("serial flush worker is closed");
+
+    /*
+     * Same misclassification on the shutdown path: a writer-closed rejection
+     * is infrastructure, not a provider failure, but the classifier returns
+     * true and the calendar is written an exponential backoff anyway.
+     */
+    expect(shouldApplyOAuthIngestBackoff(caught)).toBe(false);
+  });
+});

--- a/services/cron/tests/utils/ingest-reserve-backoff-misclassification.test.ts
+++ b/services/cron/tests/utils/ingest-reserve-backoff-misclassification.test.ts
@@ -8,27 +8,12 @@ import { OperationTimeoutError, withAbortTimeout } from "../../src/utils/with-ab
 import { requiresReauthentication } from "../../src/utils/error-flags";
 
 /*
- * The reserveIngestFlushWeight call is awaited INSIDE runSourceIngest's work callback
- * (ingest-sources.ts:1196-1200, 1400-1404, 1571-1575) under the source's
- * 120s abort signal. When the shared 64MB budget is pinned (eight
- * NEVER_INGESTED_WEIGHT holds of budget/8 while their fetches sleep in
- * provider throttles), a parked reserve() rejects with the source's
- * OperationTimeoutError at its deadline; on shutdown, close() rejects every
- * parked reserver with "serial flush worker is closed". Neither error ever
- * touched the calendar's provider.
- *
- * Both rejections propagate to runSourceIngest's catch (lines 219-223),
- * where shouldApplyOAuthIngestBackoff (line 230: !requiresReauthentication)
- * classifies EVERY non-reauth error as a provider failure and applies
- * exponential ingest backoff (5min doubling to a 6h cap) to the calendar.
- *
- * Desired property asserted here: an error produced purely by flush-budget
- * starvation or writer shutdown must NOT qualify a calendar for provider
- * backoff. On current code the classifier returns true for both, so these
- * tests FAIL, proving the misclassification.
+ * A reserve() that times out on a pinned flush budget, or is rejected by
+ * writer shutdown, never touched the calendar's provider — so it must not
+ * qualify the calendar for exponential provider backoff.
  */
 
-// Exact mirror of ingest-sources.ts:230-231 (the predicate is not exported).
+/* Mirror of the production gate, which is not exported. */
 const shouldApplyOAuthIngestBackoff = (error: unknown): boolean =>
   !requiresReauthentication(error);
 
@@ -41,18 +26,13 @@ describe("flush-budget infrastructure errors versus provider backoff", () => {
       (task: () => Promise<number>) => task(),
       { budget: WEIGHT_BUDGET, capacity: 50 },
     );
-    // Pin the budget exactly as eight concurrent cold-start sources do.
     const holds = await Promise.all(
       Array.from({ length: COLD_START_SOURCES }, () =>
         worker.reserve(NEVER_INGESTED_WEIGHT)),
     );
     expect(COLD_START_SOURCES * NEVER_INGESTED_WEIGHT).toBe(WEIGHT_BUDGET);
 
-    /*
-     * A ninth cold source parks in reserve()'s FIFO (budget/8 is far above
-     * the budget/64 express-lane ceiling) and hits its source deadline, the
-     * same withAbortTimeout mechanism that arms the production 120s signal.
-     */
+    /* Budget/8 is far above the budget/64 express lane, so a ninth source parks. */
     let caught: unknown = null;
     try {
       await withAbortTimeout(
@@ -64,12 +44,6 @@ describe("flush-budget infrastructure errors versus provider backoff", () => {
     }
     expect(caught).toBeInstanceOf(OperationTimeoutError);
 
-    /*
-     * The calendar's provider was never contacted. runSourceIngest's catch
-     * must not hand this error to applyIngestBackoff — yet the production
-     * classifier exempts only reauthentication errors, so this expect fails
-     * with true on current code.
-     */
     expect(shouldApplyOAuthIngestBackoff(caught)).toBe(false);
 
     for (const hold of holds) {
@@ -88,7 +62,6 @@ describe("flush-budget infrastructure errors versus provider backoff", () => {
         worker.reserve(NEVER_INGESTED_WEIGHT)),
     );
 
-    // A parked reserver caught by shutdown: close() rejects it outright.
     let caught: unknown = null;
     const parked = worker.reserve(NEVER_INGESTED_WEIGHT).catch((error: unknown) => {
       caught = error;
@@ -103,11 +76,6 @@ describe("flush-budget infrastructure errors versus provider backoff", () => {
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toBe("serial flush worker is closed");
 
-    /*
-     * Same misclassification on the shutdown path: a writer-closed rejection
-     * is infrastructure, not a provider failure, but the classifier returns
-     * true and the calendar is written an exponential backoff anyway.
-     */
     expect(shouldApplyOAuthIngestBackoff(caught)).toBe(false);
   });
 });

--- a/services/cron/tests/utils/ingest-scheduling-herd.test.ts
+++ b/services/cron/tests/utils/ingest-scheduling-herd.test.ts
@@ -2,18 +2,12 @@ import { describe, expect, it } from "vitest";
 import { allSettledGroupedWithConcurrency } from "@keeper.sh/calendar";
 
 /*
- * The cron container runs with DATABASE_POOL_MAX 25 (deploy/compose.yaml), and
- * every launched source task performs pooled reads BEFORE the weighted
- * reserve() can park it: the backoff attempt read, the currentSource re-read,
- * getRequiredSourceRanges, and the estimator's count(*) on event_states. The
- * scheduler is therefore the only thing that can bound how many of those
- * pre-reserve reads race the pool at the top of a pass. This test drives the
- * real group scheduler with the production options from
- * src/jobs/ingest-sources.ts (USER_GROUP_CONCURRENCY groups at
- * USER_CALENDAR_CONCURRENCY tasks each) and requires the peak number of
- * simultaneously launched source tasks to stay within the pool.
+ * Every launched source task does pooled reads BEFORE the weighted reserve()
+ * can park it, so the scheduler is the only bound on how many of those reads
+ * race the pool at the top of a pass.
  */
 
+/* DATABASE_POOL_MAX for the cron container, from deploy/compose.yaml. */
 const CRON_DATABASE_POOL_MAX = 25;
 
 const INGEST_SOURCES_PATH = new URL(
@@ -40,10 +34,7 @@ describe("per-pass ingest scheduling", () => {
     const groupConcurrency = readProductionConstant(source, "USER_GROUP_CONCURRENCY");
     const taskConcurrency = readProductionConstant(source, "USER_CALENDAR_CONCURRENCY");
 
-    /*
-     * A full fleet pass: every user group carries taskConcurrency sources, the
-     * shape that maximises simultaneous launches under the grouped scheduler.
-     */
+    /* Full groups at full width: the shape that maximises simultaneous launches. */
     const userCount = groupConcurrency;
     const tasks: (() => Promise<void>)[] = [];
     const groupKeys: string[] = [];
@@ -56,10 +47,6 @@ describe("per-pass ingest scheduling", () => {
         groupKeys.push(`user-${userIndex}`);
         // eslint-disable-next-line no-loop-func -- The shared counters ARE the measurement; per repo precedent in tests/migration-check.test.ts.
         tasks.push(async () => {
-          /*
-           * Stand-in for the pre-reserve pooled read sequence: the task counts
-           * as in flight from launch until its first reads would have finished.
-           */
           inFlight++;
           peakInFlight = Math.max(peakInFlight, inFlight);
           await sleep(5);

--- a/services/cron/tests/utils/ingest-scheduling-herd.test.ts
+++ b/services/cron/tests/utils/ingest-scheduling-herd.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { allSettledGroupedWithConcurrency } from "@keeper.sh/calendar";
+
+/*
+ * The cron container runs with DATABASE_POOL_MAX 25 (deploy/compose.yaml), and
+ * every launched source task performs pooled reads BEFORE the weighted
+ * reserve() can park it: the backoff attempt read, the currentSource re-read,
+ * getRequiredSourceRanges, and the estimator's count(*) on event_states. The
+ * scheduler is therefore the only thing that can bound how many of those
+ * pre-reserve reads race the pool at the top of a pass. This test drives the
+ * real group scheduler with the production options from
+ * src/jobs/ingest-sources.ts (USER_GROUP_CONCURRENCY groups at
+ * USER_CALENDAR_CONCURRENCY tasks each) and requires the peak number of
+ * simultaneously launched source tasks to stay within the pool.
+ */
+
+const CRON_DATABASE_POOL_MAX = 25;
+
+const INGEST_SOURCES_PATH = new URL(
+  "../../src/jobs/ingest-sources.ts",
+  import.meta.url,
+).pathname;
+
+const readProductionConstant = (source: string, name: string): number => {
+  const match = source.match(new RegExp(`const ${name} = (\\d[\\d_]*);`));
+  if (!match?.[1]) {
+    throw new Error(`${name} not found in ingest-sources.ts`);
+  }
+  return Number(match[1].replaceAll("_", ""));
+};
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+describe("per-pass ingest scheduling", () => {
+  it("keeps concurrently launched source tasks within the database pool", async () => {
+    const source = await Bun.file(INGEST_SOURCES_PATH).text();
+    const groupConcurrency = readProductionConstant(source, "USER_GROUP_CONCURRENCY");
+    const taskConcurrency = readProductionConstant(source, "USER_CALENDAR_CONCURRENCY");
+
+    /*
+     * A full fleet pass: every user group carries taskConcurrency sources, the
+     * shape that maximises simultaneous launches under the grouped scheduler.
+     */
+    const userCount = groupConcurrency;
+    const tasks: (() => Promise<void>)[] = [];
+    const groupKeys: string[] = [];
+
+    let inFlight = 0;
+    let peakInFlight = 0;
+
+    for (let userIndex = 0; userIndex < userCount; userIndex++) {
+      for (let sourceIndex = 0; sourceIndex < taskConcurrency; sourceIndex++) {
+        groupKeys.push(`user-${userIndex}`);
+        // eslint-disable-next-line no-loop-func -- The shared counters ARE the measurement; per repo precedent in tests/migration-check.test.ts.
+        tasks.push(async () => {
+          /*
+           * Stand-in for the pre-reserve pooled read sequence: the task counts
+           * as in flight from launch until its first reads would have finished.
+           */
+          inFlight++;
+          peakInFlight = Math.max(peakInFlight, inFlight);
+          await sleep(5);
+          inFlight--;
+        });
+      }
+    }
+
+    await allSettledGroupedWithConcurrency(tasks, groupKeys, {
+      groupConcurrency,
+      taskConcurrency,
+    });
+
+    expect(peakInFlight).toBeLessThanOrEqual(CRON_DATABASE_POOL_MAX);
+  });
+});

--- a/services/cron/tests/utils/ingest-timeout-provider-hang-backoff.test.ts
+++ b/services/cron/tests/utils/ingest-timeout-provider-hang-backoff.test.ts
@@ -6,38 +6,20 @@ import {
 import { OperationTimeoutError, withAbortTimeout } from "../../src/utils/with-abort-timeout";
 
 /*
- * A provider that hangs (or is persistently slow past the 120s source
- * deadline) surfaces as the SAME OperationTimeoutError that withAbortTimeout
- * raises for budget-starvation and shutdown cases (with-abort-timeout.ts:35
- * aborts on ANY deadline overrun with no cause discrimination). The
- * infrastructure exemption in error-flags.ts:24-28 therefore also exempts
- * provider-caused timeouts, and every backoff gate consumes it:
- *
- * - OAuth: shouldApplyOAuthIngestBackoff (ingest-sources.ts:278-279) is
- *   !requiresReauthentication(error), which folds in the exemption.
- * - CalDAV (ingest-sources.ts:1503-1505) and ICS (:1674) both gate on
- *   !isIngestInfrastructureError(error).
- *
- * Desired property asserted here: a timeout produced purely by a hung
- * provider fetch — no keeper flush budget, writer, or database involved —
- * MUST still qualify the calendar for ingest backoff, so the predicates
- * below must return true. On current code the blanket OperationTimeoutError
- * exemption makes them return false, so these expectations FAIL, proving a
- * hung/slow provider is retried at full cron cadence forever.
+ * A hung provider raises the same OperationTimeoutError as budget-starvation
+ * and shutdown do, so a blanket infrastructure exemption would let a hung
+ * provider escape backoff and be retried at full cron cadence forever.
  */
 
-// Exact mirror of ingest-sources.ts:278-279 (the predicate is not exported).
+/* Mirrors of the production gates, which are not exported. */
 const shouldApplyOAuthIngestBackoff = (error: unknown): boolean =>
   !requiresReauthentication(error);
 
-// Exact mirror of the ICS gate at ingest-sources.ts:1674 (CalDAV at
-// :1503-1505 adds only an auth-failure clause that a timeout never trips).
 const shouldApplyIcsIngestBackoff = (error: unknown): boolean =>
   !isIngestInfrastructureError(error);
 
 const SHORT_DEADLINE_MS = 30;
 
-// A provider hang: never settles, never touches keeper infrastructure.
 // eslint-disable-next-line no-empty-function -- The empty executor IS the hang under test; per repo precedent in tests/utils/ingest-scheduling-herd.test.ts.
 const hungProviderFetch = (): Promise<never> => new Promise<never>(() => {});
 
@@ -51,12 +33,6 @@ describe("provider-caused source timeouts versus ingest backoff", () => {
     }
     expect(caught).toBeInstanceOf(OperationTimeoutError);
 
-    /*
-     * The provider was contacted and failed to answer within the source
-     * deadline — that IS evidence of provider misbehavior, and on the
-     * provider-rate-protection branch it must accrue ingestFailureCount.
-     * The blanket exemption returns false here on current code.
-     */
     expect(shouldApplyOAuthIngestBackoff(caught)).toBe(true);
     expect(shouldApplyIcsIngestBackoff(caught)).toBe(true);
   });

--- a/services/cron/tests/utils/ingest-timeout-provider-hang-backoff.test.ts
+++ b/services/cron/tests/utils/ingest-timeout-provider-hang-backoff.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  isIngestInfrastructureError,
+  requiresReauthentication,
+} from "../../src/utils/error-flags";
+import { OperationTimeoutError, withAbortTimeout } from "../../src/utils/with-abort-timeout";
+
+/*
+ * A provider that hangs (or is persistently slow past the 120s source
+ * deadline) surfaces as the SAME OperationTimeoutError that withAbortTimeout
+ * raises for budget-starvation and shutdown cases (with-abort-timeout.ts:35
+ * aborts on ANY deadline overrun with no cause discrimination). The
+ * infrastructure exemption in error-flags.ts:24-28 therefore also exempts
+ * provider-caused timeouts, and every backoff gate consumes it:
+ *
+ * - OAuth: shouldApplyOAuthIngestBackoff (ingest-sources.ts:278-279) is
+ *   !requiresReauthentication(error), which folds in the exemption.
+ * - CalDAV (ingest-sources.ts:1503-1505) and ICS (:1674) both gate on
+ *   !isIngestInfrastructureError(error).
+ *
+ * Desired property asserted here: a timeout produced purely by a hung
+ * provider fetch — no keeper flush budget, writer, or database involved —
+ * MUST still qualify the calendar for ingest backoff, so the predicates
+ * below must return true. On current code the blanket OperationTimeoutError
+ * exemption makes them return false, so these expectations FAIL, proving a
+ * hung/slow provider is retried at full cron cadence forever.
+ */
+
+// Exact mirror of ingest-sources.ts:278-279 (the predicate is not exported).
+const shouldApplyOAuthIngestBackoff = (error: unknown): boolean =>
+  !requiresReauthentication(error);
+
+// Exact mirror of the ICS gate at ingest-sources.ts:1674 (CalDAV at
+// :1503-1505 adds only an auth-failure clause that a timeout never trips).
+const shouldApplyIcsIngestBackoff = (error: unknown): boolean =>
+  !isIngestInfrastructureError(error);
+
+const SHORT_DEADLINE_MS = 30;
+
+// A provider hang: never settles, never touches keeper infrastructure.
+// eslint-disable-next-line no-empty-function -- The empty executor IS the hang under test; per repo precedent in tests/utils/ingest-scheduling-herd.test.ts.
+const hungProviderFetch = (): Promise<never> => new Promise<never>(() => {});
+
+describe("provider-caused source timeouts versus ingest backoff", () => {
+  it("qualifies a hung provider's deadline timeout for provider backoff", async () => {
+    let caught: unknown = null;
+    try {
+      await withAbortTimeout(() => hungProviderFetch(), SHORT_DEADLINE_MS);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(OperationTimeoutError);
+
+    /*
+     * The provider was contacted and failed to answer within the source
+     * deadline — that IS evidence of provider misbehavior, and on the
+     * provider-rate-protection branch it must accrue ingestFailureCount.
+     * The blanket exemption returns false here on current code.
+     */
+    expect(shouldApplyOAuthIngestBackoff(caught)).toBe(true);
+    expect(shouldApplyIcsIngestBackoff(caught)).toBe(true);
+  });
+});

--- a/services/cron/tests/utils/ingest-token-hang-park-flag-escape.test.ts
+++ b/services/cron/tests/utils/ingest-token-hang-park-flag-escape.test.ts
@@ -4,35 +4,14 @@ import { OperationTimeoutError, withAbortTimeout } from "../../src/utils/with-ab
 import { requiresReauthentication } from "../../src/utils/error-flags";
 
 /*
- * The park-flag invariant (error-flags.ts:41-48): only a timeout observed
- * WHILE parked on keeper's own pacing — ahead of the provider request it
- * gates — may carry a park flag and stay exempt from ingest backoff. A
- * deadline consumed by a hung or persistently slow provider must accrue
- * backoff.
- *
- * The OAuth path violates this. ensureValidToken's token-refresh HTTP call
- * takes no abort signal (ingest-sources.ts:1212-1216 awaits it before
- * reserveIngestFlushWeight at 1250), so a slow provider token endpoint eats
- * the source's 120s deadline while withAbortTimeout's foreground rejects and
- * moves on. The abandoned run — which contains runSourceIngest and therefore
- * the backoff classification in its catch (lines 254-258) — keeps executing.
- * When the hung refresh finally resolves, the abandoned run reaches
- * ingestFlushWriter.reserve(weight, signal), whose already-aborted entry
- * check (serial-flush-worker.ts:412-415) stamps serialFlushReserveAborted on
- * the shared OperationTimeoutError IN PLACE, even though the abort was never
- * observed while parked — the worker is idle and would have granted
- * instantly. runSourceIngest's catch then classifies the now-stamped error:
- * requiresReauthentication -> isIngestInfrastructureError -> true, so no
- * backoff is ever applied and the provider-hung calendar retries every
- * minute forever.
- *
- * Desired property asserted here: a deadline consumed by a non-signal-aware
- * provider wait must still qualify for backoff even when the abandoned run
- * subsequently touches reserve(). On current code the entry check stamps the
- * park flag anyway, so the final expectation FAILS, proving the escape.
+ * Only a timeout observed while parked on keeper's own pacing may stay exempt
+ * from ingest backoff. A deadline eaten by a non-signal-aware provider wait
+ * must still accrue backoff — even though the abandoned run later touches
+ * reserve(), whose already-aborted entry check stamps the park flag on the
+ * shared timeout error in place.
  */
 
-// Exact mirror of ingest-sources.ts (the predicate is not exported).
+/* Mirror of the production gate, which is not exported. */
 const shouldApplyOAuthIngestBackoff = (error: unknown): boolean =>
   !requiresReauthentication(error);
 
@@ -51,11 +30,6 @@ describe("provider token-endpoint hang versus the pre-contact park exemption", (
       { budget: 1024, capacity: 50 },
     );
 
-    /*
-     * Mirrors runSourceIngest's catch: the abandoned run classifies its own
-     * rejection. Captured here so the test observes exactly what production
-     * would hand to applyIngestBackoff after the stamp.
-     */
     let abandonedRunError: unknown = null;
     let abandonedRunWouldBackoff: boolean | null = null;
     let abandonedRunSettled: (() => void) | null = null;
@@ -67,14 +41,9 @@ describe("provider token-endpoint hang versus the pre-contact park exemption", (
     try {
       await withAbortTimeout(async (signal) => {
         try {
-          // Stand-in for ensureValidToken: no signal, hangs past the deadline.
+          // Stand-in for ensureValidToken, which takes no abort signal.
           await sleep(TOKEN_ENDPOINT_HANG_MS);
-          /*
-           * The abandoned run resumes and reaches the flush reserve. The
-           * worker is idle: absent the abort this grants immediately, so the
-           * caller was never parked pre-contact — the deadline was consumed
-           * by the provider's token endpoint.
-           */
+          /* The worker is idle, so absent the abort this reserve grants instantly. */
           const reservation = await worker.reserve(1, signal);
           reservation.release();
           return 0;
@@ -90,22 +59,14 @@ describe("provider token-endpoint hang versus the pre-contact park exemption", (
       foregroundError = error;
     }
 
-    // The foreground rejected at the deadline while the refresh still hung.
     expect(foregroundError).toBeInstanceOf(OperationTimeoutError);
 
     await abandonedRunDone;
     await worker.close();
 
-    // The abandoned run rejected with the very same shared timeout reason.
+    /* Both runs reject with the one shared error object the flag is stamped on. */
     expect(abandonedRunError).toBe(foregroundError);
 
-    /*
-     * The deadline was eaten by a provider-side hang, not by parking on
-     * keeper's own pacing, so the classification the abandoned run performs
-     * must qualify the calendar for ingest backoff. On current code the
-     * reserve entry check has stamped serialFlushReserveAborted on the shared
-     * error before this catch ran, so this expectation fails with false.
-     */
     expect(abandonedRunWouldBackoff).toBe(true);
   });
 });

--- a/services/cron/tests/utils/ingest-token-hang-park-flag-escape.test.ts
+++ b/services/cron/tests/utils/ingest-token-hang-park-flag-escape.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { createSerialFlushWorker } from "@keeper.sh/calendar";
+import { OperationTimeoutError, withAbortTimeout } from "../../src/utils/with-abort-timeout";
+import { requiresReauthentication } from "../../src/utils/error-flags";
+
+/*
+ * The park-flag invariant (error-flags.ts:41-48): only a timeout observed
+ * WHILE parked on keeper's own pacing — ahead of the provider request it
+ * gates — may carry a park flag and stay exempt from ingest backoff. A
+ * deadline consumed by a hung or persistently slow provider must accrue
+ * backoff.
+ *
+ * The OAuth path violates this. ensureValidToken's token-refresh HTTP call
+ * takes no abort signal (ingest-sources.ts:1212-1216 awaits it before
+ * reserveIngestFlushWeight at 1250), so a slow provider token endpoint eats
+ * the source's 120s deadline while withAbortTimeout's foreground rejects and
+ * moves on. The abandoned run — which contains runSourceIngest and therefore
+ * the backoff classification in its catch (lines 254-258) — keeps executing.
+ * When the hung refresh finally resolves, the abandoned run reaches
+ * ingestFlushWriter.reserve(weight, signal), whose already-aborted entry
+ * check (serial-flush-worker.ts:412-415) stamps serialFlushReserveAborted on
+ * the shared OperationTimeoutError IN PLACE, even though the abort was never
+ * observed while parked — the worker is idle and would have granted
+ * instantly. runSourceIngest's catch then classifies the now-stamped error:
+ * requiresReauthentication -> isIngestInfrastructureError -> true, so no
+ * backoff is ever applied and the provider-hung calendar retries every
+ * minute forever.
+ *
+ * Desired property asserted here: a deadline consumed by a non-signal-aware
+ * provider wait must still qualify for backoff even when the abandoned run
+ * subsequently touches reserve(). On current code the entry check stamps the
+ * park flag anyway, so the final expectation FAILS, proving the escape.
+ */
+
+// Exact mirror of ingest-sources.ts (the predicate is not exported).
+const shouldApplyOAuthIngestBackoff = (error: unknown): boolean =>
+  !requiresReauthentication(error);
+
+const DEADLINE_MS = 20;
+const TOKEN_ENDPOINT_HANG_MS = 60;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+describe("provider token-endpoint hang versus the pre-contact park exemption", () => {
+  it("still applies backoff when the abandoned run hits an idle reserve after the deadline", async () => {
+    const worker = createSerialFlushWorker(
+      (task: () => Promise<number>) => task(),
+      { budget: 1024, capacity: 50 },
+    );
+
+    /*
+     * Mirrors runSourceIngest's catch: the abandoned run classifies its own
+     * rejection. Captured here so the test observes exactly what production
+     * would hand to applyIngestBackoff after the stamp.
+     */
+    let abandonedRunError: unknown = null;
+    let abandonedRunWouldBackoff: boolean | null = null;
+    let abandonedRunSettled: (() => void) | null = null;
+    const abandonedRunDone = new Promise<void>((resolve) => {
+      abandonedRunSettled = resolve;
+    });
+
+    let foregroundError: unknown = null;
+    try {
+      await withAbortTimeout(async (signal) => {
+        try {
+          // Stand-in for ensureValidToken: no signal, hangs past the deadline.
+          await sleep(TOKEN_ENDPOINT_HANG_MS);
+          /*
+           * The abandoned run resumes and reaches the flush reserve. The
+           * worker is idle: absent the abort this grants immediately, so the
+           * caller was never parked pre-contact — the deadline was consumed
+           * by the provider's token endpoint.
+           */
+          const reservation = await worker.reserve(1, signal);
+          reservation.release();
+          return 0;
+        } catch (error) {
+          abandonedRunError = error;
+          abandonedRunWouldBackoff = shouldApplyOAuthIngestBackoff(error);
+          throw error;
+        } finally {
+          abandonedRunSettled?.();
+        }
+      }, DEADLINE_MS);
+    } catch (error) {
+      foregroundError = error;
+    }
+
+    // The foreground rejected at the deadline while the refresh still hung.
+    expect(foregroundError).toBeInstanceOf(OperationTimeoutError);
+
+    await abandonedRunDone;
+    await worker.close();
+
+    // The abandoned run rejected with the very same shared timeout reason.
+    expect(abandonedRunError).toBe(foregroundError);
+
+    /*
+     * The deadline was eaten by a provider-side hang, not by parking on
+     * keeper's own pacing, so the classification the abandoned run performs
+     * must qualify the calendar for ingest backoff. On current code the
+     * reserve entry check has stamped serialFlushReserveAborted on the shared
+     * error before this catch ran, so this expectation fails with false.
+     */
+    expect(abandonedRunWouldBackoff).toBe(true);
+  });
+});

--- a/services/cron/tests/utils/ingest-weight-throttle-stall.test.ts
+++ b/services/cron/tests/utils/ingest-weight-throttle-stall.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { createSerialFlushWorker } from "@keeper.sh/calendar";
+import {
+  NEVER_INGESTED_WEIGHT,
+  WEIGHT_BUDGET,
+  WEIGHT_FLOOR,
+} from "../../src/utils/ingest-weight";
+
+/*
+ * Reserve-before-fetch holds a source's flush weight across its ENTIRE
+ * provider fetch, including signal-bound waits inside it (the google per-user
+ * limiter's waitForRetry loop, slow or hung provider responses up to the 120s
+ * deadline). NEVER_INGESTED_WEIGHT is WEIGHT_BUDGET / 8, so eight
+ * concurrently launched first-ingest sources — 4 distinct users at
+ * taskConcurrency 2 — pin 100% of the budget while doing nothing but
+ * sleeping in a rate limiter. Because one module-level flush writer is
+ * shared by the OAuth, CalDAV, and ICS families, every other source
+ * fleet-wide then parks in reserve()'s FIFO.
+ *
+ * This test reproduces that composition with the production constants and
+ * asserts the desired property: a tiny warm-source reservation from another
+ * family must still be admitted while cold-start fetches are merely waiting
+ * on their providers. On current code it is not — the budget is fully
+ * pinned — so this test FAILS, proving the stall.
+ */
+
+const COLD_START_SOURCES = 8;
+const OTHER_FAMILY_WAIT_MS = 200;
+
+describe("shared flush budget under cold-start provider throttling", () => {
+  it("admits a small warm reservation while cold fetches sleep in a rate limiter", async () => {
+    const flushed: number[] = [];
+    const worker = createSerialFlushWorker(
+      (task: () => Promise<number>) => task(),
+      { budget: WEIGHT_BUDGET, capacity: 50 },
+    );
+
+    /*
+     * Eight cold-start sources reserve budget/8 each, exactly as
+     * reserveIngestFlushWeight sizes a never-ingested calendar, then enter
+     * their provider fetch and park in the per-user limiter's retry wait.
+     */
+    const coldReservations = await Promise.all(
+      Array.from({ length: COLD_START_SOURCES }, () =>
+        worker.reserve(NEVER_INGESTED_WEIGHT)),
+    );
+    // The budget is now fully committed: 8 * (WEIGHT_BUDGET / 8).
+    expect(COLD_START_SOURCES * NEVER_INGESTED_WEIGHT).toBe(WEIGHT_BUDGET);
+
+    /*
+     * A warm ICS source from a different provider family now needs only the
+     * floor weight (16KB of a 64MB budget). Its provider is healthy; nothing
+     * about it is throttled. It must not stall behind sleeping cold fetches.
+     */
+    let warmAdmitted = false;
+    const warmReservation = worker
+      .reserve(WEIGHT_FLOOR)
+      .then((reservation) => {
+        warmAdmitted = true;
+        return reservation;
+      });
+
+    // Give the worker ample real time to admit the 16KB reservation.
+    await new Promise((resolve) => {
+      setTimeout(resolve, OTHER_FAMILY_WAIT_MS);
+    });
+
+    /*
+     * Desired behavior: throttle waits inside one family's provider fetches
+     * must not pin the shared budget against every other family. Current
+     * code holds all eight cold weights through the sleep, so this expect
+     * fails with warmAdmitted === false.
+     */
+    expect(warmAdmitted).toBe(true);
+
+    // Cleanup: the cold fetches "return" and release, letting things drain.
+    for (const reservation of coldReservations) {
+      reservation.release();
+    }
+    const settledWarm = await warmReservation;
+    flushed.push(await settledWarm.submit(() => Promise.resolve(1)));
+    expect(flushed).toEqual([1]);
+    await worker.close();
+  });
+});

--- a/services/cron/tests/utils/ingest-weight-throttle-stall.test.ts
+++ b/services/cron/tests/utils/ingest-weight-throttle-stall.test.ts
@@ -7,21 +7,10 @@ import {
 } from "../../src/utils/ingest-weight";
 
 /*
- * Reserve-before-fetch holds a source's flush weight across its ENTIRE
- * provider fetch, including signal-bound waits inside it (the google per-user
- * limiter's waitForRetry loop, slow or hung provider responses up to the 120s
- * deadline). NEVER_INGESTED_WEIGHT is WEIGHT_BUDGET / 8, so eight
- * concurrently launched first-ingest sources — 4 distinct users at
- * taskConcurrency 2 — pin 100% of the budget while doing nothing but
- * sleeping in a rate limiter. Because one module-level flush writer is
- * shared by the OAuth, CalDAV, and ICS families, every other source
- * fleet-wide then parks in reserve()'s FIFO.
- *
- * This test reproduces that composition with the production constants and
- * asserts the desired property: a tiny warm-source reservation from another
- * family must still be admitted while cold-start fetches are merely waiting
- * on their providers. On current code it is not — the budget is fully
- * pinned — so this test FAILS, proving the stall.
+ * NEVER_INGESTED_WEIGHT is WEIGHT_BUDGET / 8, so eight cold-start sources pin
+ * the whole shared budget while merely sleeping in a provider rate limiter.
+ * One flush writer serves the OAuth, CalDAV, and ICS families, so a tiny warm
+ * reservation from another family must still be admitted through that.
  */
 
 const COLD_START_SOURCES = 8;
@@ -35,23 +24,13 @@ describe("shared flush budget under cold-start provider throttling", () => {
       { budget: WEIGHT_BUDGET, capacity: 50 },
     );
 
-    /*
-     * Eight cold-start sources reserve budget/8 each, exactly as
-     * reserveIngestFlushWeight sizes a never-ingested calendar, then enter
-     * their provider fetch and park in the per-user limiter's retry wait.
-     */
     const coldReservations = await Promise.all(
       Array.from({ length: COLD_START_SOURCES }, () =>
         worker.reserve(NEVER_INGESTED_WEIGHT)),
     );
-    // The budget is now fully committed: 8 * (WEIGHT_BUDGET / 8).
     expect(COLD_START_SOURCES * NEVER_INGESTED_WEIGHT).toBe(WEIGHT_BUDGET);
 
-    /*
-     * A warm ICS source from a different provider family now needs only the
-     * floor weight (16KB of a 64MB budget). Its provider is healthy; nothing
-     * about it is throttled. It must not stall behind sleeping cold fetches.
-     */
+    /* A healthy warm source of another family needs only the floor: 16KB of 64MB. */
     let warmAdmitted = false;
     const warmReservation = worker
       .reserve(WEIGHT_FLOOR)
@@ -60,20 +39,12 @@ describe("shared flush budget under cold-start provider throttling", () => {
         return reservation;
       });
 
-    // Give the worker ample real time to admit the 16KB reservation.
     await new Promise((resolve) => {
       setTimeout(resolve, OTHER_FAMILY_WAIT_MS);
     });
 
-    /*
-     * Desired behavior: throttle waits inside one family's provider fetches
-     * must not pin the shared budget against every other family. Current
-     * code holds all eight cold weights through the sleep, so this expect
-     * fails with warmAdmitted === false.
-     */
     expect(warmAdmitted).toBe(true);
 
-    // Cleanup: the cold fetches "return" and release, letting things drain.
     for (const reservation of coldReservations) {
       reservation.release();
     }

--- a/services/cron/tests/utils/ingest-weight.test.ts
+++ b/services/cron/tests/utils/ingest-weight.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { eventStatesTable } from "@keeper.sh/database/schema";
+import {
+  BYTES_PER_EVENT,
+  WEIGHT_BUDGET,
+  WEIGHT_FLOOR,
+  countStoredEvents,
+  estimateIngestWeight,
+} from "../../src/utils/ingest-weight";
+
+/*
+ * A weighted permit must be sized BEFORE the provider fetch begins, so the
+ * estimate has to come from what we already know: the stored event count from
+ * the previous ingest. Items vary by two-plus orders of magnitude (a 12-event
+ * personal calendar vs a 3,000-event ICS feed), so a count-based limit cannot
+ * bound memory — a byte-weight estimate can. These tests pin the estimator's
+ * three rules (history-based clamp, never-ingested self-limit, fallback on a
+ * failed count read) plus the real pooled-database count query.
+ */
+
+const NEVER_INGESTED_DEFAULT = WEIGHT_BUDGET / 8;
+
+describe("estimateIngestWeight constants", () => {
+  it("pins the named weight constants", () => {
+    expect(BYTES_PER_EVENT).toBe(1024);
+    expect(WEIGHT_FLOOR).toBe(16_384);
+    // 64MB: 64 * 1024 * 1024.
+    expect(WEIGHT_BUDGET).toBe(67_108_864);
+  });
+});
+
+describe("estimateIngestWeight for calendars that have ingested before", () => {
+  it("weighs by stored count times bytes per event", async () => {
+    const countStoredEventsMock = vi.fn(() => Promise.resolve(300));
+
+    const weight = await estimateIngestWeight(
+      { countStoredEvents: countStoredEventsMock },
+      "calendar-1",
+      true,
+    );
+
+    expect(countStoredEventsMock).toHaveBeenCalledWith("calendar-1");
+    expect(weight).toBe(300 * BYTES_PER_EVENT);
+  });
+
+  it("clamps a tiny calendar up to the weight floor", async () => {
+    const countStoredEventsMock = vi.fn(() => Promise.resolve(3));
+
+    const weight = await estimateIngestWeight(
+      { countStoredEvents: countStoredEventsMock },
+      "calendar-tiny",
+      true,
+    );
+
+    expect(weight).toBe(WEIGHT_FLOOR);
+  });
+
+  it("clamps a huge calendar down to the full budget", async () => {
+    const countStoredEventsMock = vi.fn(() => Promise.resolve(1_000_000));
+
+    const weight = await estimateIngestWeight(
+      { countStoredEvents: countStoredEventsMock },
+      "calendar-huge",
+      true,
+    );
+
+    expect(weight).toBe(WEIGHT_BUDGET);
+  });
+});
+
+describe("estimateIngestWeight for never-ingested calendars", () => {
+  it("returns an eighth of the budget regardless of stored count", async () => {
+    /*
+     * A launch flood of unknown-size first ingests must self-limit to ~8
+     * concurrent fetches, so the unknown case claims budget/8 even when a
+     * stale stored count exists.
+     */
+    const countStoredEventsMock = vi.fn(() => Promise.resolve(1_000_000));
+
+    const weight = await estimateIngestWeight(
+      { countStoredEvents: countStoredEventsMock },
+      "calendar-new",
+      false,
+    );
+
+    expect(weight).toBe(NEVER_INGESTED_DEFAULT);
+  });
+});
+
+describe("estimateIngestWeight when the count read fails", () => {
+  it("falls back to the never-ingested default instead of failing the ingest", async () => {
+    const countStoredEventsMock = vi.fn(() =>
+      Promise.reject(new Error("connection reset")),
+    );
+
+    const weight = await estimateIngestWeight(
+      { countStoredEvents: countStoredEventsMock },
+      "calendar-flaky",
+      true,
+    );
+
+    expect(weight).toBe(NEVER_INGESTED_DEFAULT);
+  });
+});
+
+describe("countStoredEvents", () => {
+  it("counts event states for the calendar against the injected database", async () => {
+    const fromMock = vi.fn();
+    const whereMock = vi.fn(() => Promise.resolve([{ count: 42 }]));
+    const selectMock = vi.fn(() => ({
+      from: fromMock.mockReturnValue({ where: whereMock }),
+    }));
+    const database = { select: selectMock };
+
+    const stored = await countStoredEvents(database as never, "calendar-9");
+
+    expect(stored).toBe(42);
+    expect(fromMock).toHaveBeenCalledWith(eventStatesTable);
+    expect(whereMock).toHaveBeenCalledWith(
+      eq(eventStatesTable.calendarId, "calendar-9"),
+    );
+  });
+});

--- a/services/cron/tests/utils/ingest-weight.test.ts
+++ b/services/cron/tests/utils/ingest-weight.test.ts
@@ -10,13 +10,9 @@ import {
 } from "../../src/utils/ingest-weight";
 
 /*
- * A weighted permit must be sized BEFORE the provider fetch begins, so the
- * estimate has to come from what we already know: the stored event count from
- * the previous ingest. Items vary by two-plus orders of magnitude (a 12-event
- * personal calendar vs a 3,000-event ICS feed), so a count-based limit cannot
- * bound memory — a byte-weight estimate can. These tests pin the estimator's
- * three rules (history-based clamp, never-ingested self-limit, fallback on a
- * failed count read) plus the real pooled-database count query.
+ * The permit is sized BEFORE the fetch, so the estimate can only come from the
+ * previous ingest's stored count. Calendars vary by two-plus orders of
+ * magnitude, so a count-based limit cannot bound memory; a byte weight can.
  */
 
 const NEVER_INGESTED_DEFAULT = WEIGHT_BUDGET / 8;
@@ -71,11 +67,7 @@ describe("estimateIngestWeight for calendars that have ingested before", () => {
 
 describe("estimateIngestWeight for never-ingested calendars", () => {
   it("returns an eighth of the budget regardless of stored count", async () => {
-    /*
-     * A launch flood of unknown-size first ingests must self-limit to ~8
-     * concurrent fetches, so the unknown case claims budget/8 even when a
-     * stale stored count exists.
-     */
+    /* Budget/8 self-limits a flood of unknown-size first ingests to ~8 at a time. */
     const countStoredEventsMock = vi.fn(() => Promise.resolve(1_000_000));
 
     const weight = await estimateIngestWeight(

--- a/services/cron/tests/utils/persist-probe-redis-flake-backoff.test.ts
+++ b/services/cron/tests/utils/persist-probe-redis-flake-backoff.test.ts
@@ -1,0 +1,133 @@
+import { ingestSource } from "@keeper.sh/calendar";
+import type { SourceEvent } from "@keeper.sh/calendar";
+import { SyncLockRenewalError } from "@keeper.sh/sync";
+import { describe, expect, it } from "vitest";
+import {
+  isIngestInfrastructureError,
+  requiresReauthentication,
+} from "../../src/utils/error-flags";
+
+/*
+ * The thrash-hunt fix added an isCurrent() re-probe inside the flush
+ * transaction (ingest.ts:273) and kept the pre-enqueue probe (ingest.ts:260),
+ * both with no error handling. isCurrent() is two Redis round trips on
+ * refreshLockRedis (throwIfRenewalFailed + the IS_CURRENT_SCRIPT eval,
+ * sync-lock.ts:224-236), so a transient rejection — an ioredis command
+ * timeout, MaxRetriesPerRequestError, or a SyncLockRenewalError from a single
+ * blipped renewal tick — propagates out of ingestSource as the ingest error.
+ *
+ * The exemption gate (error-flags.ts) recognizes only the literal teardown
+ * message "Connection is closed." plus the flush-worker/pacing park flags, so
+ * every family's shouldApplyBackoff predicate (OAuth at ingest-sources.ts:
+ * 278-279, CalDAV at :1503-1505, ICS at :1674) applies exponential provider
+ * ingest backoff for a keeper-Redis flake on a calendar whose provider fetch
+ * SUCCEEDED. The sibling post-commit probe was hardened for exactly this
+ * (resetIngestBackoffIfCurrent, ingest-sources.ts:203-223: "a Redis blip in
+ * the probe ... must never feed the backoff escalator"); the persist-time
+ * probe was not.
+ *
+ * Invariant under test: a currency probe that cannot answer must not commit
+ * the flush (the lease may be lost), and it must not surface as a provider
+ * failure — the run either contains the flake, or escapes with an error every
+ * backoff gate exempts.
+ */
+
+const CALENDAR_ID = "calendar-persist-probe-flake";
+
+// Exact mirror of ingest-sources.ts:278-279 (the predicate is not exported).
+const shouldApplyOAuthIngestBackoff = (error: unknown): boolean =>
+  !requiresReauthentication(error);
+
+// Exact mirror of the ICS gate at ingest-sources.ts:1674 (CalDAV at
+// :1503-1505 adds only an auth-failure clause a Redis flake never trips).
+const shouldApplyHostFamilyBackoff = (error: unknown): boolean =>
+  !isIngestInfrastructureError(error);
+
+const makeEvent = (uid: string, startHour: number): SourceEvent => ({
+  availability: "busy",
+  endTime: new Date(Date.UTC(2026, 7, 20, startHour + 1)),
+  isAllDay: false,
+  startTime: new Date(Date.UTC(2026, 7, 20, startHour)),
+  title: uid,
+  uid,
+});
+
+interface RunOutcome {
+  caught: unknown;
+  flushCount: number;
+}
+
+/*
+ * Real ingestSource wired the way every cron family wires it: fetch succeeds
+ * (the provider answered), the currency probe is the injected lock handle.
+ */
+const runIngestWithProbe = async (
+  isCurrent: () => Promise<boolean>,
+): Promise<RunOutcome> => {
+  let flushCount = 0;
+  let caught: unknown = null;
+  try {
+    await ingestSource({
+      calendarId: CALENDAR_ID,
+      fetchEvents: () => Promise.resolve({ events: [makeEvent("event-x", 9)] }),
+      isCurrent,
+      withPersistenceTransaction: (work) => work({
+        readExistingEvents: () => Promise.resolve([]),
+        flush: () => {
+          flushCount += 1;
+          return Promise.resolve();
+        },
+      }),
+    });
+  } catch (error) {
+    caught = error;
+  }
+  return { caught, flushCount };
+};
+
+const expectExemptFromEveryBackoffGate = (outcome: RunOutcome): void => {
+  /* Currency unconfirmed: the snapshot must not have been committed. */
+  expect(outcome.flushCount).toBe(0);
+
+  /*
+   * Containment (resolving without a flush, like the superseded path) also
+   * satisfies the invariant; only an ESCAPING error must be exempt.
+   */
+  if (outcome.caught === null) {
+    return;
+  }
+  expect(isIngestInfrastructureError(outcome.caught)).toBe(true);
+  expect(shouldApplyOAuthIngestBackoff(outcome.caught)).toBe(false);
+  expect(shouldApplyHostFamilyBackoff(outcome.caught)).toBe(false);
+};
+
+describe("Redis flake in the ingest currency probe versus provider backoff", () => {
+  it("exempts an ioredis flake at the persist-time re-probe from every family's backoff gate", async () => {
+    /*
+     * An ioredis command timeout: the pre-enqueue probe passes, then the eval at
+     * the persist-time re-probe blips. The provider fetch already succeeded.
+     */
+    let probeCalls = 0;
+    const outcome = await runIngestWithProbe(() => {
+      probeCalls += 1;
+      if (probeCalls === 1) {
+        return Promise.resolve(true);
+      }
+      return Promise.reject(new Error("Command timed out"));
+    });
+    expect(probeCalls).toBeGreaterThanOrEqual(2);
+    expectExemptFromEveryBackoffGate(outcome);
+  });
+
+  it("exempts a single blipped renewal tick (SyncLockRenewalError) surfacing through the probe", async () => {
+    /*
+     * The handle's throwIfRenewalFailed (sync-lock.ts:213-217) throws on the FIRST probe
+     * after one failed renewal tick, even though a later tick would clear the
+     * flag ("a single blip must not strand the run").
+     */
+    const outcome = await runIngestWithProbe(() => Promise.reject(
+      new SyncLockRenewalError(CALENDAR_ID, new Error("Command timed out")),
+    ));
+    expectExemptFromEveryBackoffGate(outcome);
+  });
+});

--- a/services/cron/tests/utils/persist-probe-redis-flake-backoff.test.ts
+++ b/services/cron/tests/utils/persist-probe-redis-flake-backoff.test.ts
@@ -8,38 +8,19 @@ import {
 } from "../../src/utils/error-flags";
 
 /*
- * The thrash-hunt fix added an isCurrent() re-probe inside the flush
- * transaction (ingest.ts:273) and kept the pre-enqueue probe (ingest.ts:260),
- * both with no error handling. isCurrent() is two Redis round trips on
- * refreshLockRedis (throwIfRenewalFailed + the IS_CURRENT_SCRIPT eval,
- * sync-lock.ts:224-236), so a transient rejection — an ioredis command
- * timeout, MaxRetriesPerRequestError, or a SyncLockRenewalError from a single
- * blipped renewal tick — propagates out of ingestSource as the ingest error.
- *
- * The exemption gate (error-flags.ts) recognizes only the literal teardown
- * message "Connection is closed." plus the flush-worker/pacing park flags, so
- * every family's shouldApplyBackoff predicate (OAuth at ingest-sources.ts:
- * 278-279, CalDAV at :1503-1505, ICS at :1674) applies exponential provider
- * ingest backoff for a keeper-Redis flake on a calendar whose provider fetch
- * SUCCEEDED. The sibling post-commit probe was hardened for exactly this
- * (resetIngestBackoffIfCurrent, ingest-sources.ts:203-223: "a Redis blip in
- * the probe ... must never feed the backoff escalator"); the persist-time
- * probe was not.
- *
- * Invariant under test: a currency probe that cannot answer must not commit
- * the flush (the lease may be lost), and it must not surface as a provider
- * failure — the run either contains the flake, or escapes with an error every
- * backoff gate exempts.
+ * The currency probe is two Redis round trips on keeper's own refreshLockRedis,
+ * so it can flake on a calendar whose provider fetch SUCCEEDED. A probe that
+ * cannot answer must not commit the flush (the lease may be lost) and must not
+ * surface as a provider failure: the run either contains the flake, or escapes
+ * with an error every backoff gate exempts.
  */
 
 const CALENDAR_ID = "calendar-persist-probe-flake";
 
-// Exact mirror of ingest-sources.ts:278-279 (the predicate is not exported).
+/* Mirrors of the production gates, which are not exported. */
 const shouldApplyOAuthIngestBackoff = (error: unknown): boolean =>
   !requiresReauthentication(error);
 
-// Exact mirror of the ICS gate at ingest-sources.ts:1674 (CalDAV at
-// :1503-1505 adds only an auth-failure clause a Redis flake never trips).
 const shouldApplyHostFamilyBackoff = (error: unknown): boolean =>
   !isIngestInfrastructureError(error);
 
@@ -57,10 +38,6 @@ interface RunOutcome {
   flushCount: number;
 }
 
-/*
- * Real ingestSource wired the way every cron family wires it: fetch succeeds
- * (the provider answered), the currency probe is the injected lock handle.
- */
 const runIngestWithProbe = async (
   isCurrent: () => Promise<boolean>,
 ): Promise<RunOutcome> => {
@@ -86,13 +63,9 @@ const runIngestWithProbe = async (
 };
 
 const expectExemptFromEveryBackoffGate = (outcome: RunOutcome): void => {
-  /* Currency unconfirmed: the snapshot must not have been committed. */
   expect(outcome.flushCount).toBe(0);
 
-  /*
-   * Containment (resolving without a flush, like the superseded path) also
-   * satisfies the invariant; only an ESCAPING error must be exempt.
-   */
+  /* Containing the flake without flushing also satisfies the invariant. */
   if (outcome.caught === null) {
     return;
   }
@@ -103,10 +76,7 @@ const expectExemptFromEveryBackoffGate = (outcome: RunOutcome): void => {
 
 describe("Redis flake in the ingest currency probe versus provider backoff", () => {
   it("exempts an ioredis flake at the persist-time re-probe from every family's backoff gate", async () => {
-    /*
-     * An ioredis command timeout: the pre-enqueue probe passes, then the eval at
-     * the persist-time re-probe blips. The provider fetch already succeeded.
-     */
+    /* The pre-enqueue probe passes; the persist-time re-probe blips. */
     let probeCalls = 0;
     const outcome = await runIngestWithProbe(() => {
       probeCalls += 1;
@@ -121,9 +91,8 @@ describe("Redis flake in the ingest currency probe versus provider backoff", () 
 
   it("exempts a single blipped renewal tick (SyncLockRenewalError) surfacing through the probe", async () => {
     /*
-     * The handle's throwIfRenewalFailed (sync-lock.ts:213-217) throws on the FIRST probe
-     * after one failed renewal tick, even though a later tick would clear the
-     * flag ("a single blip must not strand the run").
+     * The lock handle throws on the first probe after one failed renewal tick,
+     * even though a later tick would clear the flag.
      */
     const outcome = await runIngestWithProbe(() => Promise.reject(
       new SyncLockRenewalError(CALENDAR_ID, new Error("Command timed out")),

--- a/services/cron/tests/utils/shutdown-drain-deadline.test.ts
+++ b/services/cron/tests/utils/shutdown-drain-deadline.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerFlushDrain } from "../../src/utils/flush-drains";
+import { createSerialFlushWorker } from "../../../../packages/calendar/src/core/utils/serial-flush-worker";
+
+/*
+ * SIGTERM triggers entrykit's cleanup, which awaits shutdownDatabases().
+ * shutdownDatabases awaits drainFlushWriters() with no deadline, and the
+ * registered drain in production is ingestFlushWriter.close(), which resolves
+ * only when the pump goes idle. A single wedged flush (a run() that never
+ * settles, e.g. a half-open connection) therefore turns graceful shutdown
+ * into a permanent hang: closeDatabase never runs and the process lingers
+ * until the supervisor SIGKILLs it. This test pins that shutdown must settle
+ * within a bounded time even when one flush is wedged.
+ */
+
+const TEST_DATABASE_URL = "postgres://cron-test/keeper";
+const SHUTDOWN_DEADLINE_MS = 3000;
+const WEDGED_ITEM_CLIENT_DEADLINE_MS = 5000;
+
+const mocks = vi.hoisted(() => {
+  const closeDatabase = vi.fn();
+  const createDatabase = vi.fn(() => Promise.resolve({ name: "fake-database" }));
+  return { closeDatabase, createDatabase };
+});
+
+vi.mock("../../src/env", () => ({
+  default: {
+    COMMERCIAL_MODE: false,
+    DATABASE_POOL_MAX: 10,
+    DATABASE_URL: TEST_DATABASE_URL,
+    REDIS_URL: "redis://cron-test:6379",
+  },
+}));
+
+vi.mock("@keeper.sh/database", () => ({
+  closeDatabase: mocks.closeDatabase,
+  createDatabase: mocks.createDatabase,
+}));
+
+vi.mock("ioredis", () => ({
+  // The flag gives disconnect a `this` use so oxlint accepts the stub.
+  default: class FakeRedis {
+    public connected = true;
+
+    public disconnect(): void {
+      this.connected = false;
+    }
+  },
+}));
+
+vi.mock("@keeper.sh/premium", () => ({
+  createPremiumService: () => ({}),
+}));
+
+vi.mock("@keeper.sh/calendar", () => ({
+  resolveWebhookConfig: () => null,
+}));
+
+vi.mock("@polar-sh/sdk", () => ({
+  // The member keeps oxlint's no-extraneous-class satisfied on this stub.
+  Polar: class FakePolar {
+    public readonly mocked = true;
+  },
+}));
+
+describe("shutdown drain deadline", () => {
+  it("settles shutdownDatabases within a bounded time even when one flush is wedged", async () => {
+    const context = await import("../../src/context");
+    const { shutdownDatabases } = context as unknown as {
+      shutdownDatabases: () => Promise<void>;
+    };
+
+    /*
+     * A wedged flush: run() never settles, exactly the half-open-connection
+     * scenario the serial-flush-worker's own comments describe. The pump
+     * awaits it to settlement, so close() waits forever on idleWaiters.
+     */
+    const wedgedWorker = createSerialFlushWorker<{ deadlineAt: number }, null>(
+      () => new Promise<null>(() => {
+        // Never settles: models the half-open connection.
+      }),
+    );
+    const wedgedSubmit = wedgedWorker.submit({
+      // A short client deadline so the run's timer does not outlive the test.
+      deadlineAt: Date.now() + WEDGED_ITEM_CLIENT_DEADLINE_MS,
+    });
+    // The client-side deadline rejects the caller; the run stays wedged.
+    wedgedSubmit.catch(() => null);
+
+    // Mirrors ingest-sources.ts: registerFlushDrain(() => ingestFlushWriter.close()).
+    registerFlushDrain(() => wedgedWorker.close());
+
+    let shutdownState = "still-draining";
+    const shutdown = shutdownDatabases().then(() => {
+      shutdownState = "completed";
+      return null;
+    });
+    shutdown.catch(() => null);
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, SHUTDOWN_DEADLINE_MS);
+    });
+
+    /*
+     * Graceful shutdown must complete within the bound: without a drain
+     * deadline this stays "still-draining" forever and closeDatabase is
+     * never reached for either database instance.
+     */
+    expect(shutdownState).toBe("completed");
+    expect(mocks.closeDatabase).toHaveBeenCalledTimes(2);
+  });
+});

--- a/services/cron/tests/utils/shutdown-drain-deadline.test.ts
+++ b/services/cron/tests/utils/shutdown-drain-deadline.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import { registerFlushDrain } from "../../src/utils/flush-drains";
 import { createSerialFlushWorker } from "../../../../packages/calendar/src/core/utils/serial-flush-worker";
 
 /*
@@ -62,7 +61,8 @@ vi.mock("@polar-sh/sdk", () => ({
 describe("shutdown drain deadline", () => {
   it("settles shutdownDatabases within a bounded time even when one flush is wedged", async () => {
     const context = await import("../../src/context");
-    const { shutdownDatabases } = context as unknown as {
+    const { flushDrainRegistry, shutdownDatabases } = context as unknown as {
+      flushDrainRegistry: { register: (drain: () => Promise<void>) => void };
       shutdownDatabases: () => Promise<void>;
     };
 
@@ -77,7 +77,7 @@ describe("shutdown drain deadline", () => {
     /* The client deadline rejects the caller while the run itself stays wedged. */
     wedgedSubmit.catch(() => null);
 
-    registerFlushDrain(() => wedgedWorker.close());
+    flushDrainRegistry.register(() => wedgedWorker.close());
 
     let shutdownState = "still-draining";
     const shutdown = shutdownDatabases().then(() => {

--- a/services/cron/tests/utils/shutdown-drain-deadline.test.ts
+++ b/services/cron/tests/utils/shutdown-drain-deadline.test.ts
@@ -3,18 +3,14 @@ import { registerFlushDrain } from "../../src/utils/flush-drains";
 import { createSerialFlushWorker } from "../../../../packages/calendar/src/core/utils/serial-flush-worker";
 
 /*
- * SIGTERM triggers entrykit's cleanup, which awaits shutdownDatabases().
- * shutdownDatabases awaits drainFlushWriters() with no deadline, and the
- * registered drain in production is ingestFlushWriter.close(), which resolves
- * only when the pump goes idle. A single wedged flush (a run() that never
- * settles, e.g. a half-open connection) therefore turns graceful shutdown
- * into a permanent hang: closeDatabase never runs and the process lingers
- * until the supervisor SIGKILLs it. This test pins that shutdown must settle
- * within a bounded time even when one flush is wedged.
+ * The registered drain is ingestFlushWriter.close(), which resolves only when
+ * the pump goes idle, so without a deadline one wedged flush turns graceful
+ * shutdown into a permanent hang: closeDatabase never runs.
  */
 
 const TEST_DATABASE_URL = "postgres://cron-test/keeper";
 const SHUTDOWN_DEADLINE_MS = 3000;
+/* Outlives the shutdown bound, so the flush is still wedged when it is measured. */
 const WEDGED_ITEM_CLIENT_DEADLINE_MS = 5000;
 
 const mocks = vi.hoisted(() => {
@@ -70,24 +66,17 @@ describe("shutdown drain deadline", () => {
       shutdownDatabases: () => Promise<void>;
     };
 
-    /*
-     * A wedged flush: run() never settles, exactly the half-open-connection
-     * scenario the serial-flush-worker's own comments describe. The pump
-     * awaits it to settlement, so close() waits forever on idleWaiters.
-     */
     const wedgedWorker = createSerialFlushWorker<{ deadlineAt: number }, null>(
       () => new Promise<null>(() => {
-        // Never settles: models the half-open connection.
+        // Never settles: models a half-open connection.
       }),
     );
     const wedgedSubmit = wedgedWorker.submit({
-      // A short client deadline so the run's timer does not outlive the test.
       deadlineAt: Date.now() + WEDGED_ITEM_CLIENT_DEADLINE_MS,
     });
-    // The client-side deadline rejects the caller; the run stays wedged.
+    /* The client deadline rejects the caller while the run itself stays wedged. */
     wedgedSubmit.catch(() => null);
 
-    // Mirrors ingest-sources.ts: registerFlushDrain(() => ingestFlushWriter.close()).
     registerFlushDrain(() => wedgedWorker.close());
 
     let shutdownState = "still-draining";
@@ -101,11 +90,6 @@ describe("shutdown drain deadline", () => {
       setTimeout(resolve, SHUTDOWN_DEADLINE_MS);
     });
 
-    /*
-     * Graceful shutdown must complete within the bound: without a drain
-     * deadline this stays "still-draining" forever and closeDatabase is
-     * never reached for either database instance.
-     */
     expect(shutdownState).toBe("completed");
     expect(mocks.closeDatabase).toHaveBeenCalledTimes(2);
   });

--- a/services/cron/tests/utils/shutdown-force-close-flush-backoff.test.ts
+++ b/services/cron/tests/utils/shutdown-force-close-flush-backoff.test.ts
@@ -1,0 +1,93 @@
+import { createSerialFlushWorker } from "@keeper.sh/calendar";
+import { closeDatabase, createDatabase, resolveDatabaseErrorClassification } from "@keeper.sh/database";
+import { sql } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { requiresReauthentication } from "../../src/utils/error-flags";
+
+/*
+ * Shutdown's drain deadline (services/cron/src/context.ts) races
+ * drainFlushWriters() against FLUSH_DRAIN_DEADLINE_MS and, when the drain
+ * loses, closes the flush database with a bounded grace. That force-close
+ * kills the still-running flush connection, so the flush rejects with a Bun
+ * connection error (db-connection-terminated / db-connection-unavailable).
+ * That failure is keeper's own shutdown infrastructure — the calendar's
+ * provider was never at fault — so it must carry the same provider-backoff
+ * exemption as every other shutdown rejection (SerialFlushWorkerClosedError,
+ * the redis-teardown message, reserve-park aborts). This reproduces the exact
+ * shutdown sequence and pins that exemption via requiresReauthentication, the
+ * gate shouldApplyOAuthIngestBackoff negates in ingest-sources.ts.
+ */
+
+const TEST_DATABASE_URL = process.env.KEEPER_TEST_DATABASE_URL;
+
+// Mirrors FLUSH_DRAIN_DEADLINE_MS and CLOSE_GRACE_SECONDS in services/cron/src/context.ts.
+const FLUSH_DRAIN_DEADLINE_MS = 2000;
+const CLOSE_GRACE_SECONDS = 2;
+// Long enough that the flush is still mid-statement when the grace expires.
+const WEDGED_FLUSH_SECONDS = 10;
+const FLUSH_BUDGET = 1000;
+const FLUSH_CAPACITY = 50;
+const CONNECTION_SLUGS = ["db-connection-terminated", "db-connection-unavailable"];
+
+describe.skipIf(!TEST_DATABASE_URL)(
+  "drain-deadline force-close versus provider ingest backoff",
+  () => {
+    it("exempts a flush killed by the shutdown force-close from provider backoff", async () => {
+      const flushDatabase = await createDatabase(TEST_DATABASE_URL as string, {
+        maxConnections: 1,
+      });
+      const worker = createSerialFlushWorker(
+        (task: () => Promise<unknown>) => task(),
+        { budget: FLUSH_BUDGET, capacity: FLUSH_CAPACITY },
+      );
+
+      // An in-flight flush transaction, exactly as ingest submits one at SIGTERM.
+      const reservation = await worker.reserve(1);
+      const flush = reservation.submit(async () =>
+        await flushDatabase.transaction(async (transaction) => {
+          await transaction.execute(sql`select pg_sleep(${WEDGED_FLUSH_SECONDS})`);
+        }));
+      const observedError = flush.then(
+        () => null,
+        (error: unknown) => error,
+      );
+      // Give the statement time to reach the server before shutdown begins.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 300);
+      });
+
+      // The shutdownDatabases sequence from services/cron/src/context.ts.
+      const drain = worker.close().then(
+        () => "drained",
+        () => "drain-failed",
+      );
+      let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+      const deadline = new Promise<string>((resolve) => {
+        deadlineTimer = setTimeout(() => {
+          resolve("deadline");
+        }, FLUSH_DRAIN_DEADLINE_MS);
+      });
+      const raceOutcome = await Promise.race([drain, deadline]);
+      if (deadlineTimer !== null) {
+        clearTimeout(deadlineTimer);
+      }
+      // The drain lost the race: the flush is still in flight when close begins.
+      expect(raceOutcome).toBe("deadline");
+      closeDatabase(flushDatabase, { graceSeconds: CLOSE_GRACE_SECONDS });
+
+      const error = await observedError;
+      // Let the pump settle so the suite exits cleanly.
+      await drain;
+
+      // The force-close killed the flush with a connection-class database error.
+      expect(error).not.toBeNull();
+      expect(resolveDatabaseErrorClassification(error)?.slug).toBeOneOf(CONNECTION_SLUGS);
+      /*
+       * The failure came from keeper's own shutdown, never the provider, so it
+       * must pass the exemption gate: requiresReauthentication(error) is what
+       * shouldApplyOAuthIngestBackoff negates before applyIngestBackoff runs.
+       */
+      expect(requiresReauthentication(error)).toBe(true);
+    }, 30_000);
+  },
+);

--- a/services/cron/tests/utils/shutdown-force-close-flush-backoff.test.ts
+++ b/services/cron/tests/utils/shutdown-force-close-flush-backoff.test.ts
@@ -5,28 +5,22 @@ import { describe, expect, it } from "vitest";
 import { requiresReauthentication } from "../../src/utils/error-flags";
 
 /*
- * Shutdown's drain deadline (services/cron/src/context.ts) races
- * drainFlushWriters() against FLUSH_DRAIN_DEADLINE_MS and, when the drain
- * loses, closes the flush database with a bounded grace. That force-close
- * kills the still-running flush connection, so the flush rejects with a Bun
- * connection error (db-connection-terminated / db-connection-unavailable).
- * That failure is keeper's own shutdown infrastructure — the calendar's
- * provider was never at fault — so it must carry the same provider-backoff
- * exemption as every other shutdown rejection (SerialFlushWorkerClosedError,
- * the redis-teardown message, reserve-park aborts). This reproduces the exact
- * shutdown sequence and pins that exemption via requiresReauthentication, the
- * gate shouldApplyOAuthIngestBackoff negates in ingest-sources.ts.
+ * When the drain loses its race, the force-close kills the running flush
+ * connection and the flush rejects with a Bun connection error. That is
+ * keeper's own shutdown, never the provider, so it must carry the same
+ * backoff exemption as every other shutdown rejection.
  */
 
 const TEST_DATABASE_URL = process.env.KEEPER_TEST_DATABASE_URL;
 
-// Mirrors FLUSH_DRAIN_DEADLINE_MS and CLOSE_GRACE_SECONDS in services/cron/src/context.ts.
+/* Mirrors FLUSH_DRAIN_DEADLINE_MS and CLOSE_GRACE_SECONDS in src/context.ts. */
 const FLUSH_DRAIN_DEADLINE_MS = 2000;
 const CLOSE_GRACE_SECONDS = 2;
-// Long enough that the flush is still mid-statement when the grace expires.
+/* Long enough that the flush is still mid-statement when the grace expires. */
 const WEDGED_FLUSH_SECONDS = 10;
 const FLUSH_BUDGET = 1000;
 const FLUSH_CAPACITY = 50;
+const STATEMENT_REACHES_SERVER_MS = 300;
 const CONNECTION_SLUGS = ["db-connection-terminated", "db-connection-unavailable"];
 
 describe.skipIf(!TEST_DATABASE_URL)(
@@ -41,7 +35,6 @@ describe.skipIf(!TEST_DATABASE_URL)(
         { budget: FLUSH_BUDGET, capacity: FLUSH_CAPACITY },
       );
 
-      // An in-flight flush transaction, exactly as ingest submits one at SIGTERM.
       const reservation = await worker.reserve(1);
       const flush = reservation.submit(async () =>
         await flushDatabase.transaction(async (transaction) => {
@@ -51,12 +44,11 @@ describe.skipIf(!TEST_DATABASE_URL)(
         () => null,
         (error: unknown) => error,
       );
-      // Give the statement time to reach the server before shutdown begins.
       await new Promise((resolve) => {
-        setTimeout(resolve, 300);
+        setTimeout(resolve, STATEMENT_REACHES_SERVER_MS);
       });
 
-      // The shutdownDatabases sequence from services/cron/src/context.ts.
+      /* The shutdownDatabases sequence from src/context.ts. */
       const drain = worker.close().then(
         () => "drained",
         () => "drain-failed",
@@ -71,22 +63,14 @@ describe.skipIf(!TEST_DATABASE_URL)(
       if (deadlineTimer !== null) {
         clearTimeout(deadlineTimer);
       }
-      // The drain lost the race: the flush is still in flight when close begins.
       expect(raceOutcome).toBe("deadline");
       closeDatabase(flushDatabase, { graceSeconds: CLOSE_GRACE_SECONDS });
 
       const error = await observedError;
-      // Let the pump settle so the suite exits cleanly.
       await drain;
 
-      // The force-close killed the flush with a connection-class database error.
       expect(error).not.toBeNull();
       expect(resolveDatabaseErrorClassification(error)?.slug).toBeOneOf(CONNECTION_SLUGS);
-      /*
-       * The failure came from keeper's own shutdown, never the provider, so it
-       * must pass the exemption gate: requiresReauthentication(error) is what
-       * shouldApplyOAuthIngestBackoff negates before applyIngestBackoff runs.
-       */
       expect(requiresReauthentication(error)).toBe(true);
     }, 30_000);
   },

--- a/services/cron/tests/utils/shutdown-redis-teardown-backoff.test.ts
+++ b/services/cron/tests/utils/shutdown-redis-teardown-backoff.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import Redis from "ioredis";
+import { isIngestInfrastructureError, requiresReauthentication } from "../../src/utils/error-flags";
+
+/*
+ * Shutdown ordering (services/cron/src/index.ts:28-33) runs baker.stopAll();
+ * destroy(); shutdownRefreshLockRedis(); await shutdownDatabases(). stopAll
+ * stops FUTURE passes but does not wait for the in-flight pass, and
+ * shutdownRefreshLockRedis (context.ts:76-78) is a bare
+ * refreshLockRedis.disconnect() that executes before the 2s flush drain. Every
+ * mid-flight ingest task's next Redis operation on that client — the
+ * sourceIngestLock isCurrent probe (packages/sync/src/sync-lock.ts:224-231,
+ * called from ingest.ts:260 inside runSourceIngest's work with no local
+ * catch), the rate limiter's eval, the Outlook lease SET — then rejects with
+ * ioredis's bare "Connection is closed." Error.
+ *
+ * That rejection never contacted the calendar's provider, but it carries no
+ * flag and matches no exemption in error-flags.ts, so runSourceIngest's catch
+ * (ingest-sources.ts:258-262) applies exponential provider ingest backoff —
+ * and the write lands, because the pooled `database` stays open through the
+ * drain window (context.ts:29-47). The same "shutdown must not punish
+ * innocent calendars" invariant was already wired for
+ * SerialFlushWorkerClosedError; this asserts it for the Redis-teardown
+ * channel. On current code the classifier treats the teardown error as a
+ * provider failure, so this test FAILS, proving the issue.
+ */
+
+// Exact mirror of ingest-sources.ts:278-279 (the predicate is not exported).
+const shouldApplyOAuthIngestBackoff = (error: unknown): boolean =>
+  !requiresReauthentication(error);
+
+// Mirror of the refreshLockRedis construction in context.ts:68-72.
+const buildRefreshLockRedis = (): Redis =>
+  new Redis("redis://127.0.0.1:1", {
+    commandTimeout: 10_000,
+    maxRetriesPerRequest: 3,
+    lazyConnect: true,
+  });
+
+describe("refreshLockRedis teardown during an in-flight ingest", () => {
+  it("does not qualify the connection-closed rejection for provider backoff", async () => {
+    const refreshLockRedis = buildRefreshLockRedis();
+    // Mirror of shutdownRefreshLockRedis (context.ts:76-78) firing mid-pass.
+    refreshLockRedis.disconnect();
+
+    let caught: unknown = null;
+    try {
+      // The isCurrent probe's round trip (sync-lock.ts:221) after teardown.
+      await refreshLockRedis.get("source-ingest:calendar-1");
+    } catch (error) {
+      caught = error;
+    }
+
+    // Guard: this is the exact ioredis teardown rejection, nothing synthetic.
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toBe("Connection is closed.");
+
+    // Keeper tore down its own Redis client; the provider never misbehaved.
+    expect(isIngestInfrastructureError(caught)).toBe(true);
+    expect(shouldApplyOAuthIngestBackoff(caught)).toBe(false);
+  });
+});

--- a/services/cron/tests/utils/shutdown-redis-teardown-backoff.test.ts
+++ b/services/cron/tests/utils/shutdown-redis-teardown-backoff.test.ts
@@ -3,33 +3,18 @@ import Redis from "ioredis";
 import { isIngestInfrastructureError, requiresReauthentication } from "../../src/utils/error-flags";
 
 /*
- * Shutdown ordering (services/cron/src/index.ts:28-33) runs baker.stopAll();
- * destroy(); shutdownRefreshLockRedis(); await shutdownDatabases(). stopAll
- * stops FUTURE passes but does not wait for the in-flight pass, and
- * shutdownRefreshLockRedis (context.ts:76-78) is a bare
- * refreshLockRedis.disconnect() that executes before the 2s flush drain. Every
- * mid-flight ingest task's next Redis operation on that client — the
- * sourceIngestLock isCurrent probe (packages/sync/src/sync-lock.ts:224-231,
- * called from ingest.ts:260 inside runSourceIngest's work with no local
- * catch), the rate limiter's eval, the Outlook lease SET — then rejects with
- * ioredis's bare "Connection is closed." Error.
- *
- * That rejection never contacted the calendar's provider, but it carries no
- * flag and matches no exemption in error-flags.ts, so runSourceIngest's catch
- * (ingest-sources.ts:258-262) applies exponential provider ingest backoff —
- * and the write lands, because the pooled `database` stays open through the
- * drain window (context.ts:29-47). The same "shutdown must not punish
- * innocent calendars" invariant was already wired for
- * SerialFlushWorkerClosedError; this asserts it for the Redis-teardown
- * channel. On current code the classifier treats the teardown error as a
- * provider failure, so this test FAILS, proving the issue.
+ * Shutdown disconnects refreshLockRedis while a pass is still in flight, so
+ * every ingest task's next probe rejects with ioredis's bare "Connection is
+ * closed." Shutdown must not punish innocent calendars: that rejection never
+ * contacted the provider, yet the pooled database stays open long enough for
+ * a backoff write to land.
  */
 
-// Exact mirror of ingest-sources.ts:278-279 (the predicate is not exported).
+/* Mirror of the production gate, which is not exported. */
 const shouldApplyOAuthIngestBackoff = (error: unknown): boolean =>
   !requiresReauthentication(error);
 
-// Mirror of the refreshLockRedis construction in context.ts:68-72.
+/* Mirror of the refreshLockRedis construction in src/context.ts. */
 const buildRefreshLockRedis = (): Redis =>
   new Redis("redis://127.0.0.1:1", {
     commandTimeout: 10_000,
@@ -40,22 +25,19 @@ const buildRefreshLockRedis = (): Redis =>
 describe("refreshLockRedis teardown during an in-flight ingest", () => {
   it("does not qualify the connection-closed rejection for provider backoff", async () => {
     const refreshLockRedis = buildRefreshLockRedis();
-    // Mirror of shutdownRefreshLockRedis (context.ts:76-78) firing mid-pass.
     refreshLockRedis.disconnect();
 
     let caught: unknown = null;
     try {
-      // The isCurrent probe's round trip (sync-lock.ts:221) after teardown.
       await refreshLockRedis.get("source-ingest:calendar-1");
     } catch (error) {
       caught = error;
     }
 
-    // Guard: this is the exact ioredis teardown rejection, nothing synthetic.
+    /* The exact ioredis teardown rejection, not a synthetic stand-in. */
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toBe("Connection is closed.");
 
-    // Keeper tore down its own Redis client; the provider never misbehaved.
     expect(isIngestInfrastructureError(caught)).toBe(true);
     expect(shouldApplyOAuthIngestBackoff(caught)).toBe(false);
   });

--- a/services/cron/tests/utils/with-abort-timeout-enforcement.test.ts
+++ b/services/cron/tests/utils/with-abort-timeout-enforcement.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { withAbortTimeout } from "../../src/utils/with-abort-timeout";
+
+/*
+ * A pooled database read that takes no AbortSignal and hangs on a half-open
+ * connection never settles on its own. The scheduler worker in
+ * packages/calendar/src/core/utils/concurrency.ts holds its slot by awaiting
+ * task() to settlement, so withAbortTimeout must force the wrapped operation
+ * to settle at the deadline or the slot is stranded for the whole pass.
+ */
+const nonCooperativeHang = (): Promise<never> =>
+  Promise.withResolvers<never>().promise;
+
+describe("withAbortTimeout deadline enforcement", () => {
+  it("settles a non-signal-aware hung operation once the deadline fires", async () => {
+    const timeoutMs = 50;
+    const graceMs = 450;
+    let outcome = "still pending after deadline plus grace";
+
+    const wrapped = withAbortTimeout(nonCooperativeHang, timeoutMs)
+      .then(
+        () => {
+          outcome = "resolved";
+          return outcome;
+        },
+        () => {
+          outcome = "rejected at deadline";
+          return outcome;
+        },
+      );
+
+    const grace = new Promise((resolve) => {
+      setTimeout(resolve, timeoutMs + graceMs);
+    });
+    await Promise.race([wrapped, grace]);
+
+    expect(outcome).toBe("rejected at deadline");
+  });
+});

--- a/services/cron/tests/utils/with-abort-timeout-enforcement.test.ts
+++ b/services/cron/tests/utils/with-abort-timeout-enforcement.test.ts
@@ -2,11 +2,9 @@ import { describe, expect, it } from "vitest";
 import { withAbortTimeout } from "../../src/utils/with-abort-timeout";
 
 /*
- * A pooled database read that takes no AbortSignal and hangs on a half-open
- * connection never settles on its own. The scheduler worker in
- * packages/calendar/src/core/utils/concurrency.ts holds its slot by awaiting
- * task() to settlement, so withAbortTimeout must force the wrapped operation
- * to settle at the deadline or the slot is stranded for the whole pass.
+ * The scheduler worker holds its slot by awaiting task() to settlement, so
+ * withAbortTimeout must settle an operation that takes no AbortSignal —
+ * otherwise one half-open connection strands a slot for the whole pass.
  */
 const nonCooperativeHang = (): Promise<never> =>
   Promise.withResolvers<never>().promise;

--- a/services/cron/tests/utils/with-abort-timeout.test.ts
+++ b/services/cron/tests/utils/with-abort-timeout.test.ts
@@ -21,20 +21,19 @@ describe("withAbortTimeout", () => {
     });
   });
 
-  it("waits for non-cooperative work to stop before reporting the timeout", async () => {
+  it("reports the timeout without waiting for non-cooperative work", async () => {
     const operation = Promise.withResolvers<boolean>();
     let settled = false;
     const result = withAbortTimeout(() => operation.promise, 1).finally(() => {
       settled = true;
     });
 
-    await new Promise((resolve) => {
-      setTimeout(resolve, 10);
-    });
-    expect(settled).toBe(false);
-
-    operation.resolve(true);
     await expect(result).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(settled).toBe(true);
+
+    // A late settlement of the abandoned operation must be harmless.
+    operation.resolve(true);
+    await operation.promise;
   });
 });
 


### PR DESCRIPTION
This branch replaces `SOURCE_CONCURRENCY = 5` — the March backpressure scar (#233) doing rate-limit, write-bound, and memory-bound duty it was never designed for — with a dedicated owner for each of those duties. Four commits, each verified red-first.

**1. Per-family provider rate protection.** `resolveRateLimiter` covered exactly one family: Google. Now all four are keyed at the granularity each provider actually enforces: google→userId (existing windowed limiter), outlook→accountId via **`createLeasedSemaphore`** (capacity 3, one under Graph's documented `MailboxConcurrency` of 4; TTL'd per-slot `SET NX PX` keys so a crashed holder self-frees at 150s; the adapter releases the lease when the source finishes so an account's fourth calendar never waits out a TTL longer than its own deadline), caldav→server host and ical→feed host via **`createHostRateLimiter`** (30/min shared per host). The CalDAV branch also covers the branded `fastmail`/`icloud` provider values via `isCalDAVProvider`.

**2. Single-writer flush.** All ingest persistence flows through one dedicated `createDatabase(url, { maxConnections: 1 })` connection via a bounded serial flush worker — the March invariant (concurrent write transactions stay bounded) enforced structurally instead of by throttling collection.

**3. Weighted reserve-before-fetch.** Memory is bounded by a 64MB byte budget: each source reserves weight (stored-event count × 1KB, floor 16KB; never-ingested defaults to budget/8; whales clamp to the full budget) *before* fetching, released in `finally`. `SOURCE_CONCURRENCY` is deleted; `USER_GROUP_CONCURRENCY = 12` (×2 calendars per user = 24) is sized to the cron container's 25-connection pool, since every launched source performs ~4 pooled reads before its reserve can park it.

**4. Hardening (adversarial review + 4 rounds of red-recursive hunting, 12 proven fixes).** The wired-bypass genus was fully cleared at the consumption point: the Outlook semaphore is acquired at the single Graph choke-point, and the CalDAV/ICS limiters are acquired before each fetch, all pinned by consumption tests. The advisory-lock wait inside the flush transaction is bounded to 5s so a contended calendar cannot park the writer slot for 120s. The flush pump has a client-side deadline that rejects the caller while awaiting the run to settlement (weight held until the abandoned run settles); queued submits honor abort. A bounded express lane (grants ≤ budget/64, oversubscription capped at budget/16, 16-overtake fairness bound) keeps warm sources flowing while cold-start holds sleep in provider throttle waits, without starving heavy heads. Stale lease releases are fenced by client-side expiry. `withAbortTimeout` now enforces its deadline even against non-signal-aware hangs. Infrastructure errors (reserve timeouts, writer shutdown) are exempt from provider backoff in every family. Shutdown drains the flush writer under a 2s deadline before closing the databases. The per-calendar ingest lock acquires as "background" so an in-flight run's finished fetch persists instead of being discarded as superseded.

Also corrected here: cron passes are **serial** (cronbake re-arms only after a pass completes), so same-calendar overlap comes from timeout-abandoned runs and webhook-driven worker syncs — every comment claiming "passes overlap (overrunProtection is off)" was rewritten.

Known limitation, deliberate: a blocked acquirer waits while holding its scheduler slot, so a saturated host can idle slots in its family. The fix (re-enqueue instead of slot-holding waits) belongs with the bounded-tick scheduling work, not here.

**Watch after deploy:** `wait.flush_reserve_ms` (new segment), Graph 429/`MailboxConcurrency` errors (should fall), pass makespan (should shrink with 24-wide collection), flush-writer submit latency, and cron memory ceiling (should stay under budget + 4MB oversubscription headroom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
