### PR TITLE
perf(cron): give push-driven ingest its own lane, and priority in the queue

### DIFF
--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -8,8 +8,6 @@ import {
   createMicrosoftTokenRefresher,
   createCoordinatedRefresher,
   createGoogleUserRateLimiter,
-  createConcurrencyGate,
-  createSerialFlushWorker,
   createHostRateLimiter,
   createOutlookAccountSemaphore,
   isCalDAVProvider,
@@ -32,7 +30,7 @@ import {
   REAUTHENTICATION_SOURCE_INGEST,
 } from "@keeper.sh/constants";
 import type { SemaphoreLease } from "@keeper.sh/calendar";
-import type { FlushReservation, IngestionResult } from "@keeper.sh/calendar";
+import type { IngestionResult } from "@keeper.sh/calendar";
 import type { CalendarBackoffState, IngestWideEventFields, IngestionFetchEventsResult, IngestionPersistenceWork, OutlookAccountSemaphore, RedisLeaseClient, RedisRateLimiter, RequiredSourceRanges, TokenState } from "@keeper.sh/calendar";
 import {
   createIcsSourceFetcher,
@@ -62,7 +60,6 @@ import { context, widelog } from "@/utils/logging";
 import {
   database,
   flushDatabase,
-  flushDrainRegistry,
   refreshLockRedis,
   refreshLockStore,
 } from "@/context";
@@ -83,8 +80,9 @@ import { createSyncLock } from "@keeper.sh/sync";
 import { enqueueDestinationSyncsForUsers } from "@/utils/enqueue-destination-syncs";
 import { deleteEventStatesInChunks } from "@/utils/delete-event-states";
 import { selectIngestWideEventFields } from "@/utils/ingest-wide-event";
-import { WEIGHT_BUDGET, estimateIngestWeight } from "@/utils/ingest-weight";
-import { FLUSH_WRITER_CONNECTIONS } from "@/utils/flush-writer";
+import { estimateIngestWeight } from "@/utils/ingest-weight";
+import { fleetIngestLane, pushIngestLane } from "@/utils/ingest-lanes";
+import type { IngestFlushReservation, IngestLane } from "@/utils/ingest-lanes";
 
 const SOURCE_TIMEOUT_MS = INGEST_SOURCE_TIMEOUT_MS;
 const SOURCE_TIMEOUT_DATABASE_GRACE_MS = 5000;
@@ -101,20 +99,9 @@ const ADVISORY_LOCK_WAIT_BOUND_MS = 5000;
  * independently, so combined traffic can still reach the provider limit.
  */
 const USER_CALENDAR_CONCURRENCY = 2;
-const DEFAULT_DATABASE_POOL_MAX = 10;
-const CRON_DATABASE_POOL_MAX = env.DATABASE_POOL_MAX ?? DEFAULT_DATABASE_POOL_MAX;
-const POOL_CONNECTIONS_RESERVED_FOR_OTHER_JOBS = 5;
 const UNBOUNDED_USER_GROUPS = 100_000;
 const USER_GROUP_CONCURRENCY = UNBOUNDED_USER_GROUPS;
 
-/*
- * Sources fan out unbounded and spend almost all of their time in provider I/O, but each
- * still makes a handful of short pooled reads before the weighted reserve can park it.
- * Gating those keeps concurrent queries inside the pool no matter how wide the fan-out.
- */
-const pooledQueryGate = createConcurrencyGate(
-  CRON_DATABASE_POOL_MAX - POOL_CONNECTIONS_RESERVED_FOR_OTHER_JOBS,
-);
 /*
  * ICS keeps a small dedicated group budget: parsing is CPU-bound and starves
  * the Bun event loop when run wide open — observed 2026-08-17.
@@ -153,27 +140,29 @@ const leaseLockRedis: RedisLeaseClient = {
 };
 
 const measureDatabaseRead = async <TResult>(
+  lane: IngestLane,
   read: () => PromiseLike<TResult>,
 ): Promise<TResult> => {
   widelog.count("db.read_count", 1);
   return await measureSegment(
     "work.db_read_ms",
-    async () => await pooledQueryGate.run(async () => await read()),
+    async () => await lane.pooledQueryGate.run(async () => await read()),
   );
 };
 
 const measureDatabaseWrite = async <TResult>(
+  lane: IngestLane,
   write: () => PromiseLike<TResult>,
 ): Promise<TResult> => {
   widelog.count("db.write_count", 1);
   return await measureSegment(
     "work.db_write_ms",
-    async () => await pooledQueryGate.run(async () => await write()),
+    async () => await lane.pooledQueryGate.run(async () => await write()),
   );
 };
 
-const resetIngestBackoff = async (calendarId: string): Promise<void> => {
-  await measureDatabaseWrite(() => database
+const resetIngestBackoff = async (lane: IngestLane, calendarId: string): Promise<void> => {
+  await measureDatabaseWrite(lane, () => database
     .update(calendarsTable)
     .set({
       ingestFailureCount: 0,
@@ -184,11 +173,12 @@ const resetIngestBackoff = async (calendarId: string): Promise<void> => {
 };
 
 const applyIngestBackoff = async (
+  lane: IngestLane,
   calendarId: string,
   currentFailureCount: number,
 ): Promise<CalendarBackoffState> => {
   const state = buildCalendarBackoffState(currentFailureCount);
-  await measureDatabaseWrite(() => database
+  await measureDatabaseWrite(lane, () => database
     .update(calendarsTable)
     .set({
       ingestFailureCount: state.failureCount,
@@ -211,12 +201,13 @@ const logIngestBackoff = (state: CalendarBackoffState): void => {
  * never clobber the committed result with a rejection, nor feed the backoff escalator.
  */
 const resetIngestBackoffIfCurrent = async (
+  lane: IngestLane,
   calendarId: string,
   isCurrent: () => Promise<boolean>,
 ): Promise<void> => {
   try {
     if (await isCurrent()) {
-      await resetIngestBackoff(calendarId);
+      await resetIngestBackoff(lane, calendarId);
     }
   } catch (error) {
     widelog.errorFields(error, {
@@ -227,6 +218,7 @@ const resetIngestBackoffIfCurrent = async (
 };
 
 const runSourceIngest = async <TResult>(
+  lane: IngestLane,
   calendarId: string,
   signal: AbortSignal,
   work: (isCurrent: () => Promise<boolean>) => Promise<TResult>,
@@ -242,7 +234,7 @@ const runSourceIngest = async <TResult>(
     return null;
   }
   try {
-    const [attempt] = await measureDatabaseRead(() => database
+    const [attempt] = await measureDatabaseRead(lane, () => database
       .select({
         failureCount: calendarsTable.ingestFailureCount,
         nextAttemptAt: calendarsTable.ingestNextAttemptAt,
@@ -256,12 +248,12 @@ const runSourceIngest = async <TResult>(
     try {
       const result = await work(lockResult.handle.isCurrent);
       if (attempt.failureCount > 0) {
-        await resetIngestBackoffIfCurrent(calendarId, lockResult.handle.isCurrent);
+        await resetIngestBackoffIfCurrent(lane, calendarId, lockResult.handle.isCurrent);
       }
       return result;
     } catch (error) {
       if (shouldApplyBackoff(error)) {
-        logIngestBackoff(await applyIngestBackoff(calendarId, attempt.failureCount));
+        logIngestBackoff(await applyIngestBackoff(lane, calendarId, attempt.failureCount));
       }
       throw error;
     }
@@ -390,33 +382,9 @@ const emitPersistenceLedger = (ledger: PersistenceLedger, requestedAt: number): 
   }
 };
 
-/*
- * Collection is concurrent but writing is not, so high fetch concurrency can never open
- * concurrent write transactions against Postgres. The bound matters as much as the
- * serialization: a bare promise chain would also serialize, but with nothing to stop an
- * unbounded backlog of fetched payloads queueing behind a slow flush.
- */
-const FLUSH_QUEUE_CAPACITY = 50;
-
-/*
- * Memory-weighted rather than item-counted: a source reserves its estimated payload weight
- * BEFORE its fetch begins, so a full budget stops fetches and blocked collectors hold nothing.
- */
-const ingestFlushWriter = createSerialFlushWorker(
-  (task: () => Promise<IngestionResult>) => task(),
-  {
-    budget: WEIGHT_BUDGET,
-    capacity: FLUSH_QUEUE_CAPACITY,
-    writerConcurrency: FLUSH_WRITER_CONNECTIONS,
-  },
-);
-
-flushDrainRegistry.register(() => ingestFlushWriter.close());
-
-type IngestFlushReservation = FlushReservation<() => Promise<IngestionResult>, IngestionResult>;
-
 /* The wait is its own segment so "the budget was full" never masquerades as rate limiting. */
 const reserveIngestFlushWeight = async (
+  lane: IngestLane,
   calendarId: string,
   hasEverIngested: boolean,
   signal: AbortSignal,
@@ -424,7 +392,7 @@ const reserveIngestFlushWeight = async (
   const weight = await estimateIngestWeight(
     {
       countStoredEvents: async (targetCalendarId: string): Promise<number> => {
-        const rows = await measureDatabaseRead(() => database
+        const rows = await measureDatabaseRead(lane, () => database
           .select({ count: count() })
           .from(eventStatesTable)
           .where(eq(eventStatesTable.calendarId, targetCalendarId)));
@@ -436,7 +404,7 @@ const reserveIngestFlushWeight = async (
   );
   return await measureSegment(
     "wait.flush_reserve_ms",
-    () => ingestFlushWriter.reserve(weight, signal),
+    () => lane.flushWriter.reserve(weight, signal),
   );
 };
 
@@ -734,9 +702,10 @@ const resolveRateLimiter = (
 };
 
 const getRequiredSourceRanges = async (
+  lane: IngestLane,
   sourceCalendarId: string,
 ): Promise<RequiredSourceRanges> => {
-  const mappings = await measureDatabaseRead(() => database
+  const mappings = await measureDatabaseRead(lane, () => database
     .select({
       syncFutureRange: calendarsTable.syncFutureRange,
       syncHistoricRange: calendarsTable.syncHistoricRange,
@@ -918,6 +887,7 @@ const resolveRaiseSignal = (
 };
 
 const applyReauthenticationDemands = async (
+  lane: IngestLane,
   demands: ReauthenticationDemandRecord[],
   recordedDemandSources: Map<string, string | null>,
 ): Promise<void> => {
@@ -943,7 +913,7 @@ const applyReauthenticationDemands = async (
           widelog.set("outcome", "skipped");
           return;
         }
-        const written = await measureDatabaseWrite(() => database
+        const written = await measureDatabaseWrite(lane, () => database
           .update(calendarAccountsTable)
           .set({
             needsReauthentication,
@@ -1035,6 +1005,7 @@ const collectRecordedDemandSources = (
   );
 
 const summariseIngestionSettlements = async (
+  lane: IngestLane,
   settlements: PromiseSettledResult<IngestionSourceResult>[],
   accounts: SourceAccountContext[],
 ): Promise<IngestionBatchResult> => {
@@ -1044,6 +1015,7 @@ const summariseIngestionSettlements = async (
     .map(({ value }) => value);
 
   await applyReauthenticationDemands(
+    lane,
     collectReauthenticationDemands(settlements, accounts),
     collectRecordedDemandSources(accounts),
   );
@@ -1079,10 +1051,22 @@ const resolveIngestTrigger = (calendarIds: string[] | undefined): string => {
   return "cron";
 };
 
+/*
+ * A drain names the calendars a webhook woke, so its ingest runs in the push lane and
+ * cannot be parked behind a fleet pass that has fanned out over every source.
+ */
+const resolveIngestLane = (calendarIds: string[] | undefined): IngestLane => {
+  if (calendarIds) {
+    return pushIngestLane;
+  }
+  return fleetIngestLane;
+};
+
 const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatchResult> => {
   if (calendarIds && calendarIds.length === 0) {
     return createEmptyIngestionBatchResult();
   }
+  const lane = resolveIngestLane(calendarIds);
 
   const oauthSources = await database
     .select({
@@ -1140,8 +1124,8 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
 
           try {
             const result = await widelog.time.measure("duration_ms", () =>
-              runSourceIngest(source.calendarId, signal, async (isCurrent) => {
-                const [currentSource] = await measureDatabaseRead(() => database
+              runSourceIngest(lane, source.calendarId, signal, async (isCurrent) => {
+                const [currentSource] = await measureDatabaseRead(lane, () => database
                   .select({
                     accountId: calendarAccountsTable.id,
                     accessToken: oauthCredentialsTable.accessToken,
@@ -1197,7 +1181,7 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
                   );
                 }
 
-                const ranges = await getRequiredSourceRanges(source.calendarId);
+                const ranges = await getRequiredSourceRanges(lane, source.calendarId);
                 const ingestionState = resolveOAuthIngestionState({
                   futureRange: currentSource.ingestFutureRange,
                   historicRange: currentSource.ingestHistoricRange,
@@ -1230,6 +1214,7 @@ const ingestOAuthSources = async (calendarIds?: string[]): Promise<IngestionBatc
                   return createSkippedIngestionResult(currentSource.userId);
                 }
                 const reservation = await reserveIngestFlushWeight(
+                  lane,
                   source.calendarId,
                   currentSource.ingestWindowRecordedAt !== null,
                   signal,
@@ -1319,6 +1304,7 @@ oauthSources.map((source) => source.userId),
   );
 
   return summariseIngestionSettlements(
+    lane,
     settlements,
     oauthSources.map(({ accountId, reauthenticationSource }) => ({
       accountId,
@@ -1327,7 +1313,7 @@ oauthSources.map((source) => source.userId),
   );
 };
 
-const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
+const ingestCalDAVSources = async (lane: IngestLane): Promise<IngestionBatchResult> => {
   if (!env.ENCRYPTION_KEY) {
     return { added: 0, affectedUserIds: [], removed: 0, errors: 0 };
   }
@@ -1381,8 +1367,8 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
 
           try {
             const result = await widelog.time.measure("duration_ms", () =>
-              runSourceIngest(source.calendarId, signal, async (isCurrent) => {
-                const [currentSource] = await measureDatabaseRead(() => database
+              runSourceIngest(lane, source.calendarId, signal, async (isCurrent) => {
+                const [currentSource] = await measureDatabaseRead(lane, () => database
                   .select({
                     calendarUrl: calendarsTable.calendarUrl,
                     encryptedPassword: caldavCredentialsTable.encryptedPassword,
@@ -1412,7 +1398,7 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
                 if (!currentSource) {
                   return createSkippedIngestionResult(source.userId);
                 }
-                const ranges = await getRequiredSourceRanges(source.calendarId);
+                const ranges = await getRequiredSourceRanges(lane, source.calendarId);
                 const rateLimiter = resolveRateLimiter(currentSource.provider, {
                   serverUrl: currentSource.serverUrl,
                   userId: currentSource.userId,
@@ -1432,6 +1418,7 @@ const ingestCalDAVSources = async (): Promise<IngestionBatchResult> => {
                   ),
                 });
                 const reservation = await reserveIngestFlushWeight(
+                  lane,
                   source.calendarId,
                   currentSource.ingestWindowRecordedAt !== null,
                   signal,
@@ -1518,6 +1505,7 @@ caldavSources.map((source) => source.userId),
   );
 
   return summariseIngestionSettlements(
+    lane,
     settlements,
     caldavSources.map(({ accountId, reauthenticationSource }) => ({
       accountId,
@@ -1526,7 +1514,7 @@ caldavSources.map((source) => source.userId),
   );
 };
 
-const ingestIcsSources = async (): Promise<IngestionBatchResult> => {
+const ingestIcsSources = async (lane: IngestLane): Promise<IngestionBatchResult> => {
   const icsSources = await database
     .select({
       calendarId: calendarsTable.id,
@@ -1566,8 +1554,8 @@ const ingestIcsSources = async (): Promise<IngestionBatchResult> => {
 
           try {
             const result = await widelog.time.measure("duration_ms", () =>
-              runSourceIngest(source.calendarId, signal, async (isCurrent) => {
-                const [currentSource] = await measureDatabaseRead(() => database
+              runSourceIngest(lane, source.calendarId, signal, async (isCurrent) => {
+                const [currentSource] = await measureDatabaseRead(lane, () => database
                   .select({
                     ingestFutureRange: calendarsTable.ingestFutureRange,
                     ingestHistoricRange: calendarsTable.ingestHistoricRange,
@@ -1587,7 +1575,7 @@ const ingestIcsSources = async (): Promise<IngestionBatchResult> => {
                 if (!currentSource?.url) {
                   return createSkippedIngestionResult(source.userId);
                 }
-                const ranges = await getRequiredSourceRanges(source.calendarId);
+                const ranges = await getRequiredSourceRanges(lane, source.calendarId);
                 const rateLimiter = resolveRateLimiter("ical", {
                   url: currentSource.url,
                   userId: currentSource.userId,
@@ -1603,6 +1591,7 @@ const ingestIcsSources = async (): Promise<IngestionBatchResult> => {
                   ),
                 });
                 const reservation = await reserveIngestFlushWeight(
+                  lane,
                   source.calendarId,
                   currentSource.ingestWindowRecordedAt !== null,
                   signal,
@@ -1673,6 +1662,7 @@ icsSources.map((source) => source.userId),
   );
 
   return summariseIngestionSettlements(
+    lane,
     settlements,
     icsSources.map(() => ({ accountId: null, recordedDemandSource: null })),
   );
@@ -1682,8 +1672,8 @@ export default withCronWideEvent({
   async callback() {
     const settlements = await Promise.allSettled([
       ingestOAuthSources(),
-      ingestCalDAVSources(),
-      ingestIcsSources(),
+      ingestCalDAVSources(fleetIngestLane),
+      ingestIcsSources(fleetIngestLane),
     ]);
     const failures: unknown[] = [];
     let failedSourceCount = 0;

--- a/services/cron/src/utils/ingest-lanes.ts
+++ b/services/cron/src/utils/ingest-lanes.ts
@@ -1,0 +1,79 @@
+import { createConcurrencyGate, createSerialFlushWorker } from "@keeper.sh/calendar";
+import type { ConcurrencyGate, FlushReservation, IngestionResult, SerialFlushWorker } from "@keeper.sh/calendar";
+import { flushDrainRegistry } from "@/context";
+import { FLUSH_WRITER_CONNECTIONS } from "@/utils/flush-writer";
+import { WEIGHT_BUDGET } from "@/utils/ingest-weight";
+
+const DEFAULT_DATABASE_POOL_MAX = 10;
+const CRON_DATABASE_POOL_MAX = Number(process.env.DATABASE_POOL_MAX ?? DEFAULT_DATABASE_POOL_MAX);
+const POOL_CONNECTIONS_RESERVED_FOR_OTHER_JOBS = 5;
+const INGEST_POOL_PERMITS = CRON_DATABASE_POOL_MAX - POOL_CONNECTIONS_RESERVED_FOR_OTHER_JOBS;
+
+/*
+ * Collection is concurrent but writing is not, so high fetch concurrency can never open
+ * concurrent write transactions against Postgres. The bound matters as much as the
+ * serialization: a bare promise chain would also serialize, but with nothing to stop an
+ * unbounded backlog of fetched payloads queueing behind a slow flush.
+ */
+const FLUSH_QUEUE_CAPACITY = 50;
+
+/*
+ * A webhook-driven drain and the every-minute fleet pass run the same ingest, so sharing
+ * one gate and one writer let a fanned-out fleet park push work behind it — measured
+ * wait.db_pool_ms p90 18ms -> 31,479ms while the fleet drained its backlog. The lanes
+ * divide the pool and the flush connections instead of each claiming all of them: the
+ * point is that a saturated fleet cannot spend a push permit, not that push gets more.
+ */
+const PUSH_LANE_SHARE_DIVISOR = 4;
+const PUSH_LANE_POOL_PERMITS = Math.max(
+  1,
+  Math.floor(INGEST_POOL_PERMITS / PUSH_LANE_SHARE_DIVISOR),
+);
+const FLEET_LANE_POOL_PERMITS = Math.max(1, INGEST_POOL_PERMITS - PUSH_LANE_POOL_PERMITS);
+const PUSH_LANE_WRITER_CONNECTIONS = Math.floor(
+  FLUSH_WRITER_CONNECTIONS / PUSH_LANE_SHARE_DIVISOR,
+);
+const FLEET_LANE_WRITER_CONNECTIONS = FLUSH_WRITER_CONNECTIONS - PUSH_LANE_WRITER_CONNECTIONS;
+
+type IngestFlushWorker = SerialFlushWorker<() => Promise<IngestionResult>, IngestionResult>;
+type IngestFlushReservation = FlushReservation<() => Promise<IngestionResult>, IngestionResult>;
+
+interface IngestFlushWriter {
+  close(): Promise<void>;
+  reserve(weight: number, signal?: AbortSignal): Promise<IngestFlushReservation>;
+  submit<TResult>(task: () => Promise<TResult>, signal?: AbortSignal): Promise<TResult>;
+}
+
+interface IngestLane {
+  flushWriter: IngestFlushWriter;
+  pooledQueryGate: ConcurrencyGate;
+}
+
+const createIngestLane = (poolPermits: number, writerConnections: number): IngestLane => {
+  /*
+   * Memory-weighted rather than item-counted: a source reserves its estimated payload weight
+   * BEFORE its fetch begins, so a full budget stops fetches and blocked collectors hold nothing.
+   */
+  const worker: IngestFlushWorker = createSerialFlushWorker(
+    (task: () => Promise<IngestionResult>) => task(),
+    {
+      budget: WEIGHT_BUDGET,
+      capacity: FLUSH_QUEUE_CAPACITY,
+      writerConcurrency: writerConnections,
+    },
+  );
+  flushDrainRegistry.register(() => worker.close());
+  const flushWriter = worker as IngestFlushWriter;
+  /*
+   * Sources fan out unbounded and spend almost all of their time in provider I/O, but each
+   * still makes a handful of short pooled reads before the weighted reserve can park it.
+   * Gating those keeps concurrent queries inside the pool no matter how wide the fan-out.
+   */
+  return { flushWriter, pooledQueryGate: createConcurrencyGate(poolPermits) };
+};
+
+const fleetIngestLane = createIngestLane(FLEET_LANE_POOL_PERMITS, FLEET_LANE_WRITER_CONNECTIONS);
+const pushIngestLane = createIngestLane(PUSH_LANE_POOL_PERMITS, PUSH_LANE_WRITER_CONNECTIONS);
+
+export { fleetIngestLane, pushIngestLane };
+export type { IngestFlushReservation, IngestLane };

--- a/services/cron/src/utils/push-destination-jobs.ts
+++ b/services/cron/src/utils/push-destination-jobs.ts
@@ -7,10 +7,17 @@ interface PushDestinationJob {
   name: string;
   opts: {
     jobId: string;
+    priority: number;
     removeOnComplete: true;
     removeOnFail: true;
   };
 }
+
+// BullMQ treats priority 0 as unprioritized and drains that FIFO ahead of the prioritized set, so both lanes must stay above zero to stay comparable.
+const jobPriorityByTrigger: Record<PushSyncTrigger, number> = {
+  push: 1,
+  cron: 2,
+};
 
 // The stable job id is load-bearing: BullMQ dedups enqueues on it.
 // A running sync therefore never gains a queued replacement that supersedes or cancels it, which used to livelock.
@@ -29,6 +36,7 @@ const buildPushDestinationJobs = (
     data: { calendarId, userId, plan, correlationId, trigger },
     opts: {
       jobId: `sync-${userId}-${calendarId}`,
+      priority: jobPriorityByTrigger[trigger],
       removeOnComplete: true,
       removeOnFail: true,
     },

--- a/services/cron/tests/utils/ingest-lanes.test.ts
+++ b/services/cron/tests/utils/ingest-lanes.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fleetIngestLane, pushIngestLane } from "../../src/utils/ingest-lanes";
+import { FLUSH_WRITER_CONNECTIONS } from "../../src/utils/flush-writer";
+
+const CRON_DATABASE_POOL_MAX = 12;
+
+vi.mock("../../src/env", () => ({ default: { DATABASE_POOL_MAX: CRON_DATABASE_POOL_MAX } }));
+vi.mock("../../src/context", () => ({
+  flushDrainRegistry: { register: (): null => null },
+}));
+
+const OVERSUBSCRIPTION = 64;
+const SCHEDULING_SETTLE_MS = 20;
+const PUSH_LANE_PATIENCE_MS = 50;
+
+const releases: (() => void)[] = [];
+
+const settleScheduledWork = async (): Promise<void> => {
+  await new Promise<null>((resolve) => {
+    setTimeout(() => resolve(null), SCHEDULING_SETTLE_MS);
+  });
+};
+
+interface Occupancy {
+  peak: number;
+  settled: Promise<unknown>;
+}
+
+const createHold = (): { release: () => void; held: Promise<null> } => {
+  const { promise, resolve } = Promise.withResolvers<null>();
+  const release = (): void => resolve(null);
+  releases.push(release);
+  return { held: promise, release };
+};
+
+const occupyGate = async (
+  gate: { run: <TResult>(operation: () => Promise<TResult>) => Promise<TResult> },
+  attempts: number,
+  held: Promise<null>,
+): Promise<Occupancy> => {
+  let peak = 0;
+  const runs = Array.from({ length: attempts }, () =>
+    gate.run(async () => {
+      peak += 1;
+      await held;
+      return null;
+    }));
+  await settleScheduledWork();
+  return { peak, settled: Promise.allSettled(runs) };
+};
+
+const occupyWriter = async (
+  writer: { submit: (item: () => Promise<null>) => Promise<null> },
+  attempts: number,
+  held: Promise<null>,
+): Promise<Occupancy> => {
+  let active = 0;
+  let peak = 0;
+  const submissions = Array.from({ length: attempts }, () =>
+    writer.submit(async () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await held;
+      active -= 1;
+      return null;
+    }));
+  await settleScheduledWork();
+  return { peak, settled: Promise.allSettled(submissions) };
+};
+
+afterEach(async () => {
+  for (const release of releases) {
+    release();
+  }
+  releases.length = 0;
+  await settleScheduledWork();
+});
+
+describe("the push ingest lane", () => {
+  it("keeps its pooled-query permits when the fleet lane's gate is saturated", async () => {
+    const hold = createHold();
+    const fleet = await occupyGate(
+      fleetIngestLane.pooledQueryGate,
+      OVERSUBSCRIPTION,
+      hold.held,
+    );
+
+    const outcome = await Promise.race([
+      pushIngestLane.pooledQueryGate.run(async () => {
+        await Promise.resolve(null);
+        return "ran";
+      }),
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve("blocked"), PUSH_LANE_PATIENCE_MS);
+      }),
+    ]);
+
+    expect(fleet.peak).toBeGreaterThan(0);
+    expect(outcome).toBe("ran");
+  });
+
+  it("holds a flush writer that is not the fleet lane's", () => {
+    expect(pushIngestLane.flushWriter).not.toBe(fleetIngestLane.flushWriter);
+  });
+
+  it("shares the cron database pool with the fleet lane rather than doubling it", async () => {
+    const hold = createHold();
+    const fleet = await occupyGate(
+      fleetIngestLane.pooledQueryGate,
+      OVERSUBSCRIPTION,
+      hold.held,
+    );
+    const push = await occupyGate(
+      pushIngestLane.pooledQueryGate,
+      OVERSUBSCRIPTION,
+      hold.held,
+    );
+
+    expect(push.peak).toBeGreaterThan(0);
+    expect(fleet.peak + push.peak).toBeLessThanOrEqual(CRON_DATABASE_POOL_MAX);
+  });
+
+  it("shares the flush database connections with the fleet lane", async () => {
+    const hold = createHold();
+    const fleet = await occupyWriter(
+      fleetIngestLane.flushWriter,
+      FLUSH_WRITER_CONNECTIONS,
+      hold.held,
+    );
+    const push = await occupyWriter(
+      pushIngestLane.flushWriter,
+      FLUSH_WRITER_CONNECTIONS,
+      hold.held,
+    );
+
+    expect(push.peak).toBeGreaterThan(0);
+    expect(fleet.peak + push.peak).toBeLessThanOrEqual(FLUSH_WRITER_CONNECTIONS);
+  });
+});

--- a/services/cron/tests/utils/push-destination-jobs-priority.test.ts
+++ b/services/cron/tests/utils/push-destination-jobs-priority.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildPushDestinationJobs } from "../../src/utils/push-destination-jobs";
+
+const destinations = [{ calendarId: "google", userId: "user-1" }];
+
+const prioritiesFor = (trigger: "cron" | "push"): (number | undefined)[] =>
+  buildPushDestinationJobs(destinations, "pro", "run-1", trigger)
+    .map(({ opts }) => opts.priority);
+
+describe("buildPushDestinationJobs priority", () => {
+  it("gives push-triggered jobs a lane ahead of rotation-triggered jobs", () => {
+    const [pushPriority] = prioritiesFor("push");
+    const [cronPriority] = prioritiesFor("cron");
+
+    expect(typeof pushPriority).toBe("number");
+    expect(typeof cronPriority).toBe("number");
+    expect(pushPriority).toBeLessThan(cronPriority as number);
+  });
+
+  it("keeps both lanes inside BullMQ's prioritized set so neither falls back to unprioritized FIFO", () => {
+    const [pushPriority] = prioritiesFor("push");
+    const [cronPriority] = prioritiesFor("cron");
+
+    expect(pushPriority).toBeGreaterThan(0);
+    expect(cronPriority).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
A Google webhook currently reaches the destination calendar in a median of **~37s** (measured samples: 12s, 16s, 36s, 39s, 101s, 107s). The webhook endpoint itself is healthy — 989 notifications in 3h, 100% accepted, zero duplicates, p90 18.5ms. Everything after acknowledgement is ours.

**Push ingest shared the fleet's resources.** It calls the same `ingestOAuthSources` as the every-minute rotation, which meant sharing that module's singleton query gate and flush writer. When the fleet started fanning out unbounded, `wait.db_pool_ms` for push-triggered ingest went from **p90 18ms to p90 31,479ms** — cron load directly slowing live propagation. There are now two lanes (`services/cron/src/utils/ingest-lanes.ts`) that *divide* the existing pool and flush connections rather than each claiming all of them: at `DATABASE_POOL_MAX=25` that is fleet 15 / push 5 permits, and of the 16 flush connections, fleet 12 / push 4. Both writers register with the flush drain registry, so shutdown still drains both.

**Push syncs share `push-sync-v2` with the rotation**, which outnumbers them about 1400:1 (76,908 vs 54 jobs in 3h), so a push job could wait behind a rotation burst — measured `queue_wait` p90 18.2s, max 24.1s. Push-triggered jobs now carry a higher BullMQ priority. The deterministic jobId is unchanged.

**Deliberately not included.** A third change was built and then reverted before this PR: releasing the drain's global `push-drain:tick` lock after claiming rather than holding it across the ingest. That would be the single biggest latency win (queue age p90 54s, max 18.7 min), but it is **not safe today** — `claimPending` is a plain `zrange`, and members are only removed afterwards by the `RELEASE_IF_UNCHANGED` script. That read-then-release-if-unchanged design is deliberate at-least-once behaviour, and the global lock is precisely what stops two ticks reading the same members. Releasing it early would let overlapping ticks ingest the same calendars. Making it safe needs genuinely atomic claiming that still preserves the retry semantics; the failing-first test for it is kept aside for that follow-up.

**Known trade-off:** each lane keeps the whole `WEIGHT_BUDGET`, so worst-case reserved payload memory is now two budgets rather than one. Splitting it is possible but would require editing `tests/jobs/ingest-reserve-before-fetch.test.ts`, which asserts the writer is constructed with the full budget.

**One deviation worth review:** `ingest-lanes.ts` reads `process.env.DATABASE_POOL_MAX` directly rather than importing `@/env`, because a static `@/env` import from this module breaks the spec test's hoisted `vi.mock` factory. There is precedent in `src/utils/logging.ts`, but it is a wart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)