### PR TITLE
fix(sync): update destination events in place instead of delete and re-push

### DIFF
--- a/packages/calendar/src/core/sync-engine/flush.ts
+++ b/packages/calendar/src/core/sync-engine/flush.ts
@@ -59,6 +59,8 @@ const createDatabaseFlush = (database: BunSQLClient): (changes: PendingChanges) 
                 deleteIdentifier: update.deleteIdentifier,
                 syncEventHash: update.syncEventHash,
                 syncEventId: update.syncEventId,
+                startTime: update.startTime,
+                endTime: update.endTime,
               })
               .where(eq(eventMappingsTable.id, update.id));
           }

--- a/packages/calendar/src/core/sync-engine/index.ts
+++ b/packages/calendar/src/core/sync-engine/index.ts
@@ -100,7 +100,7 @@ const resolveOutcome = (superseded: boolean): string => {
 };
 
 interface OperationError {
-  type: "add" | "remove";
+  type: "add" | "remove" | "update";
   error: string;
   errorType?: string;
   statusCode?: number;
@@ -315,6 +315,14 @@ const processUpdateResults = (
 
     if (!pushResult?.success) {
       unresolved.push(operation);
+      if (pushResult?.error) {
+        errors.push({
+          type: "update",
+          error: pushResult.error,
+          ...(pushResult.errorType && { errorType: pushResult.errorType }),
+          ...(typeof pushResult.statusCode === "number" && { statusCode: pushResult.statusCode }),
+        });
+      }
       continue;
     }
 

--- a/packages/calendar/src/core/sync-engine/index.ts
+++ b/packages/calendar/src/core/sync-engine/index.ts
@@ -14,7 +14,7 @@ import type { SyncProgressUpdate } from "../sync/types";
 import { createSyncEventContentHash } from "../events/content-hash";
 import { computeSyncOperations } from "../sync/operations";
 import type { ReconciliationScope, StaleReasonCounts } from "../sync/operations";
-import type { CalendarSyncProvider, PendingChanges } from "./types";
+import type { CalendarSyncProvider, EventUpdate, PendingChanges, PendingUpdate } from "./types";
 
 /*
  * A run whose provider rejects everything produces one error per operation. The wide
@@ -81,11 +81,12 @@ const createTimedProvider = (
   provider: CalendarSyncProvider,
   timer: ReturnType<typeof createPhaseTimer>,
 ): CalendarSyncProvider => {
-  const { getSyncDiagnostics, getThrottleMetrics } = provider;
+  const { getSyncDiagnostics, getThrottleMetrics, updateEvents } = provider;
   return {
     deleteEvents: (eventIds) => timer.measure("provider_delete", () => provider.deleteEvents(eventIds)),
     listRemoteEvents: (options) => provider.listRemoteEvents(options),
     pushEvents: (events) => timer.measure("provider_push", () => provider.pushEvents(events)),
+    ...(updateEvents && { updateEvents: (updates: EventUpdate[]) => timer.measure("provider_push", () => updateEvents(updates)) }),
     ...(getSyncDiagnostics && { getSyncDiagnostics: () => getSyncDiagnostics() }),
     ...(getThrottleMetrics && { getThrottleMetrics: () => getThrottleMetrics() }),
   };
@@ -288,6 +289,52 @@ const processAddResults = (
   return { changes, added, addFailed, conflictsResolved, errors };
 };
 
+const processUpdateResults = (
+  replacements: Extract<SyncOperation, { type: "replace" }>[],
+  pushResults: PushResult[],
+): {
+  changes: PendingChanges;
+  updated: number;
+  conflictsResolved: number;
+  errors: OperationError[];
+  unresolved: Extract<SyncOperation, { type: "replace" }>[];
+} => {
+  const updates: PendingUpdate[] = [];
+  const errors: OperationError[] = [];
+  const unresolved: Extract<SyncOperation, { type: "replace" }>[] = [];
+  let updated = 0;
+  let conflictsResolved = 0;
+
+  for (let index = 0; index < replacements.length; index++) {
+    const operation = replacements[index];
+    const pushResult = pushResults[index];
+
+    if (!operation) {
+      continue;
+    }
+
+    if (!pushResult?.success) {
+      unresolved.push(operation);
+      continue;
+    }
+
+    updated += 1;
+    if (pushResult.conflictResolved) {
+      conflictsResolved += 1;
+    }
+    updates.push({
+      deleteIdentifier: pushResult.deleteId ?? pushResult.remoteId ?? operation.deleteId,
+      endTime: operation.event.endTime,
+      id: operation.staleMappingId,
+      startTime: operation.event.startTime,
+      syncEventHash: createSyncEventContentHash(operation.event),
+      syncEventId: operation.event.id,
+    });
+  }
+
+  return { changes: { inserts: [], deletes: [], updates }, updated, conflictsResolved, errors, unresolved };
+};
+
 const processDeleteResults = (
   removeOperations: Extract<SyncOperation, { type: "remove" }>[],
   deleteResults: DeleteResult[],
@@ -334,6 +381,7 @@ interface ExecuteRemoteResult {
   pushEcho: PushEchoCounts;
   superseded: boolean;
   checkpointRejected: boolean;
+  updateFallbacks: number;
 }
 
 interface RunResult {
@@ -342,6 +390,11 @@ interface RunResult {
   conflictsResolved: number;
   errors: OperationError[];
   pushEcho?: PushEchoCounts;
+}
+
+interface UpdateRunResult {
+  runResult: RunResult;
+  unresolved: Extract<SyncOperation, { type: "replace" }>[];
 }
 
 const executeAddRun = async (
@@ -360,6 +413,30 @@ const executeAddRun = async (
     conflictsResolved,
     errors,
     pushEcho,
+  };
+};
+
+const executeUpdateRun = async (
+  replacements: Extract<SyncOperation, { type: "replace" }>[],
+  updateEvents: NonNullable<CalendarSyncProvider["updateEvents"]>,
+): Promise<UpdateRunResult> => {
+  const updates: EventUpdate[] = replacements.map((operation) => ({
+    deleteId: operation.deleteId,
+    event: operation.event,
+  }));
+  const pushResults = await updateEvents(updates);
+  const { updated, conflictsResolved, changes, errors, unresolved } = processUpdateResults(replacements, pushResults);
+  const pushEcho = createPushEchoCounts();
+  tallyPushEcho(pushEcho, pushResults);
+  return {
+    runResult: {
+      changes,
+      result: { added: updated, addFailed: 0, removed: 0, removeFailed: 0 },
+      conflictsResolved,
+      errors,
+      pushEcho,
+    },
+    unresolved,
   };
 };
 
@@ -387,6 +464,9 @@ const mergeRunResult = (
   if (includeChanges) {
     state.changes.inserts.push(...runResult.changes.inserts);
     state.changes.deletes.push(...runResult.changes.deletes);
+    if (runResult.changes.updates) {
+      state.changes.updates = [...(state.changes.updates ?? []), ...runResult.changes.updates];
+    }
   }
   state.result = {
     added: state.result.added + runResult.result.added,
@@ -431,6 +511,7 @@ interface ChunkedExecutionState {
   superseded: boolean;
   checkpointRejected: boolean;
   protectedRemoteUids: Set<string>;
+  updateFallbacks: number;
 }
 
 const checkpointRun = async (
@@ -438,7 +519,8 @@ const checkpointRun = async (
   changes: PendingChanges,
   checkpoint?: CheckpointCallback,
 ): Promise<boolean> => {
-  if (!checkpoint || (changes.inserts.length === 0 && changes.deletes.length === 0)) {
+  const updateCount = changes.updates?.length ?? 0;
+  if (!checkpoint || (changes.inserts.length === 0 && changes.deletes.length === 0 && updateCount === 0)) {
     return true;
   }
 
@@ -516,21 +598,14 @@ const executeRemoves = async (
   await checkSuperseded(state, isCurrent);
 };
 
-const executeReplacements = async (
+const replaceViaDeleteThenAdd = async (
   replacements: Extract<SyncOperation, { type: "replace" }>[],
   calendarId: string,
   provider: CalendarSyncProvider,
   mappingsByRemoteIdentity: Map<string, EventMapping>,
   state: ChunkedExecutionState,
-  totalOperations: number,
-  isCurrent?: () => Promise<boolean>,
-  onRunComplete?: ProgressCallback,
   checkpoint?: CheckpointCallback,
-): Promise<void> => {
-  if (replacements.length === 0) {
-    return;
-  }
-
+): Promise<boolean> => {
   const removes: Extract<SyncOperation, { type: "remove" }>[] = replacements.map((operation) => ({
     deleteId: operation.deleteId,
     startTime: operation.event.startTime,
@@ -569,8 +644,70 @@ const executeReplacements = async (
     const addResult = await executeAddRun(adds, calendarId, provider);
     mergeRunResult(state, addResult);
     if (!(await checkpointRun(state, addResult.changes, checkpoint))) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const executeReplacements = async (
+  replacements: Extract<SyncOperation, { type: "replace" }>[],
+  calendarId: string,
+  provider: CalendarSyncProvider,
+  mappingsByRemoteIdentity: Map<string, EventMapping>,
+  state: ChunkedExecutionState,
+  totalOperations: number,
+  isCurrent?: () => Promise<boolean>,
+  onRunComplete?: ProgressCallback,
+  checkpoint?: CheckpointCallback,
+): Promise<void> => {
+  if (replacements.length === 0) {
+    return;
+  }
+
+  const { updateEvents } = provider;
+  if (updateEvents) {
+    const { runResult, unresolved } = await executeUpdateRun(replacements, updateEvents);
+    mergeRunResult(state, runResult);
+    const unresolvedMappingIds = new Set(unresolved.map((operation) => operation.staleMappingId));
+    for (const replacement of replacements) {
+      if (!unresolvedMappingIds.has(replacement.staleMappingId)) {
+        state.protectedRemoteUids.add(replacement.uid);
+      }
+    }
+    state.updateFallbacks += unresolved.length;
+    if (!(await checkpointRun(state, runResult.changes, checkpoint))) {
       return;
     }
+    if (unresolved.length > 0) {
+      const recovered = await replaceViaDeleteThenAdd(
+        unresolved,
+        calendarId,
+        provider,
+        mappingsByRemoteIdentity,
+        state,
+        checkpoint,
+      );
+      if (!recovered) {
+        return;
+      }
+    }
+    state.processed += replacements.length * 2;
+    onRunComplete?.(state.processed, totalOperations);
+    await checkSuperseded(state, isCurrent);
+    return;
+  }
+
+  if (!(await replaceViaDeleteThenAdd(
+    replacements,
+    calendarId,
+    provider,
+    mappingsByRemoteIdentity,
+    state,
+    checkpoint,
+  ))) {
+    return;
   }
 
   state.processed += replacements.length * 2;
@@ -608,7 +745,7 @@ const executeRemoteOperations = async (
   const operationChunks = chunkOperations(operations, OPERATION_CHUNK_SIZE);
   const totalOperations = getTotalOperationCount(operations);
   const state: ChunkedExecutionState = {
-    changes: { inserts: [], deletes: [] },
+    changes: { inserts: [], deletes: [], updates: [] },
     result: { added: 0, addFailed: 0, removed: 0, removeFailed: 0 },
     conflictsResolved: 0,
     errors: [],
@@ -617,6 +754,7 @@ const executeRemoteOperations = async (
     superseded: false,
     checkpointRejected: false,
     protectedRemoteUids: new Set<string>(),
+    updateFallbacks: 0,
   };
 
   for (const chunk of operationChunks) {
@@ -684,6 +822,7 @@ const executeRemoteOperations = async (
     pushEcho: state.pushEcho,
     superseded: state.superseded,
     checkpointRejected: state.checkpointRejected,
+    updateFallbacks: state.updateFallbacks,
   };
 };
 
@@ -931,6 +1070,7 @@ const syncCalendar = async (options: SyncCalendarOptions): Promise<SyncCalendarR
     wideEvent["events.removed"] = outcome.result.removed;
     wideEvent["events.remove_failed"] = outcome.result.removeFailed;
     wideEvent["events.conflicts_resolved"] = outcome.conflictsResolved;
+    wideEvent["events.update_fallbacks"] = outcome.updateFallbacks;
     wideEvent["superseded"] = outcome.superseded;
     appendPushEchoFields(wideEvent, outcome.pushEcho);
 

--- a/packages/calendar/src/core/sync-engine/types.ts
+++ b/packages/calendar/src/core/sync-engine/types.ts
@@ -7,10 +7,16 @@ import type {
   RemoteEvent,
 } from "../types";
 
+interface EventUpdate {
+  deleteId: string;
+  event: MaterializedSyncableEvent;
+}
+
 interface CalendarSyncProvider {
   // Must run before reconciliation, not in the serializer, or mapping and remote disagree and churn forever.
   normalizeEvent?: (event: MaterializedSyncableEvent) => MaterializedSyncableEvent;
   pushEvents: (events: MaterializedSyncableEvent[]) => Promise<PushResult[]>;
+  updateEvents?: (updates: EventUpdate[]) => Promise<PushResult[]>;
   deleteEvents: (eventIds: string[]) => Promise<DeleteResult[]>;
   listRemoteEvents: (options: ListRemoteEventsOptions) => Promise<RemoteEvent[]>;
   getThrottleMetrics?: () => ProviderThrottleMetrics;
@@ -31,7 +37,9 @@ interface PendingInsert {
 
 interface PendingUpdate {
   deleteIdentifier: string;
+  endTime: Date;
   id: string;
+  startTime: Date;
   syncEventHash: string;
   syncEventId: string;
 }
@@ -42,4 +50,4 @@ interface PendingChanges {
   updates?: PendingUpdate[];
 }
 
-export type { CalendarSyncProvider, PendingChanges, PendingInsert, PendingUpdate };
+export type { CalendarSyncProvider, EventUpdate, PendingChanges, PendingInsert, PendingUpdate };

--- a/packages/calendar/src/core/sync/operations.ts
+++ b/packages/calendar/src/core/sync/operations.ts
@@ -75,7 +75,9 @@ interface RemoteStateChanges {
 
 interface MappingUpdate {
   deleteIdentifier: string;
+  endTime: Date;
   id: string;
+  startTime: Date;
   syncEventHash: string;
   syncEventId: string;
 }
@@ -692,7 +694,9 @@ const computeSyncOperations = (
     ) {
       mappingUpdatesById.set(mapping.id, {
         deleteIdentifier: remoteEvent.deleteId,
+        endTime: localEvent.endTime,
         id: mapping.id,
+        startTime: localEvent.startTime,
         syncEventHash: createSyncEventContentHash(localEvent),
         syncEventId: localEvent.id,
       });
@@ -705,7 +709,9 @@ const computeSyncOperations = (
     }
     mappingUpdatesById.set(mapping.id, {
       deleteIdentifier: remoteEvent.deleteId,
+      endTime: event.endTime,
       id: mapping.id,
+      startTime: event.startTime,
       syncEventHash: createSyncEventContentHash(event),
       syncEventId: event.id,
     });

--- a/packages/calendar/src/providers/caldav/destination/provider.ts
+++ b/packages/calendar/src/providers/caldav/destination/provider.ts
@@ -163,6 +163,13 @@ const toListingDiagnostics = (listing: CalDAVListingStats): Record<string, numbe
   "remote_objects.unrequested_count": listing.unrequestedCount,
 });
 
+const toCalendarBaseUrl = (calendarUrl: string): string => {
+  if (calendarUrl.endsWith("/")) {
+    return calendarUrl;
+  }
+  return `${calendarUrl}/`;
+};
+
 const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
   const calendarHost = new URL(config.calendarUrl).hostname;
   const removeCounts: CalDAVRemoveCounts = {
@@ -247,20 +254,27 @@ const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
       ),
     );
 
-  const toObjectHref = (deleteId: string): string => {
+  const calendarBaseUrl = toCalendarBaseUrl(config.calendarUrl);
+
+  const toObjectUrl = (deleteId: string): string => {
     if (deleteId.includes("/")) {
-      return new URL(deleteId, config.calendarUrl).href;
+      return new URL(deleteId, calendarBaseUrl).href;
     }
-    return new URL(`${deleteId}.ics`, config.calendarUrl).href;
+    return new URL(`${deleteId}.ics`, calendarBaseUrl).href;
   };
 
-  /* A rewrite must land on the object the mapping already points at, or the PUT orphans a duplicate. */
-  const assertUpdateTargetsUid = (deleteId: string, uid: string): void => {
-    const target = toObjectHref(deleteId);
-    const expected = toObjectHref(uid);
-    if (target !== expected) {
-      throw new Error(`CalDAV update target ${target} does not match deterministic object ${expected}`);
+  /*
+   * Servers may return the href percent-encoded, and every Keeper UID contains an
+   * "@". Comparing decoded basenames keeps the write on the object the mapping
+   * already points at instead of a reconstructed href that never matches.
+   */
+  const resolveUpdateTargetUrl = (deleteId: string, uid: string): string => {
+    const objectUrl = toObjectUrl(deleteId);
+    const filename = decodeURIComponent(new URL(objectUrl).pathname.split("/").at(-1) ?? "");
+    if (filename !== `${uid}.ics`) {
+      throw new Error(`CalDAV update target ${objectUrl} does not belong to event ${uid}`);
     }
+    return objectUrl;
   };
 
   const updateEvents = (updates: EventUpdate[]): Promise<PushResult[]> =>
@@ -269,13 +283,11 @@ const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
         rateLimiter.execute(async (): Promise<PushResult> => {
           try {
             const uid = generateDeterministicEventUid(event.id);
-            assertUpdateTargetsUid(deleteId, uid);
+            const objectUrl = resolveUpdateTargetUrl(deleteId, uid);
 
-            await client.createCalendarObject({
-              calendarUrl: config.calendarUrl,
-              filename: `${uid}.ics`,
+            await client.updateCalendarObjectByUrl({
               iCalString: eventToICalString(event, uid),
-              overwrite: true,
+              objectUrl,
             });
 
             return { deleteId, echo: CALDAV_PUSH_ECHO, remoteId: uid, success: true };

--- a/packages/calendar/src/providers/caldav/destination/provider.ts
+++ b/packages/calendar/src/providers/caldav/destination/provider.ts
@@ -23,6 +23,7 @@ import {
   parseICalCalendarsToRemoteEvents,
   parseICalToRemoteEvent,
 } from "../shared/ics";
+import type { EventUpdate } from "../../../core/sync-engine/types";
 import type { SafeFetchOptions } from "../../../utils/safe-fetch";
 import { normalizeCalDAVEvent } from "./normalize-event";
 
@@ -246,6 +247,48 @@ const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
       ),
     );
 
+  const toObjectHref = (deleteId: string): string => {
+    if (deleteId.includes("/")) {
+      return new URL(deleteId, config.calendarUrl).href;
+    }
+    return new URL(`${deleteId}.ics`, config.calendarUrl).href;
+  };
+
+  /* A rewrite must land on the object the mapping already points at, or the PUT orphans a duplicate. */
+  const assertUpdateTargetsUid = (deleteId: string, uid: string): void => {
+    const target = toObjectHref(deleteId);
+    const expected = toObjectHref(uid);
+    if (target !== expected) {
+      throw new Error(`CalDAV update target ${target} does not match deterministic object ${expected}`);
+    }
+  };
+
+  const updateEvents = (updates: EventUpdate[]): Promise<PushResult[]> =>
+    Promise.all(
+      updates.map(({ deleteId, event }) =>
+        rateLimiter.execute(async (): Promise<PushResult> => {
+          try {
+            const uid = generateDeterministicEventUid(event.id);
+            assertUpdateTargetsUid(deleteId, uid);
+
+            await client.createCalendarObject({
+              calendarUrl: config.calendarUrl,
+              filename: `${uid}.ics`,
+              iCalString: eventToICalString(event, uid),
+              overwrite: true,
+            });
+
+            return { deleteId, echo: CALDAV_PUSH_ECHO, remoteId: uid, success: true };
+          } catch (error) {
+            if (config.safeFetchOptions?.signal?.aborted) {
+              throw error;
+            }
+            return createFailureResult(error);
+          }
+        }, config.safeFetchOptions?.signal),
+      ),
+    );
+
   const recordRemoveFailure = (error: unknown): void => {
     const httpError = findCalDAVHttpError(error);
     if (!httpError) {
@@ -369,6 +412,7 @@ const createCalDAVSyncProvider = (config: CalDAVSyncProviderConfig) => {
 
   return {
     pushEvents,
+    updateEvents,
     deleteEvents,
     getSyncDiagnostics,
     listRemoteEvents,

--- a/packages/calendar/src/providers/caldav/shared/client.ts
+++ b/packages/calendar/src/providers/caldav/shared/client.ts
@@ -275,13 +275,16 @@ class CalDAVClient {
     calendarUrl: string;
     filename: string;
     iCalString: string;
+    overwrite?: boolean;
   }): Promise<void> {
     const client = await this.getClient();
 
+    // Without dropping If-None-Match the PUT is a create-only request and a rewrite answers 412.
     const response = await client.createCalendarObject({
       calendar: { url: params.calendarUrl },
       filename: params.filename,
       iCalString: params.iCalString,
+      ...(params.overwrite && { headersToExclude: ["If-None-Match"] }),
     });
 
     if (response.status === 412) {

--- a/packages/calendar/src/providers/caldav/shared/client.ts
+++ b/packages/calendar/src/providers/caldav/shared/client.ts
@@ -58,7 +58,7 @@ class CalDAVIncompleteMultiGetError extends Error {
   }
 }
 
-type CalDAVWriteOperation = "create" | "delete";
+type CalDAVWriteOperation = "create" | "delete" | "update";
 
 class CalDAVHttpError extends Error {
   readonly operation: CalDAVWriteOperation;
@@ -275,16 +275,13 @@ class CalDAVClient {
     calendarUrl: string;
     filename: string;
     iCalString: string;
-    overwrite?: boolean;
   }): Promise<void> {
     const client = await this.getClient();
 
-    // Without dropping If-None-Match the PUT is a create-only request and a rewrite answers 412.
     const response = await client.createCalendarObject({
       calendar: { url: params.calendarUrl },
       filename: params.filename,
       iCalString: params.iCalString,
-      ...(params.overwrite && { headersToExclude: ["If-None-Match"] }),
     });
 
     if (response.status === 412) {
@@ -303,6 +300,19 @@ class CalDAVClient {
       etag: params.etag,
       objectUrl: CalDAVClient.normalizeUrl(params.calendarUrl, params.filename),
     });
+  }
+
+  async updateCalendarObjectByUrl(params: {
+    objectUrl: string;
+    iCalString: string;
+  }): Promise<void> {
+    const client = await this.getClient();
+
+    const response = await client.updateCalendarObject({
+      calendarObject: { data: params.iCalString, url: params.objectUrl },
+    });
+
+    await assertSuccessfulResponse(response, "update");
   }
 
   async deleteCalendarObjectByUrl(params: {

--- a/packages/calendar/tests/core/sync-engine/checkpoint-update-only-run.test.ts
+++ b/packages/calendar/tests/core/sync-engine/checkpoint-update-only-run.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import { executeRemoteOperations } from "../../../src/core/sync-engine/index";
+import { computeSyncOperations } from "../../../src/core/sync/operations";
+import type { MaterializedSyncableEvent, SyncOperation } from "../../../src/core/types";
+import type { EventMapping } from "../../../src/core/events/mappings";
+import type { CalendarSyncProvider, EventUpdate, PendingChanges } from "../../../src/core/sync-engine/types";
+
+const TEST_RECONCILIATION_SCOPE = {
+  authoritativeWindow: {
+    timeMax: new Date("2100-01-01T00:00:00.000Z"),
+    timeMin: new Date("2000-01-01T00:00:00.000Z"),
+  },
+  requestedWindow: {
+    timeMax: new Date("2100-01-01T00:00:00.000Z"),
+    timeMin: new Date("2000-01-01T00:00:00.000Z"),
+  },
+};
+
+const makeEvent = (id: string): MaterializedSyncableEvent => ({
+  id,
+  sourceEventUid: `uid-${id}`,
+  startTime: new Date("2026-03-15T09:00:00Z"),
+  endTime: new Date("2026-03-15T10:00:00Z"),
+  summary: `Event ${id} renamed`,
+  calendarId: "cal-1",
+  calendarName: "Test Calendar",
+  calendarUrl: null,
+});
+
+const makeMapping = (): EventMapping => ({
+  id: "map-1",
+  eventStateId: "ev-1",
+  syncEventId: "ev-1",
+  calendarId: "dest-cal-1",
+  sourceCalendarId: "cal-1",
+  destinationEventUid: "remote-1@keeper.sh",
+  deleteIdentifier: "/calendar/remote-1@keeper.sh.ics",
+  syncEventHash: "diverged-remote-hash",
+  startTime: new Date("2026-03-15T09:00:00Z"),
+  endTime: new Date("2026-03-15T10:00:00Z"),
+});
+
+const makeRemoteEvent = (mapping: EventMapping) => ({
+  deleteId: mapping.deleteIdentifier,
+  endTime: mapping.endTime,
+  isKeeperEvent: true,
+  startTime: mapping.startTime,
+  uid: mapping.destinationEventUid,
+});
+
+const createRecordingProvider = () => {
+  const deletedIds: string[][] = [];
+  const pushedEvents: MaterializedSyncableEvent[][] = [];
+  const updatedBatches: EventUpdate[][] = [];
+
+  const provider: CalendarSyncProvider = {
+    deleteEvents: (eventIds) => {
+      deletedIds.push(eventIds);
+      return Promise.resolve(eventIds.map(() => ({ success: true })));
+    },
+    listRemoteEvents: () => Promise.resolve([]),
+    pushEvents: (events) => {
+      pushedEvents.push(events);
+      return Promise.resolve(events.map((event) => ({ remoteId: event.id, success: true })));
+    },
+    updateEvents: (updates) => {
+      updatedBatches.push(updates);
+      return Promise.resolve(updates.map((update) => ({
+        deleteId: update.deleteId,
+        remoteId: update.event.id,
+        success: true,
+      })));
+    },
+  };
+
+  return { deletedIds, provider, pushedEvents, updatedBatches };
+};
+
+const progressed: number[] = [];
+
+describe("checkpointing an update-only run", () => {
+  it("invokes the checkpoint callback when the run produced only in-place updates", async () => {
+    const mapping = makeMapping();
+    const { operations } = computeSyncOperations(
+      [makeEvent("ev-1")],
+      [mapping],
+      [makeRemoteEvent(mapping)],
+      TEST_RECONCILIATION_SCOPE,
+    );
+    expect(operations.filter((operation) => operation.type === "replace")).toHaveLength(1);
+    expect(operations.filter((operation) => operation.type !== "replace")).toHaveLength(0);
+
+    const { provider } = createRecordingProvider();
+    const checkpointed: PendingChanges[] = [];
+
+    const outcome = await executeRemoteOperations(
+      operations,
+      [mapping],
+      "dest-cal-1",
+      provider,
+      () => Promise.resolve(true),
+      (processed) => progressed.push(processed),
+      (changes) => {
+        checkpointed.push(changes);
+        return Promise.resolve(true);
+      },
+    );
+
+    expect(checkpointed).toHaveLength(1);
+    expect(checkpointed[0]?.inserts).toEqual([]);
+    expect(checkpointed[0]?.deletes).toEqual([]);
+    expect(checkpointed[0]?.updates).toHaveLength(1);
+    expect(outcome.checkpointRejected).toBe(false);
+  });
+
+  it("halts the run when the update-only checkpoint is rejected", async () => {
+    const mapping = makeMapping();
+    const { operations } = computeSyncOperations(
+      [makeEvent("ev-1"), makeEvent("ev-2")],
+      [mapping],
+      [makeRemoteEvent(mapping)],
+      TEST_RECONCILIATION_SCOPE,
+    );
+    const replacements = operations.filter(
+      (operation): operation is Extract<SyncOperation, { type: "replace" }> => operation.type === "replace",
+    );
+    const adds = operations.filter((operation) => operation.type === "add");
+    expect(replacements).toHaveLength(1);
+    expect(adds).toHaveLength(1);
+
+    const { deletedIds, provider, pushedEvents, updatedBatches } = createRecordingProvider();
+    let checkpointCalls = 0;
+
+    const outcome = await executeRemoteOperations(
+      operations,
+      [mapping],
+      "dest-cal-1",
+      provider,
+      () => Promise.resolve(true),
+      (processed) => progressed.push(processed),
+      () => {
+        checkpointCalls += 1;
+        return Promise.resolve(false);
+      },
+    );
+
+    expect(checkpointCalls).toBe(1);
+    expect(outcome.checkpointRejected).toBe(true);
+    expect(updatedBatches).toHaveLength(1);
+    expect(pushedEvents).toEqual([]);
+    expect(deletedIds).toEqual([]);
+  });
+});

--- a/packages/calendar/tests/core/sync-engine/failed-update-falls-back.test.ts
+++ b/packages/calendar/tests/core/sync-engine/failed-update-falls-back.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { executeRemoteOperations } from "../../../src/core/sync-engine/index";
+import type { CalendarSyncProvider } from "../../../src/core/sync-engine/types";
+import type { DeleteResult, MaterializedSyncableEvent, PushResult, SyncOperation } from "../../../src/core/types";
+import type { EventMapping } from "../../../src/core/events/mappings";
+
+const makeEvent = (id: string): MaterializedSyncableEvent => ({
+  id,
+  sourceEventUid: `uid-${id}`,
+  startTime: new Date("2026-03-15T09:00:00Z"),
+  endTime: new Date("2026-03-15T10:00:00Z"),
+  summary: `Event ${id}`,
+  calendarId: "cal-1",
+  calendarName: "Test Calendar",
+  calendarUrl: null,
+});
+
+const makeMapping = (index: number): EventMapping => ({
+  id: `map-${index}`,
+  eventStateId: `ev-${index}`,
+  syncEventId: `ev-${index}`,
+  calendarId: "dest-cal-1",
+  sourceCalendarId: "cal-1",
+  destinationEventUid: `remote-${index}@keeper.sh`,
+  deleteIdentifier: `/calendar/remote-${index}@keeper.sh.ics`,
+  syncEventHash: "stale-hash",
+  startTime: new Date("2026-03-15T09:00:00Z"),
+  endTime: new Date("2026-03-15T10:00:00Z"),
+});
+
+const makeReplacement = (index: number): Extract<SyncOperation, { type: "replace" }> => ({
+  type: "replace",
+  event: makeEvent(`ev-${index}`),
+  staleMappingId: `map-${index}`,
+  uid: `remote-${index}@keeper.sh`,
+  deleteId: `/calendar/remote-${index}@keeper.sh.ics`,
+});
+
+const createUpdateCapableProvider = (
+  updateResults: PushResult[],
+  deleteResults: DeleteResult[] = [{ success: true }, { success: true }],
+) => {
+  const deleteCalls: string[][] = [];
+  const pushCalls: MaterializedSyncableEvent[][] = [];
+  const updateCalls: { deleteId: string; event: MaterializedSyncableEvent }[][] = [];
+
+  const provider: CalendarSyncProvider = {
+    deleteEvents: (eventIds) => {
+      deleteCalls.push(eventIds);
+      return Promise.resolve(deleteResults.slice(0, eventIds.length));
+    },
+    listRemoteEvents: () => Promise.resolve([]),
+    pushEvents: (events) => {
+      pushCalls.push(events);
+      return Promise.resolve(events.map((event): PushResult => ({
+        success: true,
+        remoteId: `${event.sourceEventUid}@keeper.sh`,
+        deleteId: `/calendar/${event.sourceEventUid}@keeper.sh.ics`,
+      })));
+    },
+    updateEvents: (updates) => {
+      updateCalls.push(updates);
+      return Promise.resolve(updateResults.slice(0, updates.length));
+    },
+  };
+
+  return { deleteCalls, provider, pushCalls, updateCalls };
+};
+
+describe("a failed in-place update", () => {
+  it("falls back to delete-then-add for only the failed operation", async () => {
+    const replacements = [makeReplacement(1), makeReplacement(2)];
+    const mappings = [makeMapping(1), makeMapping(2)];
+    const { deleteCalls, provider, pushCalls, updateCalls } = createUpdateCapableProvider([
+      { success: true, remoteId: "remote-1@keeper.sh", deleteId: "/calendar/remote-1@keeper.sh.ics" },
+      { success: false, error: "gone", errorType: "server_error", statusCode: 404 },
+    ]);
+
+    const outcome = await executeRemoteOperations(
+      replacements,
+      mappings,
+      "dest-cal-1",
+      provider,
+    );
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]).toHaveLength(2);
+
+    expect(deleteCalls).toEqual([["/calendar/remote-2@keeper.sh.ics"]]);
+    expect(pushCalls).toEqual([[replacements[1]?.event]]);
+
+    expect(outcome.changes.updates).toHaveLength(1);
+    expect(outcome.changes.updates?.[0]).toMatchObject({
+      id: "map-1",
+      syncEventId: "ev-1",
+    });
+
+    expect(outcome.changes.deletes).toEqual(["map-2"]);
+    expect(outcome.changes.inserts).toHaveLength(1);
+    expect(outcome.changes.inserts[0]).toMatchObject({
+      destinationEventUid: "uid-ev-2@keeper.sh",
+      syncEventId: "ev-2",
+    });
+  });
+
+  it("does not re-add a fallback whose delete also failed", async () => {
+    const replacements = [makeReplacement(1)];
+    const mappings = [makeMapping(1)];
+    const { deleteCalls, provider, pushCalls } = createUpdateCapableProvider(
+      [{ success: false, error: "gone", errorType: "server_error", statusCode: 404 }],
+      [{ success: false, error: "boom", errorType: "server_error", statusCode: 500 }],
+    );
+
+    const outcome = await executeRemoteOperations(replacements, mappings, "dest-cal-1", provider);
+
+    expect(deleteCalls).toEqual([["/calendar/remote-1@keeper.sh.ics"]]);
+    expect(pushCalls).toEqual([]);
+    expect(outcome.changes.inserts).toEqual([]);
+    expect(outcome.changes.deletes).toEqual([]);
+    expect(outcome.result.removeFailed).toBe(1);
+  });
+
+  it("leaves a fully successful update batch untouched by the fallback", async () => {
+    const replacements = [makeReplacement(1), makeReplacement(2)];
+    const mappings = [makeMapping(1), makeMapping(2)];
+    const { deleteCalls, provider, pushCalls } = createUpdateCapableProvider([
+      { success: true, remoteId: "remote-1@keeper.sh", deleteId: "/calendar/remote-1@keeper.sh.ics" },
+      { success: true, remoteId: "remote-2@keeper.sh", deleteId: "/calendar/remote-2@keeper.sh.ics" },
+    ]);
+
+    const outcome = await executeRemoteOperations(replacements, mappings, "dest-cal-1", provider);
+
+    expect(deleteCalls).toEqual([]);
+    expect(pushCalls).toEqual([]);
+    expect(outcome.changes.updates).toHaveLength(2);
+    expect(outcome.changes.deletes).toEqual([]);
+    expect(outcome.changes.inserts).toEqual([]);
+  });
+});

--- a/packages/calendar/tests/core/sync-engine/in-place-update-mapping-rewrite.test.ts
+++ b/packages/calendar/tests/core/sync-engine/in-place-update-mapping-rewrite.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { executeRemoteOperations } from "../../../src/core/sync-engine/index";
+import { computeSyncOperations } from "../../../src/core/sync/operations";
+import { createSyncEventContentHash } from "../../../src/core/events/content-hash";
+import type { MaterializedSyncableEvent, SyncOperation } from "../../../src/core/types";
+import type { EventMapping } from "../../../src/core/events/mappings";
+import type { CalendarSyncProvider, PendingChanges } from "../../../src/core/sync-engine/types";
+
+const TEST_RECONCILIATION_SCOPE = {
+  authoritativeWindow: {
+    timeMax: new Date("2100-01-01T00:00:00.000Z"),
+    timeMin: new Date("2000-01-01T00:00:00.000Z"),
+  },
+  requestedWindow: {
+    timeMax: new Date("2100-01-01T00:00:00.000Z"),
+    timeMin: new Date("2000-01-01T00:00:00.000Z"),
+  },
+};
+
+const MAPPING_ID = "map-1";
+const EXISTING_DELETE_IDENTIFIER = "/calendar/remote-1@keeper.sh.ics";
+const CANONICAL_DELETE_IDENTIFIER = "https://caldav.example/calendar/remote-1@keeper.sh.ics";
+
+const makeEvent = (): MaterializedSyncableEvent => ({
+  id: "ev-1",
+  sourceEventUid: "uid-ev-1",
+  startTime: new Date("2026-03-15T09:00:00Z"),
+  endTime: new Date("2026-03-15T10:00:00Z"),
+  summary: "Event ev-1 renamed",
+  calendarId: "cal-1",
+  calendarName: "Test Calendar",
+  calendarUrl: null,
+});
+
+const makeMapping = (): EventMapping => ({
+  id: MAPPING_ID,
+  eventStateId: "ev-1",
+  syncEventId: "ev-1",
+  calendarId: "dest-cal-1",
+  sourceCalendarId: "cal-1",
+  destinationEventUid: "remote-1@keeper.sh",
+  deleteIdentifier: EXISTING_DELETE_IDENTIFIER,
+  syncEventHash: "diverged-remote-hash",
+  startTime: new Date("2026-03-15T09:00:00Z"),
+  endTime: new Date("2026-03-15T10:00:00Z"),
+});
+
+const createUpdateCapableProvider = (): CalendarSyncProvider => ({
+  deleteEvents: (eventIds) => Promise.resolve(eventIds.map(() => ({ success: true }))),
+  listRemoteEvents: () => Promise.resolve([]),
+  pushEvents: (events) => Promise.resolve(events.map((event) => ({ remoteId: event.id, success: true }))),
+  updateEvents: (updates) =>
+    Promise.resolve(updates.map(() => ({
+      deleteId: CANONICAL_DELETE_IDENTIFIER,
+      remoteId: "remote-1@keeper.sh",
+      success: true,
+    }))),
+});
+
+describe("in-place update mapping changes", () => {
+  it("rewrites the existing mapping row instead of deleting and re-inserting it", async () => {
+    const event = makeEvent();
+    const mapping = makeMapping();
+    const remoteEvent = {
+      deleteId: mapping.deleteIdentifier,
+      endTime: mapping.endTime,
+      isKeeperEvent: true,
+      startTime: mapping.startTime,
+      uid: mapping.destinationEventUid,
+    };
+    const { operations } = computeSyncOperations(
+      [event],
+      [mapping],
+      [remoteEvent],
+      TEST_RECONCILIATION_SCOPE,
+    );
+    const replacements = operations.filter(
+      (operation): operation is Extract<SyncOperation, { type: "replace" }> => operation.type === "replace",
+    );
+    expect(replacements).toHaveLength(1);
+    expect(replacements[0]?.staleMappingId).toBe(MAPPING_ID);
+
+    const checkpointed: PendingChanges[] = [];
+    const result = await executeRemoteOperations(
+      operations,
+      [mapping],
+      "dest-cal-1",
+      createUpdateCapableProvider(),
+      globalThis.undefined,
+      globalThis.undefined,
+      (changes) => {
+        checkpointed.push(changes);
+        return Promise.resolve(true);
+      },
+    );
+
+    expect(checkpointed).toHaveLength(1);
+    expect(checkpointed[0]?.updates).toEqual([{
+      deleteIdentifier: CANONICAL_DELETE_IDENTIFIER,
+      endTime: event.endTime,
+      id: MAPPING_ID,
+      startTime: event.startTime,
+      syncEventHash: createSyncEventContentHash(event),
+      syncEventId: event.id,
+    }]);
+    expect(checkpointed[0]?.inserts).toEqual([]);
+    expect(checkpointed[0]?.deletes).toEqual([]);
+
+    expect(result.changes.inserts).toEqual([]);
+    expect(result.changes.deletes).toEqual([]);
+  });
+});

--- a/packages/calendar/tests/core/sync-engine/index.test.ts
+++ b/packages/calendar/tests/core/sync-engine/index.test.ts
@@ -784,7 +784,9 @@ describe("syncCalendar", () => {
       inserts: [],
       updates: [{
         deleteIdentifier: "google-provider-occurrence-id",
+        endTime: occurrence.endTime,
         id: mapping.id,
+        startTime: occurrence.startTime,
         syncEventHash: createSyncEventContentHash(occurrence),
         syncEventId: occurrence.id,
       }],
@@ -1244,7 +1246,9 @@ describe("createDatabaseFlush", () => {
       deletes: ["map-1", "map-2"],
       updates: [{
         deleteIdentifier: "google-provider-occurrence-id",
+        endTime: new Date("2026-03-15T10:00:00Z"),
         id: "019c0000-0000-7000-8000-000000000001",
+        startTime: new Date("2026-03-15T09:00:00Z"),
         syncEventHash: "occurrence-hash",
         syncEventId: "materialized-occurrence-id",
       }],
@@ -1280,13 +1284,17 @@ describe("createDatabaseFlush", () => {
       updates: [
         {
           deleteIdentifier: "remote-delete-1",
+          endTime: new Date("2026-03-15T10:00:00Z"),
           id: "019c0000-0000-7000-8000-000000000001",
+          startTime: new Date("2026-03-15T09:00:00Z"),
           syncEventHash: "hash-1",
           syncEventId: "recurrence-1",
         },
         {
           deleteIdentifier: "remote-delete-2",
+          endTime: new Date("2026-03-16T10:00:00Z"),
           id: "019c0000-0000-7000-8000-000000000002",
+          startTime: new Date("2026-03-16T09:00:00Z"),
           syncEventHash: "hash-2",
           syncEventId: "recurrence-2",
         },
@@ -1296,11 +1304,15 @@ describe("createDatabaseFlush", () => {
     expect(updateValues).toEqual([
       {
         deleteIdentifier: "remote-delete-1",
+        endTime: new Date("2026-03-15T10:00:00Z"),
+        startTime: new Date("2026-03-15T09:00:00Z"),
         syncEventHash: "hash-1",
         syncEventId: "recurrence-1",
       },
       {
         deleteIdentifier: "remote-delete-2",
+        endTime: new Date("2026-03-16T10:00:00Z"),
+        startTime: new Date("2026-03-16T09:00:00Z"),
         syncEventHash: "hash-2",
         syncEventId: "recurrence-2",
       },

--- a/packages/calendar/tests/core/sync-engine/provider-update-capability.test.ts
+++ b/packages/calendar/tests/core/sync-engine/provider-update-capability.test.ts
@@ -1,0 +1,46 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { executeRemoteOperations } from "../../../src/core/sync-engine/index";
+import type { CalendarSyncProvider } from "../../../src/core/sync-engine/types";
+import type { MaterializedSyncableEvent, SyncOperation } from "../../../src/core/types";
+
+const packageRoot = fileURLToPath(new URL("../../../", import.meta.url));
+
+const makeEvent = (id: string): MaterializedSyncableEvent => ({
+  id,
+  sourceEventUid: `uid-${id}`,
+  startTime: new Date("2026-03-15T09:00:00Z"),
+  endTime: new Date("2026-03-15T10:00:00Z"),
+  summary: `Event ${id}`,
+  calendarId: "cal-1",
+  calendarName: "Test Calendar",
+  calendarUrl: null,
+});
+
+describe("provider update capability", () => {
+  it("types an optional updateEvents capability on CalendarSyncProvider", () => {
+    const typecheck = spawnSync("bun", ["x", "tsc", "--noEmit"], {
+      cwd: packageRoot,
+      encoding: "utf8",
+    });
+
+    expect(`${typecheck.stdout ?? ""}${typecheck.stderr ?? ""}`).toBe("");
+    expect(typecheck.status).toBe(0);
+  }, 180_000);
+
+  it("keeps syncing a provider that omits updateEvents", async () => {
+    const provider: CalendarSyncProvider = {
+      deleteEvents: () => Promise.resolve([]),
+      listRemoteEvents: () => Promise.resolve([]),
+      pushEvents: () => Promise.resolve([{ success: true, remoteId: "remote-1" }]),
+    };
+    const operations: SyncOperation[] = [{ type: "add", event: makeEvent("ev-1") }];
+
+    const outcome = await executeRemoteOperations(operations, [], "dest-cal-1", provider);
+
+    expect(provider.updateEvents).toBeUndefined();
+    expect(outcome.result.added).toBe(1);
+    expect(outcome.changes.inserts).toHaveLength(1);
+  });
+});

--- a/packages/calendar/tests/core/sync-engine/provider-update-capability.types.ts
+++ b/packages/calendar/tests/core/sync-engine/provider-update-capability.types.ts
@@ -1,0 +1,25 @@
+import type { CalendarSyncProvider } from "../../../src/core/sync-engine/types";
+import type { MaterializedSyncableEvent, PushResult } from "../../../src/core/types";
+
+const providerWithUpdateCapability: CalendarSyncProvider = {
+  deleteEvents: () => Promise.resolve([]),
+  listRemoteEvents: () => Promise.resolve([]),
+  pushEvents: () => Promise.resolve([]),
+  updateEvents: (updates: { deleteId: string; event: MaterializedSyncableEvent }[]): Promise<PushResult[]> =>
+    Promise.resolve(updates.map(() => ({ success: true }))),
+};
+
+const providerWithoutUpdateCapability: CalendarSyncProvider = {
+  deleteEvents: () => Promise.resolve([]),
+  listRemoteEvents: () => Promise.resolve([]),
+  pushEvents: () => Promise.resolve([]),
+};
+
+const updateEvents: NonNullable<CalendarSyncProvider["updateEvents"]> = (updates) =>
+  Promise.resolve(updates.map((update): PushResult => ({
+    deleteId: update.deleteId,
+    remoteId: update.event.sourceEventUid,
+    success: true,
+  })));
+
+export { providerWithUpdateCapability, providerWithoutUpdateCapability, updateEvents };

--- a/packages/calendar/tests/core/sync-engine/replace-fallback-without-capability.test.ts
+++ b/packages/calendar/tests/core/sync-engine/replace-fallback-without-capability.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { executeRemoteOperations } from "../../../src/core/sync-engine/index";
+import type { CalendarSyncProvider } from "../../../src/core/sync-engine/types";
+import type { DeleteResult, MaterializedSyncableEvent, PushResult, SyncOperation } from "../../../src/core/types";
+import type { EventMapping } from "../../../src/core/events/mappings";
+
+const makeEvent = (id: string): MaterializedSyncableEvent => ({
+  id,
+  sourceEventUid: `uid-${id}`,
+  startTime: new Date("2026-03-15T09:00:00Z"),
+  endTime: new Date("2026-03-15T10:00:00Z"),
+  summary: `Event ${id}`,
+  calendarId: "cal-1",
+  calendarName: "Test Calendar",
+  calendarUrl: null,
+});
+
+const makeMapping = (index: number): EventMapping => ({
+  id: `map-${index}`,
+  eventStateId: `ev-${index}`,
+  syncEventId: `ev-${index}`,
+  calendarId: "dest-cal-1",
+  sourceCalendarId: "cal-1",
+  destinationEventUid: `remote-${index}@keeper.sh`,
+  deleteIdentifier: `/calendar/remote-${index}@keeper.sh.ics`,
+  syncEventHash: "stale-hash",
+  startTime: new Date("2026-03-15T09:00:00Z"),
+  endTime: new Date("2026-03-15T10:00:00Z"),
+});
+
+const makeReplacement = (index: number): Extract<SyncOperation, { type: "replace" }> => ({
+  type: "replace",
+  event: makeEvent(`ev-${index}`),
+  staleMappingId: `map-${index}`,
+  uid: `remote-${index}@keeper.sh`,
+  deleteId: `/calendar/remote-${index}@keeper.sh.ics`,
+});
+
+const createLegacyProvider = (deleteResults: DeleteResult[]) => {
+  const deleteCalls: string[][] = [];
+  const pushCalls: MaterializedSyncableEvent[][] = [];
+
+  const provider: CalendarSyncProvider = {
+    deleteEvents: (eventIds) => {
+      deleteCalls.push(eventIds);
+      return Promise.resolve(deleteResults.slice(0, eventIds.length));
+    },
+    listRemoteEvents: () => Promise.resolve([]),
+    pushEvents: (events) => {
+      pushCalls.push(events);
+      return Promise.resolve(events.map((event): PushResult => ({
+        success: true,
+        remoteId: `${event.sourceEventUid}@keeper.sh`,
+        deleteId: `/calendar/${event.sourceEventUid}@keeper.sh.ics`,
+      })));
+    },
+  };
+
+  return { deleteCalls, provider, pushCalls };
+};
+
+describe("executeReplacements without an update-capable provider", () => {
+  it("deletes then re-adds every replacement", async () => {
+    const replacements = [makeReplacement(1), makeReplacement(2)];
+    const mappings = [makeMapping(1), makeMapping(2)];
+    const { deleteCalls, provider, pushCalls } = createLegacyProvider([
+      { success: true },
+      { success: true },
+    ]);
+    const progress: number[][] = [];
+
+    const outcome = await executeRemoteOperations(
+      replacements,
+      mappings,
+      "dest-cal-1",
+      provider,
+      () => Promise.resolve(true),
+      (processed, total) => progress.push([processed, total]),
+    );
+
+    expect(provider.updateEvents).toBeUndefined();
+    expect(deleteCalls).toEqual([[
+      "/calendar/remote-1@keeper.sh.ics",
+      "/calendar/remote-2@keeper.sh.ics",
+    ]]);
+    expect(pushCalls).toEqual([[replacements[0]?.event, replacements[1]?.event]]);
+    expect(outcome.result).toEqual({ added: 2, addFailed: 0, removed: 2, removeFailed: 0 });
+    expect(outcome.changes.deletes).toEqual(["map-1", "map-2"]);
+    expect(outcome.changes.inserts).toHaveLength(2);
+    expect(outcome.changes.inserts[0]).toMatchObject({
+      calendarId: "dest-cal-1",
+      destinationEventUid: "uid-ev-1@keeper.sh",
+      deleteIdentifier: "/calendar/uid-ev-1@keeper.sh.ics",
+      eventStateId: "ev-1",
+      syncEventId: "ev-1",
+      sourceCalendarId: "cal-1",
+    });
+    expect(outcome.errors).toEqual([]);
+    expect(progress).toEqual([[4, 4]]);
+  });
+
+  it("skips the re-add for a replacement whose delete failed", async () => {
+    const replacements = [makeReplacement(1), makeReplacement(2)];
+    const mappings = [makeMapping(1), makeMapping(2)];
+    const { deleteCalls, provider, pushCalls } = createLegacyProvider([
+      { success: false, error: "boom", errorType: "server_error", statusCode: 500 },
+      { success: true },
+    ]);
+
+    const outcome = await executeRemoteOperations(replacements, mappings, "dest-cal-1", provider);
+
+    expect(deleteCalls).toHaveLength(1);
+    expect(pushCalls).toEqual([[replacements[1]?.event]]);
+    expect(outcome.result).toEqual({ added: 1, addFailed: 0, removed: 1, removeFailed: 1 });
+    expect(outcome.changes.deletes).toEqual(["map-2"]);
+    expect(outcome.changes.inserts).toHaveLength(1);
+    expect(outcome.errors).toEqual([
+      { type: "remove", error: "boom", errorType: "server_error", statusCode: 500 },
+    ]);
+  });
+});

--- a/packages/calendar/tests/core/sync-engine/replace-in-place-update.test.ts
+++ b/packages/calendar/tests/core/sync-engine/replace-in-place-update.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { executeRemoteOperations } from "../../../src/core/sync-engine/index";
+import { computeSyncOperations } from "../../../src/core/sync/operations";
+import type { MaterializedSyncableEvent, SyncOperation } from "../../../src/core/types";
+import type { EventMapping } from "../../../src/core/events/mappings";
+import type { CalendarSyncProvider, EventUpdate } from "../../../src/core/sync-engine/types";
+
+const TEST_RECONCILIATION_SCOPE = {
+  authoritativeWindow: {
+    timeMax: new Date("2100-01-01T00:00:00.000Z"),
+    timeMin: new Date("2000-01-01T00:00:00.000Z"),
+  },
+  requestedWindow: {
+    timeMax: new Date("2100-01-01T00:00:00.000Z"),
+    timeMin: new Date("2000-01-01T00:00:00.000Z"),
+  },
+};
+
+const makeEvent = (id: string): MaterializedSyncableEvent => ({
+  id,
+  sourceEventUid: `uid-${id}`,
+  startTime: new Date("2026-03-15T09:00:00Z"),
+  endTime: new Date("2026-03-15T10:00:00Z"),
+  summary: `Event ${id} renamed`,
+  calendarId: "cal-1",
+  calendarName: "Test Calendar",
+  calendarUrl: null,
+});
+
+const makeMapping = (): EventMapping => ({
+  id: "map-1",
+  eventStateId: "ev-1",
+  syncEventId: "ev-1",
+  calendarId: "dest-cal-1",
+  sourceCalendarId: "cal-1",
+  destinationEventUid: "remote-1@keeper.sh",
+  deleteIdentifier: "/calendar/remote-1@keeper.sh.ics",
+  syncEventHash: "diverged-remote-hash",
+  startTime: new Date("2026-03-15T09:00:00Z"),
+  endTime: new Date("2026-03-15T10:00:00Z"),
+});
+
+const createRecordingProvider = () => {
+  const deletedIds: string[][] = [];
+  const pushedEvents: MaterializedSyncableEvent[][] = [];
+  const updatedBatches: EventUpdate[][] = [];
+
+  const provider: CalendarSyncProvider = {
+    deleteEvents: (eventIds) => {
+      deletedIds.push(eventIds);
+      return Promise.resolve(eventIds.map(() => ({ success: true })));
+    },
+    listRemoteEvents: () => Promise.resolve([]),
+    pushEvents: (events) => {
+      pushedEvents.push(events);
+      return Promise.resolve(events.map((event) => ({ remoteId: event.id, success: true })));
+    },
+    updateEvents: (updates) => {
+      updatedBatches.push(updates);
+      return Promise.resolve(updates.map((update) => ({
+        deleteId: update.deleteId,
+        remoteId: update.event.id,
+        success: true,
+      })));
+    },
+  };
+
+  return { deletedIds, provider, pushedEvents, updatedBatches };
+};
+
+describe("executeReplacements with an update-capable provider", () => {
+  it("updates the remote object in place instead of deleting and re-adding it", async () => {
+    const event = makeEvent("ev-1");
+    const mapping = makeMapping();
+    const remoteEvent = {
+      deleteId: mapping.deleteIdentifier,
+      endTime: mapping.endTime,
+      isKeeperEvent: true,
+      startTime: mapping.startTime,
+      uid: mapping.destinationEventUid,
+    };
+    const { operations } = computeSyncOperations(
+      [event],
+      [mapping],
+      [remoteEvent],
+      TEST_RECONCILIATION_SCOPE,
+    );
+    const replacements = operations.filter(
+      (operation): operation is Extract<SyncOperation, { type: "replace" }> => operation.type === "replace",
+    );
+    expect(replacements).toHaveLength(1);
+
+    const { deletedIds, provider, pushedEvents, updatedBatches } = createRecordingProvider();
+
+    await executeRemoteOperations(operations, [mapping], "dest-cal-1", provider);
+
+    expect(deletedIds).toEqual([]);
+    expect(pushedEvents).toEqual([]);
+    expect(updatedBatches).toHaveLength(1);
+    expect(updatedBatches[0]).toEqual([{
+      deleteId: replacements[0]?.deleteId,
+      event: replacements[0]?.event,
+    }]);
+  });
+});

--- a/packages/calendar/tests/core/sync-engine/update-writes-mapping-times.test.ts
+++ b/packages/calendar/tests/core/sync-engine/update-writes-mapping-times.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { createDatabaseFlush } from "../../../src/core/sync-engine/flush";
+import { executeRemoteOperations } from "../../../src/core/sync-engine/index";
+import { computeSyncOperations } from "../../../src/core/sync/operations";
+import type { MaterializedSyncableEvent, SyncOperation } from "../../../src/core/types";
+import type { EventMapping } from "../../../src/core/events/mappings";
+import type { CalendarSyncProvider, PendingChanges } from "../../../src/core/sync-engine/types";
+
+const TEST_RECONCILIATION_SCOPE = {
+  authoritativeWindow: {
+    timeMax: new Date("2100-01-01T00:00:00.000Z"),
+    timeMin: new Date("2000-01-01T00:00:00.000Z"),
+  },
+  requestedWindow: {
+    timeMax: new Date("2100-01-01T00:00:00.000Z"),
+    timeMin: new Date("2000-01-01T00:00:00.000Z"),
+  },
+};
+
+const MAPPING_ID = "map-1";
+const REMOTE_UID = "remote-1@keeper.sh";
+const REMOTE_HREF = "https://caldav.example/calendar/remote-1@keeper.sh.ics";
+const ORIGINAL_START = new Date("2026-03-15T09:00:00Z");
+const ORIGINAL_END = new Date("2026-03-15T10:00:00Z");
+const MOVED_START = new Date("2026-03-15T14:00:00Z");
+const MOVED_END = new Date("2026-03-15T15:00:00Z");
+
+const makeEvent = (startTime: Date, endTime: Date): MaterializedSyncableEvent => ({
+  id: "ev-1",
+  sourceEventUid: "uid-ev-1",
+  startTime,
+  endTime,
+  summary: "Shared calendar standup",
+  calendarId: "cal-1",
+  calendarName: "Test Calendar",
+  calendarUrl: null,
+});
+
+const makeRemoteEvent = (startTime: Date, endTime: Date) => ({
+  deleteId: REMOTE_HREF,
+  endTime,
+  isKeeperEvent: true,
+  startTime,
+  uid: REMOTE_UID,
+});
+
+const createUpdateCapableProvider = (): CalendarSyncProvider => ({
+  deleteEvents: (eventIds) => Promise.resolve(eventIds.map(() => ({ success: true }))),
+  listRemoteEvents: () => Promise.resolve([]),
+  pushEvents: (events) =>
+    Promise.resolve(events.map(() => ({ deleteId: REMOTE_HREF, remoteId: REMOTE_UID, success: true }))),
+  updateEvents: (updates) =>
+    Promise.resolve(updates.map(() => ({ deleteId: REMOTE_HREF, remoteId: REMOTE_UID, success: true }))),
+});
+
+type MappingColumnValues = Partial<Pick<
+  EventMapping,
+  "deleteIdentifier" | "endTime" | "startTime" | "syncEventHash" | "syncEventId"
+>>;
+
+const flushUpdatesAgainstRecorder = async (
+  changes: PendingChanges,
+): Promise<MappingColumnValues[]> => {
+  const setValues: MappingColumnValues[] = [];
+  const fakeDatabase = {
+    transaction: (callback: (transaction: unknown) => Promise<void>) => callback({
+      delete: () => ({ where: () => Promise.resolve() }),
+      insert: () => ({ values: () => ({ onConflictDoNothing: () => Promise.resolve() }) }),
+      update: () => ({
+        set: (values: MappingColumnValues) => {
+          setValues.push(values);
+          return { where: () => Promise.resolve() };
+        },
+      }),
+    }),
+  };
+
+  await createDatabaseFlush(fakeDatabase as never)(changes);
+
+  return setValues;
+};
+
+describe("in-place update mapping times", () => {
+  it("writes the new start and end times so the next reconciliation sees no staleness", async () => {
+    const provider = createUpdateCapableProvider();
+
+    const firstCycle = computeSyncOperations(
+      [makeEvent(ORIGINAL_START, ORIGINAL_END)],
+      [],
+      [],
+      TEST_RECONCILIATION_SCOPE,
+    );
+    const adds = firstCycle.operations.filter(
+      (operation): operation is Extract<SyncOperation, { type: "add" }> => operation.type === "add",
+    );
+    expect(adds).toHaveLength(1);
+
+    const addRun = await executeRemoteOperations(
+      firstCycle.operations,
+      [],
+      "dest-cal-1",
+      provider,
+    );
+    const [insert] = addRun.changes.inserts;
+    if (!insert) {
+      throw new Error("expected the first cycle to insert a mapping");
+    }
+    const mapping: EventMapping = {
+      calendarId: insert.calendarId,
+      deleteIdentifier: insert.deleteIdentifier,
+      destinationEventUid: insert.destinationEventUid,
+      endTime: insert.endTime,
+      eventStateId: insert.eventStateId,
+      id: MAPPING_ID,
+      sourceCalendarId: insert.sourceCalendarId,
+      startTime: insert.startTime,
+      syncEventHash: insert.syncEventHash,
+      syncEventId: insert.syncEventId,
+    };
+
+    const movedEvent = makeEvent(MOVED_START, MOVED_END);
+    const secondCycle = computeSyncOperations(
+      [movedEvent],
+      [mapping],
+      [makeRemoteEvent(ORIGINAL_START, ORIGINAL_END)],
+      TEST_RECONCILIATION_SCOPE,
+    );
+    const replacements = secondCycle.operations.filter(
+      (operation): operation is Extract<SyncOperation, { type: "replace" }> => operation.type === "replace",
+    );
+    expect(replacements).toHaveLength(1);
+
+    const updateRun = await executeRemoteOperations(
+      secondCycle.operations,
+      [mapping],
+      "dest-cal-1",
+      provider,
+    );
+    expect(updateRun.changes.updates).toHaveLength(1);
+
+    const setValues = await flushUpdatesAgainstRecorder(updateRun.changes);
+    const [written] = setValues;
+    if (!written) {
+      throw new Error("expected the flush to issue one mapping update");
+    }
+    expect(written.startTime).toEqual(MOVED_START);
+    expect(written.endTime).toEqual(MOVED_END);
+
+    const updatedMapping: EventMapping = { ...mapping, ...written };
+    const thirdCycle = computeSyncOperations(
+      [movedEvent],
+      [updatedMapping],
+      [makeRemoteEvent(MOVED_START, MOVED_END)],
+      TEST_RECONCILIATION_SCOPE,
+    );
+
+    expect(thirdCycle.operations).toEqual([]);
+    expect(thirdCycle.staleMappingIds).toEqual([]);
+  });
+});

--- a/packages/calendar/tests/core/sync/operations.test.ts
+++ b/packages/calendar/tests/core/sync/operations.test.ts
@@ -828,7 +828,9 @@ describe("computeSyncOperations", () => {
     expect(computeSyncOperations([event], [mapping], [remoteEvent])).toEqual({
       mappingUpdates: [{
         deleteIdentifier: remoteEvent.deleteId,
+        endTime: event.endTime,
         id: mapping.id,
+        startTime: event.startTime,
         syncEventHash: createSyncEventContentHash(event),
         syncEventId: event.id,
       }],
@@ -878,7 +880,9 @@ describe("computeSyncOperations", () => {
     expect(computeSyncOperations([event], [mapping], [remoteEvent])).toEqual({
       mappingUpdates: [{
         deleteIdentifier: remoteEvent.deleteId,
+        endTime: event.endTime,
         id: mapping.id,
+        startTime: event.startTime,
         syncEventHash: createSyncEventContentHash(event),
         syncEventId: event.id,
       }],
@@ -934,13 +938,17 @@ describe("computeSyncOperations", () => {
     expect(result.mappingUpdates).toEqual([
       {
         deleteIdentifier: remoteEvents[0]?.deleteId,
+        endTime: first.endTime,
         id: "legacy-mapping-0",
+        startTime: first.startTime,
         syncEventHash: createSyncEventContentHash(first),
         syncEventId: first.id,
       },
       {
         deleteIdentifier: remoteEvents[2]?.deleteId,
+        endTime: third.endTime,
         id: "legacy-mapping-2",
+        startTime: third.startTime,
         syncEventHash: createSyncEventContentHash(third),
         syncEventId: third.id,
       },

--- a/packages/calendar/tests/providers/caldav/destination/replace-uses-update-when-available.test.ts
+++ b/packages/calendar/tests/providers/caldav/destination/replace-uses-update-when-available.test.ts
@@ -7,6 +7,7 @@ import { createCalDAVSyncProvider } from "../../../../src/providers/caldav/desti
 
 const clientMocks = vi.hoisted(() => ({
   createCalendarObject: vi.fn(),
+  updateCalendarObjectByUrl: vi.fn(),
   deleteCalendarObject: vi.fn(),
   deleteCalendarObjectByUrl: vi.fn(),
   fetchCalendarObject: vi.fn(),
@@ -34,6 +35,7 @@ vi.mock("../../../../src/providers/caldav/shared/client", () => {
 
   class CalDAVClient {
     createCalendarObject = clientMocks.createCalendarObject;
+    updateCalendarObjectByUrl = clientMocks.updateCalendarObjectByUrl;
     deleteCalendarObject = clientMocks.deleteCalendarObject;
     deleteCalendarObjectByUrl = clientMocks.deleteCalendarObjectByUrl;
     fetchCalendarObject = clientMocks.fetchCalendarObject;
@@ -97,6 +99,7 @@ describe("CalDAV replace with an update-capable provider", () => {
 
   it("rewrites the existing object with a single PUT and no DELETE", async () => {
     clientMocks.createCalendarObject.mockResolvedValue(null);
+    clientMocks.updateCalendarObjectByUrl.mockResolvedValue(null);
     clientMocks.deleteCalendarObject.mockResolvedValue(null);
     clientMocks.deleteCalendarObjectByUrl.mockResolvedValue(null);
 
@@ -104,11 +107,11 @@ describe("CalDAV replace with an update-capable provider", () => {
 
     expect(clientMocks.deleteCalendarObject).not.toHaveBeenCalled();
     expect(clientMocks.deleteCalendarObjectByUrl).not.toHaveBeenCalled();
-    expect(clientMocks.createCalendarObject).toHaveBeenCalledTimes(1);
-    expect(clientMocks.createCalendarObject.mock.calls[0]?.[0]).toMatchObject({
-      calendarUrl: "https://caldav.example.com/calendar/",
-      filename: `${uid}.ics`,
+    expect(clientMocks.createCalendarObject).not.toHaveBeenCalled();
+    expect(clientMocks.updateCalendarObjectByUrl).toHaveBeenCalledTimes(1);
+    expect(clientMocks.updateCalendarObjectByUrl.mock.calls[0]?.[0]).toMatchObject({
+      objectUrl: `https://caldav.example.com/calendar/${uid}.ics`,
     });
-    expect(clientMocks.createCalendarObject.mock.calls[0]?.[0]?.iCalString).toContain(`UID:${uid}`);
+    expect(clientMocks.updateCalendarObjectByUrl.mock.calls[0]?.[0]?.iCalString).toContain(`UID:${uid}`);
   });
 });

--- a/packages/calendar/tests/providers/caldav/destination/replace-uses-update-when-available.test.ts
+++ b/packages/calendar/tests/providers/caldav/destination/replace-uses-update-when-available.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateDeterministicEventUid } from "../../../../src/core/events/identity";
+import type { EventMapping } from "../../../../src/core/events/mappings";
+import { executeRemoteOperations } from "../../../../src/core/sync-engine/index";
+import type { MaterializedSyncableEvent, SyncOperation } from "../../../../src/core/types";
+import { createCalDAVSyncProvider } from "../../../../src/providers/caldav/destination/provider";
+
+const clientMocks = vi.hoisted(() => ({
+  createCalendarObject: vi.fn(),
+  deleteCalendarObject: vi.fn(),
+  deleteCalendarObjectByUrl: vi.fn(),
+  fetchCalendarObject: vi.fn(),
+  fetchCalendarObjects: vi.fn(),
+  resolveCalendarUrl: vi.fn(),
+}));
+
+vi.mock("../../../../src/providers/caldav/shared/client", () => {
+  class MockCalDAVHttpError extends Error {
+    status: number;
+
+    constructor(response: Response) {
+      super(`CalDAV request failed: ${response.status}`);
+      this.name = "CalDAVHttpError";
+      this.status = response.status;
+    }
+  }
+
+  class MockCalDAVCreateConflictError extends MockCalDAVHttpError {
+    constructor(response: Response) {
+      super(response);
+      this.name = "CalDAVCreateConflictError";
+    }
+  }
+
+  class CalDAVClient {
+    createCalendarObject = clientMocks.createCalendarObject;
+    deleteCalendarObject = clientMocks.deleteCalendarObject;
+    deleteCalendarObjectByUrl = clientMocks.deleteCalendarObjectByUrl;
+    fetchCalendarObject = clientMocks.fetchCalendarObject;
+    fetchCalendarObjects = clientMocks.fetchCalendarObjects;
+    resolveCalendarUrl = clientMocks.resolveCalendarUrl;
+  }
+
+  return {
+    CalDAVClient,
+    CalDAVCreateConflictError: MockCalDAVCreateConflictError,
+    CalDAVHttpError: MockCalDAVHttpError,
+  };
+});
+
+const event: MaterializedSyncableEvent = {
+  calendarId: "source-calendar-id",
+  calendarName: "Source",
+  calendarUrl: null,
+  endTime: new Date("2026-03-08T15:00:00.000Z"),
+  id: "event-state-id-1",
+  sourceEventUid: "source-event-uid-1",
+  startTime: new Date("2026-03-08T14:00:00.000Z"),
+  summary: "Renamed meeting",
+};
+
+const uid = generateDeterministicEventUid(event.id);
+
+const mapping: EventMapping = {
+  calendarId: "dest-calendar-id",
+  deleteIdentifier: `/calendar/${uid}.ics`,
+  destinationEventUid: uid,
+  endTime: event.endTime,
+  eventStateId: event.id,
+  id: "mapping-1",
+  sourceCalendarId: event.calendarId,
+  startTime: event.startTime,
+  syncEventHash: "diverged-remote-hash",
+  syncEventId: event.id,
+};
+
+const replacement: SyncOperation = {
+  deleteId: mapping.deleteIdentifier,
+  event,
+  staleMappingId: mapping.id,
+  type: "replace",
+  uid,
+};
+
+const createProvider = () =>
+  createCalDAVSyncProvider({
+    calendarUrl: "https://caldav.example.com/calendar/",
+    password: "pass",
+    serverUrl: "https://caldav.example.com",
+    username: "user",
+  });
+
+describe("CalDAV replace with an update-capable provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rewrites the existing object with a single PUT and no DELETE", async () => {
+    clientMocks.createCalendarObject.mockResolvedValue(null);
+    clientMocks.deleteCalendarObject.mockResolvedValue(null);
+    clientMocks.deleteCalendarObjectByUrl.mockResolvedValue(null);
+
+    await executeRemoteOperations([replacement], [mapping], "dest-calendar-id", createProvider());
+
+    expect(clientMocks.deleteCalendarObject).not.toHaveBeenCalled();
+    expect(clientMocks.deleteCalendarObjectByUrl).not.toHaveBeenCalled();
+    expect(clientMocks.createCalendarObject).toHaveBeenCalledTimes(1);
+    expect(clientMocks.createCalendarObject.mock.calls[0]?.[0]).toMatchObject({
+      calendarUrl: "https://caldav.example.com/calendar/",
+      filename: `${uid}.ics`,
+    });
+    expect(clientMocks.createCalendarObject.mock.calls[0]?.[0]?.iCalString).toContain(`UID:${uid}`);
+  });
+});

--- a/packages/calendar/tests/providers/caldav/destination/update-target-href.test.ts
+++ b/packages/calendar/tests/providers/caldav/destination/update-target-href.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateDeterministicEventUid } from "../../../../src/core/events/identity";
+import type { MaterializedSyncableEvent } from "../../../../src/core/types";
+import { createCalDAVSyncProvider } from "../../../../src/providers/caldav/destination/provider";
+
+const clientMocks = vi.hoisted(() => ({
+  createCalendarObject: vi.fn(),
+  deleteCalendarObject: vi.fn(),
+  deleteCalendarObjectByUrl: vi.fn(),
+  fetchCalendarObject: vi.fn(),
+  fetchCalendarObjects: vi.fn(),
+  resolveCalendarUrl: vi.fn(),
+  updateCalendarObjectByUrl: vi.fn(),
+}));
+
+vi.mock("../../../../src/providers/caldav/shared/client", () => {
+  class MockCalDAVHttpError extends Error {
+    status: number;
+
+    constructor(response: Response) {
+      super(`CalDAV request failed: ${response.status}`);
+      this.name = "CalDAVHttpError";
+      this.status = response.status;
+    }
+  }
+
+  class MockCalDAVCreateConflictError extends MockCalDAVHttpError {
+    constructor(response: Response) {
+      super(response);
+      this.name = "CalDAVCreateConflictError";
+    }
+  }
+
+  class CalDAVClient {
+    createCalendarObject = clientMocks.createCalendarObject;
+    deleteCalendarObject = clientMocks.deleteCalendarObject;
+    deleteCalendarObjectByUrl = clientMocks.deleteCalendarObjectByUrl;
+    fetchCalendarObject = clientMocks.fetchCalendarObject;
+    fetchCalendarObjects = clientMocks.fetchCalendarObjects;
+    resolveCalendarUrl = clientMocks.resolveCalendarUrl;
+    updateCalendarObjectByUrl = clientMocks.updateCalendarObjectByUrl;
+  }
+
+  return {
+    CalDAVClient,
+    CalDAVCreateConflictError: MockCalDAVCreateConflictError,
+    CalDAVHttpError: MockCalDAVHttpError,
+  };
+});
+
+const event: MaterializedSyncableEvent = {
+  calendarId: "source-calendar-id",
+  calendarName: "Source",
+  calendarUrl: null,
+  endTime: new Date("2026-03-08T15:00:00.000Z"),
+  id: "event-state-id-1",
+  sourceEventUid: "source-event-uid-1",
+  startTime: new Date("2026-03-08T14:00:00.000Z"),
+  summary: "Renamed meeting",
+};
+
+const uid = generateDeterministicEventUid(event.id);
+
+const createProvider = (calendarUrl: string) =>
+  createCalDAVSyncProvider({
+    authMethod: "basic",
+    calendarUrl,
+    password: "password",
+    serverUrl: "https://caldav.example.com/",
+    username: "user",
+  });
+
+beforeEach(() => {
+  for (const mock of Object.values(clientMocks)) {
+    mock.mockReset();
+  }
+  clientMocks.updateCalendarObjectByUrl.mockImplementation(() => Promise.resolve());
+  clientMocks.resolveCalendarUrl.mockImplementation((url: string) => Promise.resolve(url));
+});
+
+describe("resolving the in-place update target", () => {
+  it("updates an object whose listed href percent-encodes the keeper suffix", async () => {
+    const provider = createProvider("https://caldav.example.com/calendar/");
+    const deleteId = `/calendar/${encodeURIComponent(uid)}.ics`;
+
+    const [result] = await provider.updateEvents?.([{ deleteId, event }]) ?? [];
+
+    expect(result?.success).toBe(true);
+    expect(clientMocks.deleteCalendarObjectByUrl).not.toHaveBeenCalled();
+    expect(clientMocks.updateCalendarObjectByUrl).toHaveBeenCalledTimes(1);
+    expect(clientMocks.updateCalendarObjectByUrl.mock.calls[0]?.[0]?.objectUrl)
+      .toBe(`https://caldav.example.com/calendar/${encodeURIComponent(uid)}.ics`);
+  });
+
+  it("updates when the configured calendar url has no trailing slash", async () => {
+    const provider = createProvider("https://caldav.example.com/calendar");
+
+    const [result] = await provider.updateEvents?.([{ deleteId: uid, event }]) ?? [];
+
+    expect(result?.success).toBe(true);
+    expect(clientMocks.updateCalendarObjectByUrl).toHaveBeenCalledTimes(1);
+    expect(clientMocks.updateCalendarObjectByUrl.mock.calls[0]?.[0]?.objectUrl)
+      .toBe(`https://caldav.example.com/calendar/${uid}.ics`);
+  });
+
+  it("refuses to write when the href is not this event's deterministic object", async () => {
+    const provider = createProvider("https://caldav.example.com/calendar/");
+
+    const [result] = await provider.updateEvents?.([
+      { deleteId: "/calendar/somebody-elses-event.ics", event },
+    ]) ?? [];
+
+    expect(result?.success).toBe(false);
+    expect(clientMocks.updateCalendarObjectByUrl).not.toHaveBeenCalled();
+    expect(clientMocks.createCalendarObject).not.toHaveBeenCalled();
+  });
+});

--- a/packages/calendar/tests/providers/google/destination/provider.test.ts
+++ b/packages/calendar/tests/providers/google/destination/provider.test.ts
@@ -259,7 +259,9 @@ describe("createGoogleSyncProvider", () => {
     )).toEqual({
       mappingUpdates: [{
         deleteIdentifier: remoteEvents[0]?.deleteId,
+        endTime: event.endTime,
         id: legacyMapping.id,
+        startTime: event.startTime,
         syncEventHash: createSyncEventContentHash(event),
         syncEventId: event.id,
       }],


### PR DESCRIPTION
A stale mapping produced a DELETE followed by a CREATE against the destination, so every reconciliation of a shared iCloud calendar notified each participant twice — the flood reported in #875. Providers can now expose an optional `updateEvents` capability, and the CalDAV destination implements it as a single PUT to the object href the mapping already points at. Mapping rows are rewritten in place rather than deleted and reinserted, and now carry the new start and end times so a moved event does not read as `remoteTimeChanged` on the next cycle.

- Providers without the capability (Google, Outlook) keep the delete-then-add path unchanged; an update the server rejects falls back to it per operation, so a missing object still converges instead of retrying a doomed PUT.
- `PendingUpdate` gained required `startTime`/`endTime`, written through `createDatabaseFlush`; `checkpointRun` now fires for update-only runs.
- Adversarial review caught the first cut being a silent no-op: `assertUpdateTargetsUid` compared raw href strings, and every keeper UID contains an `@`, which servers return percent-encoded. Proven against a real Radicale instance. Updates now PUT to the listed href and compare decoded basenames; `createCalendarObject` keeps its `If-None-Match` and stays create-only.
- Failed updates report an `OperationError` rather than only bumping a counter, so a destination where every update fails is visible instead of reporting a clean sync.

This removes the amplifier but does not prove *why* the event goes stale every cycle. The new `events.update_fallbacks` field plus the existing `stale_reason.*` counters should settle whether iCloud is relocating objects on shared calendars.

Known follow-up, deliberately not in scope: a retryable failure (503) still escalates to the destructive fallback. That matches what main does unconditionally today, so it is not a regression, but only 404/412 really justify delete-then-create.

Refs #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)