### PR TITLE
fix(outlook): propagate recurrence and verify destination series by id

### DIFF
--- a/packages/calendar/src/core/sync-engine/types.ts
+++ b/packages/calendar/src/core/sync-engine/types.ts
@@ -22,13 +22,6 @@ interface CalendarSyncProvider {
   getRemoteEventsByIds?: (eventIds: string[]) => Promise<RemoteEvent[]>;
   getThrottleMetrics?: () => ProviderThrottleMetrics;
   getSyncDiagnostics?: () => Record<string, number | string>;
-  /**
-   * Direct by-id existence check for destination events that a bulk listRemoteEvents pass
-   * didn't surface. Optional: only providers whose listing endpoint can miss events it should
-   * find (e.g. a bounded window that could disagree with the destination API's own expansion of
-   * a recurring series) need this as a fallback before treating a mapping as genuinely gone.
-   * Returns only the events that were confirmed to still exist.
-   */
   verifyEventsExist?: (deleteIds: string[]) => Promise<RemoteEvent[]>;
 }
 

--- a/packages/calendar/src/core/sync-engine/types.ts
+++ b/packages/calendar/src/core/sync-engine/types.ts
@@ -22,6 +22,14 @@ interface CalendarSyncProvider {
   getRemoteEventsByIds?: (eventIds: string[]) => Promise<RemoteEvent[]>;
   getThrottleMetrics?: () => ProviderThrottleMetrics;
   getSyncDiagnostics?: () => Record<string, number | string>;
+  /**
+   * Direct by-id existence check for destination events that a bulk listRemoteEvents pass
+   * didn't surface. Optional: only providers whose listing endpoint can miss events it should
+   * find (e.g. a bounded window that could disagree with the destination API's own expansion of
+   * a recurring series) need this as a fallback before treating a mapping as genuinely gone.
+   * Returns only the events that were confirmed to still exist.
+   */
+  verifyEventsExist?: (deleteIds: string[]) => Promise<RemoteEvent[]>;
 }
 
 interface PendingInsert {

--- a/packages/calendar/src/providers/outlook/destination/provider.ts
+++ b/packages/calendar/src/providers/outlook/destination/provider.ts
@@ -315,7 +315,8 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
     const baseUrl = new URL(calendarEventsUrl);
     baseUrl.searchParams.set(
       "$filter",
-      `end/dateTime ge '${lookbackStart.toISOString()}'`
+      `categories/any(c:c eq '${KEEPER_CATEGORY}')`
+      + ` and end/dateTime ge '${lookbackStart.toISOString()}'`
       + ` and start/dateTime le '${lookaheadEnd.toISOString()}'`,
     );
     baseUrl.searchParams.set("$top", String(OUTLOOK_PAGE_SIZE));
@@ -326,6 +327,14 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
     return baseUrl;
   };
 
+  /**
+   * Best-effort discovery of keeper-tagged events not tracked by any mapping, so they can be
+   * cleaned up as orphans. This is intentionally bounded to a time window: a recurring series'
+   * own start/dateTime is its first (possibly long-past) occurrence, so a series that started
+   * before the window can be missed here. That's an acceptable gap for orphan discovery (a
+   * stray duplicate lingers a bit longer) - it must NOT be relied on to confirm whether an
+   * *existing* mapping's event still exists, which is what verifyEventsExist is for.
+   */
   const listRemoteEvents = async (
     options: ListRemoteEventsOptions,
   ): Promise<RemoteEvent[]> => {
@@ -403,6 +412,60 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
 
   const getThrottleMetrics = (): ProviderThrottleMetrics => ({ ...throttleMetrics });
 
+  /**
+   * Authoritative existence check for events we already track a mapping for for: a direct
+   * GET by the destination's own event id, independent of any time window, category
+   * inheritance on recurring instances, or pagination. This is what determines whether an
+   * already-pushed event should be treated as still existing - listRemoteEvents' bounded
+   * window is not reliable enough for that call for a long-running recurring series.
+   */
+  const verifyEventsExist = async (deleteIds: string[]): Promise<RemoteEvent[]> => {
+    await refreshIfNeeded();
+    const verified: RemoteEvent[] = [];
+
+    for (const deleteId of deleteIds) {
+      try {
+        const url = new URL(`${MICROSOFT_GRAPH_API}/me/events/${deleteId}`);
+        url.searchParams.set("$select", "id,iCalUId,start,end,categories");
+
+        const response = await fetch(url, {
+          headers: { Authorization: `Bearer ${tokenState.accessToken}` },
+          method: "GET",
+        });
+
+        if (response.status === HTTP_STATUS.NOT_FOUND) {
+          await response.body?.cancel?.();
+          continue;
+        }
+
+        if (!response.ok) {
+          continue;
+        }
+
+        const body = await response.json();
+        const event = outlookEventSchema.assert(body);
+        const startTime = parseEventTime(event.start);
+        const endTime = parseEventTime(event.end);
+
+        if (!event.iCalUId || !startTime || !endTime) {
+          continue;
+        }
+
+        verified.push({
+          deleteId,
+          endTime,
+          isKeeperEvent: event.categories?.includes(KEEPER_CATEGORY) ?? false,
+          startTime,
+          uid: event.iCalUId,
+        });
+      } catch {
+        continue;
+      }
+    }
+
+    return verified;
+  };
+
   return {
     deleteEvents,
     getRemoteEventsByIds,
@@ -410,6 +473,7 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
     listRemoteEvents,
     normalizeEvent: normalizeOutlookEvent,
     pushEvents,
+    verifyEventsExist,
   };
 };
 

--- a/packages/calendar/src/providers/outlook/destination/provider.ts
+++ b/packages/calendar/src/providers/outlook/destination/provider.ts
@@ -423,42 +423,36 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
     const verified: RemoteEvent[] = [];
 
     for (const deleteId of deleteIds) {
-      try {
-        const url = new URL(`${MICROSOFT_GRAPH_API}/me/events/${deleteId}`);
-        url.searchParams.set("$select", "id,iCalUId,start,end,categories");
+      config.signal?.throwIfAborted();
 
-        const response = await fetch(url, {
-          headers: { Authorization: `Bearer ${tokenState.accessToken}` },
-          method: "GET",
-        });
+      const url = new URL(`${MICROSOFT_GRAPH_API}/me/events/${deleteId}`);
+      url.searchParams.set(
+        "$select",
+        "id,iCalUId,subject,body,location,start,end,isAllDay,showAs,categories",
+      );
 
-        if (response.status === HTTP_STATUS.NOT_FOUND) {
-          await response.body?.cancel?.();
-          continue;
-        }
+      const response = await sendRequestWithRetry(url, {
+        headers: {
+          Authorization: `Bearer ${tokenState.accessToken}`,
+          Prefer: `outlook.body-content-type="text"`,
+        },
+        method: "GET",
+      });
 
-        if (!response.ok) {
-          continue;
-        }
-
-        const body = await response.json();
-        const event = outlookEventSchema.assert(body);
-        const startTime = parseEventTime(event.start);
-        const endTime = parseEventTime(event.end);
-
-        if (!event.iCalUId || !startTime || !endTime) {
-          continue;
-        }
-
-        verified.push({
-          deleteId,
-          endTime,
-          isKeeperEvent: event.categories?.includes(KEEPER_CATEGORY) ?? false,
-          startTime,
-          uid: event.iCalUId,
-        });
-      } catch {
+      if (response.status === HTTP_STATUS.NOT_FOUND) {
+        await response.body?.cancel?.();
         continue;
+      }
+
+      if (!response.ok) {
+        throw new Error(await readGraphErrorMessage(response));
+      }
+
+      const body = await response.json();
+      const remoteEvent = toOutlookRemoteEvent(outlookEventSchema.assert(body));
+
+      if (remoteEvent) {
+        verified.push(remoteEvent);
       }
     }
 

--- a/packages/calendar/src/providers/outlook/destination/provider.ts
+++ b/packages/calendar/src/providers/outlook/destination/provider.ts
@@ -315,8 +315,7 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
     const baseUrl = new URL(calendarEventsUrl);
     baseUrl.searchParams.set(
       "$filter",
-      `categories/any(c:c eq '${KEEPER_CATEGORY}')`
-      + ` and end/dateTime ge '${lookbackStart.toISOString()}'`
+      `end/dateTime ge '${lookbackStart.toISOString()}'`
       + ` and start/dateTime le '${lookaheadEnd.toISOString()}'`,
     );
     baseUrl.searchParams.set("$top", String(OUTLOOK_PAGE_SIZE));

--- a/packages/calendar/src/providers/outlook/destination/provider.ts
+++ b/packages/calendar/src/providers/outlook/destination/provider.ts
@@ -326,14 +326,6 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
     return baseUrl;
   };
 
-  /**
-   * Best-effort discovery of keeper-tagged events not tracked by any mapping, so they can be
-   * cleaned up as orphans. This is intentionally bounded to a time window: a recurring series'
-   * own start/dateTime is its first (possibly long-past) occurrence, so a series that started
-   * before the window can be missed here. That's an acceptable gap for orphan discovery (a
-   * stray duplicate lingers a bit longer) - it must NOT be relied on to confirm whether an
-   * *existing* mapping's event still exists, which is what verifyEventsExist is for.
-   */
   const listRemoteEvents = async (
     options: ListRemoteEventsOptions,
   ): Promise<RemoteEvent[]> => {
@@ -411,13 +403,6 @@ const createOutlookSyncProvider = (config: OutlookSyncProviderConfig) => {
 
   const getThrottleMetrics = (): ProviderThrottleMetrics => ({ ...throttleMetrics });
 
-  /**
-   * Authoritative existence check for events we already track a mapping for for: a direct
-   * GET by the destination's own event id, independent of any time window, category
-   * inheritance on recurring instances, or pagination. This is what determines whether an
-   * already-pushed event should be treated as still existing - listRemoteEvents' bounded
-   * window is not reliable enough for that call for a long-running recurring series.
-   */
   const verifyEventsExist = async (deleteIds: string[]): Promise<RemoteEvent[]> => {
     await refreshIfNeeded();
     const verified: RemoteEvent[] = [];

--- a/packages/calendar/src/providers/outlook/destination/serialize-event.ts
+++ b/packages/calendar/src/providers/outlook/destination/serialize-event.ts
@@ -8,6 +8,7 @@ import {
   resolveTimeZone,
   wallTimeToInstant,
 } from "../../../ics/utils/timezone-instant";
+import { buildOutlookRecurrence } from "./serialize-recurrence";
 
 const UTC_TIME_ZONE = "UTC";
 
@@ -78,10 +79,12 @@ const serializeOutlookEvent = (event: MaterializedSyncableEvent): OutlookEvent =
   const isAllDay = resolveIsAllDayEvent(event);
   const location = getOutlookLocation(event);
   const eventTimeZone = event.startTimeZone ?? "UTC";
+  const recurrence = buildOutlookRecurrence(event);
 
   return {
     ...(body && { body }),
     ...(location && { location }),
+    ...(recurrence && { recurrence }),
     categories: [KEEPER_CATEGORY],
     end: buildOutlookDateTime(event.endTime, eventTimeZone, isAllDay),
     isAllDay,

--- a/packages/calendar/src/providers/outlook/destination/serialize-recurrence.ts
+++ b/packages/calendar/src/providers/outlook/destination/serialize-recurrence.ts
@@ -1,0 +1,125 @@
+import type { IcsRecurrenceRule } from "ts-ics";
+import type { OutlookEvent } from "@keeper.sh/data-schemas";
+import { parseRecurrenceRuleFromJson } from "../../../core/events/recurrence";
+import type { SyncableEvent } from "../../../core/types";
+
+type OutlookRecurrence = NonNullable<OutlookEvent["recurrence"]>;
+type OutlookRecurrencePattern = OutlookRecurrence["pattern"];
+type OutlookRecurrenceRange = OutlookRecurrence["range"];
+
+const ICS_DAY_TO_OUTLOOK_DAY: Record<string, string> = {
+  FR: "friday",
+  MO: "monday",
+  SA: "saturday",
+  SU: "sunday",
+  TH: "thursday",
+  TU: "tuesday",
+  WE: "wednesday",
+};
+
+const OCCURRENCE_TO_INDEX: Record<number, string> = {
+  [-1]: "last",
+  1: "first",
+  2: "second",
+  3: "third",
+  4: "fourth",
+};
+
+const formatOutlookDate = (value: Date): string => value.toISOString().slice(0, 10);
+
+const buildRange = (rule: IcsRecurrenceRule, startTime: Date): OutlookRecurrenceRange => {
+  const startDate = formatOutlookDate(startTime);
+
+  if (rule.until) {
+    return { endDate: formatOutlookDate(rule.until.date), startDate, type: "endDate" };
+  }
+
+  if (typeof rule.count === "number") {
+    return { numberOfOccurrences: rule.count, startDate, type: "numbered" };
+  }
+
+  return { startDate, type: "noEnd" };
+};
+
+const WEEK_DAYS_BY_INDEX = ["SU", "MO", "TU", "WE", "TH", "FR", "SA"] as const;
+
+const buildWeeklyPattern = (rule: IcsRecurrenceRule, startTime: Date): OutlookRecurrencePattern | null => {
+  const days = rule.byDay?.map((entry) => ICS_DAY_TO_OUTLOOK_DAY[entry.day]).filter((day): day is string => Boolean(day));
+  const fallbackIcsDay = WEEK_DAYS_BY_INDEX[startTime.getUTCDay()] ?? "MO";
+  const fallbackDay = ICS_DAY_TO_OUTLOOK_DAY[fallbackIcsDay] ?? "monday";
+  const daysOfWeek = days && days.length > 0 ? days : [fallbackDay];
+
+  return { daysOfWeek, interval: rule.interval ?? 1, type: "weekly" };
+};
+
+const buildMonthlyPattern = (rule: IcsRecurrenceRule, startTime: Date): OutlookRecurrencePattern | null => {
+  const byDayEntry = rule.byDay?.[0];
+
+  if (byDayEntry && typeof byDayEntry.occurrence === "number") {
+    const index = OCCURRENCE_TO_INDEX[byDayEntry.occurrence];
+    const day = ICS_DAY_TO_OUTLOOK_DAY[byDayEntry.day];
+    if (!index || !day) {
+      return null;
+    }
+    return { daysOfWeek: [day], index, interval: rule.interval ?? 1, type: "relativeMonthly" };
+  }
+
+  const dayOfMonth = rule.byMonthday?.[0] ?? startTime.getUTCDate();
+  return { dayOfMonth, interval: rule.interval ?? 1, type: "absoluteMonthly" };
+};
+
+const buildYearlyPattern = (rule: IcsRecurrenceRule, startTime: Date): OutlookRecurrencePattern | null => {
+  const byDayEntry = rule.byDay?.[0];
+  const month = rule.byMonth?.[0] ?? startTime.getUTCMonth() + 1;
+
+  if (byDayEntry && typeof byDayEntry.occurrence === "number") {
+    const index = OCCURRENCE_TO_INDEX[byDayEntry.occurrence];
+    const day = ICS_DAY_TO_OUTLOOK_DAY[byDayEntry.day];
+    if (!index || !day) {
+      return null;
+    }
+    return { daysOfWeek: [day], index, interval: rule.interval ?? 1, month, type: "relativeYearly" };
+  }
+
+  const dayOfMonth = rule.byMonthday?.[0] ?? startTime.getUTCDate();
+  return { dayOfMonth, interval: rule.interval ?? 1, month, type: "absoluteYearly" };
+};
+
+const buildPattern = (rule: IcsRecurrenceRule, startTime: Date): OutlookRecurrencePattern | null => {
+  switch (rule.frequency) {
+    case "DAILY":
+      return { interval: rule.interval ?? 1, type: "daily" };
+    case "WEEKLY":
+      return buildWeeklyPattern(rule, startTime);
+    case "MONTHLY":
+      return buildMonthlyPattern(rule, startTime);
+    case "YEARLY":
+      return buildYearlyPattern(rule, startTime);
+    default:
+      return null;
+  }
+};
+
+/**
+ * Microsoft Graph has no equivalent to sub-daily RRULE frequencies (SECONDLY/MINUTELY/HOURLY),
+ * so those series are pushed as a single non-recurring event rather than dropped or crashing.
+ */
+const buildOutlookRecurrence = (event: SyncableEvent): OutlookRecurrence | undefined => {
+  if (!event.recurrenceRule) {
+    return undefined;
+  }
+
+  const rule = parseRecurrenceRuleFromJson(JSON.stringify(event.recurrenceRule));
+  if (!rule) {
+    return undefined;
+  }
+
+  const pattern = buildPattern(rule, event.startTime);
+  if (!pattern) {
+    return undefined;
+  }
+
+  return { pattern, range: buildRange(rule, event.startTime) };
+};
+
+export { buildOutlookRecurrence };

--- a/packages/calendar/src/providers/outlook/destination/serialize-recurrence.ts
+++ b/packages/calendar/src/providers/outlook/destination/serialize-recurrence.ts
@@ -1,6 +1,5 @@
 import type { IcsRecurrenceRule } from "ts-ics";
 import type { OutlookEvent } from "@keeper.sh/data-schemas";
-import { parseRecurrenceRuleFromJson } from "../../../core/events/recurrence";
 import type { SyncableEvent } from "../../../core/types";
 
 type OutlookRecurrence = NonNullable<OutlookEvent["recurrence"]>;
@@ -44,10 +43,14 @@ const buildRange = (rule: IcsRecurrenceRule, startTime: Date): OutlookRecurrence
 const WEEK_DAYS_BY_INDEX = ["SU", "MO", "TU", "WE", "TH", "FR", "SA"] as const;
 
 const buildWeeklyPattern = (rule: IcsRecurrenceRule, startTime: Date): OutlookRecurrencePattern | null => {
-  const days = rule.byDay?.map((entry) => ICS_DAY_TO_OUTLOOK_DAY[entry.day]).filter((day): day is string => Boolean(day));
+  const days = rule.byDay?.map((entry) => ICS_DAY_TO_OUTLOOK_DAY[entry.day]).filter((day): day is string => typeof day === "string");
   const fallbackIcsDay = WEEK_DAYS_BY_INDEX[startTime.getUTCDay()] ?? "MO";
   const fallbackDay = ICS_DAY_TO_OUTLOOK_DAY[fallbackIcsDay] ?? "monday";
-  const daysOfWeek = days && days.length > 0 ? days : [fallbackDay];
+
+  let daysOfWeek = [fallbackDay];
+  if (days && days.length > 0) {
+    daysOfWeek = days;
+  }
 
   return { daysOfWeek, interval: rule.interval ?? 1, type: "weekly" };
 };
@@ -87,16 +90,21 @@ const buildYearlyPattern = (rule: IcsRecurrenceRule, startTime: Date): OutlookRe
 
 const buildPattern = (rule: IcsRecurrenceRule, startTime: Date): OutlookRecurrencePattern | null => {
   switch (rule.frequency) {
-    case "DAILY":
+    case "DAILY": {
       return { interval: rule.interval ?? 1, type: "daily" };
-    case "WEEKLY":
+    }
+    case "WEEKLY": {
       return buildWeeklyPattern(rule, startTime);
-    case "MONTHLY":
+    }
+    case "MONTHLY": {
       return buildMonthlyPattern(rule, startTime);
-    case "YEARLY":
+    }
+    case "YEARLY": {
       return buildYearlyPattern(rule, startTime);
-    default:
+    }
+    default: {
       return null;
+    }
   }
 };
 
@@ -106,17 +114,14 @@ const buildPattern = (rule: IcsRecurrenceRule, startTime: Date): OutlookRecurren
  */
 const buildOutlookRecurrence = (event: SyncableEvent): OutlookRecurrence | undefined => {
   if (!event.recurrenceRule) {
-    return undefined;
+    return;
   }
 
-  const rule = parseRecurrenceRuleFromJson(JSON.stringify(event.recurrenceRule));
-  if (!rule) {
-    return undefined;
-  }
+  const rule = event.recurrenceRule;
 
   const pattern = buildPattern(rule, event.startTime);
   if (!pattern) {
-    return undefined;
+    return;
   }
 
   return { pattern, range: buildRange(rule, event.startTime) };

--- a/packages/calendar/tests/providers/outlook/destination/provider.test.ts
+++ b/packages/calendar/tests/providers/outlook/destination/provider.test.ts
@@ -53,12 +53,69 @@ describe("createOutlookSyncProvider", () => {
     vi.unstubAllGlobals();
   });
 
-  it("returns a provider with pushEvents, deleteEvents, and listRemoteEvents", () => {
+  it("returns a provider with pushEvents, deleteEvents, listRemoteEvents, getRemoteEventsByIds, and verifyEventsExist", () => {
     const provider = createProvider();
 
     expect(typeof provider.pushEvents).toBe("function");
     expect(typeof provider.deleteEvents).toBe("function");
     expect(typeof provider.listRemoteEvents).toBe("function");
+    expect(typeof provider.getRemoteEventsByIds).toBe("function");
+    expect(typeof provider.verifyEventsExist).toBe("function");
+  });
+
+  it("lists remote events from /events within the requested window, filtered server-side to keeper-tagged events", async () => {
+    let requestedUrl: string | null = null;
+    vi.stubGlobal("fetch", vi.fn((input: string | URL | Request) => {
+      requestedUrl = input.toString();
+      return Promise.resolve(Response.json({ value: [] }));
+    }));
+
+    const provider = createProvider();
+    await provider.listRemoteEvents({
+      timeMax: new Date("2026-07-24T00:00:00.000Z"),
+      timeMin: new Date("2026-07-10T00:00:00.000Z"),
+    });
+
+    expect(requestedUrl).not.toBeNull();
+    const url = new URL(requestedUrl ?? "");
+    expect(url.pathname).toContain("/events");
+    expect(url.pathname).not.toContain("/calendarView");
+    const filter = url.searchParams.get("$filter") ?? "";
+    expect(filter).toContain(`categories/any(c:c eq '${KEEPER_CATEGORY}')`);
+    expect(filter).toContain("end/dateTime ge");
+    expect(filter).toContain("start/dateTime le");
+  });
+
+  it("verifyEventsExist confirms a known event by direct id lookup, independent of any time window", async () => {
+    let requestedUrl: string | null = null;
+    vi.stubGlobal("fetch", vi.fn((input: string | URL | Request) => {
+      requestedUrl = input.toString();
+      return Promise.resolve(Response.json({
+        categories: [KEEPER_CATEGORY],
+        end: { dateTime: "2026-07-20T19:30:00.000" },
+        iCalUId: "series-uid-1",
+        id: "series-master-id-1",
+        start: { dateTime: "2026-01-19T16:30:00.000" },
+      }));
+    }));
+
+    const provider = createProvider();
+    const verified = await provider.verifyEventsExist(["series-master-id-1"]);
+
+    expect(requestedUrl).not.toBeNull();
+    expect(new URL(requestedUrl ?? "").pathname).toContain("/events/series-master-id-1");
+    expect(verified).toEqual([
+      expect.objectContaining({ deleteId: "series-master-id-1", uid: "series-uid-1" }),
+    ]);
+  });
+
+  it("verifyEventsExist omits ids the destination responds 404 for", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(new Response(null, { status: 404 }))));
+
+    const provider = createProvider();
+    const verified = await provider.verifyEventsExist(["deleted-event-id"]);
+
+    expect(verified).toEqual([]);
   });
 
   it("aborts a pending Graph event creation", async () => {

--- a/packages/calendar/tests/providers/outlook/destination/provider.test.ts
+++ b/packages/calendar/tests/providers/outlook/destination/provider.test.ts
@@ -63,7 +63,7 @@ describe("createOutlookSyncProvider", () => {
     expect(typeof provider.verifyEventsExist).toBe("function");
   });
 
-  it("lists remote events from /events within the requested window, filtered server-side to keeper-tagged events", async () => {
+  it("lists remote events from /events within the requested window", async () => {
     let requestedUrl: string | null = null;
     vi.stubGlobal("fetch", vi.fn((input: string | URL | Request) => {
       requestedUrl = input.toString();
@@ -81,7 +81,7 @@ describe("createOutlookSyncProvider", () => {
     expect(url.pathname).toContain("/events");
     expect(url.pathname).not.toContain("/calendarView");
     const filter = url.searchParams.get("$filter") ?? "";
-    expect(filter).toContain(`categories/any(c:c eq '${KEEPER_CATEGORY}')`);
+    expect(filter).not.toContain("categories");
     expect(filter).toContain("end/dateTime ge");
     expect(filter).toContain("start/dateTime le");
   });

--- a/packages/calendar/tests/providers/outlook/destination/serialize-recurrence.test.ts
+++ b/packages/calendar/tests/providers/outlook/destination/serialize-recurrence.test.ts
@@ -33,7 +33,7 @@ describe("buildOutlookRecurrence", () => {
   it("maps a DAILY rule with an until date to Outlook's endDate range", () => {
     const recurrence = buildOutlookRecurrence({
       ...baseEvent,
-      recurrenceRule: { frequency: "DAILY", interval: 1, until: { date: "2026-02-01T00:00:00.000Z" } },
+      recurrenceRule: { frequency: "DAILY", interval: 1, until: { date: new Date("2026-02-01T00:00:00.000Z") } },
     });
 
     expect(recurrence).toEqual({

--- a/packages/calendar/tests/providers/outlook/destination/serialize-recurrence.test.ts
+++ b/packages/calendar/tests/providers/outlook/destination/serialize-recurrence.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { buildOutlookRecurrence } from "../../../../src/providers/outlook/destination/serialize-recurrence";
+import type { SyncableEvent } from "../../../../src/core/types";
+
+const baseEvent: SyncableEvent = {
+  calendarId: "calendar-id",
+  calendarName: "Calendar",
+  calendarUrl: null,
+  endTime: new Date("2026-01-19T19:30:00.000Z"),
+  id: "event-id",
+  sourceEventUid: "source-uid",
+  startTime: new Date("2026-01-19T16:30:00.000Z"),
+  summary: "Coachen",
+};
+
+describe("buildOutlookRecurrence", () => {
+  it("returns undefined when there is no recurrence rule", () => {
+    expect(buildOutlookRecurrence(baseEvent)).toBeUndefined();
+  });
+
+  it("maps a biweekly WEEKLY rule to Outlook's weekly pattern with no end", () => {
+    const recurrence = buildOutlookRecurrence({
+      ...baseEvent,
+      recurrenceRule: { frequency: "WEEKLY", interval: 2 },
+    });
+
+    expect(recurrence).toEqual({
+      pattern: { daysOfWeek: ["monday"], interval: 2, type: "weekly" },
+      range: { startDate: "2026-01-19", type: "noEnd" },
+    });
+  });
+
+  it("maps a DAILY rule with an until date to Outlook's endDate range", () => {
+    const recurrence = buildOutlookRecurrence({
+      ...baseEvent,
+      recurrenceRule: { frequency: "DAILY", interval: 1, until: { date: "2026-02-01T00:00:00.000Z" } },
+    });
+
+    expect(recurrence).toEqual({
+      pattern: { interval: 1, type: "daily" },
+      range: { endDate: "2026-02-01", startDate: "2026-01-19", type: "endDate" },
+    });
+  });
+
+  it("maps a MONTHLY rule with byMonthday to Outlook's absoluteMonthly pattern", () => {
+    const recurrence = buildOutlookRecurrence({
+      ...baseEvent,
+      recurrenceRule: { byMonthday: [15], frequency: "MONTHLY", interval: 1 },
+    });
+
+    expect(recurrence?.pattern).toEqual({ dayOfMonth: 15, interval: 1, type: "absoluteMonthly" });
+  });
+
+  it("maps a MONTHLY rule with a byDay occurrence to Outlook's relativeMonthly pattern", () => {
+    const recurrence = buildOutlookRecurrence({
+      ...baseEvent,
+      recurrenceRule: {
+        byDay: [{ day: "MO", occurrence: -1 }],
+        frequency: "MONTHLY",
+        interval: 1,
+      },
+    });
+
+    expect(recurrence?.pattern).toEqual({
+      daysOfWeek: ["monday"],
+      index: "last",
+      interval: 1,
+      type: "relativeMonthly",
+    });
+  });
+
+  it("maps a rule with a count to Outlook's numbered range", () => {
+    const recurrence = buildOutlookRecurrence({
+      ...baseEvent,
+      recurrenceRule: { count: 5, frequency: "WEEKLY", interval: 1 },
+    });
+
+    expect(recurrence?.range).toEqual({ numberOfOccurrences: 5, startDate: "2026-01-19", type: "numbered" });
+  });
+
+  it("returns undefined for sub-daily frequencies unsupported by Microsoft Graph", () => {
+    const recurrence = buildOutlookRecurrence({
+      ...baseEvent,
+      recurrenceRule: { frequency: "HOURLY", interval: 1 },
+    });
+
+    expect(recurrence).toBeUndefined();
+  });
+});

--- a/packages/calendar/tests/providers/outlook/destination/verify-events-exist-budget.test.ts
+++ b/packages/calendar/tests/providers/outlook/destination/verify-events-exist-budget.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createOutlookSyncProvider } from "../../../../src/providers/outlook/destination/provider";
+import type { RedisRateLimiter } from "../../../../src/core/utils/redis-rate-limiter";
+
+const createProvider = (options: { rateLimiter?: RedisRateLimiter; signal?: AbortSignal } = {}) =>
+  createOutlookSyncProvider({
+    accessToken: "test-token",
+    refreshToken: "test-refresh",
+    accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+    externalCalendarId: "external-cal-1",
+    calendarId: "cal-1",
+    userId: "user-1",
+    rateLimiter: options.rateLimiter,
+    signal: options.signal,
+  });
+
+const existingEvent = (deleteId: string) => ({
+  end: { dateTime: "2026-07-17T19:00:00.0000000", timeZone: "UTC" },
+  iCalUId: `uid-${deleteId}`,
+  id: deleteId,
+  start: { dateTime: "2026-07-17T18:00:00.0000000", timeZone: "UTC" },
+});
+
+describe("verification obeys the limiter, timeout and abort", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("acquires a rate limiter slot for every verification request", async () => {
+    const fetchSpy = vi.fn((input: string | URL | Request) => {
+      const deleteId = input.toString().split("/me/events/")[1]?.split("?")[0] ?? "";
+      return Promise.resolve(Response.json(existingEvent(deleteId)));
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    const acquire = vi.fn(() => Promise.resolve());
+    const rateLimiter: RedisRateLimiter = { acquire };
+
+    const verified = await createProvider({ rateLimiter }).verifyEventsExist([
+      "first-id",
+      "second-id",
+    ]);
+
+    expect(verified).toHaveLength(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(acquire).toHaveBeenCalledTimes(2);
+  });
+
+  it("carries a request timeout signal on every verification request", async () => {
+    const fetchSpy = vi.fn((input: string | URL | Request) => {
+      const deleteId = input.toString().split("/me/events/")[1]?.split("?")[0] ?? "";
+      return Promise.resolve(Response.json(existingEvent(deleteId)));
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await createProvider().verifyEventsExist(["first-id", "second-id"]);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    for (const [, init] of fetchSpy.mock.calls as unknown as [unknown, RequestInit][]) {
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+
+  it("issues no verification request once the sync has already been aborted", async () => {
+    const fetchSpy = vi.fn((input: string | URL | Request) => {
+      const deleteId = input.toString().split("/me/events/")[1]?.split("?")[0] ?? "";
+      return Promise.resolve(Response.json(existingEvent(deleteId)));
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    const acquire = vi.fn(() => Promise.resolve());
+    const rateLimiter: RedisRateLimiter = { acquire };
+    const controller = new AbortController();
+    controller.abort(new DOMException("superseded", "AbortError"));
+
+    const provider = createProvider({ rateLimiter, signal: controller.signal });
+
+    await expect(
+      provider.verifyEventsExist(["first-id", "second-id", "third-id"]),
+    ).rejects.toThrow();
+    expect(fetchSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("stops issuing verification requests as soon as the sync aborts mid-loop", async () => {
+    const controller = new AbortController();
+    const fetchSpy = vi.fn((input: string | URL | Request) => {
+      controller.abort(new DOMException("superseded", "AbortError"));
+      const deleteId = input.toString().split("/me/events/")[1]?.split("?")[0] ?? "";
+      return Promise.resolve(Response.json(existingEvent(deleteId)));
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const provider = createProvider({ signal: controller.signal });
+
+    await expect(
+      provider.verifyEventsExist(["first-id", "second-id", "third-id"]),
+    ).rejects.toThrow();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/calendar/tests/providers/outlook/destination/verify-events-exist-divergence.test.ts
+++ b/packages/calendar/tests/providers/outlook/destination/verify-events-exist-divergence.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createOutlookSyncProvider } from "../../../../src/providers/outlook/destination/provider";
+import { identifyStaleMappings } from "../../../../src/core/sync/operations";
+import { createSyncEventContentHash } from "../../../../src/core/events/content-hash";
+import type { EventMapping } from "../../../../src/core/events/mappings";
+import type { MaterializedSyncableEvent } from "../../../../src/core/types";
+
+const DELETE_ID = "destination-event-id";
+const START_TIME = new Date("2026-09-01T15:00:00.000Z");
+const END_TIME = new Date("2026-09-01T16:00:00.000Z");
+
+const createProvider = () =>
+  createOutlookSyncProvider({
+    accessToken: "test-token",
+    refreshToken: "test-refresh",
+    accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+    externalCalendarId: "external-cal-1",
+    calendarId: "cal-1",
+    userId: "user-1",
+  });
+
+const localEvent: MaterializedSyncableEvent = {
+  availability: "busy",
+  calendarId: "cal-1",
+  calendarName: "Work",
+  calendarUrl: null,
+  description: "Original agenda",
+  endTime: END_TIME,
+  id: "sync-event-1",
+  isAllDay: false,
+  location: "Room A",
+  sourceEventUid: "source-uid-1",
+  startTime: START_TIME,
+  summary: "Original title",
+};
+
+const mapping: EventMapping = {
+  calendarId: "cal-1",
+  deleteIdentifier: DELETE_ID,
+  destinationEventUid: "ical-uid-1",
+  endTime: END_TIME,
+  eventStateId: null,
+  id: "mapping-1",
+  sourceCalendarId: null,
+  startTime: START_TIME,
+  syncEventHash: createSyncEventContentHash(localEvent),
+  syncEventId: "sync-event-1",
+};
+
+const editedRemoteEvent = {
+  body: { content: "Original agenda", contentType: "text" },
+  categories: ["Keeper"],
+  end: { dateTime: "2026-09-01T16:00:00Z", timeZone: "UTC" },
+  iCalUId: "ical-uid-1",
+  id: DELETE_ID,
+  isAllDay: false,
+  location: { displayName: "Room A" },
+  showAs: "busy",
+  start: { dateTime: "2026-09-01T15:00:00Z", timeZone: "UTC" },
+  subject: "Title the user edited on the destination",
+};
+
+describe("a verified event still shows its divergence", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps a destination-side edit visible to staleness detection", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(Response.json(editedRemoteEvent))));
+
+    const [verifiedEvent] = await createProvider().verifyEventsExist([DELETE_ID]);
+    expect(verifiedEvent).toBeDefined();
+    if (!verifiedEvent) {
+      return;
+    }
+
+    const result = identifyStaleMappings(
+      [mapping],
+      new Set(["sync-event-1"]),
+      new Map([[mapping.id, verifiedEvent]]),
+      new Map([["sync-event-1", localEvent]]),
+    );
+
+    expect(result.staleReasonCounts.remoteContentChanged).toBe(1);
+    expect(result.staleReasonCounts.remoteContentSummaryChanged).toBe(1);
+    expect(result.staleMappingIds).toEqual(["mapping-1"]);
+  });
+});

--- a/packages/calendar/tests/providers/outlook/destination/verify-events-exist-refusal.test.ts
+++ b/packages/calendar/tests/providers/outlook/destination/verify-events-exist-refusal.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createOutlookSyncProvider } from "../../../../src/providers/outlook/destination/provider";
+
+const createProvider = () =>
+  createOutlookSyncProvider({
+    accessToken: "test-token",
+    refreshToken: "test-refresh",
+    accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
+    externalCalendarId: "external-cal-1",
+    calendarId: "cal-1",
+    userId: "user-1",
+  });
+
+const graphError = (status: number, code: string, headers?: Record<string, string>): Response =>
+  Response.json(
+    { error: { code, message: `${code} from Graph.` } },
+    { headers, status },
+  );
+
+describe("verifyEventsExist refusals never vote to delete", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not report a throttled id as missing", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(graphError(429, "ApplicationThrottled", { "Retry-After": "0" }))),
+    );
+
+    await expect(createProvider().verifyEventsExist(["mapped-event-id"]))
+      .rejects.toThrow();
+  });
+
+  it("does not report an id as missing when the token expired mid-loop", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(graphError(401, "InvalidAuthenticationToken"))),
+    );
+
+    await expect(createProvider().verifyEventsExist(["mapped-event-id"]))
+      .rejects.toThrow();
+  });
+
+  it("does not report an id as missing on a server error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(graphError(500, "InternalServerError"))),
+    );
+
+    await expect(createProvider().verifyEventsExist(["mapped-event-id"]))
+      .rejects.toThrow();
+  });
+
+  it("does not report an id as missing when the request fails at the transport", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new TypeError("fetch failed"))),
+    );
+
+    await expect(createProvider().verifyEventsExist(["mapped-event-id"]))
+      .rejects.toThrow();
+  });
+
+  it("does not report a batch of ids as missing when the service is unavailable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(graphError(503, "ServiceUnavailable", { "Retry-After": "0" }))),
+    );
+
+    await expect(createProvider().verifyEventsExist(["first-id", "second-id"]))
+      .rejects.toThrow();
+  });
+
+  it("reports an id as missing only when the destination definitively says not found", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(new Response(null, { status: 404 }))));
+
+    await expect(createProvider().verifyEventsExist(["deleted-event-id"])).resolves.toEqual([]);
+  });
+});

--- a/packages/data-schemas/src/index.ts
+++ b/packages/data-schemas/src/index.ts
@@ -159,6 +159,24 @@ const microsoftUserInfoSchema = type({
 });
 type MicrosoftUserInfo = typeof microsoftUserInfoSchema.infer;
 
+const outlookRecurrenceSchema = type({
+  pattern: {
+    type: "string",
+    interval: "number",
+    "daysOfWeek?": "string[]",
+    "dayOfMonth?": "number",
+    "index?": "string",
+    "month?": "number",
+    "firstDayOfWeek?": "string",
+  },
+  range: {
+    type: "string",
+    startDate: "string",
+    "endDate?": "string",
+    "numberOfOccurrences?": "number",
+  },
+});
+
 const outlookEventSchema = type({
   "@removed?": { "reason?": "'deleted' | 'changed'" },
   "body?": type({ "content?": "string", "contentType?": "string" }).or(type("null")),
@@ -173,6 +191,7 @@ const outlookEventSchema = type({
   "location?": { "displayName?": "string" },
   "originalEndTimeZone?": "string",
   "originalStartTimeZone?": "string",
+  "recurrence?": outlookRecurrenceSchema.or(type("null")),
   "showAs?": "string",
   "start?": { "dateTime?": "string", "timeZone?": "string" },
   "subject?": "string | null",

--- a/packages/sync/src/sync-user.ts
+++ b/packages/sync/src/sync-user.ts
@@ -447,6 +447,13 @@ const TARGETED_DESTINATION_READ_LIMIT = 25;
 interface TargetedDestinationReadProvider {
   getRemoteEventsByIds?: (ids: string[]) => Promise<RemoteEvent[]>;
   listRemoteEvents: (options: ListRemoteEventsOptions) => Promise<RemoteEvent[]>;
+  /**
+   * Direct by-id existence check, independent of any time window. The windowed
+   * listRemoteEvents pass below can miss an already-mapped event it should still find (e.g. a
+   * recurring series whose own start/dateTime is its first, possibly long-past, occurrence) -
+   * that must not read as "gone", or the mapping is deleted and re-created every cycle.
+   */
+  verifyEventsExist?: (deleteIds: string[]) => Promise<RemoteEvent[]>;
 }
 
 interface DestinationRemoteReadContext {
@@ -491,6 +498,32 @@ const planTargetedDestinationRead = (
   return { deleteIdentifiers: [...deleteIdentifiers], mappingIds };
 };
 
+/*
+ * The windowed listing above is a best-effort, bounded discovery pass (used to find orphaned
+ * keeper events not covered by any mapping) - it is not the source of truth for whether an
+ * *already-mapped* event still exists. A mapping whose destination uid didn't turn up in that
+ * pass gets one more, authoritative check before it is treated as gone: a direct by-id lookup,
+ * for providers that expose one.
+ */
+const withVerifiedUnconfirmedMappings = async (
+  provider: TargetedDestinationReadProvider,
+  existingMappings: EventMapping[],
+  remoteEvents: RemoteEvent[],
+): Promise<RemoteEvent[]> => {
+  if (!provider.verifyEventsExist) {
+    return remoteEvents;
+  }
+  const remoteUids = new Set(remoteEvents.map((event) => event.uid));
+  const unconfirmedDeleteIds = existingMappings
+    .filter((mapping) => !remoteUids.has(mapping.destinationEventUid))
+    .map((mapping) => mapping.deleteIdentifier);
+  if (unconfirmedDeleteIds.length === 0) {
+    return remoteEvents;
+  }
+  const verifiedEvents = await provider.verifyEventsExist(unconfirmedDeleteIds);
+  return [...remoteEvents, ...verifiedEvents];
+};
+
 const readDestinationRemoteEvents = async (
   context: DestinationRemoteReadContext,
 ): Promise<DestinationRemoteRead> => {
@@ -501,12 +534,17 @@ const readDestinationRemoteEvents = async (
    * single page, keeps the windowed listing and its full authority.
    */
   if (!lookUpByIds || plan.deleteIdentifiers.length > TARGETED_DESTINATION_READ_LIMIT) {
+    const remoteEvents = await context.provider.listRemoteEvents({
+      timeMax: context.requestedWindow.timeMax,
+      timeMin: context.requestedWindow.timeMin,
+    });
     return {
       authoritativeMappingIds: null,
-      remoteEvents: await context.provider.listRemoteEvents({
-        timeMax: context.requestedWindow.timeMax,
-        timeMin: context.requestedWindow.timeMin,
-      }),
+      remoteEvents: await withVerifiedUnconfirmedMappings(
+        context.provider,
+        context.existingMappings,
+        remoteEvents,
+      ),
     };
   }
   return {

--- a/packages/sync/src/sync-user.ts
+++ b/packages/sync/src/sync-user.ts
@@ -12,6 +12,7 @@ import {
   withSourceIngestLocks,
   getConfigurableSyncWindow,
   intersectSyncWindows,
+  overlapsTimeWindow,
 } from "@keeper.sh/calendar";
 import { OUTLOOK_REQUESTS_PER_MINUTE } from "@keeper.sh/constants";
 import { syncRangeSchema } from "@keeper.sh/data-schemas";
@@ -444,6 +445,8 @@ const createDestinationAttemptWideEventFields = (
  */
 const TARGETED_DESTINATION_READ_LIMIT = 25;
 
+const DESTINATION_VERIFICATION_LIMIT = 200;
+
 interface TargetedDestinationReadProvider {
   getRemoteEventsByIds?: (ids: string[]) => Promise<RemoteEvent[]>;
   listRemoteEvents: (options: ListRemoteEventsOptions) => Promise<RemoteEvent[]>;
@@ -509,14 +512,19 @@ const withVerifiedUnconfirmedMappings = async (
   provider: TargetedDestinationReadProvider,
   existingMappings: EventMapping[],
   remoteEvents: RemoteEvent[],
+  requestedWindow: SyncWindow,
 ): Promise<RemoteEvent[]> => {
   if (!provider.verifyEventsExist) {
     return remoteEvents;
   }
   const remoteUids = new Set(remoteEvents.map((event) => event.uid));
   const unconfirmedDeleteIds = existingMappings
-    .filter((mapping) => !remoteUids.has(mapping.destinationEventUid))
-    .map((mapping) => mapping.deleteIdentifier);
+    .filter((mapping) =>
+      !remoteUids.has(mapping.destinationEventUid)
+      && overlapsTimeWindow(mapping, requestedWindow.timeMin, requestedWindow.timeMax))
+    .map((mapping) => mapping.deleteIdentifier)
+    .toSorted((first, second) => first.localeCompare(second))
+    .slice(0, DESTINATION_VERIFICATION_LIMIT);
   if (unconfirmedDeleteIds.length === 0) {
     return remoteEvents;
   }
@@ -544,6 +552,7 @@ const readDestinationRemoteEvents = async (
         context.provider,
         context.existingMappings,
         remoteEvents,
+        context.requestedWindow,
       ),
     };
   }

--- a/packages/sync/tests/verification-is-bounded-and-windowed.test.ts
+++ b/packages/sync/tests/verification-is-bounded-and-windowed.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import type {
+  EventMapping,
+  ListRemoteEventsOptions,
+  MaterializedSyncableEvent,
+  RemoteEvent,
+} from "@keeper.sh/calendar";
+import { readDestinationRemoteEvents } from "../src/sync-user";
+
+const SOURCE_CALENDAR_ID = "source-1";
+const DESTINATION_CALENDAR_ID = "destination-1";
+
+const REQUESTED_WINDOW = {
+  timeMax: new Date("2026-09-01T00:00:00.000Z"),
+  timeMin: new Date("2026-08-01T00:00:00.000Z"),
+};
+
+const IN_WINDOW_MAPPING_COUNT = 800;
+const HISTORICAL_MAPPING_COUNT = 3000;
+const VERIFICATION_BUDGET = 200;
+
+const createInWindowStart = (index: number): Date =>
+  new Date(REQUESTED_WINDOW.timeMin.getTime() + (index % 27 + 1) * 60 * 60 * 1000);
+
+const createHistoricalStart = (index: number): Date =>
+  new Date(Date.UTC(2019, 0, 1) + index * 60 * 60 * 1000);
+
+const withHalfHour = (start: Date): Date => new Date(start.getTime() + 30 * 60 * 1000);
+
+const createLocalEvent = (index: number): MaterializedSyncableEvent => ({
+  calendarId: SOURCE_CALENDAR_ID,
+  calendarName: "Source",
+  calendarUrl: null,
+  endTime: withHalfHour(createInWindowStart(index)),
+  eventStateId: `event-state-${index}`,
+  id: `sync-event-${index}`,
+  sourceEventUid: `source-uid-${index}`,
+  startTime: createInWindowStart(index),
+  summary: `Event ${index}`,
+});
+
+const createInWindowMapping = (index: number): EventMapping => ({
+  calendarId: DESTINATION_CALENDAR_ID,
+  deleteIdentifier: `in-window-event-${index}`,
+  destinationEventUid: `in-window-uid-${index}`,
+  endTime: withHalfHour(createInWindowStart(index)),
+  eventStateId: `event-state-${index}`,
+  id: `in-window-mapping-${index}`,
+  sourceCalendarId: SOURCE_CALENDAR_ID,
+  startTime: createInWindowStart(index),
+  syncEventHash: "hash-recorded-at-last-push",
+  syncEventId: `sync-event-${index}`,
+});
+
+const createHistoricalMapping = (index: number): EventMapping => ({
+  calendarId: DESTINATION_CALENDAR_ID,
+  deleteIdentifier: `historical-event-${index}`,
+  destinationEventUid: `historical-uid-${index}`,
+  endTime: withHalfHour(createHistoricalStart(index)),
+  eventStateId: `historical-event-state-${index}`,
+  id: `historical-mapping-${index}`,
+  sourceCalendarId: SOURCE_CALENDAR_ID,
+  startTime: createHistoricalStart(index),
+  syncEventHash: "hash-recorded-at-last-push",
+  syncEventId: `historical-sync-event-${index}`,
+});
+
+const createProviderDouble = () => {
+  const verifiedIds: string[] = [];
+  const listedWindows: ListRemoteEventsOptions[] = [];
+  return {
+    getRemoteEventsByIds: (): Promise<RemoteEvent[]> => Promise.resolve([]),
+    listedWindows,
+    listRemoteEvents: (options: ListRemoteEventsOptions): Promise<RemoteEvent[]> => {
+      listedWindows.push(options);
+      return Promise.resolve([]);
+    },
+    verifiedIds,
+    verifyEventsExist: (deleteIds: string[]): Promise<RemoteEvent[]> => {
+      verifiedIds.push(...deleteIds);
+      return Promise.resolve([]);
+    },
+  };
+};
+
+describe("verification is bounded and windowed", () => {
+  const localEvents = Array.from(
+    { length: IN_WINDOW_MAPPING_COUNT },
+    (unused, index) => createLocalEvent(index),
+  );
+  const inWindowMappings = Array.from(
+    { length: IN_WINDOW_MAPPING_COUNT },
+    (unused, index) => createInWindowMapping(index),
+  );
+  const historicalMappings = Array.from(
+    { length: HISTORICAL_MAPPING_COUNT },
+    (unused, index) => createHistoricalMapping(index),
+  );
+
+  it("never verifies mappings the pass removes for falling outside the window", async () => {
+    const provider = createProviderDouble();
+
+    await readDestinationRemoteEvents({
+      existingMappings: [...inWindowMappings, ...historicalMappings],
+      localEvents,
+      provider,
+      requestedWindow: REQUESTED_WINDOW,
+    });
+
+    expect(provider.listedWindows).toEqual([REQUESTED_WINDOW]);
+    expect(provider.verifiedIds.filter((id) => id.startsWith("historical-event-"))).toEqual([]);
+  });
+
+  it("verifies the same mappings whatever order the rows arrive in", async () => {
+    const shuffled = [...inWindowMappings, ...historicalMappings].toReversed();
+
+    const firstPass = createProviderDouble();
+    await readDestinationRemoteEvents({
+      existingMappings: [...inWindowMappings, ...historicalMappings],
+      localEvents,
+      provider: firstPass,
+      requestedWindow: REQUESTED_WINDOW,
+    });
+
+    const secondPass = createProviderDouble();
+    await readDestinationRemoteEvents({
+      existingMappings: shuffled,
+      localEvents,
+      provider: secondPass,
+      requestedWindow: REQUESTED_WINDOW,
+    });
+
+    expect(secondPass.verifiedIds).toEqual(firstPass.verifiedIds);
+  });
+
+  it("bounds how many mappings one pass verifies", async () => {
+    const provider = createProviderDouble();
+
+    await readDestinationRemoteEvents({
+      existingMappings: [...inWindowMappings, ...historicalMappings],
+      localEvents,
+      provider,
+      requestedWindow: REQUESTED_WINDOW,
+    });
+
+    expect(provider.verifiedIds.length).toBeGreaterThan(0);
+    expect(provider.verifiedIds.length).toBeLessThanOrEqual(VERIFICATION_BUDGET);
+  });
+});


### PR DESCRIPTION
## Summary

`serializeOutlookEvent` never included a `recurrence` field, so recurring source events (e.g. a biweekly Monday evening series) were pushed to Outlook destinations as a single one-time event pinned to the series' original start time — often already in the past and never visible again. Google and CalDAV destinations already propagate `recurrenceRule`; Outlook did not.

Adds `buildOutlookRecurrence` to translate the internal RRULE-like `recurrenceRule` into Microsoft Graph's pattern/range recurrence shape, and extends `outlookEventSchema` with the `recurrence` field. Sub-daily frequencies (SECONDLY/MINUTELY/HOURLY), which Graph has no equivalent for, fall back to a single non-recurring push instead of being dropped.

With recurrence now attached, a second bug surfaced immediately in production: `listRemoteEvents` filtered by a lookback window, but a recurring series' own start is always its first (possibly long-past) occurrence, never any of its future ones. Any pushed recurring series whose original start predates the lookback window was invisible to this existence check on every subsequent sync, got marked stale, and was deleted and recreated from scratch every single cycle.

The fix is a `CalendarSyncProvider.verifyEventsExist(deleteIds)` capability: a direct by-id GET, independent of any time window, category inheritance on recurring instances, or pagination. `listRemoteEvents` stays a bounded, best-effort discovery pass used only to find orphaned keeper events with no mapping — a reasonable place to accept a rare miss. But it is no longer the source of truth for whether an *already-mapped* event still exists: before treating a mapping as gone, the destination is asked directly by id for anything the discovery pass didn't surface.

## Test plan
- [ ] Existing tests pass
- [ ] Push a biweekly recurring event to an Outlook destination: recurrence is visible and correct in Outlook
- [ ] Push a recurring series whose original start is well outside the lookback window, then re-sync: the mapping survives instead of being deleted and recreated