### PR TITLE
fix(copy): Pro title/desc gate and $45 yearly

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Keeper.sh is a simple & open-source calendar syncing tool. It allows you to pull events from your Google Calendar, Outlook, iCloud, Fastmail, CalDAV server, or remotely hosted iCal and ICS links, and push them to one or many calendars so the time slots can align across them all. Google, Outlook, iCloud, Fastmail, and CalDAV are first-class integrations that can each be used as a source or as a destination, while iCal and ICS links are pull-only. It also serves as a global MCP server and API for you or your agents to manage all your calendars from one convenient interface.
 
-The recommended way to run it is the hosted version at [keeper.sh](https://keeper.sh/register): the same code, minus the server, the domain, the upgrades, the backups and the Google and Microsoft sign-in apps you would otherwise register yourself. Self-hosting is a first-class path and every Pro feature is included when you self-host — that is not a trial, and it is not going away. It costs you the upkeep instead of the $5.
+The recommended way to run it is the hosted version at [keeper.sh](https://www.keeper.sh/register): the same code, minus the server, the domain, the upgrades, the backups and the Google and Microsoft sign-in apps you would otherwise register yourself. Self-hosting is a first-class path and every Pro feature is included when you self-host — that is not a trial, and it is not going away. It costs you the upkeep instead of the $5.
 
 # Features
 
@@ -127,12 +127,12 @@ Neither half is schedule-only. `POST /api/v1/sync`, or `trigger_sync` over MCP, 
 
 This is the version I would point most people at, including people perfectly capable of running it themselves. It is the same engine on hardware I keep running, so the hours go into your calendar instead of your infrastructure — and paying for it is what funds the work on both versions.
 
-Head to [keeper.sh](https://keeper.sh/register) to get started with the cloud-hosted version.
+Head to [keeper.sh](https://www.keeper.sh/register) to get started with the cloud-hosted version.
 
 |                             | Free       | Pro (Cloud-Hosted) | Pro (Self-Hosted) |
 | --------------------------- | ---------- | ------------------ | ----------------- |
 | **Monthly Price**           | $0 USD     | $5 USD             | $0                |
-| **Annual Price**            | $0 USD     | $42 USD (-30%)     | $0                |
+| **Annual Price**            | $0 USD     | $45 USD (-25%)     | $0                |
 | **Refresh Interval**        | 30 minutes | 1 minute           | 1 minute          |
 | **Linked Account Limit**    | 2          | ∞                  | ∞                 |
 | **Sync Mapping Limit**      | 3          | ∞                  | ∞                 |

--- a/applications/web/public/llms-full.txt
+++ b/applications/web/public/llms-full.txt
@@ -49,7 +49,7 @@ Each calendar can be read from, written to, or both. A pasted iCal link can only
 
 Leaving detail behind is the default on both routes out of Keeper.sh: the copies written to your other calendars, and the links you share.
 
-A calendar you copy events from holds back their titles, descriptions and locations. The copy's title comes from a template that starts as `{{calendar_name}}`, so a colleague sees the calendar's name in the slot. Turning any of the three back on is a per-calendar setting, and a deliberate act.
+A calendar you copy events from holds back their titles, descriptions and locations. The copy's title comes from a template that starts as `{{calendar_name}}`, so a colleague sees the calendar's name in the slot. Turning any of the three back on is a per-calendar Pro setting, and a deliberate act.
 
 Shared iCal links hide event names, descriptions and locations too. They show time blocks labelled "Busy".
 
@@ -62,7 +62,7 @@ Per-calendar settings:
 - Skip all-day events
 - Skip Google's own event types (Focus Time, Working Location, Out of Office)
 
-Changing the title template, the event filters and the date range covered are Pro settings. Hiding titles, descriptions and locations is the default on every plan.
+Turning titles, descriptions or locations back on, changing the title template, the event filters and the date range covered are Pro settings. Hiding titles, descriptions and locations is the default on every plan.
 
 ### Shareable Calendar Link
 
@@ -85,7 +85,7 @@ A connection runs one way. If you want two calendars to match each other, that i
 ## Pricing
 
 - **Free**: 2 calendar accounts, 3 connections, 1 shared link, changes landing every 30 minutes, 25 API requests a day
-- **Pro ($5 a month, or $42 a year)**: Unlimited accounts, connections and shared links, Google and Outlook changes landing within seconds, event filters, link customization, uncapped API requests, priority support
+- **Pro ($5 a month, or $45 a year)**: Unlimited accounts, connections and shared links, Google and Outlook changes landing within seconds, event filters, link customization, uncapped API requests, priority support
 
 There is no cap on how many calendars an account holds. An account is one connected Google, Outlook, iCloud, Fastmail or CalDAV login, or one iCal subscription. A connection is one calendar wired into one other calendar.
 

--- a/applications/web/public/llms.txt
+++ b/applications/web/public/llms.txt
@@ -7,14 +7,14 @@ Keeper.sh is for people whose commitments are split across accounts that cannot 
 ## Key Features
 
 - Works with Google Calendar, Outlook, Microsoft 365, iCloud, Fastmail, any CalDAV server, and calendar links you paste in. Pasted links are read-only
-- A copy carries the calendar's name in place of the event title. Descriptions and locations are left behind too, and you turn each one back on per calendar
+- A copy carries the calendar's name in place of the event title. Descriptions and locations are left behind too, and Pro lets you turn each one back on per calendar
 - Guest lists are never written to another calendar or to a shared link, on any plan
 - One shareable calendar link covering everything you connect, labelled "Busy" by default, and it opens in any calendar app
 - A REST API under `/api/v1` for calendars, accounts, events, invitations, free-time search and on-demand sync, using `kpr_` API tokens
 - An MCP server with fourteen tools over OAuth 2.1. An AI agent can read your week, book and amend events, RSVP, find open slots, and pause or force a sync
 - Open source under AGPL-3.0, with Docker Compose images you can run yourself
 - On Pro, Google and Outlook notify Keeper.sh as changes happen, so copies land within seconds. iCloud, Fastmail and other CalDAV calendars are read on a timer, because Apple publishes no way to be told an event changed
-- Free covers 2 calendar accounts, 3 connections and 1 shared link, reading every minute and copying every 30. Pro is $5 a month or $42 a year, unlimited, with Google and Outlook changes copied within seconds
+- Free covers 2 calendar accounts, 3 connections and 1 shared link, reading every minute and copying every 30. Pro is $5 a month or $45 a year, unlimited, with Google and Outlook changes copied within seconds
 
 ## Links
 

--- a/applications/web/src/features/marketing/how-it-works-steps.ts
+++ b/applications/web/src/features/marketing/how-it-works-steps.ts
@@ -13,7 +13,7 @@ export const HOW_IT_WORKS_STEPS: HowItWorksStep[] = [
   },
   {
     title: "Choose what each calendar shows",
-    body: "You set this per calendar. One can carry the full title, description and location while another shows a plain block. Pro adds filters to skip events.",
+    body: "Copies start as a busy block named after the source calendar. Pro lets you turn the title, description and location back on, and adds filters to skip events.",
   },
   {
     title: "Keeper.sh takes it from there",

--- a/applications/web/src/routes/(marketing)/pricing.tsx
+++ b/applications/web/src/routes/(marketing)/pricing.tsx
@@ -26,7 +26,7 @@ import { Breadcrumb } from "@/components/ui/primitives/breadcrumb";
 const breadcrumbs = breadcrumbTrail({ name: "Pricing", path: "/pricing" });
 
 const PAGE_DESCRIPTION =
-  "Keeper.sh is free for 2 calendar accounts and 3 connections. Pro is $5 a month, or $42 a year, for unlimited calendars and Google and Outlook changes that land within seconds.";
+  "Keeper.sh is free for 2 calendar accounts and 3 connections. Pro is $5 a month, or $45 a year, for unlimited calendars and Google and Outlook changes that land within seconds.";
 
 type FaqItem = {
   question: string;
@@ -48,7 +48,7 @@ const FAQ_ITEMS: FaqItem[] = [
   },
   {
     question: "Is there a discount for paying annually?",
-    answer: "Pro is $5 per month, or $42 per year if you pay annually.",
+    answer: "Pro is $5 per month, or $45 per year if you pay annually (25% off $60).",
   },
   {
     question: "Is self-hosting free?",
@@ -90,7 +90,7 @@ function PricingPage() {
       <header className="flex flex-col gap-1.5">
         <Heading1>Pricing</Heading1>
         <Text size="base" tone="muted" className="max-w-[64ch] leading-6">
-          Start free with two calendar accounts and three connections. Pro is $5 a month, or $42 a year, for as many
+          Start free with two calendar accounts and three connections. Pro is $5 a month, or $45 a year, for as many
           calendars as you want.
         </Text>
       </header>


### PR DESCRIPTION
## Summary
- Homepage how-it-works step 2 and llms files now say turning title/description/location on is Pro, matching the API gate and `/docs/what-a-copied-event-shows`.
- Leftover hosted yearly copy is \$45 (25% off \$60), not \$42 / 30%: README, pricing page, llms.txt, llms-full.txt.
- README signup links go to `https://www.keeper.sh/register`.

Polar products, prices, coupons, and checkout code are not touched.

## Test plan
- [ ] Homepage and /features how-it-works step 2 read as Pro for titles
- [ ] /pricing FAQ and hero say \$45/year
- [ ] llms.txt / llms-full.txt no longer imply unhiding is Free
- [ ] README table shows \$45 USD (-25%) and www register hrefs