### PR TITLE
fix(ci): close older seo/claude bump PRs when a new one opens

### DIFF
--- a/.github/workflows/submodule-bump.yml
+++ b/.github/workflows/submodule-bump.yml
@@ -110,6 +110,14 @@ jobs:
             gh pr create --title "chore($NAME): bump to $PIN" --body "" --head "$BRANCH"
           fi
 
+          # One open bump PR per submodule. A newer pin supersedes the rest.
+          gh pr list --state open --json number,headRefName --jq \
+            ".[] | select(.headRefName | startswith(\"chore/bump-${NAME}-\")) | select(.headRefName != \"${BRANCH}\") | .number" \
+          | while read -r n; do
+              [ -n "$n" ] || continue
+              gh pr close "$n" --comment "Superseded by chore($NAME): bump to $PIN."
+            done
+
       - name: Report a failed bump
         if: failure()
         env:


### PR DESCRIPTION
## Summary
- After the submodule bump workflow opens a new `chore/bump-{seo,claude,infra}-*` PR, it closes any other open bump PRs for that same submodule.
- A newer pin supersedes the rest. We do not stack them.

## Test plan
- [ ] Trigger a second seo (or claude) bump while one is still open
- [ ] Confirm the new PR stays open and the previous one closes with a superseded comment
- [ ] Confirm a seo bump does not close a claude bump (or any other PR)