### PR TITLE
chore(deploy): let the worker scale to multiple replicas

### DIFF
--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -69,7 +69,6 @@ services:
 
   worker:
     image: ghcr.io/ridafkih/keeper-worker:2
-    container_name: keeper-worker
     env_file: .env
     environment:
       ENV: production

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -70,6 +70,8 @@ services:
   worker:
     image: ghcr.io/ridafkih/keeper-worker:2
     env_file: .env
+    deploy:
+      replicas: ${WORKER_REPLICAS:-1}
     environment:
       ENV: production
       DATABASE_POOL_MAX: "25"


### PR DESCRIPTION
One line. `container_name` pins a service to a single container, and Compose refuses to scale it — so `docker compose up --scale worker=N` fails today. Removing it makes N possible; the default is still one.

**Why the worker is the safe service to replicate.** BullMQ hands each job to exactly one consumer, with `lockDuration` and `stalledInterval` already covering a replica dying mid-job. Cross-process coordination is Redis-based (the per-destination sync lock), not in-memory. No ports are published, so nothing collides, and the only volume is a read-only cert bundle.

**Cron is deliberately left alone.** cronbake schedules per-process with no leader election, so two cron containers would run overlapping fleet passes; and the flush-generation tracker is process-local by design, so a second cron would widen exactly the stale-write window that tracker exists to close.

**What changes operationally:** `docker logs keeper-worker` becomes `keeper-worker-1`. Logging is unaffected otherwise — `OTEL_SERVICE_NAME=keeper-worker` is set in `services/worker/entrypoint.sh`, so every replica reports under the same `service_name` label and is distinguished by `instance_id`.

**What to watch if you scale up:** each replica opens its own database pool, so connections multiply by N (at `DATABASE_POOL_MAX=25`, two workers is 50 against 189 with ~88 in use).

A separate confirmation pass is verifying that nothing in the worker assumes it is the only instance before we actually run more than one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)