### PR TITLE
fix(auth): generate a username for social sign-ups

### DIFF
--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { type } from "arktype";
 import { betterAuth } from "better-auth";
 import { createAuthMiddleware } from "better-auth/api";
@@ -41,6 +42,30 @@ interface SendEmailParams {
   user: EmailUser;
   url: string;
 }
+
+const USERNAME_BASE_MAX_LENGTH = 32;
+const USERNAME_SUFFIX_LENGTH = 8;
+
+/**
+ * The `username-only` plugin marks `username` as a required, unique column on
+ * the user model. Social providers (Google, Microsoft) don't supply a username,
+ * so new-user creation from a social sign-in fails with `username_is_required`.
+ * This derives a stable, unique-enough username from the provider profile.
+ */
+const generateSocialUsername = (profile: {
+  email?: string | null;
+  name?: string | null;
+}): string => {
+  const emailLocalPart = profile.email?.split("@")[0] ?? "";
+  const base =
+    (emailLocalPart || profile.name || "")
+      .toLowerCase()
+      .replaceAll(/[^a-z0-9._-]+/g, "-")
+      .replaceAll(/^[-._]+|[-._]+$/g, "")
+      .slice(0, USERNAME_BASE_MAX_LENGTH) || "user";
+  const suffix = randomUUID().replaceAll("-", "").slice(0, USERNAME_SUFFIX_LENGTH);
+  return `${base}-${suffix}`;
+};
 
 interface AuthConfig {
   database: BunSQLDatabase;
@@ -226,6 +251,12 @@ const createAuth = (config: AuthConfig) => {
       accessType: "offline",
       clientId: googleClientId,
       clientSecret: googleClientSecret,
+      mapProfileToUser: (profile) => ({
+        username: generateSocialUsername({
+          email: profile.email,
+          name: profile.name,
+        }),
+      }),
       prompt: "consent",
       scope: ["https://www.googleapis.com/auth/calendar.events"],
     };
@@ -235,6 +266,12 @@ const createAuth = (config: AuthConfig) => {
     socialProviders.microsoft = {
       clientId: microsoftClientId,
       clientSecret: microsoftClientSecret,
+      mapProfileToUser: (profile) => ({
+        username: generateSocialUsername({
+          email: profile.email ?? profile.preferred_username,
+          name: profile.name,
+        }),
+      }),
       prompt: "consent",
       scope: ["offline_access", "User.Read", "Calendars.ReadWrite"],
     };


### PR DESCRIPTION
## What

Adds `mapProfileToUser` to the Google and Microsoft social providers so a new user created via social sign-in gets a generated `username`.

## Why

In self-hosted mode (`COMMERCIAL_MODE` unset) the `username-only` plugin adds a **required, unique** `username` column to the user model (`packages/auth/src/plugins/username-only/utils/schema.ts`). Google/Microsoft profiles don't supply a username, so first-time social sign-in failed during user creation — the OAuth callback threw `APIError: username is required` and redirected the browser to `/api/auth/error?error=username_is_required`.

## How

- New `generateSocialUsername(profile)` helper derives a username from the sanitized email local-part (falling back to the profile name, then `"user"`), constrained to the plugin's allowed charset `[a-z0-9._-]`, plus a short random suffix (`randomUUID`) for uniqueness against the unique constraint.
- Wired into both `socialProviders.google` and `socialProviders.microsoft`. Microsoft falls back to `preferred_username` when `email` is absent.

Example outputs: `dotphicc-9221f333`, `first.last-tag-3a9d3ec4`, and `user-5c594013` for empty/non-Latin profiles.

## Notes for reviewers

- Only affects **new** social users; `mapProfileToUser` runs at account creation, so returning users and account-linking are unchanged.
- Username/password (`username-only`) sign-up is unaffected — it still validates its own input.
- `bun run types` passes for `@keeper.sh/auth`.

## Testing

Self-hosted dev with `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` set: "Continue with Google" for a brand-new account now creates the user and lands on `/dashboard` instead of redirecting to the `username_is_required` error page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)