### PR TITLE
fix(ci): pin checks.yml GITHUB_TOKEN to contents:read

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,6 +3,9 @@ name: Check Code Standards
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   types:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add workflow-level `permissions: contents: read` to `.github/workflows/checks.yml`.
- Addresses CodeQL #1–#6 (`actions/missing-workflow-permissions`). Same shape as `submodule-bump.yml`.

## Test plan
- [ ] PR checks still run
- [ ] After merge, Rel confirms CodeQL #1–#6 close