### PR TITLE
feat(web): add calendar month and week views

### DIFF
--- a/applications/web/src/features/dashboard/components/calendar-frame.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-frame.tsx
@@ -7,25 +7,28 @@ interface CalendarFrameProps {
    * inside the header card, so they stay put while the grid scrolls. No
    * separator is drawn between the two; the slot owns its own lines. */
   columnHeader: ReactNode;
-  /** Caps the grid card's content height (px). The card still shrinks to fit
-   * short viewports, but stops growing past this on tall ones — so a grid with
-   * a natural height (24 hours) is not left floating in empty card. */
+  /** Caps the grid's height (px). It still shrinks to fit short viewports,
+   * but stops growing past this on tall ones — so a grid with a natural
+   * height (24 hours) does not stretch past its content. */
   gridMaxHeight?: CSSProperties["maxHeight"];
-  /** The grid itself; fills the second card. */
+  /** The grid itself; fills the space beneath the header card. */
   children: ReactNode;
 }
 
 /**
  * The calendar pane's chrome: a header card (toolbar over column labels)
- * stacked on a grid card, matching the sidebar's card rhythm. The grid card
- * carries `overflow-hidden` + `isolate` so a scrolling child is clipped to its
- * rounded corners, and `min-h-0 flex-1` so that child can size itself.
+ * stacked on a bare grid. The grid has no card of its own — like the
+ * sidebar's sync status and event graph, it sits straight on the page
+ * background, and each view fades its own rules out toward the edges so the
+ * grid dissolves into the page instead of stopping at a border. The wrapper
+ * carries `overflow-hidden` so a scrolling child is clipped to the pane, and
+ * `min-h-0 flex-1` so that child can size itself.
  *
  * Each view renders its own frame, so switching views swaps the whole thing.
- * The cards and the header's rows carry `view-transition-name`s so that, when
- * the switch runs inside a view transition (see `CalendarView`), the header
- * card's height morphs between the two column headers and the grid card
- * slides to meet it instead of both snapping.
+ * The header card, its rows and the grid carry `view-transition-name`s so
+ * that, when the switch runs inside a view transition (see `CalendarView`),
+ * the header card's height morphs between the two column headers and the
+ * grid slides to meet it instead of both snapping.
  */
 export function CalendarFrame({
   toolbar,
@@ -47,9 +50,8 @@ export function CalendarFrame({
         </div>
         <div style={{ viewTransitionName: "calendar-column-header" }}>{columnHeader}</div>
       </header>
-      {/* `box-content` so `gridMaxHeight` measures the content, not the border. */}
       <div
-        className="box-content flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs isolate"
+        className="flex min-h-0 flex-1 flex-col overflow-hidden"
         style={{ maxHeight: gridMaxHeight, viewTransitionName: "calendar-grid" }}
       >
         {children}

--- a/applications/web/src/features/dashboard/components/calendar-frame.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-frame.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+interface CalendarFrameProps {
+  /** Title, view switcher and paging controls; the header card's top row. */
+  toolbar: ReactNode;
+  /** The column labels (weekday / date row) that sit beneath the toolbar,
+   * inside the header card, so they stay put while the grid scrolls. */
+  columnHeader: ReactNode;
+  /** The grid itself; fills the second card. */
+  children: ReactNode;
+}
+
+/**
+ * The calendar pane's chrome: a header card (toolbar over column labels)
+ * stacked on a grid card, matching the sidebar's card rhythm. The grid card
+ * carries `overflow-hidden` + `isolate` so a scrolling child is clipped to its
+ * rounded corners, and `min-h-0 flex-1` so that child can size itself.
+ */
+export function CalendarFrame({ toolbar, columnHeader, children }: CalendarFrameProps) {
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col gap-3">
+      <header className="flex shrink-0 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs">
+        <div className="flex items-center justify-between gap-3 px-4 py-3">{toolbar}</div>
+        <div className="border-t border-border-elevated">{columnHeader}</div>
+      </header>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs isolate">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/applications/web/src/features/dashboard/components/calendar-frame.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-frame.tsx
@@ -28,7 +28,7 @@ export function CalendarFrame({
   children,
 }: CalendarFrameProps) {
   return (
-    <div className="flex h-full min-h-0 w-full flex-col gap-3">
+    <div className="flex h-full min-h-0 w-full flex-col gap-1.5">
       <header className="flex shrink-0 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs">
         <div className="flex items-center justify-between gap-3 px-4 py-3">{toolbar}</div>
         {columnHeader}

--- a/applications/web/src/features/dashboard/components/calendar-frame.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-frame.tsx
@@ -20,6 +20,12 @@ interface CalendarFrameProps {
  * stacked on a grid card, matching the sidebar's card rhythm. The grid card
  * carries `overflow-hidden` + `isolate` so a scrolling child is clipped to its
  * rounded corners, and `min-h-0 flex-1` so that child can size itself.
+ *
+ * Each view renders its own frame, so switching views swaps the whole thing.
+ * The cards and the header's rows carry `view-transition-name`s so that, when
+ * the switch runs inside a view transition (see `CalendarView`), the header
+ * card's height morphs between the two column headers and the grid card
+ * slides to meet it instead of both snapping.
  */
 export function CalendarFrame({
   toolbar,
@@ -29,14 +35,22 @@ export function CalendarFrame({
 }: CalendarFrameProps) {
   return (
     <div className="flex h-full min-h-0 w-full flex-col gap-1.5">
-      <header className="flex shrink-0 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs">
-        <div className="flex items-center justify-between gap-3 px-4 py-3">{toolbar}</div>
-        {columnHeader}
+      <header
+        className="flex shrink-0 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs"
+        style={{ viewTransitionName: "calendar-header" }}
+      >
+        <div
+          className="flex items-center justify-between gap-3 px-4 py-3"
+          style={{ viewTransitionName: "calendar-toolbar" }}
+        >
+          {toolbar}
+        </div>
+        <div style={{ viewTransitionName: "calendar-column-header" }}>{columnHeader}</div>
       </header>
       {/* `box-content` so `gridMaxHeight` measures the content, not the border. */}
       <div
         className="box-content flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs isolate"
-        style={{ maxHeight: gridMaxHeight }}
+        style={{ maxHeight: gridMaxHeight, viewTransitionName: "calendar-grid" }}
       >
         {children}
       </div>

--- a/applications/web/src/features/dashboard/components/calendar-frame.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-frame.tsx
@@ -50,8 +50,10 @@ export function CalendarFrame({
         </div>
         <div style={{ viewTransitionName: "calendar-column-header" }}>{columnHeader}</div>
       </header>
+      {/* `mx-px` insets the grid by the header card's border, so its columns
+          share the column header's origin and width and the two line up. */}
       <div
-        className="flex min-h-0 flex-1 flex-col overflow-hidden"
+        className="mx-px flex min-h-0 flex-1 flex-col overflow-hidden"
         style={{ maxHeight: gridMaxHeight, viewTransitionName: "calendar-grid" }}
       >
         {children}

--- a/applications/web/src/features/dashboard/components/calendar-frame.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-frame.tsx
@@ -4,7 +4,8 @@ interface CalendarFrameProps {
   /** Title, view switcher and paging controls; the header card's top row. */
   toolbar: ReactNode;
   /** The column labels (weekday / date row) that sit beneath the toolbar,
-   * inside the header card, so they stay put while the grid scrolls. */
+   * inside the header card, so they stay put while the grid scrolls. No
+   * separator is drawn between the two; the slot owns its own lines. */
   columnHeader: ReactNode;
   /** The grid itself; fills the second card. */
   children: ReactNode;
@@ -21,7 +22,7 @@ export function CalendarFrame({ toolbar, columnHeader, children }: CalendarFrame
     <div className="flex h-full min-h-0 w-full flex-col gap-3">
       <header className="flex shrink-0 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs">
         <div className="flex items-center justify-between gap-3 px-4 py-3">{toolbar}</div>
-        <div className="border-t border-border-elevated">{columnHeader}</div>
+        {columnHeader}
       </header>
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs isolate">
         {children}

--- a/applications/web/src/features/dashboard/components/calendar-frame.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-frame.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 interface CalendarFrameProps {
   /** Title, view switcher and paging controls; the header card's top row. */
@@ -7,6 +7,10 @@ interface CalendarFrameProps {
    * inside the header card, so they stay put while the grid scrolls. No
    * separator is drawn between the two; the slot owns its own lines. */
   columnHeader: ReactNode;
+  /** Caps the grid card's content height (px). The card still shrinks to fit
+   * short viewports, but stops growing past this on tall ones — so a grid with
+   * a natural height (24 hours) is not left floating in empty card. */
+  gridMaxHeight?: CSSProperties["maxHeight"];
   /** The grid itself; fills the second card. */
   children: ReactNode;
 }
@@ -17,14 +21,23 @@ interface CalendarFrameProps {
  * carries `overflow-hidden` + `isolate` so a scrolling child is clipped to its
  * rounded corners, and `min-h-0 flex-1` so that child can size itself.
  */
-export function CalendarFrame({ toolbar, columnHeader, children }: CalendarFrameProps) {
+export function CalendarFrame({
+  toolbar,
+  columnHeader,
+  gridMaxHeight,
+  children,
+}: CalendarFrameProps) {
   return (
     <div className="flex h-full min-h-0 w-full flex-col gap-3">
       <header className="flex shrink-0 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs">
         <div className="flex items-center justify-between gap-3 px-4 py-3">{toolbar}</div>
         {columnHeader}
       </header>
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs isolate">
+      {/* `box-content` so `gridMaxHeight` measures the content, not the border. */}
+      <div
+        className="box-content flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs isolate"
+        style={{ maxHeight: gridMaxHeight }}
+      >
         {children}
       </div>
     </div>

--- a/applications/web/src/features/dashboard/components/calendar-frame.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-frame.tsx
@@ -1,35 +1,12 @@
 import type { CSSProperties, ReactNode } from "react";
 
 interface CalendarFrameProps {
-  /** Title, view switcher and paging controls; the header card's top row. */
   toolbar: ReactNode;
-  /** The column labels (weekday / date row) that sit beneath the toolbar,
-   * inside the header card, so they stay put while the grid scrolls. No
-   * separator is drawn between the two; the slot owns its own lines. */
   columnHeader: ReactNode;
-  /** Caps the grid's height (px). It still shrinks to fit short viewports,
-   * but stops growing past this on tall ones — so a grid with a natural
-   * height (24 hours) does not stretch past its content. */
   gridMaxHeight?: CSSProperties["maxHeight"];
-  /** The grid itself; fills the space beneath the header card. */
   children: ReactNode;
 }
 
-/**
- * The calendar pane's chrome: a header card (toolbar over column labels)
- * stacked on a bare grid. The grid has no card of its own — like the
- * sidebar's sync status and event graph, it sits straight on the page
- * background, and each view fades its own rules out toward the edges so the
- * grid dissolves into the page instead of stopping at a border. The wrapper
- * carries `overflow-hidden` so a scrolling child is clipped to the pane, and
- * `min-h-0 flex-1` so that child can size itself.
- *
- * Each view renders its own frame, so switching views swaps the whole thing.
- * The header card, its rows and the grid carry `view-transition-name`s so
- * that, when the switch runs inside a view transition (see `CalendarView`),
- * the header card's height morphs between the two column headers and the
- * grid slides to meet it instead of both snapping.
- */
 export function CalendarFrame({
   toolbar,
   columnHeader,
@@ -50,8 +27,7 @@ export function CalendarFrame({
         </div>
         <div style={{ viewTransitionName: "calendar-column-header" }}>{columnHeader}</div>
       </header>
-      {/* `mx-px` insets the grid by the header card's border, so its columns
-          share the column header's origin and width and the two line up. */}
+      {/* `mx-px` insets the grid by the header card's border so their columns line up. */}
       <div
         className="mx-px flex min-h-0 flex-1 flex-col overflow-hidden"
         style={{ maxHeight: gridMaxHeight, viewTransitionName: "calendar-grid" }}

--- a/applications/web/src/features/dashboard/components/calendar-helpers.ts
+++ b/applications/web/src/features/dashboard/components/calendar-helpers.ts
@@ -79,24 +79,25 @@ export function formatMonthTitle(anchor: Date): string {
   return anchor.toLocaleDateString("en-US", { month: "long", year: "numeric" });
 }
 
-/** Toolbar title for a week, e.g. "Aug 17 – 23, 2026" or, across a month/year
- * boundary, "Aug 31 – Sep 6, 2026". */
+/** Toolbar title for a week, e.g. "Aug 16 – 22, 2026", "Aug 31 – Sep 6, 2026"
+ * across a month boundary, or "Dec 28, 2025 – Jan 3, 2026" across a year.
+ *
+ * Numeric day/year parts are composed directly rather than via
+ * `toLocaleDateString`, because asking Intl for a day+year format with no month
+ * ("Aug 16 – 22, 2026") renders an unsupported fallback like "2026 (day: 22)". */
 export function formatWeekTitle(anchor: Date): string {
   const start = startOfWeek(anchor);
   const end = addDays(start, 6);
-  const sameMonth = isSameMonth(start, end);
-  const sameYear = start.getFullYear() === end.getFullYear();
-  const startText = start.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: sameYear ? undefined : "numeric",
-  });
-  const endText = end.toLocaleDateString("en-US", {
-    month: sameMonth ? undefined : "short",
-    day: "numeric",
-    year: "numeric",
-  });
-  return `${startText} – ${endText}`;
+  const startMonth = start.toLocaleDateString("en-US", { month: "short" });
+  const endMonth = end.toLocaleDateString("en-US", { month: "short" });
+
+  if (isSameMonth(start, end)) {
+    return `${startMonth} ${start.getDate()} – ${end.getDate()}, ${end.getFullYear()}`;
+  }
+  if (start.getFullYear() === end.getFullYear()) {
+    return `${startMonth} ${start.getDate()} – ${endMonth} ${end.getDate()}, ${end.getFullYear()}`;
+  }
+  return `${startMonth} ${start.getDate()}, ${start.getFullYear()} – ${endMonth} ${end.getDate()}, ${end.getFullYear()}`;
 }
 
 /** Hours of the day (0–23) for the week-view time gutter and gridlines. */

--- a/applications/web/src/features/dashboard/components/calendar-helpers.ts
+++ b/applications/web/src/features/dashboard/components/calendar-helpers.ts
@@ -21,6 +21,17 @@ export function addMonths(date: Date, months: number): Date {
   return new Date(date.getFullYear(), date.getMonth() + months, date.getDate());
 }
 
+/** `date` shifted by `days`, at midnight. */
+export function addDays(date: Date, days: number): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + days);
+}
+
+/** Midnight on the first `WEEK_STARTS_ON` weekday on or before `date`. */
+export function startOfWeek(date: Date): Date {
+  const offset = (date.getDay() - WEEK_STARTS_ON + 7) % 7;
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() - offset);
+}
+
 /** Whether two dates fall in the same calendar month and year. */
 export function isSameMonth(a: Date, b: Date): boolean {
   return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
@@ -57,7 +68,44 @@ export const WEEKDAY_LABELS = Array.from({ length: 7 }, (_, index) => {
   return day.toLocaleDateString("en-US", { weekday: "short" });
 });
 
+/** The 7 days of the week containing `anchor`, from `WEEK_STARTS_ON`. */
+export function getWeekDays(anchor: Date): Date[] {
+  const weekStart = startOfWeek(anchor);
+  return Array.from({ length: 7 }, (_, index) => addDays(weekStart, index));
+}
+
 /** Toolbar title for a month, e.g. "August 2026". */
 export function formatMonthTitle(anchor: Date): string {
   return anchor.toLocaleDateString("en-US", { month: "long", year: "numeric" });
+}
+
+/** Toolbar title for a week, e.g. "Aug 17 – 23, 2026" or, across a month/year
+ * boundary, "Aug 31 – Sep 6, 2026". */
+export function formatWeekTitle(anchor: Date): string {
+  const start = startOfWeek(anchor);
+  const end = addDays(start, 6);
+  const sameMonth = isSameMonth(start, end);
+  const sameYear = start.getFullYear() === end.getFullYear();
+  const startText = start.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: sameYear ? undefined : "numeric",
+  });
+  const endText = end.toLocaleDateString("en-US", {
+    month: sameMonth ? undefined : "short",
+    day: "numeric",
+    year: "numeric",
+  });
+  return `${startText} – ${endText}`;
+}
+
+/** Hours of the day (0–23) for the week-view time gutter and gridlines. */
+export const HOURS = Array.from({ length: 24 }, (_, hour) => hour);
+
+/** Short hour label for the gutter, e.g. "1am", "12pm". */
+export function formatHourLabel(hour: number): string {
+  return new Date(2023, 0, 1, hour)
+    .toLocaleTimeString("en-US", { hour: "numeric" })
+    .replace(" ", "")
+    .toLowerCase();
 }

--- a/applications/web/src/features/dashboard/components/calendar-helpers.ts
+++ b/applications/web/src/features/dashboard/components/calendar-helpers.ts
@@ -10,6 +10,14 @@ export const WEEK_STARTS_ON = 0;
 /** Cells in a fixed 6×7 month grid. */
 const GRID_CELLS = 42;
 
+/** Day columns shown at once in the week view. */
+export const WEEK_VIEW_DAYS = 7;
+
+/** Midnight on `date`'s day. */
+export function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
 /** Midnight on the first day of `date`'s month. */
 export function startOfMonth(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), 1);
@@ -24,6 +32,13 @@ export function addMonths(date: Date, months: number): Date {
 /** `date` shifted by `days`, at midnight. */
 export function addDays(date: Date, days: number): Date {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate() + days);
+}
+
+/** First day of the week view's rolling range when it is centred on `anchor`:
+ * `anchor` sits in the middle column, with the same number of days either
+ * side (3 for a 7-day view). Midnight. */
+export function startOfVisibleWeek(anchor: Date): Date {
+  return addDays(anchor, -Math.floor(WEEK_VIEW_DAYS / 2));
 }
 
 /** Midnight on the first `WEEK_STARTS_ON` weekday on or before `date`. */
@@ -79,15 +94,16 @@ export function formatMonthTitle(anchor: Date): string {
   return anchor.toLocaleDateString("en-US", { month: "long", year: "numeric" });
 }
 
-/** Toolbar title for a week, e.g. "Aug 16 – 22, 2026", "Aug 31 – Sep 6, 2026"
- * across a month boundary, or "Dec 28, 2025 – Jan 3, 2026" across a year.
+/** Toolbar title for the week view's rolling range centred on `anchor`, e.g.
+ * "Aug 19 – 25, 2026", "Aug 29 – Sep 4, 2026" across a month boundary, or
+ * "Dec 29, 2025 – Jan 4, 2026" across a year.
  *
  * Numeric day/year parts are composed directly rather than via
  * `toLocaleDateString`, because asking Intl for a day+year format with no month
- * ("Aug 16 – 22, 2026") renders an unsupported fallback like "2026 (day: 22)". */
+ * ("Aug 19 – 25, 2026") renders an unsupported fallback like "2026 (day: 25)". */
 export function formatWeekTitle(anchor: Date): string {
-  const start = startOfWeek(anchor);
-  const end = addDays(start, 6);
+  const start = startOfVisibleWeek(anchor);
+  const end = addDays(start, WEEK_VIEW_DAYS - 1);
   const startMonth = start.toLocaleDateString("en-US", { month: "short" });
   const endMonth = end.toLocaleDateString("en-US", { month: "short" });
 

--- a/applications/web/src/features/dashboard/components/calendar-helpers.ts
+++ b/applications/web/src/features/dashboard/components/calendar-helpers.ts
@@ -1,0 +1,63 @@
+/**
+ * Native-`Date` helpers for the month calendar grid. Keeper does not depend on
+ * `date-fns`, so the grid math is done with the standard `Date`/`Intl` APIs,
+ * matching the day-offset approach already used in `event-graph.tsx`.
+ */
+
+/** First column of the week. 0 = Sunday, 1 = Monday. */
+export const WEEK_STARTS_ON = 0;
+
+/** Cells in a fixed 6×7 month grid. */
+const GRID_CELLS = 42;
+
+/** Midnight on the first day of `date`'s month. */
+export function startOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+/** `date` shifted by `months`, clamped to the same day-of-month semantics as
+ * the `Date` constructor (day 1 keeps callers on solid ground). */
+export function addMonths(date: Date, months: number): Date {
+  return new Date(date.getFullYear(), date.getMonth() + months, date.getDate());
+}
+
+/** Whether two dates fall in the same calendar month and year. */
+export function isSameMonth(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
+}
+
+/** Whether two dates fall on the same calendar day. */
+export function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+/** The 42 days of the 6×7 grid for `anchor`'s month, starting from the first
+ * `WEEK_STARTS_ON` weekday on or before the month's first day. */
+export function getMonthGridDays(anchor: Date): Date[] {
+  const monthStart = startOfMonth(anchor);
+  const leadingDays = (monthStart.getDay() - WEEK_STARTS_ON + 7) % 7;
+  const gridStart = new Date(
+    monthStart.getFullYear(),
+    monthStart.getMonth(),
+    monthStart.getDate() - leadingDays,
+  );
+  return Array.from({ length: GRID_CELLS }, (_, index) => {
+    return new Date(gridStart.getFullYear(), gridStart.getMonth(), gridStart.getDate() + index);
+  });
+}
+
+/** Short weekday labels (e.g. "Sun"…"Sat") ordered from `WEEK_STARTS_ON`. */
+export const WEEKDAY_LABELS = Array.from({ length: 7 }, (_, index) => {
+  // 2023-01-01 is a Sunday, so it anchors the label sequence.
+  const day = new Date(2023, 0, 1 + WEEK_STARTS_ON + index);
+  return day.toLocaleDateString("en-US", { weekday: "short" });
+});
+
+/** Toolbar title for a month, e.g. "August 2026". */
+export function formatMonthTitle(anchor: Date): string {
+  return anchor.toLocaleDateString("en-US", { month: "long", year: "numeric" });
+}

--- a/applications/web/src/features/dashboard/components/calendar-helpers.ts
+++ b/applications/web/src/features/dashboard/components/calendar-helpers.ts
@@ -1,52 +1,35 @@
-/**
- * Native-`Date` helpers for the month calendar grid. Keeper does not depend on
- * `date-fns`, so the grid math is done with the standard `Date`/`Intl` APIs,
- * matching the day-offset approach already used in `event-graph.tsx`.
- */
-
-/** First column of the week. 0 = Sunday, 1 = Monday. */
+/** 0 = Sunday, as `Date#getDay`. */
 export const WEEK_STARTS_ON = 0;
 
-/** Cells in a fixed 6×7 month grid. */
 const GRID_CELLS = 42;
 
-/** Day columns shown at once in the week view. */
 export const WEEK_VIEW_DAYS = 7;
 
-/** Midnight on `date`'s day. */
 export function startOfDay(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
 
-/** Midnight on the first day of `date`'s month. */
 export function startOfMonth(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), 1);
 }
 
-/** `date` shifted by `months`, clamped to the same day-of-month semantics as
- * the `Date` constructor (day 1 keeps callers on solid ground). */
 export function addMonths(date: Date, months: number): Date {
   return new Date(date.getFullYear(), date.getMonth() + months, date.getDate());
 }
 
-/** `date` shifted by `days`, at midnight. */
 export function addDays(date: Date, days: number): Date {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate() + days);
 }
 
-/** First day of the week view's rolling range when it is centred on `anchor`:
- * `anchor` sits in the middle column, with the same number of days either
- * side (3 for a 7-day view). Midnight. */
+/** First day of the week view's rolling range centred on `anchor`. */
 export function startOfVisibleWeek(anchor: Date): Date {
   return addDays(anchor, -Math.floor(WEEK_VIEW_DAYS / 2));
 }
 
-/** Whether two dates fall in the same calendar month and year. */
 export function isSameMonth(a: Date, b: Date): boolean {
   return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
 }
 
-/** Whether two dates fall on the same calendar day. */
 export function isSameDay(a: Date, b: Date): boolean {
   return (
     a.getFullYear() === b.getFullYear() &&
@@ -55,8 +38,6 @@ export function isSameDay(a: Date, b: Date): boolean {
   );
 }
 
-/** The 42 days of the 6×7 grid for `anchor`'s month, starting from the first
- * `WEEK_STARTS_ON` weekday on or before the month's first day. */
 export function getMonthGridDays(anchor: Date): Date[] {
   const monthStart = startOfMonth(anchor);
   const leadingDays = (monthStart.getDay() - WEEK_STARTS_ON + 7) % 7;
@@ -70,25 +51,17 @@ export function getMonthGridDays(anchor: Date): Date[] {
   });
 }
 
-/** Short weekday labels (e.g. "Sun"…"Sat") ordered from `WEEK_STARTS_ON`. */
 export const WEEKDAY_LABELS = Array.from({ length: 7 }, (_, index) => {
   // 2023-01-01 is a Sunday, so it anchors the label sequence.
   const day = new Date(2023, 0, 1 + WEEK_STARTS_ON + index);
   return day.toLocaleDateString("en-US", { weekday: "short" });
 });
 
-/** Toolbar title for a month, e.g. "August 2026". */
 export function formatMonthTitle(anchor: Date): string {
   return anchor.toLocaleDateString("en-US", { month: "long", year: "numeric" });
 }
 
-/** Toolbar title for the week view's rolling range centred on `anchor`, e.g.
- * "Aug 19 – 25, 2026", "Aug 29 – Sep 4, 2026" across a month boundary, or
- * "Dec 29, 2025 – Jan 4, 2026" across a year.
- *
- * Numeric day/year parts are composed directly rather than via
- * `toLocaleDateString`, because asking Intl for a day+year format with no month
- * ("Aug 19 – 25, 2026") renders an unsupported fallback like "2026 (day: 25)". */
+// Composed by hand: Intl has no day+year-without-month format ("Aug 19 – 25, 2026").
 export function formatWeekTitle(anchor: Date): string {
   const start = startOfVisibleWeek(anchor);
   const end = addDays(start, WEEK_VIEW_DAYS - 1);
@@ -104,10 +77,8 @@ export function formatWeekTitle(anchor: Date): string {
   return `${startMonth} ${start.getDate()}, ${start.getFullYear()} – ${endMonth} ${end.getDate()}, ${end.getFullYear()}`;
 }
 
-/** Hours of the day (0–23) for the week-view time gutter and gridlines. */
 export const HOURS = Array.from({ length: 24 }, (_, hour) => hour);
 
-/** Short hour label for the gutter, e.g. "1am", "12pm". */
 export function formatHourLabel(hour: number): string {
   return new Date(2023, 0, 1, hour)
     .toLocaleTimeString("en-US", { hour: "numeric" })

--- a/applications/web/src/features/dashboard/components/calendar-helpers.ts
+++ b/applications/web/src/features/dashboard/components/calendar-helpers.ts
@@ -41,12 +41,6 @@ export function startOfVisibleWeek(anchor: Date): Date {
   return addDays(anchor, -Math.floor(WEEK_VIEW_DAYS / 2));
 }
 
-/** Midnight on the first `WEEK_STARTS_ON` weekday on or before `date`. */
-export function startOfWeek(date: Date): Date {
-  const offset = (date.getDay() - WEEK_STARTS_ON + 7) % 7;
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate() - offset);
-}
-
 /** Whether two dates fall in the same calendar month and year. */
 export function isSameMonth(a: Date, b: Date): boolean {
   return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
@@ -82,12 +76,6 @@ export const WEEKDAY_LABELS = Array.from({ length: 7 }, (_, index) => {
   const day = new Date(2023, 0, 1 + WEEK_STARTS_ON + index);
   return day.toLocaleDateString("en-US", { weekday: "short" });
 });
-
-/** The 7 days of the week containing `anchor`, from `WEEK_STARTS_ON`. */
-export function getWeekDays(anchor: Date): Date[] {
-  const weekStart = startOfWeek(anchor);
-  return Array.from({ length: 7 }, (_, index) => addDays(weekStart, index));
-}
 
 /** Toolbar title for a month, e.g. "August 2026". */
 export function formatMonthTitle(anchor: Date): string {

--- a/applications/web/src/features/dashboard/components/calendar-view.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-view.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { flushSync } from "react-dom";
 import ChevronLeft from "lucide-react/dist/esm/icons/chevron-left";
 import ChevronRight from "lucide-react/dist/esm/icons/chevron-right";
 import { cn } from "@/utils/cn";
@@ -36,6 +37,22 @@ export function CalendarView() {
 
   const title = view === "month" ? formatMonthTitle(anchor) : formatWeekTitle(anchor);
 
+  // Switch views inside a view transition where available, so the header card
+  // morphs between the two column headers (see `CalendarFrame`) rather than
+  // snapping. `flushSync` commits the new view inside the transition's DOM
+  // update callback, as the API requires.
+  const switchView = (mode: CalendarViewMode) => {
+    if (mode === view) return;
+    const reduceMotion = globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    if (reduceMotion || typeof document.startViewTransition !== "function") {
+      setView(mode);
+      return;
+    }
+    document.startViewTransition(() => {
+      flushSync(() => setView(mode));
+    });
+  };
+
   const step = (direction: 1 | -1) => {
     setAnchor((current) =>
       view === "month" ? addMonths(current, direction) : addDays(current, direction * 7),
@@ -53,7 +70,7 @@ export function CalendarView() {
             <button
               key={mode}
               type="button"
-              onClick={() => setView(mode)}
+              onClick={() => switchView(mode)}
               className={cn(
                 "rounded-md px-2.5 py-1 text-sm font-medium capitalize transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                 mode === view

--- a/applications/web/src/features/dashboard/components/calendar-view.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-view.tsx
@@ -11,7 +11,6 @@ import {
   formatMonthTitle,
   formatWeekTitle,
   getMonthGridDays,
-  getWeekDays,
 } from "./calendar-helpers";
 
 type CalendarViewMode = "week" | "month";
@@ -31,7 +30,6 @@ export function CalendarView() {
   const [anchor, setAnchor] = useState(() => new Date());
 
   const monthDays = useMemo(() => getMonthGridDays(anchor), [anchor]);
-  const weekDays = useMemo(() => getWeekDays(anchor), [anchor]);
 
   const title = view === "month" ? formatMonthTitle(anchor) : formatWeekTitle(anchor);
 
@@ -95,7 +93,7 @@ export function CalendarView() {
       {view === "month" ? (
         <MonthGrid anchor={anchor} days={monthDays} />
       ) : (
-        <WeekGrid days={weekDays} />
+        <WeekGrid anchor={anchor} onVisibleWeekChange={setAnchor} />
       )}
     </div>
   );

--- a/applications/web/src/features/dashboard/components/calendar-view.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-view.tsx
@@ -40,7 +40,7 @@ export function CalendarView() {
   };
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs">
+    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs isolate">
       <header className="flex items-center justify-between gap-3 px-4 py-3">
         <Text as="span" size="base" tone="default" className="font-medium">
           {title}

--- a/applications/web/src/features/dashboard/components/calendar-view.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-view.tsx
@@ -1,0 +1,56 @@
+import { useMemo, useState } from "react";
+import ChevronLeft from "lucide-react/dist/esm/icons/chevron-left";
+import ChevronRight from "lucide-react/dist/esm/icons/chevron-right";
+import { cn } from "@/utils/cn";
+import { Text } from "@/components/ui/primitives/text";
+import { MonthGrid } from "./month-grid";
+import { addMonths, formatMonthTitle, getMonthGridDays, startOfMonth } from "./calendar-helpers";
+
+const navButton =
+  "flex size-8 items-center justify-center rounded-lg text-foreground-muted hover:bg-background-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+/**
+ * The dashboard's month calendar pane. Skeleton only: a titled, navigable month
+ * grid with no events. Owns the visible month (`anchor`, always the first of the
+ * month) and lets the user page between months.
+ */
+export function CalendarView() {
+  const [anchor, setAnchor] = useState(() => startOfMonth(new Date()));
+  const days = useMemo(() => getMonthGridDays(anchor), [anchor]);
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs">
+      <header className="flex items-center justify-between gap-3 px-4 py-3">
+        <Text as="span" size="base" tone="default" className="font-medium">
+          {formatMonthTitle(anchor)}
+        </Text>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className="rounded-lg px-2.5 py-1.5 text-sm font-medium text-foreground-muted hover:bg-background-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => setAnchor(startOfMonth(new Date()))}
+          >
+            Today
+          </button>
+          <button
+            type="button"
+            aria-label="Previous month"
+            className={cn(navButton)}
+            onClick={() => setAnchor((current) => addMonths(current, -1))}
+          >
+            <ChevronLeft size={16} />
+          </button>
+          <button
+            type="button"
+            aria-label="Next month"
+            className={cn(navButton)}
+            onClick={() => setAnchor((current) => addMonths(current, 1))}
+          >
+            <ChevronRight size={16} />
+          </button>
+        </div>
+      </header>
+      <MonthGrid anchor={anchor} days={days} />
+    </div>
+  );
+}

--- a/applications/web/src/features/dashboard/components/calendar-view.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-view.tsx
@@ -21,10 +21,11 @@ const navButton =
   "flex size-8 items-center justify-center rounded-lg text-foreground-muted hover:bg-background-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 
 /**
- * The dashboard's calendar pane: a toolbar card (title, week/month switcher,
- * paging) stacked over a grid card, matching the sidebar's card rhythm.
- * Skeleton only: no events yet. Owns the visible range (`anchor`, any
- * date inside it) and the active `view`, and lets the user page the range.
+ * The dashboard's calendar pane. Owns the visible range (`anchor`, any date
+ * inside it) and the active `view`, and lets the user page the range. Renders
+ * the toolbar and hands it to the active grid, which places it in the header
+ * card above its own column labels (see `CalendarFrame`). Skeleton only: no
+ * events yet.
  */
 export function CalendarView() {
   const [view, setView] = useState<CalendarViewMode>("month");
@@ -40,67 +41,56 @@ export function CalendarView() {
     );
   };
 
-  return (
-    <div className="flex h-full min-h-0 w-full flex-col gap-3">
-      <header className="flex shrink-0 items-center justify-between gap-3 rounded-2xl border border-border-elevated bg-background-elevated px-4 py-3 shadow-xs">
-        <Text as="span" size="base" tone="default" className="font-medium">
-          {title}
-        </Text>
-        <div className="flex items-center gap-3">
-          <div className="flex items-center rounded-lg bg-background-hover p-0.5">
-            {VIEWS.map((mode) => (
-              <button
-                key={mode}
-                type="button"
-                onClick={() => setView(mode)}
-                className={cn(
-                  "rounded-md px-2.5 py-1 text-sm font-medium capitalize transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                  mode === view
-                    ? "bg-background-elevated text-foreground shadow-xs"
-                    : "text-foreground-muted hover:text-foreground",
-                )}
-              >
-                {mode}
-              </button>
-            ))}
-          </div>
-          <div className="flex items-center gap-1">
+  const toolbar = (
+    <>
+      <Text as="span" size="base" tone="default" className="font-medium">
+        {title}
+      </Text>
+      <div className="flex items-center gap-3">
+        <div className="flex items-center rounded-lg bg-background-hover p-0.5">
+          {VIEWS.map((mode) => (
             <button
+              key={mode}
               type="button"
-              className="rounded-lg px-2.5 py-1.5 text-sm font-medium text-foreground-muted hover:bg-background-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              onClick={() => setAnchor(new Date())}
+              onClick={() => setView(mode)}
+              className={cn(
+                "rounded-md px-2.5 py-1 text-sm font-medium capitalize transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                mode === view
+                  ? "bg-background-elevated text-foreground shadow-xs"
+                  : "text-foreground-muted hover:text-foreground",
+              )}
             >
-              Today
+              {mode}
             </button>
-            <button
-              type="button"
-              aria-label="Previous"
-              className={cn(navButton)}
-              onClick={() => step(-1)}
-            >
-              <ChevronLeft size={16} />
-            </button>
-            <button
-              type="button"
-              aria-label="Next"
-              className={cn(navButton)}
-              onClick={() => step(1)}
-            >
-              <ChevronRight size={16} />
-            </button>
-          </div>
+          ))}
         </div>
-      </header>
-      {/* The grid card. `overflow-hidden` + `isolate` clip the week scroller to
-          the rounded corners; `min-h-0 flex-1` lets the scroller size itself
-          so its sticky day header holds through the full vertical scroll. */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs isolate">
-        {view === "month" ? (
-          <MonthGrid anchor={anchor} days={monthDays} />
-        ) : (
-          <WeekGrid anchor={anchor} onVisibleWeekChange={setAnchor} />
-        )}
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className="rounded-lg px-2.5 py-1.5 text-sm font-medium text-foreground-muted hover:bg-background-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => setAnchor(new Date())}
+          >
+            Today
+          </button>
+          <button
+            type="button"
+            aria-label="Previous"
+            className={cn(navButton)}
+            onClick={() => step(-1)}
+          >
+            <ChevronLeft size={16} />
+          </button>
+          <button type="button" aria-label="Next" className={cn(navButton)} onClick={() => step(1)}>
+            <ChevronRight size={16} />
+          </button>
+        </div>
       </div>
-    </div>
+    </>
+  );
+
+  return view === "month" ? (
+    <MonthGrid anchor={anchor} days={monthDays} toolbar={toolbar} />
+  ) : (
+    <WeekGrid anchor={anchor} onVisibleWeekChange={setAnchor} toolbar={toolbar} />
   );
 }

--- a/applications/web/src/features/dashboard/components/calendar-view.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-view.tsx
@@ -21,8 +21,9 @@ const navButton =
   "flex size-8 items-center justify-center rounded-lg text-foreground-muted hover:bg-background-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 
 /**
- * The dashboard's calendar pane. Skeleton only: a titled, navigable grid with a
- * week/month view switcher and no events. Owns the visible range (`anchor`, any
+ * The dashboard's calendar pane: a toolbar card (title, week/month switcher,
+ * paging) stacked over a grid card, matching the sidebar's card rhythm.
+ * Skeleton only: no events yet. Owns the visible range (`anchor`, any
  * date inside it) and the active `view`, and lets the user page the range.
  */
 export function CalendarView() {
@@ -40,8 +41,8 @@ export function CalendarView() {
   };
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs isolate">
-      <header className="flex items-center justify-between gap-3 px-4 py-3">
+    <div className="flex h-full min-h-0 w-full flex-col gap-3">
+      <header className="flex shrink-0 items-center justify-between gap-3 rounded-2xl border border-border-elevated bg-background-elevated px-4 py-3 shadow-xs">
         <Text as="span" size="base" tone="default" className="font-medium">
           {title}
         </Text>
@@ -90,11 +91,16 @@ export function CalendarView() {
           </div>
         </div>
       </header>
-      {view === "month" ? (
-        <MonthGrid anchor={anchor} days={monthDays} />
-      ) : (
-        <WeekGrid anchor={anchor} onVisibleWeekChange={setAnchor} />
-      )}
+      {/* The grid card. `overflow-hidden` + `isolate` clip the week scroller to
+          the rounded corners; `min-h-0 flex-1` lets the scroller size itself
+          so its sticky day header holds through the full vertical scroll. */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs isolate">
+        {view === "month" ? (
+          <MonthGrid anchor={anchor} days={monthDays} />
+        ) : (
+          <WeekGrid anchor={anchor} onVisibleWeekChange={setAnchor} />
+        )}
+      </div>
     </div>
   );
 }

--- a/applications/web/src/features/dashboard/components/calendar-view.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-view.tsx
@@ -4,53 +4,99 @@ import ChevronRight from "lucide-react/dist/esm/icons/chevron-right";
 import { cn } from "@/utils/cn";
 import { Text } from "@/components/ui/primitives/text";
 import { MonthGrid } from "./month-grid";
-import { addMonths, formatMonthTitle, getMonthGridDays, startOfMonth } from "./calendar-helpers";
+import { WeekGrid } from "./week-grid";
+import {
+  addDays,
+  addMonths,
+  formatMonthTitle,
+  formatWeekTitle,
+  getMonthGridDays,
+  getWeekDays,
+} from "./calendar-helpers";
+
+type CalendarViewMode = "week" | "month";
+
+const VIEWS: CalendarViewMode[] = ["week", "month"];
 
 const navButton =
   "flex size-8 items-center justify-center rounded-lg text-foreground-muted hover:bg-background-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 
 /**
- * The dashboard's month calendar pane. Skeleton only: a titled, navigable month
- * grid with no events. Owns the visible month (`anchor`, always the first of the
- * month) and lets the user page between months.
+ * The dashboard's calendar pane. Skeleton only: a titled, navigable grid with a
+ * week/month view switcher and no events. Owns the visible range (`anchor`, any
+ * date inside it) and the active `view`, and lets the user page the range.
  */
 export function CalendarView() {
-  const [anchor, setAnchor] = useState(() => startOfMonth(new Date()));
-  const days = useMemo(() => getMonthGridDays(anchor), [anchor]);
+  const [view, setView] = useState<CalendarViewMode>("month");
+  const [anchor, setAnchor] = useState(() => new Date());
+
+  const monthDays = useMemo(() => getMonthGridDays(anchor), [anchor]);
+  const weekDays = useMemo(() => getWeekDays(anchor), [anchor]);
+
+  const title = view === "month" ? formatMonthTitle(anchor) : formatWeekTitle(anchor);
+
+  const step = (direction: 1 | -1) => {
+    setAnchor((current) =>
+      view === "month" ? addMonths(current, direction) : addDays(current, direction * 7),
+    );
+  };
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs">
       <header className="flex items-center justify-between gap-3 px-4 py-3">
         <Text as="span" size="base" tone="default" className="font-medium">
-          {formatMonthTitle(anchor)}
+          {title}
         </Text>
-        <div className="flex items-center gap-1">
-          <button
-            type="button"
-            className="rounded-lg px-2.5 py-1.5 text-sm font-medium text-foreground-muted hover:bg-background-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            onClick={() => setAnchor(startOfMonth(new Date()))}
-          >
-            Today
-          </button>
-          <button
-            type="button"
-            aria-label="Previous month"
-            className={cn(navButton)}
-            onClick={() => setAnchor((current) => addMonths(current, -1))}
-          >
-            <ChevronLeft size={16} />
-          </button>
-          <button
-            type="button"
-            aria-label="Next month"
-            className={cn(navButton)}
-            onClick={() => setAnchor((current) => addMonths(current, 1))}
-          >
-            <ChevronRight size={16} />
-          </button>
+        <div className="flex items-center gap-3">
+          <div className="flex items-center rounded-lg bg-background-hover p-0.5">
+            {VIEWS.map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setView(mode)}
+                className={cn(
+                  "rounded-md px-2.5 py-1 text-sm font-medium capitalize transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  mode === view
+                    ? "bg-background-elevated text-foreground shadow-xs"
+                    : "text-foreground-muted hover:text-foreground",
+                )}
+              >
+                {mode}
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              className="rounded-lg px-2.5 py-1.5 text-sm font-medium text-foreground-muted hover:bg-background-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              onClick={() => setAnchor(new Date())}
+            >
+              Today
+            </button>
+            <button
+              type="button"
+              aria-label="Previous"
+              className={cn(navButton)}
+              onClick={() => step(-1)}
+            >
+              <ChevronLeft size={16} />
+            </button>
+            <button
+              type="button"
+              aria-label="Next"
+              className={cn(navButton)}
+              onClick={() => step(1)}
+            >
+              <ChevronRight size={16} />
+            </button>
+          </div>
         </div>
       </header>
-      <MonthGrid anchor={anchor} days={days} />
+      {view === "month" ? (
+        <MonthGrid anchor={anchor} days={monthDays} />
+      ) : (
+        <WeekGrid days={weekDays} />
+      )}
     </div>
   );
 }

--- a/applications/web/src/features/dashboard/components/calendar-view.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-view.tsx
@@ -21,14 +21,15 @@ const navButton =
   "flex size-8 items-center justify-center rounded-lg text-foreground-muted hover:bg-background-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 
 /**
- * The dashboard's calendar pane. Owns the visible range (`anchor`, any date
- * inside it) and the active `view`, and lets the user page the range. Renders
+ * The dashboard's calendar pane. Owns the active `view` and its `anchor` — the
+ * day the week view centres on (today on entry), or any day inside the month
+ * the month view shows — and lets the user page the range. Renders
  * the toolbar and hands it to the active grid, which places it in the header
  * card above its own column labels (see `CalendarFrame`). Skeleton only: no
  * events yet.
  */
 export function CalendarView() {
-  const [view, setView] = useState<CalendarViewMode>("month");
+  const [view, setView] = useState<CalendarViewMode>("week");
   const [anchor, setAnchor] = useState(() => new Date());
 
   const monthDays = useMemo(() => getMonthGridDays(anchor), [anchor]);
@@ -91,6 +92,6 @@ export function CalendarView() {
   return view === "month" ? (
     <MonthGrid anchor={anchor} days={monthDays} toolbar={toolbar} />
   ) : (
-    <WeekGrid anchor={anchor} onVisibleWeekChange={setAnchor} toolbar={toolbar} />
+    <WeekGrid anchor={anchor} onCenterDayChange={setAnchor} toolbar={toolbar} />
   );
 }

--- a/applications/web/src/features/dashboard/components/calendar-view.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-view.tsx
@@ -21,14 +21,6 @@ const VIEWS: CalendarViewMode[] = ["week", "month"];
 const navButton =
   "flex size-8 items-center justify-center rounded-lg text-foreground-muted hover:bg-background-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 
-/**
- * The dashboard's calendar pane. Owns the active `view` and its `anchor` — the
- * day the week view centres on (today on entry), or any day inside the month
- * the month view shows — and lets the user page the range. Renders
- * the toolbar and hands it to the active grid, which places it in the header
- * card above its own column labels (see `CalendarFrame`). Skeleton only: no
- * events yet.
- */
 export function CalendarView() {
   const [view, setView] = useState<CalendarViewMode>("week");
   const [anchor, setAnchor] = useState(() => new Date());
@@ -37,10 +29,6 @@ export function CalendarView() {
 
   const title = view === "month" ? formatMonthTitle(anchor) : formatWeekTitle(anchor);
 
-  // Switch views inside a view transition where available, so the header card
-  // morphs between the two column headers (see `CalendarFrame`) rather than
-  // snapping. `flushSync` commits the new view inside the transition's DOM
-  // update callback, as the API requires.
   const switchView = (mode: CalendarViewMode) => {
     if (mode === view) return;
     const reduceMotion = globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches;

--- a/applications/web/src/features/dashboard/components/calendar-view.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-view.tsx
@@ -93,12 +93,12 @@ export function CalendarView() {
           <button
             type="button"
             aria-label="Previous"
-            className={cn(navButton)}
+            className={navButton}
             onClick={() => step(-1)}
           >
             <ChevronLeft size={16} />
           </button>
-          <button type="button" aria-label="Next" className={cn(navButton)} onClick={() => step(1)}>
+          <button type="button" aria-label="Next" className={navButton} onClick={() => step(1)}>
             <ChevronRight size={16} />
           </button>
         </div>

--- a/applications/web/src/features/dashboard/components/month-grid.tsx
+++ b/applications/web/src/features/dashboard/components/month-grid.tsx
@@ -1,6 +1,8 @@
+import type { ReactNode } from "react";
 import { cn } from "@/utils/cn";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
 import { Text } from "@/components/ui/primitives/text";
+import { CalendarFrame } from "./calendar-frame";
 import { isSameDay, isSameMonth, WEEKDAY_LABELS } from "./calendar-helpers";
 
 interface MonthGridProps {
@@ -8,32 +10,38 @@ interface MonthGridProps {
   anchor: Date;
   /** The 42 days of the 6×7 grid, from `getMonthGridDays`. */
   days: Date[];
+  /** The pane's toolbar, rendered in the header card above the weekday row. */
+  toolbar: ReactNode;
 }
 
 /**
- * The month grid skeleton: a weekday header over a 6×7 grid of day cells.
- * Presentational only — no events are rendered yet; each cell reserves space
- * where event pills will later go.
+ * The month view skeleton: a weekday label row in the header card over a 6×7
+ * grid of day cells in the grid card. Presentational only — no events are
+ * rendered yet; each cell reserves space where event pills will later go.
  */
-export function MonthGrid({ anchor, days }: MonthGridProps) {
+export function MonthGrid({ anchor, days, toolbar }: MonthGridProps) {
   const today = useStartOfToday();
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="grid grid-cols-7">
-        {WEEKDAY_LABELS.map((label) => (
-          <Text
-            key={label}
-            as="span"
-            size="xs"
-            tone="muted"
-            className="px-2 py-2 font-medium uppercase tracking-wide"
-          >
-            {label}
-          </Text>
-        ))}
-      </div>
-      <div className="grid min-h-0 flex-1 grid-cols-7 grid-rows-6 border-t border-border-elevated">
+    <CalendarFrame
+      toolbar={toolbar}
+      columnHeader={
+        <div className="grid grid-cols-7">
+          {WEEKDAY_LABELS.map((label) => (
+            <Text
+              key={label}
+              as="span"
+              size="xs"
+              tone="muted"
+              className="px-2 py-2 font-medium uppercase tracking-wide"
+            >
+              {label}
+            </Text>
+          ))}
+        </div>
+      }
+    >
+      <div className="grid min-h-0 flex-1 grid-cols-7 grid-rows-6">
         {days.map((day) => {
           const inMonth = isSameMonth(day, anchor);
           const isToday = isSameDay(day, today);
@@ -61,6 +69,6 @@ export function MonthGrid({ anchor, days }: MonthGridProps) {
           );
         })}
       </div>
-    </div>
+    </CalendarFrame>
   );
 }

--- a/applications/web/src/features/dashboard/components/month-grid.tsx
+++ b/applications/web/src/features/dashboard/components/month-grid.tsx
@@ -1,9 +1,44 @@
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { cn } from "@/utils/cn";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
 import { Text } from "@/components/ui/primitives/text";
 import { CalendarFrame } from "./calendar-frame";
 import { isSameDay, isSameMonth, WEEKDAY_LABELS } from "./calendar-helpers";
+
+const COLUMNS = 7;
+const ROWS = 6;
+
+/** Depth of the rule layer's edge fades, in pixels. */
+const EDGE_FADE_SIZE = 24;
+
+/** The cell rules, painted as one layer behind the cells rather than as cell
+ * borders: a 1px line at the trailing edge of every column and row tile, so
+ * the lines land on the cell boundaries. Keeping them on their own layer lets
+ * them be faded at the edges without touching the day numbers. */
+const CELL_RULES: CSSProperties = {
+  backgroundImage: [
+    "linear-gradient(to right, transparent calc(100% - 1px), var(--color-border-elevated) calc(100% - 1px))",
+    "linear-gradient(to bottom, transparent calc(100% - 1px), var(--color-border-elevated) calc(100% - 1px))",
+  ].join(", "),
+  backgroundSize: `calc(100% / ${COLUMNS}) 100%, 100% calc(100% / ${ROWS})`,
+  backgroundRepeat: "repeat-x, repeat-y",
+};
+
+/** Fades the rule layer out toward all four edges, so the rules dissolve into
+ * the page background — and the outermost trailing-edge lines, which would
+ * otherwise frame the grid, vanish with them. The two gradients intersect so
+ * each corner fades on both axes. */
+const EDGE_FADE = [
+  `linear-gradient(to bottom, transparent, black ${EDGE_FADE_SIZE}px, black calc(100% - ${EDGE_FADE_SIZE}px), transparent)`,
+  `linear-gradient(to right, transparent, black ${EDGE_FADE_SIZE}px, black calc(100% - ${EDGE_FADE_SIZE}px), transparent)`,
+].join(", ");
+const RULE_LAYER_STYLE: CSSProperties = {
+  ...CELL_RULES,
+  maskImage: EDGE_FADE,
+  WebkitMaskImage: EDGE_FADE,
+  maskComposite: "intersect",
+  WebkitMaskComposite: "source-in",
+};
 
 interface MonthGridProps {
   /** Any date within the month being displayed (dims days outside it). */
@@ -15,9 +50,10 @@ interface MonthGridProps {
 }
 
 /**
- * The month view skeleton: a weekday label row in the header card over a 6×7
- * grid of day cells in the grid card. Presentational only — no events are
- * rendered yet; each cell reserves space where event pills will later go.
+ * The month view skeleton: a weekday label row in the header card over a bare
+ * 6×7 grid of day cells whose rules fade out toward the edges. Presentational
+ * only — no events are rendered yet; each cell reserves space where event
+ * pills will later go.
  */
 export function MonthGrid({ anchor, days, toolbar }: MonthGridProps) {
   const today = useStartOfToday();
@@ -41,33 +77,34 @@ export function MonthGrid({ anchor, days, toolbar }: MonthGridProps) {
         </div>
       }
     >
-      <div className="grid min-h-0 flex-1 grid-cols-7 grid-rows-6">
-        {days.map((day) => {
-          const inMonth = isSameMonth(day, anchor);
-          const isToday = isSameDay(day, today);
-          return (
-            <div
-              key={day.getTime()}
-              className={cn(
-                "flex min-h-0 flex-col gap-0.5 overflow-hidden border-r border-b border-border-elevated p-1.5 [&:nth-child(7n)]:border-r-0 [&:nth-last-child(-n+7)]:border-b-0",
-                !inMonth && "bg-background-hover/40",
-              )}
-            >
-              <span
-                className={cn(
-                  "flex size-6 items-center justify-center self-start text-xs font-medium tabular-nums",
-                  isToday && "rounded-full bg-emerald-400 text-neutral-950",
-                  !isToday && inMonth && "text-foreground",
-                  !isToday && !inMonth && "text-foreground-disabled",
-                )}
+      <div className="relative min-h-0 flex-1">
+        {/* Cell rules, behind the cells and faded toward the edges. */}
+        <div aria-hidden className="pointer-events-none absolute inset-0" style={RULE_LAYER_STYLE} />
+        <div className="relative grid h-full grid-cols-7 grid-rows-6">
+          {days.map((day) => {
+            const inMonth = isSameMonth(day, anchor);
+            const isToday = isSameDay(day, today);
+            return (
+              <div
+                key={day.getTime()}
+                className="flex min-h-0 flex-col gap-0.5 overflow-hidden p-1.5"
               >
-                {day.getDate()}
-              </span>
-              {/* Event pills will render here in a later stage. */}
-              <div className="min-h-0 flex-1" />
-            </div>
-          );
-        })}
+                <span
+                  className={cn(
+                    "flex size-6 items-center justify-center self-start text-xs font-medium tabular-nums",
+                    isToday && "rounded-full bg-emerald-400 text-neutral-950",
+                    !isToday && inMonth && "text-foreground",
+                    !isToday && !inMonth && "text-foreground-disabled",
+                  )}
+                >
+                  {day.getDate()}
+                </span>
+                {/* Event pills will render here in a later stage. */}
+                <div className="min-h-0 flex-1" />
+              </div>
+            );
+          })}
+        </div>
       </div>
     </CalendarFrame>
   );

--- a/applications/web/src/features/dashboard/components/month-grid.tsx
+++ b/applications/web/src/features/dashboard/components/month-grid.tsx
@@ -33,7 +33,7 @@ export function MonthGrid({ anchor, days }: MonthGridProps) {
           </Text>
         ))}
       </div>
-      <div className="grid min-h-0 flex-1 grid-cols-7 grid-rows-6 border-t border-l border-border-elevated">
+      <div className="grid min-h-0 flex-1 grid-cols-7 grid-rows-6 border-t border-border-elevated">
         {days.map((day) => {
           const inMonth = isSameMonth(day, anchor);
           const isToday = isSameDay(day, today);
@@ -41,7 +41,7 @@ export function MonthGrid({ anchor, days }: MonthGridProps) {
             <div
               key={day.getTime()}
               className={cn(
-                "flex min-h-0 flex-col gap-0.5 overflow-hidden border-r border-b border-border-elevated p-1.5",
+                "flex min-h-0 flex-col gap-0.5 overflow-hidden border-r border-b border-border-elevated p-1.5 [&:nth-child(7n)]:border-r-0 [&:nth-last-child(-n+7)]:border-b-0",
                 !inMonth && "bg-background-hover/40",
               )}
             >

--- a/applications/web/src/features/dashboard/components/month-grid.tsx
+++ b/applications/web/src/features/dashboard/components/month-grid.tsx
@@ -1,0 +1,66 @@
+import { cn } from "@/utils/cn";
+import { useStartOfToday } from "@/hooks/use-start-of-today";
+import { Text } from "@/components/ui/primitives/text";
+import { isSameDay, isSameMonth, WEEKDAY_LABELS } from "./calendar-helpers";
+
+interface MonthGridProps {
+  /** Any date within the month being displayed (dims days outside it). */
+  anchor: Date;
+  /** The 42 days of the 6×7 grid, from `getMonthGridDays`. */
+  days: Date[];
+}
+
+/**
+ * The month grid skeleton: a weekday header over a 6×7 grid of day cells.
+ * Presentational only — no events are rendered yet; each cell reserves space
+ * where event pills will later go.
+ */
+export function MonthGrid({ anchor, days }: MonthGridProps) {
+  const today = useStartOfToday();
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="grid grid-cols-7">
+        {WEEKDAY_LABELS.map((label) => (
+          <Text
+            key={label}
+            as="span"
+            size="xs"
+            tone="muted"
+            className="px-2 py-2 font-medium uppercase tracking-wide"
+          >
+            {label}
+          </Text>
+        ))}
+      </div>
+      <div className="grid min-h-0 flex-1 grid-cols-7 grid-rows-6 border-t border-l border-border-elevated">
+        {days.map((day) => {
+          const inMonth = isSameMonth(day, anchor);
+          const isToday = isSameDay(day, today);
+          return (
+            <div
+              key={day.getTime()}
+              className={cn(
+                "flex min-h-0 flex-col gap-0.5 overflow-hidden border-r border-b border-border-elevated p-1.5",
+                !inMonth && "bg-background-hover/40",
+              )}
+            >
+              <span
+                className={cn(
+                  "flex size-6 items-center justify-center self-start text-xs font-medium tabular-nums",
+                  isToday && "rounded-full bg-emerald-400 text-neutral-950",
+                  !isToday && inMonth && "text-foreground",
+                  !isToday && !inMonth && "text-foreground-disabled",
+                )}
+              >
+                {day.getDate()}
+              </span>
+              {/* Event pills will render here in a later stage. */}
+              <div className="min-h-0 flex-1" />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/applications/web/src/features/dashboard/components/month-grid.tsx
+++ b/applications/web/src/features/dashboard/components/month-grid.tsx
@@ -8,13 +8,9 @@ import { isSameDay, isSameMonth, WEEKDAY_LABELS } from "./calendar-helpers";
 const COLUMNS = 7;
 const ROWS = 6;
 
-/** Depth of the rule layer's edge fades, in pixels. */
 const EDGE_FADE_SIZE = 24;
 
-/** The cell rules, painted as one layer behind the cells rather than as cell
- * borders: a 1px line at the trailing edge of every column and row tile, so
- * the lines land on the cell boundaries. Keeping them on their own layer lets
- * them be faded at the edges without touching the day numbers. */
+// Cell rules on their own layer behind the cells, so they can fade at the edges without touching the day numbers.
 const CELL_RULES: CSSProperties = {
   backgroundImage: [
     "linear-gradient(to right, transparent calc(100% - 1px), var(--color-border-elevated) calc(100% - 1px))",
@@ -24,10 +20,6 @@ const CELL_RULES: CSSProperties = {
   backgroundRepeat: "repeat-x, repeat-y",
 };
 
-/** Fades the rule layer out toward all four edges, so the rules dissolve into
- * the page background — and the outermost trailing-edge lines, which would
- * otherwise frame the grid, vanish with them. The two gradients intersect so
- * each corner fades on both axes. */
 const EDGE_FADE = [
   `linear-gradient(to bottom, transparent, black ${EDGE_FADE_SIZE}px, black calc(100% - ${EDGE_FADE_SIZE}px), transparent)`,
   `linear-gradient(to right, transparent, black ${EDGE_FADE_SIZE}px, black calc(100% - ${EDGE_FADE_SIZE}px), transparent)`,
@@ -41,20 +33,11 @@ const RULE_LAYER_STYLE: CSSProperties = {
 };
 
 interface MonthGridProps {
-  /** Any date within the month being displayed (dims days outside it). */
   anchor: Date;
-  /** The 42 days of the 6×7 grid, from `getMonthGridDays`. */
   days: Date[];
-  /** The pane's toolbar, rendered in the header card above the weekday row. */
   toolbar: ReactNode;
 }
 
-/**
- * The month view skeleton: a weekday label row in the header card over a bare
- * 6×7 grid of day cells whose rules fade out toward the edges. Presentational
- * only — no events are rendered yet; each cell reserves space where event
- * pills will later go.
- */
 export function MonthGrid({ anchor, days, toolbar }: MonthGridProps) {
   const today = useStartOfToday();
 
@@ -78,7 +61,6 @@ export function MonthGrid({ anchor, days, toolbar }: MonthGridProps) {
       }
     >
       <div className="relative min-h-0 flex-1">
-        {/* Cell rules, behind the cells and faded toward the edges. */}
         <div aria-hidden className="pointer-events-none absolute inset-0" style={RULE_LAYER_STYLE} />
         <div className="relative grid h-full grid-cols-7 grid-rows-6">
           {days.map((day) => {

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { cn } from "@/utils/cn";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
 import { Text } from "@/components/ui/primitives/text";
@@ -19,6 +19,15 @@ const VISIBLE_COLUMNS = 7;
 const BUFFER_WEEKS = 26;
 
 const MS_PER_DAY = 86_400_000;
+
+/** A 1px column rule along a cell's left edge that fades out toward the top,
+ * so the day row's lines dissolve into the toolbar above instead of meeting
+ * a separator at a hard corner. Sits exactly where the grid's `border-l` is. */
+const FADED_COLUMN_RULE: CSSProperties = {
+  backgroundImage: "linear-gradient(to top, var(--color-border-elevated) 35%, transparent)",
+  backgroundSize: "1px 100%",
+  backgroundRepeat: "no-repeat",
+};
 
 interface WeekGridProps {
   /** Any date inside the week to show; drives the horizontal scroll position. */
@@ -79,6 +88,13 @@ export function WeekGrid({ anchor, onVisibleWeekChange, toolbar }: WeekGridProps
     return Math.max((el.clientWidth - GUTTER_WIDTH) / VISIBLE_COLUMNS, 1);
   }, []);
 
+  /** Mirrors the scroller's horizontal offset onto the header's day row. */
+  const syncHeaderStrip = useCallback(() => {
+    const scroller = scrollerRef.current;
+    const headerStrip = headerStripRef.current;
+    if (scroller && headerStrip) headerStrip.scrollLeft = scroller.scrollLeft;
+  }, []);
+
   const scrollToWeek = useCallback(
     (weekStart: Date, behavior: ScrollBehavior) => {
       const el = scrollerRef.current;
@@ -87,8 +103,11 @@ export function WeekGrid({ anchor, onVisibleWeekChange, toolbar }: WeekGridProps
       const clamped = Math.max(0, Math.min(index, stripDays.length - VISIBLE_COLUMNS));
       alignedWeekMsRef.current = weekStart.getTime();
       el.scrollTo({ left: clamped * columnWidth(), behavior });
+      // An instant jump lands before any scroll event; mirror it right away so
+      // the header never shows a stale week, even for a frame.
+      if (behavior === "auto") syncHeaderStrip();
     },
-    [columnWidth, stripDays],
+    [columnWidth, stripDays, syncHeaderStrip],
   );
 
   // On mount, jump to the anchor week and down to business hours (auto, no
@@ -129,11 +148,9 @@ export function WeekGrid({ anchor, onVisibleWeekChange, toolbar }: WeekGridProps
   }, [scrollToWeek]);
 
   const handleScroll = () => {
-    // Mirror the horizontal offset onto the header's day row synchronously —
-    // not inside the rAF below — so it never trails the grid by a frame.
-    const scroller = scrollerRef.current;
-    const headerStrip = headerStripRef.current;
-    if (scroller && headerStrip) headerStrip.scrollLeft = scroller.scrollLeft;
+    // Mirror synchronously — not inside the rAF below — so the header never
+    // trails the grid by a frame.
+    syncHeaderStrip();
     if (rafRef.current !== null) return;
     rafRef.current = requestAnimationFrame(() => {
       rafRef.current = null;
@@ -174,7 +191,8 @@ export function WeekGrid({ anchor, onVisibleWeekChange, toolbar }: WeekGridProps
             return (
               <div
                 key={day.getTime()}
-                className="flex flex-col items-center justify-center gap-1 border-l border-border-elevated"
+                className="flex flex-col items-center justify-center gap-1"
+                style={FADED_COLUMN_RULE}
               >
                 <Text as="span" size="xs" tone="muted" className="font-medium uppercase tracking-wide">
                   {day.toLocaleDateString("en-US", { weekday: "short" })}

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -35,14 +35,22 @@ const MS_PER_DAY = 86_400_000;
  * the horizontal lines read as a secondary, quieter layer under the columns. */
 const HOUR_RULE_COLOR = "color-mix(in oklab, var(--color-border-elevated) 45%, transparent)";
 
-/** A 1px column rule along a cell's left edge that fades out toward the top,
- * so the day row's lines dissolve into the toolbar above instead of meeting
- * a separator at a hard corner. Sits exactly where the grid's `border-l` is. */
-const FADED_COLUMN_RULE: CSSProperties = {
-  backgroundImage: "linear-gradient(to top, var(--color-border-elevated) 35%, transparent)",
-  backgroundSize: "1px 100%",
-  backgroundRepeat: "no-repeat",
+/** The day-column rules: a 1px line at the left edge of every column, tiled
+ * one column apart. They are painted on the *viewport* boxes (the grid's
+ * scroller and the header's strip viewport) rather than on the day cells, so
+ * they are pinned to the visible area and run its full height — through a
+ * vertical overscroll bounce too, instead of stopping at the content's edge.
+ * Horizontal scrolling is followed via `--strip-scroll`, which `handleScroll`
+ * keeps equal to the scroller's `scrollLeft`. Both boxes use the same column
+ * width expression, so header and grid lines coincide to the pixel. */
+const COLUMN_RULES: CSSProperties = {
+  backgroundImage: "linear-gradient(to right, var(--color-border-elevated) 0 1px, transparent 1px)",
+  backgroundRepeat: "repeat-x",
 };
+
+/** Fades the header's column rules out toward the top, so they dissolve into
+ * the toolbar above instead of meeting it at a hard corner. */
+const HEADER_RULE_FADE = "linear-gradient(to top, black 35%, transparent)";
 
 interface WeekGridProps {
   /** The day to centre the visible range on; drives the horizontal scroll
@@ -111,11 +119,16 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
     return Math.max((el.clientWidth - GUTTER_WIDTH) / VISIBLE_COLUMNS, 1);
   }, []);
 
-  /** Mirrors the scroller's horizontal offset onto the header's day row. */
+  /** Mirrors the scroller's horizontal offset onto the header's day row, and
+   * into `--strip-scroll` on both boxes so their column rules follow along. */
   const syncHeaderStrip = useCallback(() => {
     const scroller = scrollerRef.current;
     const headerStrip = headerStripRef.current;
-    if (scroller && headerStrip) headerStrip.scrollLeft = scroller.scrollLeft;
+    if (!scroller || !headerStrip) return;
+    headerStrip.scrollLeft = scroller.scrollLeft;
+    const offset = `${scroller.scrollLeft}px`;
+    scroller.style.setProperty("--strip-scroll", offset);
+    headerStrip.style.setProperty("--strip-scroll", offset);
   }, []);
 
   /** Scrolls the strip so `centerDay` (midnight) sits in the middle column. */
@@ -222,9 +235,21 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
     <div className="flex" style={{ height: HEADER_HEIGHT }}>
       {/* Spacer over the grid's time gutter, keeping the columns aligned. */}
       <div className="shrink-0" style={{ width: GUTTER_WIDTH }} />
-      <div ref={headerStripRef} className="min-w-0 flex-1 overflow-hidden">
+      <div ref={headerStripRef} className="relative min-w-0 flex-1 overflow-hidden">
+        {/* Column rules, pinned to the viewport and faded toward the top. */}
         <div
-          className="grid h-full"
+          aria-hidden
+          className="pointer-events-none absolute inset-0"
+          style={{
+            ...COLUMN_RULES,
+            backgroundSize: `calc(100% / ${VISIBLE_COLUMNS}) 100%`,
+            backgroundPositionX: "calc(0px - var(--strip-scroll, 0px))",
+            maskImage: HEADER_RULE_FADE,
+            WebkitMaskImage: HEADER_RULE_FADE,
+          }}
+        />
+        <div
+          className="relative grid h-full"
           style={{
             gridTemplateColumns: columnsTemplate,
             width: `calc(${stripDays.length} * 100% / ${VISIBLE_COLUMNS})`,
@@ -236,7 +261,6 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
               <div
                 key={day.getTime()}
                 className="flex flex-col items-center justify-center gap-1"
-                style={FADED_COLUMN_RULE}
               >
                 <Text as="span" size="xs" tone="muted" className="font-medium uppercase tracking-wide">
                   {day.toLocaleDateString("en-US", { weekday: "short" })}
@@ -266,8 +290,14 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
       <div
         ref={scrollerRef}
         onScroll={handleScroll}
-        className="flex min-h-0 flex-1 items-start overflow-auto overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-        style={{ scrollSnapType: "x mandatory", scrollPaddingLeft: GUTTER_WIDTH }}
+        className="flex min-h-0 flex-1 items-start overflow-auto overscroll-x-none [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        style={{
+          ...COLUMN_RULES,
+          backgroundSize: `calc((100% - ${GUTTER_WIDTH}px) / ${VISIBLE_COLUMNS}) 100%`,
+          backgroundPositionX: `calc(${GUTTER_WIDTH}px - var(--strip-scroll, 0px))`,
+          scrollSnapType: "x mandatory",
+          scrollPaddingLeft: GUTTER_WIDTH,
+        }}
       >
         {/* Pinned time gutter. */}
         <div
@@ -293,17 +323,24 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
             height: HOUR_HEIGHT * HOURS.length,
           }}
         >
+          {/* Hour rules, starting one row down so neither the top nor the
+              bottom edge of the grid carries a line. */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 bottom-0"
+            style={{
+              top: HOUR_HEIGHT,
+              backgroundImage: `linear-gradient(to bottom, ${HOUR_RULE_COLOR} 0 1px, transparent 1px)`,
+              backgroundSize: `100% ${HOUR_HEIGHT}px`,
+            }}
+          />
           {stripDays.map((day) => {
             const isToday = isSameDay(day, today);
             return (
               <div
                 key={day.getTime()}
-                className="relative border-l border-border-elevated"
-                style={{
-                  scrollSnapAlign: "start",
-                  backgroundImage: `linear-gradient(to bottom, ${HOUR_RULE_COLOR} 0 1px, transparent 1px)`,
-                  backgroundSize: `100% ${HOUR_HEIGHT}px`,
-                }}
+                className="relative"
+                style={{ scrollSnapAlign: "start" }}
               >
                 {/* Event blocks will render here in a later stage. */}
                 {isToday && nowFraction != null && (

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -1,14 +1,16 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import { cn } from "@/utils/cn";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
 import { Text } from "@/components/ui/primitives/text";
+import { CalendarFrame } from "./calendar-frame";
 import { addDays, formatHourLabel, HOURS, isSameDay, startOfWeek } from "./calendar-helpers";
 
 /** Width of the left time gutter, in pixels. */
 const GUTTER_WIDTH = 52;
 /** Height of a single hour row, in pixels. */
 const HOUR_HEIGHT = 48;
-/** Height of the sticky weekday/date header row, in pixels. */
+/** Height of the weekday/date header row, in pixels. */
 const HEADER_HEIGHT = 56;
 /** Visible day columns (a week). */
 const VISIBLE_COLUMNS = 7;
@@ -24,17 +26,23 @@ interface WeekGridProps {
   /** Reports the week (its Sunday) scrolled into view, so the pane title and
    * paging stay in sync with manual horizontal scrolling. */
   onVisibleWeekChange: (weekStart: Date) => void;
+  /** The pane's toolbar, rendered in the header card above the day row. */
+  toolbar: ReactNode;
 }
 
 /**
- * The week grid skeleton, modelled on qali's time strip: a pinned left time
- * gutter, a sticky day header, and a single two-axis scroller whose buffered
- * day columns snap one day at a time — so the week scrolls horizontally like
- * qali's. Presentational only: no events; a current-time line marks today.
+ * The week view skeleton, modelled on qali's time strip: a pinned left time
+ * gutter and a single two-axis scroller whose buffered day columns snap one
+ * day at a time — so the week scrolls horizontally like qali's. The day row
+ * lives in the header card above; it has no scroller of its own and simply
+ * mirrors the grid's horizontal offset, so the two always line up.
+ * Presentational only: no events; a current-time line marks today.
  */
-export function WeekGrid({ anchor, onVisibleWeekChange }: WeekGridProps) {
+export function WeekGrid({ anchor, onVisibleWeekChange, toolbar }: WeekGridProps) {
   const today = useStartOfToday();
   const scrollerRef = useRef<HTMLDivElement>(null);
+  /** The overflow-hidden viewport around the day row, in the header card. */
+  const headerStripRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number | null>(null);
   const mountedRef = useRef(false);
   /** The week (ms) the strip is currently aligned to; guards the anchor effect
@@ -101,6 +109,11 @@ export function WeekGrid({ anchor, onVisibleWeekChange }: WeekGridProps) {
   }, [anchor, scrollToWeek]);
 
   const handleScroll = () => {
+    // Mirror the horizontal offset onto the header's day row synchronously —
+    // not inside the rAF below — so it never trails the grid by a frame.
+    const scroller = scrollerRef.current;
+    const headerStrip = headerStripRef.current;
+    if (scroller && headerStrip) headerStrip.scrollLeft = scroller.scrollLeft;
     if (rafRef.current !== null) return;
     rafRef.current = requestAnimationFrame(() => {
       rafRef.current = null;
@@ -124,42 +137,17 @@ export function WeekGrid({ anchor, onVisibleWeekChange }: WeekGridProps) {
     [],
   );
 
-  return (
-    <div
-      ref={scrollerRef}
-      onScroll={handleScroll}
-      className="flex min-h-0 flex-1 items-start overflow-auto overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-      style={{ scrollSnapType: "x mandatory", scrollPaddingLeft: GUTTER_WIDTH }}
-    >
-      {/* Pinned time gutter. */}
-      <div
-        className="sticky left-0 z-30 flex shrink-0 flex-col bg-background-elevated"
-        style={{ width: GUTTER_WIDTH }}
-      >
+  const dayRow = (
+    <div className="flex" style={{ height: HEADER_HEIGHT }}>
+      {/* Spacer over the grid's time gutter, keeping the columns aligned. */}
+      <div className="shrink-0" style={{ width: GUTTER_WIDTH }} />
+      <div ref={headerStripRef} className="min-w-0 flex-1 overflow-hidden">
         <div
-          className="sticky top-0 z-10 shrink-0 border-b border-border-elevated bg-background-elevated"
-          style={{ height: HEADER_HEIGHT }}
-        />
-        <div className="relative shrink-0" style={{ height: HOUR_HEIGHT * HOURS.length }}>
-          {HOURS.slice(1).map((hour) => (
-            <span
-              key={hour}
-              className="absolute right-1.5 -translate-y-1/2 text-[10px] tabular-nums text-foreground-muted"
-              style={{ top: hour * HOUR_HEIGHT }}
-            >
-              {formatHourLabel(hour)}
-            </span>
-          ))}
-        </div>
-      </div>
-      {/* Buffered day strip: 7 columns fill the viewport, the rest overflow. */}
-      <div
-        className="flex shrink-0 flex-col"
-        style={{ width: `calc(${stripDays.length} * (100% - ${GUTTER_WIDTH}px) / ${VISIBLE_COLUMNS})` }}
-      >
-        <div
-          className="sticky top-0 z-20 grid shrink-0 border-b border-border-elevated bg-background-elevated"
-          style={{ gridTemplateColumns: columnsTemplate, height: HEADER_HEIGHT }}
+          className="grid h-full"
+          style={{
+            gridTemplateColumns: columnsTemplate,
+            width: `calc(${stripDays.length} * 100% / ${VISIBLE_COLUMNS})`,
+          }}
         >
           {stripDays.map((day) => {
             const isToday = isSameDay(day, today);
@@ -167,7 +155,6 @@ export function WeekGrid({ anchor, onVisibleWeekChange }: WeekGridProps) {
               <div
                 key={day.getTime()}
                 className="flex flex-col items-center justify-center gap-1 border-l border-border-elevated"
-                style={{ scrollSnapAlign: "start" }}
               >
                 <Text as="span" size="xs" tone="muted" className="font-medium uppercase tracking-wide">
                   {day.toLocaleDateString("en-US", { weekday: "short" })}
@@ -184,9 +171,41 @@ export function WeekGrid({ anchor, onVisibleWeekChange }: WeekGridProps) {
             );
           })}
         </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <CalendarFrame toolbar={toolbar} columnHeader={dayRow}>
+      <div
+        ref={scrollerRef}
+        onScroll={handleScroll}
+        className="flex min-h-0 flex-1 items-start overflow-auto overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        style={{ scrollSnapType: "x mandatory", scrollPaddingLeft: GUTTER_WIDTH }}
+      >
+        {/* Pinned time gutter. */}
+        <div
+          className="relative sticky left-0 z-30 shrink-0 bg-background-elevated"
+          style={{ width: GUTTER_WIDTH, height: HOUR_HEIGHT * HOURS.length }}
+        >
+          {HOURS.slice(1).map((hour) => (
+            <span
+              key={hour}
+              className="absolute right-1.5 -translate-y-1/2 text-[10px] tabular-nums text-foreground-muted"
+              style={{ top: hour * HOUR_HEIGHT }}
+            >
+              {formatHourLabel(hour)}
+            </span>
+          ))}
+        </div>
+        {/* Buffered day strip: 7 columns fill the viewport, the rest overflow. */}
         <div
           className="relative grid shrink-0"
-          style={{ gridTemplateColumns: columnsTemplate, height: HOUR_HEIGHT * HOURS.length }}
+          style={{
+            gridTemplateColumns: columnsTemplate,
+            width: `calc(${stripDays.length} * (100% - ${GUTTER_WIDTH}px) / ${VISIBLE_COLUMNS})`,
+            height: HOUR_HEIGHT * HOURS.length,
+          }}
         >
           {stripDays.map((day) => {
             const isToday = isSameDay(day, today);
@@ -213,6 +232,6 @@ export function WeekGrid({ anchor, onVisibleWeekChange }: WeekGridProps) {
           })}
         </div>
       </div>
-    </div>
+    </CalendarFrame>
   );
 }

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -108,6 +108,26 @@ export function WeekGrid({ anchor, onVisibleWeekChange, toolbar }: WeekGridProps
     }
   }, [anchor, scrollToWeek]);
 
+  // Column widths are a fraction of the scroller's width, but the horizontal
+  // offset is kept in pixels — so a viewport resize would silently drift the
+  // strip to a different week (and snap it mid-week). Re-snap to the week the
+  // strip was aligned to whenever the scroller's width changes.
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    let lastWidth = el.clientWidth;
+    const observer = new ResizeObserver(() => {
+      const width = el.clientWidth;
+      if (width === 0 || width === lastWidth) return;
+      lastWidth = width;
+      const alignedWeekMs = alignedWeekMsRef.current;
+      if (alignedWeekMs === null) return;
+      scrollToWeek(new Date(alignedWeekMs), "auto");
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [scrollToWeek]);
+
   const handleScroll = () => {
     // Mirror the horizontal offset onto the header's day row synchronously —
     // not inside the rAF below — so it never trails the grid by a frame.

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -100,6 +100,11 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
    * the anchor effect from re-scrolling in response to the strip's own scroll
    * reports. */
   const alignedCenterMsRef = useRef<number | null>(null);
+  /** The scroller's width (px) the strip was last aligned at. Column widths
+   * are a fraction of it, so a scroll report arriving while the width differs
+   * is the strip mid-resize — its offset still belongs to the old width — and
+   * not the user paging; it is ignored and the resize observer re-aligns. */
+  const alignedWidthRef = useRef<number | null>(null);
 
   // The buffered strip is centred on the range active when the grid mounts, so
   // the entry range sits mid-buffer and paging stays inside it.
@@ -152,6 +157,7 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
       const index = Math.round((first.getTime() - stripDays[0].getTime()) / MS_PER_DAY);
       const clamped = Math.max(0, Math.min(index, stripDays.length - VISIBLE_COLUMNS));
       alignedCenterMsRef.current = centerDay.getTime();
+      alignedWidthRef.current = el.clientWidth;
       el.scrollTo({ left: clamped * columnWidth(), behavior });
       // An instant jump lands before any scroll event; mirror it right away so
       // the header never shows a stale range, even for a frame.
@@ -198,17 +204,19 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
   // Column widths are a fraction of the scroller's width, but the horizontal
   // offset is kept in pixels — so a viewport resize would silently drift the
   // strip to different days. Re-snap to the day the strip was centred on
-  // whenever the scroller's width changes.
+  // whenever the scroller's width changes. (`handleScroll` ignores the scroll
+  // events a resize produces, so that day is still the one the user chose.)
   useEffect(() => {
     const el = scrollerRef.current;
     if (!el || typeof ResizeObserver === "undefined") return;
-    let lastWidth = el.clientWidth;
     const observer = new ResizeObserver(() => {
       const width = el.clientWidth;
-      if (width === 0 || width === lastWidth) return;
-      lastWidth = width;
+      if (width === 0 || width === alignedWidthRef.current) return;
       const alignedCenterMs = alignedCenterMsRef.current;
-      if (alignedCenterMs === null) return;
+      if (alignedCenterMs === null) {
+        alignedWidthRef.current = width;
+        return;
+      }
       scrollToCenter(new Date(alignedCenterMs), "auto");
     });
     observer.observe(el);
@@ -224,6 +232,10 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
       rafRef.current = null;
       const el = scrollerRef.current;
       if (!el) return;
+      // Mid-resize: the offset belongs to the old width, so reading it against
+      // the new one would land on a different day. The resize observer
+      // re-aligns the strip to the chosen day; don't report this one.
+      if (el.clientWidth !== alignedWidthRef.current) return;
       const index = Math.max(
         0,
         Math.min(Math.round(el.scrollLeft / columnWidth()), stripDays.length - VISIBLE_COLUMNS),

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -4,7 +4,15 @@ import { cn } from "@/utils/cn";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
 import { Text } from "@/components/ui/primitives/text";
 import { CalendarFrame } from "./calendar-frame";
-import { addDays, formatHourLabel, HOURS, isSameDay, startOfWeek } from "./calendar-helpers";
+import {
+  addDays,
+  formatHourLabel,
+  HOURS,
+  isSameDay,
+  startOfDay,
+  startOfVisibleWeek,
+  WEEK_VIEW_DAYS,
+} from "./calendar-helpers";
 
 /** Width of the left time gutter, in pixels. */
 const GUTTER_WIDTH = 52;
@@ -13,8 +21,10 @@ const HOUR_HEIGHT = 48;
 /** Height of the weekday/date header row, in pixels. */
 const HEADER_HEIGHT = 56;
 /** Visible day columns (a week). */
-const VISIBLE_COLUMNS = 7;
-/** Weeks buffered on each side of the entry week, giving the strip a long,
+const VISIBLE_COLUMNS = WEEK_VIEW_DAYS;
+/** Offset of the centre column from the first visible one. */
+const CENTER_OFFSET = Math.floor(VISIBLE_COLUMNS / 2);
+/** Weeks buffered on each side of the entry range, giving the strip a long,
  * effectively-continuous horizontal scroll range without recentering logic. */
 const BUFFER_WEEKS = 26;
 
@@ -30,11 +40,12 @@ const FADED_COLUMN_RULE: CSSProperties = {
 };
 
 interface WeekGridProps {
-  /** Any date inside the week to show; drives the horizontal scroll position. */
+  /** The day to centre the visible range on; drives the horizontal scroll
+   * position. Today on entry, so today sits in the middle column. */
   anchor: Date;
-  /** Reports the week (its Sunday) scrolled into view, so the pane title and
-   * paging stay in sync with manual horizontal scrolling. */
-  onVisibleWeekChange: (weekStart: Date) => void;
+  /** Reports the day now in the centre column after manual horizontal
+   * scrolling, so the pane title and paging stay in sync with the strip. */
+  onCenterDayChange: (centerDay: Date) => void;
   /** The pane's toolbar, rendered in the header card above the day row. */
   toolbar: ReactNode;
 }
@@ -42,26 +53,29 @@ interface WeekGridProps {
 /**
  * The week view skeleton, modelled on qali's time strip: a pinned left time
  * gutter and a single two-axis scroller whose buffered day columns snap one
- * day at a time — so the week scrolls horizontally like qali's. The day row
- * lives in the header card above; it has no scroller of its own and simply
- * mirrors the grid's horizontal offset, so the two always line up.
+ * day at a time — so the week scrolls horizontally like qali's. The visible
+ * range is a rolling seven days centred on `anchor` rather than a calendar
+ * week, so "Today" puts today in the middle and paging keeps that alignment.
+ * The day row lives in the header card above; it has no scroller of its own
+ * and simply mirrors the grid's horizontal offset, so the two always line up.
  * Presentational only: no events; a current-time line marks today.
  */
-export function WeekGrid({ anchor, onVisibleWeekChange, toolbar }: WeekGridProps) {
+export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) {
   const today = useStartOfToday();
   const scrollerRef = useRef<HTMLDivElement>(null);
   /** The overflow-hidden viewport around the day row, in the header card. */
   const headerStripRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number | null>(null);
   const mountedRef = useRef(false);
-  /** The week (ms) the strip is currently aligned to; guards the anchor effect
-   * from re-scrolling in response to the strip's own scroll reports. */
-  const alignedWeekMsRef = useRef<number | null>(null);
+  /** The centre day (ms, midnight) the strip is currently aligned to; guards
+   * the anchor effect from re-scrolling in response to the strip's own scroll
+   * reports. */
+  const alignedCenterMsRef = useRef<number | null>(null);
 
-  // The buffered strip is centered on the week active when the grid mounts, so
-  // the entry week sits mid-range and paging stays inside the buffer.
+  // The buffered strip is centred on the range active when the grid mounts, so
+  // the entry range sits mid-buffer and paging stays inside it.
   const [stripDays] = useState(() => {
-    const start = addDays(startOfWeek(anchor), -BUFFER_WEEKS * 7);
+    const start = addDays(startOfVisibleWeek(anchor), -BUFFER_WEEKS * 7);
     return Array.from({ length: (BUFFER_WEEKS * 2 + 1) * 7 }, (_, index) =>
       addDays(start, index),
     );
@@ -95,42 +109,44 @@ export function WeekGrid({ anchor, onVisibleWeekChange, toolbar }: WeekGridProps
     if (scroller && headerStrip) headerStrip.scrollLeft = scroller.scrollLeft;
   }, []);
 
-  const scrollToWeek = useCallback(
-    (weekStart: Date, behavior: ScrollBehavior) => {
+  /** Scrolls the strip so `centerDay` (midnight) sits in the middle column. */
+  const scrollToCenter = useCallback(
+    (centerDay: Date, behavior: ScrollBehavior) => {
       const el = scrollerRef.current;
       if (!el) return;
-      const index = Math.round((weekStart.getTime() - stripDays[0].getTime()) / MS_PER_DAY);
+      const first = startOfVisibleWeek(centerDay);
+      const index = Math.round((first.getTime() - stripDays[0].getTime()) / MS_PER_DAY);
       const clamped = Math.max(0, Math.min(index, stripDays.length - VISIBLE_COLUMNS));
-      alignedWeekMsRef.current = weekStart.getTime();
+      alignedCenterMsRef.current = centerDay.getTime();
       el.scrollTo({ left: clamped * columnWidth(), behavior });
       // An instant jump lands before any scroll event; mirror it right away so
-      // the header never shows a stale week, even for a frame.
+      // the header never shows a stale range, even for a frame.
       if (behavior === "auto") syncHeaderStrip();
     },
     [columnWidth, stripDays, syncHeaderStrip],
   );
 
-  // On mount, jump to the anchor week and down to business hours (auto, no
+  // On mount, centre the anchor day and jump down to business hours (auto, no
   // animation); afterwards, smooth-scroll whenever the anchor moves to a
-  // different week than the strip is aligned to (button paging / Today).
+  // different day than the strip is centred on (button paging / Today).
   useLayoutEffect(() => {
-    const weekStart = startOfWeek(anchor);
+    const centerDay = startOfDay(anchor);
     if (!mountedRef.current) {
       mountedRef.current = true;
-      scrollToWeek(weekStart, "auto");
+      scrollToCenter(centerDay, "auto");
       const el = scrollerRef.current;
       if (el) el.scrollTop = Math.max(0, (new Date().getHours() - 1) * HOUR_HEIGHT);
       return;
     }
-    if (weekStart.getTime() !== alignedWeekMsRef.current) {
-      scrollToWeek(weekStart, "smooth");
+    if (centerDay.getTime() !== alignedCenterMsRef.current) {
+      scrollToCenter(centerDay, "smooth");
     }
-  }, [anchor, scrollToWeek]);
+  }, [anchor, scrollToCenter]);
 
   // Column widths are a fraction of the scroller's width, but the horizontal
   // offset is kept in pixels — so a viewport resize would silently drift the
-  // strip to a different week (and snap it mid-week). Re-snap to the week the
-  // strip was aligned to whenever the scroller's width changes.
+  // strip to different days. Re-snap to the day the strip was centred on
+  // whenever the scroller's width changes.
   useEffect(() => {
     const el = scrollerRef.current;
     if (!el || typeof ResizeObserver === "undefined") return;
@@ -139,13 +155,13 @@ export function WeekGrid({ anchor, onVisibleWeekChange, toolbar }: WeekGridProps
       const width = el.clientWidth;
       if (width === 0 || width === lastWidth) return;
       lastWidth = width;
-      const alignedWeekMs = alignedWeekMsRef.current;
-      if (alignedWeekMs === null) return;
-      scrollToWeek(new Date(alignedWeekMs), "auto");
+      const alignedCenterMs = alignedCenterMsRef.current;
+      if (alignedCenterMs === null) return;
+      scrollToCenter(new Date(alignedCenterMs), "auto");
     });
     observer.observe(el);
     return () => observer.disconnect();
-  }, [scrollToWeek]);
+  }, [scrollToCenter]);
 
   const handleScroll = () => {
     // Mirror synchronously — not inside the rAF below — so the header never
@@ -160,10 +176,10 @@ export function WeekGrid({ anchor, onVisibleWeekChange, toolbar }: WeekGridProps
         0,
         Math.min(Math.round(el.scrollLeft / columnWidth()), stripDays.length - VISIBLE_COLUMNS),
       );
-      const weekStart = startOfWeek(stripDays[index]);
-      if (weekStart.getTime() === alignedWeekMsRef.current) return;
-      alignedWeekMsRef.current = weekStart.getTime();
-      onVisibleWeekChange(weekStart);
+      const centerDay = stripDays[index + CENTER_OFFSET];
+      if (centerDay.getTime() === alignedCenterMsRef.current) return;
+      alignedCenterMsRef.current = centerDay.getTime();
+      onCenterDayChange(centerDay);
     });
   };
 

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -1,30 +1,55 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { cn } from "@/utils/cn";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
 import { Text } from "@/components/ui/primitives/text";
-import { formatHourLabel, HOURS, isSameDay } from "./calendar-helpers";
+import { addDays, formatHourLabel, HOURS, isSameDay, startOfWeek } from "./calendar-helpers";
 
 /** Width of the left time gutter, in pixels. */
 const GUTTER_WIDTH = 52;
 /** Height of a single hour row, in pixels. */
 const HOUR_HEIGHT = 48;
+/** Height of the sticky weekday/date header row, in pixels. */
+const HEADER_HEIGHT = 56;
+/** Visible day columns (a week). */
+const VISIBLE_COLUMNS = 7;
+/** Weeks buffered on each side of the entry week, giving the strip a long,
+ * effectively-continuous horizontal scroll range without recentering logic. */
+const BUFFER_WEEKS = 26;
 
 const MS_PER_DAY = 86_400_000;
 
 interface WeekGridProps {
-  /** The 7 days of the week, from `getWeekDays`. */
-  days: Date[];
+  /** Any date inside the week to show; drives the horizontal scroll position. */
+  anchor: Date;
+  /** Reports the week (its Sunday) scrolled into view, so the pane title and
+   * paging stay in sync with manual horizontal scrolling. */
+  onVisibleWeekChange: (weekStart: Date) => void;
 }
 
 /**
- * The week grid skeleton, modelled on qali's time strip: a left time gutter of
- * hour labels, a header row of the 7 days, and a scrollable 24-hour body with a
- * column per day. Presentational only — no events; a faint current-time line
- * marks today when it is in view.
+ * The week grid skeleton, modelled on qali's time strip: a pinned left time
+ * gutter, a sticky day header, and a single two-axis scroller whose buffered
+ * day columns snap one day at a time — so the week scrolls horizontally like
+ * qali's. Presentational only: no events; a current-time line marks today.
  */
-export function WeekGrid({ days }: WeekGridProps) {
+export function WeekGrid({ anchor, onVisibleWeekChange }: WeekGridProps) {
   const today = useStartOfToday();
-  const columnsTemplate = `${GUTTER_WIDTH}px repeat(7, minmax(0, 1fr))`;
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number | null>(null);
+  const mountedRef = useRef(false);
+  /** The week (ms) the strip is currently aligned to; guards the anchor effect
+   * from re-scrolling in response to the strip's own scroll reports. */
+  const alignedWeekMsRef = useRef<number | null>(null);
+
+  // The buffered strip is centered on the week active when the grid mounts, so
+  // the entry week sits mid-range and paging stays inside the buffer.
+  const [stripDays] = useState(() => {
+    const start = addDays(startOfWeek(anchor), -BUFFER_WEEKS * 7);
+    return Array.from({ length: (BUFFER_WEEKS * 2 + 1) * 7 }, (_, index) =>
+      addDays(start, index),
+    );
+  });
+  const columnsTemplate = `repeat(${stripDays.length}, minmax(0, 1fr))`;
 
   // Resolve the current-time line on the client only, so SSR and hydration
   // agree (the server has no stable "now").
@@ -40,62 +65,137 @@ export function WeekGrid({ days }: WeekGridProps) {
     return () => globalThis.clearInterval(interval);
   }, []);
 
+  const columnWidth = useCallback(() => {
+    const el = scrollerRef.current;
+    if (!el) return 1;
+    return Math.max((el.clientWidth - GUTTER_WIDTH) / VISIBLE_COLUMNS, 1);
+  }, []);
+
+  const scrollToWeek = useCallback(
+    (weekStart: Date, behavior: ScrollBehavior) => {
+      const el = scrollerRef.current;
+      if (!el) return;
+      const index = Math.round((weekStart.getTime() - stripDays[0].getTime()) / MS_PER_DAY);
+      const clamped = Math.max(0, Math.min(index, stripDays.length - VISIBLE_COLUMNS));
+      alignedWeekMsRef.current = weekStart.getTime();
+      el.scrollTo({ left: clamped * columnWidth(), behavior });
+    },
+    [columnWidth, stripDays],
+  );
+
+  // On mount, jump to the anchor week and down to business hours (auto, no
+  // animation); afterwards, smooth-scroll whenever the anchor moves to a
+  // different week than the strip is aligned to (button paging / Today).
+  useLayoutEffect(() => {
+    const weekStart = startOfWeek(anchor);
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      scrollToWeek(weekStart, "auto");
+      const el = scrollerRef.current;
+      if (el) el.scrollTop = Math.max(0, (new Date().getHours() - 1) * HOUR_HEIGHT);
+      return;
+    }
+    if (weekStart.getTime() !== alignedWeekMsRef.current) {
+      scrollToWeek(weekStart, "smooth");
+    }
+  }, [anchor, scrollToWeek]);
+
+  const handleScroll = () => {
+    if (rafRef.current !== null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      const el = scrollerRef.current;
+      if (!el) return;
+      const index = Math.max(
+        0,
+        Math.min(Math.round(el.scrollLeft / columnWidth()), stripDays.length - VISIBLE_COLUMNS),
+      );
+      const weekStart = startOfWeek(stripDays[index]);
+      if (weekStart.getTime() === alignedWeekMsRef.current) return;
+      alignedWeekMsRef.current = weekStart.getTime();
+      onVisibleWeekChange(weekStart);
+    });
+  };
+
+  useEffect(
+    () => () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    },
+    [],
+  );
+
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <div
+      ref={scrollerRef}
+      onScroll={handleScroll}
+      className="flex min-h-0 flex-1 overflow-auto overscroll-x-contain [scrollbar-width:thin]"
+      style={{ scrollSnapType: "x mandatory", scrollPaddingLeft: GUTTER_WIDTH }}
+    >
+      {/* Pinned time gutter. */}
       <div
-        className="grid shrink-0 border-b border-border-elevated"
-        style={{ gridTemplateColumns: columnsTemplate }}
+        className="sticky left-0 z-30 flex shrink-0 flex-col bg-background-elevated"
+        style={{ width: GUTTER_WIDTH }}
       >
-        {/* Gutter corner. */}
-        <div />
-        {days.map((day) => {
-          const isToday = isSameDay(day, today);
-          return (
-            <div
-              key={day.getTime()}
-              className="flex flex-col items-center gap-1 border-l border-border-elevated py-2"
+        <div
+          className="sticky top-0 z-10 shrink-0 border-b border-border-elevated bg-background-elevated"
+          style={{ height: HEADER_HEIGHT }}
+        />
+        <div className="relative shrink-0" style={{ height: HOUR_HEIGHT * HOURS.length }}>
+          {HOURS.slice(1).map((hour) => (
+            <span
+              key={hour}
+              className="absolute right-1.5 -translate-y-1/2 text-[10px] tabular-nums text-foreground-muted"
+              style={{ top: hour * HOUR_HEIGHT }}
             >
-              <Text as="span" size="xs" tone="muted" className="font-medium uppercase tracking-wide">
-                {day.toLocaleDateString("en-US", { weekday: "short" })}
-              </Text>
-              <span
-                className={cn(
-                  "flex size-6 items-center justify-center text-xs font-medium tabular-nums",
-                  isToday ? "rounded-full bg-emerald-400 text-neutral-950" : "text-foreground",
-                )}
-              >
-                {day.getDate()}
-              </span>
-            </div>
-          );
-        })}
+              {formatHourLabel(hour)}
+            </span>
+          ))}
+        </div>
       </div>
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      {/* Buffered day strip: 7 columns fill the viewport, the rest overflow. */}
+      <div
+        className="flex shrink-0 flex-col"
+        style={{ width: `calc(${stripDays.length} * (100% - ${GUTTER_WIDTH}px) / ${VISIBLE_COLUMNS})` }}
+      >
+        <div
+          className="sticky top-0 z-20 grid border-b border-border-elevated bg-background-elevated"
+          style={{ gridTemplateColumns: columnsTemplate, height: HEADER_HEIGHT }}
+        >
+          {stripDays.map((day) => {
+            const isToday = isSameDay(day, today);
+            return (
+              <div
+                key={day.getTime()}
+                className="flex flex-col items-center justify-center gap-1 border-l border-border-elevated"
+                style={{ scrollSnapAlign: "start" }}
+              >
+                <Text as="span" size="xs" tone="muted" className="font-medium uppercase tracking-wide">
+                  {day.toLocaleDateString("en-US", { weekday: "short" })}
+                </Text>
+                <span
+                  className={cn(
+                    "flex size-6 items-center justify-center text-xs font-medium tabular-nums",
+                    isToday ? "rounded-full bg-emerald-400 text-neutral-950" : "text-foreground",
+                  )}
+                >
+                  {day.getDate()}
+                </span>
+              </div>
+            );
+          })}
+        </div>
         <div
           className="relative grid"
-          style={{
-            gridTemplateColumns: columnsTemplate,
-            height: HOUR_HEIGHT * HOURS.length,
-          }}
+          style={{ gridTemplateColumns: columnsTemplate, height: HOUR_HEIGHT * HOURS.length }}
         >
-          <div className="relative">
-            {HOURS.slice(1).map((hour) => (
-              <span
-                key={hour}
-                className="absolute right-1.5 -translate-y-1/2 text-[10px] tabular-nums text-foreground-muted"
-                style={{ top: hour * HOUR_HEIGHT }}
-              >
-                {formatHourLabel(hour)}
-              </span>
-            ))}
-          </div>
-          {days.map((day) => {
+          {stripDays.map((day) => {
             const isToday = isSameDay(day, today);
             return (
               <div
                 key={day.getTime()}
                 className="relative border-l border-border-elevated"
                 style={{
+                  scrollSnapAlign: "start",
                   backgroundImage:
                     "linear-gradient(to bottom, var(--color-border-elevated) 0 1px, transparent 1px)",
                   backgroundSize: `100% ${HOUR_HEIGHT}px`,

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -128,7 +128,7 @@ export function WeekGrid({ anchor, onVisibleWeekChange }: WeekGridProps) {
     <div
       ref={scrollerRef}
       onScroll={handleScroll}
-      className="flex min-h-0 flex-1 overflow-auto overscroll-x-contain [scrollbar-width:thin]"
+      className="flex min-h-0 flex-1 overflow-auto overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       style={{ scrollSnapType: "x mandatory", scrollPaddingLeft: GUTTER_WIDTH }}
     >
       {/* Pinned time gutter. */}

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
+import { useRouter } from "@tanstack/react-router";
 import { cn } from "@/utils/cn";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
 import { Text } from "@/components/ui/primitives/text";
@@ -62,11 +63,15 @@ interface WeekGridProps {
  */
 export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) {
   const today = useStartOfToday();
+  const router = useRouter();
   const scrollerRef = useRef<HTMLDivElement>(null);
   /** The overflow-hidden viewport around the day row, in the header card. */
   const headerStripRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number | null>(null);
   const mountedRef = useRef(false);
+  /** Tears down the one-shot "re-centre after the router restores scroll"
+   * listener set up on mount, if it is still pending at unmount. */
+  const restorationCleanupRef = useRef<(() => void) | null>(null);
   /** The centre day (ms, midnight) the strip is currently aligned to; guards
    * the anchor effect from re-scrolling in response to the strip's own scroll
    * reports. */
@@ -133,15 +138,33 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
     const centerDay = startOfDay(anchor);
     if (!mountedRef.current) {
       mountedRef.current = true;
-      scrollToCenter(centerDay, "auto");
-      const el = scrollerRef.current;
-      if (el) el.scrollTop = Math.max(0, (new Date().getHours() - 1) * HOUR_HEIGHT);
+      const center = () => {
+        scrollToCenter(centerDay, "auto");
+        const el = scrollerRef.current;
+        if (el) el.scrollTop = Math.max(0, (new Date().getHours() - 1) * HOUR_HEIGHT);
+      };
+      center();
+      // The router's scroll restoration replays this element's offsets from the
+      // last visit right after the route renders — later in this same commit —
+      // which would drag the strip back to wherever it was then. Centre again
+      // once that has run. If it hasn't run by the next frame it won't for
+      // this mount, so stop listening rather than re-centring on a later
+      // navigation.
+      const unsubscribe = router.subscribe("onRendered", () => {
+        unsubscribe();
+        center();
+      });
+      const frame = requestAnimationFrame(unsubscribe);
+      restorationCleanupRef.current = () => {
+        cancelAnimationFrame(frame);
+        unsubscribe();
+      };
       return;
     }
     if (centerDay.getTime() !== alignedCenterMsRef.current) {
       scrollToCenter(centerDay, "smooth");
     }
-  }, [anchor, scrollToCenter]);
+  }, [anchor, router, scrollToCenter]);
 
   // Column widths are a fraction of the scroller's width, but the horizontal
   // offset is kept in pixels — so a viewport resize would silently drift the
@@ -186,6 +209,7 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
   useEffect(
     () => () => {
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      restorationCleanupRef.current?.();
     },
     [],
   );

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -230,7 +230,11 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
   );
 
   return (
-    <CalendarFrame toolbar={toolbar} columnHeader={dayRow}>
+    <CalendarFrame
+      toolbar={toolbar}
+      columnHeader={dayRow}
+      gridMaxHeight={HOUR_HEIGHT * HOURS.length}
+    >
       <div
         ref={scrollerRef}
         onScroll={handleScroll}

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -128,7 +128,7 @@ export function WeekGrid({ anchor, onVisibleWeekChange }: WeekGridProps) {
     <div
       ref={scrollerRef}
       onScroll={handleScroll}
-      className="flex min-h-0 flex-1 overflow-auto overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      className="flex min-h-0 flex-1 items-start overflow-auto overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       style={{ scrollSnapType: "x mandatory", scrollPaddingLeft: GUTTER_WIDTH }}
     >
       {/* Pinned time gutter. */}

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -31,6 +31,10 @@ const BUFFER_WEEKS = 26;
 
 const MS_PER_DAY = 86_400_000;
 
+/** Colour of the hour rules across the grid: the column-rule token, faded so
+ * the horizontal lines read as a secondary, quieter layer under the columns. */
+const HOUR_RULE_COLOR = "color-mix(in oklab, var(--color-border-elevated) 45%, transparent)";
+
 /** A 1px column rule along a cell's left edge that fades out toward the top,
  * so the day row's lines dissolve into the toolbar above instead of meeting
  * a separator at a hard corner. Sits exactly where the grid's `border-l` is. */
@@ -297,8 +301,7 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
                 className="relative border-l border-border-elevated"
                 style={{
                   scrollSnapAlign: "start",
-                  backgroundImage:
-                    "linear-gradient(to bottom, var(--color-border-elevated) 0 1px, transparent 1px)",
+                  backgroundImage: `linear-gradient(to bottom, ${HOUR_RULE_COLOR} 0 1px, transparent 1px)`,
                   backgroundSize: `100% ${HOUR_HEIGHT}px`,
                 }}
               >

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -52,6 +52,18 @@ const COLUMN_RULES: CSSProperties = {
  * the toolbar above instead of meeting it at a hard corner. */
 const HEADER_RULE_FADE = "linear-gradient(to top, black 35%, transparent)";
 
+/** Depth of the grid's top and bottom edge fades, in pixels. Shallow enough
+ * to stay clear of the first and last hour labels at the scroll extremes. */
+const GRID_EDGE_FADE_SIZE = 24;
+
+/** Fades the grid's scroller out at its top and bottom edges, so rules,
+ * labels and the current-time line dissolve into the page background instead
+ * of stopping at a hard edge. Applied to the scroller box, so it stays pinned
+ * to the visible area while the content scrolls beneath it — through a
+ * vertical overscroll bounce too. Vertical only: a horizontal fade would dim
+ * the time gutter's labels and the outermost day column. */
+const GRID_EDGE_FADE = `linear-gradient(to bottom, transparent, black ${GRID_EDGE_FADE_SIZE}px, black calc(100% - ${GRID_EDGE_FADE_SIZE}px), transparent)`;
+
 interface WeekGridProps {
   /** The day to centre the visible range on; drives the horizontal scroll
    * position. Today on entry, so today sits in the middle column. */
@@ -297,11 +309,14 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
           backgroundPositionX: `calc(${GUTTER_WIDTH}px - var(--strip-scroll, 0px))`,
           scrollSnapType: "x mandatory",
           scrollPaddingLeft: GUTTER_WIDTH,
+          maskImage: GRID_EDGE_FADE,
+          WebkitMaskImage: GRID_EDGE_FADE,
         }}
       >
-        {/* Pinned time gutter. */}
+        {/* Pinned time gutter; opaque in the page colour so the columns scroll
+            under it. */}
         <div
-          className="relative sticky left-0 z-30 shrink-0 bg-background-elevated"
+          className="relative sticky left-0 z-30 shrink-0 bg-background"
           style={{ width: GUTTER_WIDTH, height: HOUR_HEIGHT * HOURS.length }}
         >
           {HOURS.slice(1).map((hour) => (

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -158,7 +158,7 @@ export function WeekGrid({ anchor, onVisibleWeekChange }: WeekGridProps) {
         style={{ width: `calc(${stripDays.length} * (100% - ${GUTTER_WIDTH}px) / ${VISIBLE_COLUMNS})` }}
       >
         <div
-          className="sticky top-0 z-20 grid border-b border-border-elevated bg-background-elevated"
+          className="sticky top-0 z-20 grid shrink-0 border-b border-border-elevated bg-background-elevated"
           style={{ gridTemplateColumns: columnsTemplate, height: HEADER_HEIGHT }}
         >
           {stripDays.map((day) => {
@@ -185,7 +185,7 @@ export function WeekGrid({ anchor, onVisibleWeekChange }: WeekGridProps) {
           })}
         </div>
         <div
-          className="relative grid"
+          className="relative grid shrink-0"
           style={{ gridTemplateColumns: columnsTemplate, height: HOUR_HEIGHT * HOURS.length }}
         >
           {stripDays.map((day) => {

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -323,17 +323,6 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
             height: HOUR_HEIGHT * HOURS.length,
           }}
         >
-          {/* Hour rules, starting one row down so neither the top nor the
-              bottom edge of the grid carries a line. */}
-          <div
-            aria-hidden
-            className="pointer-events-none absolute inset-x-0 bottom-0"
-            style={{
-              top: HOUR_HEIGHT,
-              backgroundImage: `linear-gradient(to bottom, ${HOUR_RULE_COLOR} 0 1px, transparent 1px)`,
-              backgroundSize: `100% ${HOUR_HEIGHT}px`,
-            }}
-          />
           {stripDays.map((day) => {
             const isToday = isSameDay(day, today);
             return (
@@ -342,6 +331,19 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
                 className="relative"
                 style={{ scrollSnapAlign: "start" }}
               >
+                {/* Hour rules, painted per cell (one strip-wide layer is too
+                    large a box for some engines to paint a background on) and
+                    starting one row down, so neither the top nor the bottom
+                    edge of the grid carries a line. */}
+                <div
+                  aria-hidden
+                  className="pointer-events-none absolute inset-x-0 bottom-0"
+                  style={{
+                    top: HOUR_HEIGHT,
+                    backgroundImage: `linear-gradient(to bottom, ${HOUR_RULE_COLOR} 0 1px, transparent 1px)`,
+                    backgroundSize: `100% ${HOUR_HEIGHT}px`,
+                  }}
+                />
                 {/* Event blocks will render here in a later stage. */}
                 {isToday && nowFraction != null && (
                   <div

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from "react";
+import { cn } from "@/utils/cn";
+import { useStartOfToday } from "@/hooks/use-start-of-today";
+import { Text } from "@/components/ui/primitives/text";
+import { formatHourLabel, HOURS, isSameDay } from "./calendar-helpers";
+
+/** Width of the left time gutter, in pixels. */
+const GUTTER_WIDTH = 52;
+/** Height of a single hour row, in pixels. */
+const HOUR_HEIGHT = 48;
+
+const MS_PER_DAY = 86_400_000;
+
+interface WeekGridProps {
+  /** The 7 days of the week, from `getWeekDays`. */
+  days: Date[];
+}
+
+/**
+ * The week grid skeleton, modelled on qali's time strip: a left time gutter of
+ * hour labels, a header row of the 7 days, and a scrollable 24-hour body with a
+ * column per day. Presentational only — no events; a faint current-time line
+ * marks today when it is in view.
+ */
+export function WeekGrid({ days }: WeekGridProps) {
+  const today = useStartOfToday();
+  const columnsTemplate = `${GUTTER_WIDTH}px repeat(7, minmax(0, 1fr))`;
+
+  // Resolve the current-time line on the client only, so SSR and hydration
+  // agree (the server has no stable "now").
+  const [nowFraction, setNowFraction] = useState<number | null>(null);
+  useEffect(() => {
+    const update = () => {
+      const now = new Date();
+      const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+      setNowFraction((now.getTime() - startOfDay.getTime()) / MS_PER_DAY);
+    };
+    update();
+    const interval = globalThis.setInterval(update, 60_000);
+    return () => globalThis.clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div
+        className="grid shrink-0 border-b border-border-elevated"
+        style={{ gridTemplateColumns: columnsTemplate }}
+      >
+        {/* Gutter corner. */}
+        <div />
+        {days.map((day) => {
+          const isToday = isSameDay(day, today);
+          return (
+            <div
+              key={day.getTime()}
+              className="flex flex-col items-center gap-1 border-l border-border-elevated py-2"
+            >
+              <Text as="span" size="xs" tone="muted" className="font-medium uppercase tracking-wide">
+                {day.toLocaleDateString("en-US", { weekday: "short" })}
+              </Text>
+              <span
+                className={cn(
+                  "flex size-6 items-center justify-center text-xs font-medium tabular-nums",
+                  isToday ? "rounded-full bg-emerald-400 text-neutral-950" : "text-foreground",
+                )}
+              >
+                {day.getDate()}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div
+          className="relative grid"
+          style={{
+            gridTemplateColumns: columnsTemplate,
+            height: HOUR_HEIGHT * HOURS.length,
+          }}
+        >
+          <div className="relative">
+            {HOURS.slice(1).map((hour) => (
+              <span
+                key={hour}
+                className="absolute right-1.5 -translate-y-1/2 text-[10px] tabular-nums text-foreground-muted"
+                style={{ top: hour * HOUR_HEIGHT }}
+              >
+                {formatHourLabel(hour)}
+              </span>
+            ))}
+          </div>
+          {days.map((day) => {
+            const isToday = isSameDay(day, today);
+            return (
+              <div
+                key={day.getTime()}
+                className="relative border-l border-border-elevated"
+                style={{
+                  backgroundImage:
+                    "linear-gradient(to bottom, var(--color-border-elevated) 0 1px, transparent 1px)",
+                  backgroundSize: `100% ${HOUR_HEIGHT}px`,
+                }}
+              >
+                {/* Event blocks will render here in a later stage. */}
+                {isToday && nowFraction != null && (
+                  <div
+                    className="pointer-events-none absolute inset-x-0 z-10 h-0.5 -translate-y-1/2 bg-red-500"
+                    style={{ top: `${nowFraction * 100}%` }}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -93,9 +93,9 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
   const headerStripRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number | null>(null);
   const mountedRef = useRef(false);
-  /** Tears down the one-shot "re-centre after the router restores scroll"
-   * listener set up on mount, if it is still pending at unmount. */
-  const restorationCleanupRef = useRef<(() => void) | null>(null);
+  /** The scroller's vertical offset as last scrolled, so it can be put back
+   * after the router replays a cached one (see the `onRendered` effect). */
+  const scrollTopRef = useRef(0);
   /** The centre day (ms, midnight) the strip is currently aligned to; guards
    * the anchor effect from re-scrolling in response to the strip's own scroll
    * reports. */
@@ -173,33 +173,39 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
     const centerDay = startOfDay(anchor);
     if (!mountedRef.current) {
       mountedRef.current = true;
-      const center = () => {
-        scrollToCenter(centerDay, "auto");
-        const el = scrollerRef.current;
-        if (el) el.scrollTop = Math.max(0, (new Date().getHours() - 1) * HOUR_HEIGHT);
-      };
-      center();
-      // The router's scroll restoration replays this element's offsets from the
-      // last visit right after the route renders — later in this same commit —
-      // which would drag the strip back to wherever it was then. Centre again
-      // once that has run. If it hasn't run by the next frame it won't for
-      // this mount, so stop listening rather than re-centring on a later
-      // navigation.
-      const unsubscribe = router.subscribe("onRendered", () => {
-        unsubscribe();
-        center();
-      });
-      const frame = requestAnimationFrame(unsubscribe);
-      restorationCleanupRef.current = () => {
-        cancelAnimationFrame(frame);
-        unsubscribe();
-      };
+      scrollToCenter(centerDay, "auto");
+      const el = scrollerRef.current;
+      if (el) {
+        el.scrollTop = Math.max(0, (new Date().getHours() - 1) * HOUR_HEIGHT);
+        scrollTopRef.current = el.scrollTop;
+      }
       return;
     }
     if (centerDay.getTime() !== alignedCenterMsRef.current) {
       scrollToCenter(centerDay, "smooth");
     }
-  }, [anchor, router, scrollToCenter]);
+  }, [anchor, scrollToCenter]);
+
+  // The router's scroll restoration replays every scrollable element's cached
+  // offsets once a navigation has rendered — this scroller's included, even
+  // though the pane stays mounted across the dashboard's child routes and its
+  // live position is the truth. The cache is sampled on a throttle, so the
+  // replayed offset can be a stale, mid-scroll one that leaves the strip off
+  // its column (snapping it onto a neighbouring day) and at a different hour.
+  // The router registers its listener when it is created, so this one runs
+  // after it: put the strip back where it was. On the first load that also
+  // re-centres on today after the last visit's offsets are replayed.
+  useEffect(
+    () =>
+      router.subscribe("onRendered", () => {
+        const el = scrollerRef.current;
+        const alignedCenterMs = alignedCenterMsRef.current;
+        if (!el || alignedCenterMs === null) return;
+        el.scrollTop = scrollTopRef.current;
+        scrollToCenter(new Date(alignedCenterMs), "auto");
+      }),
+    [router, scrollToCenter],
+  );
 
   // Column widths are a fraction of the scroller's width, but the horizontal
   // offset is kept in pixels — so a viewport resize would silently drift the
@@ -227,6 +233,8 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
     // Mirror synchronously — not inside the rAF below — so the header never
     // trails the grid by a frame.
     syncHeaderStrip();
+    const scroller = scrollerRef.current;
+    if (scroller) scrollTopRef.current = scroller.scrollTop;
     if (rafRef.current !== null) return;
     rafRef.current = requestAnimationFrame(() => {
       rafRef.current = null;
@@ -250,7 +258,6 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
   useEffect(
     () => () => {
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
-      restorationCleanupRef.current?.();
     },
     [],
   );

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -335,7 +335,7 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
         {/* Pinned time gutter; opaque in the page colour so the columns scroll
             under it. */}
         <div
-          className="relative sticky left-0 z-30 shrink-0 bg-background"
+          className="sticky left-0 z-30 shrink-0 bg-background"
           style={{ width: GUTTER_WIDTH, height: HOUR_HEIGHT * HOURS.length }}
         >
           {HOURS.slice(1).map((hour) => (

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -25,9 +25,6 @@ const BUFFER_WEEKS = 26;
 
 const MS_PER_DAY = 86_400_000;
 
-// Faded so the hour lines read as a quieter layer under the column rules.
-const HOUR_RULE_COLOR = "color-mix(in oklab, var(--color-border-elevated) 45%, transparent)";
-
 // Painted on the viewport boxes, not the cells, so the rules span overscroll; `--strip-scroll` keeps them following the grid.
 const COLUMN_RULES: CSSProperties = {
   backgroundImage: "linear-gradient(to right, var(--color-border-elevated) 0 1px, transparent 1px)",
@@ -251,12 +248,11 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
       <div
         ref={scrollerRef}
         onScroll={handleScroll}
-        className="flex min-h-0 flex-1 items-start overflow-auto overscroll-x-none [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="flex min-h-0 flex-1 items-start snap-x snap-mandatory overflow-auto overscroll-x-none [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         style={{
           ...COLUMN_RULES,
           backgroundSize: `calc((100% - ${GUTTER_WIDTH}px) / ${VISIBLE_COLUMNS}) 100%`,
           backgroundPositionX: `calc(${GUTTER_WIDTH}px - var(--strip-scroll, 0px))`,
-          scrollSnapType: "x mandatory",
           scrollPaddingLeft: GUTTER_WIDTH,
           maskImage: GRID_EDGE_FADE,
           WebkitMaskImage: GRID_EDGE_FADE,
@@ -287,20 +283,12 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
           {stripDays.map((day) => {
             const isToday = isSameDay(day, today);
             return (
-              <div
-                key={day.getTime()}
-                className="relative"
-                style={{ scrollSnapAlign: "start" }}
-              >
+              <div key={day.getTime()} className="relative snap-start">
                 {/* Hour rules, per cell — one strip-wide background layer is too large for some engines to paint. */}
                 <div
                   aria-hidden
-                  className="pointer-events-none absolute inset-x-0 bottom-0"
-                  style={{
-                    top: HOUR_HEIGHT,
-                    backgroundImage: `linear-gradient(to bottom, ${HOUR_RULE_COLOR} 0 1px, transparent 1px)`,
-                    backgroundSize: `100% ${HOUR_HEIGHT}px`,
-                  }}
+                  className="pointer-events-none absolute inset-x-0 bottom-0 bg-[linear-gradient(to_bottom,var(--color-border-hour)_0_1px,transparent_1px)]"
+                  style={{ top: HOUR_HEIGHT, backgroundSize: `100% ${HOUR_HEIGHT}px` }}
                 />
                 {/* Event blocks will render here in a later stage. */}
                 {isToday && nowFraction != null && (

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -15,99 +15,52 @@ import {
   WEEK_VIEW_DAYS,
 } from "./calendar-helpers";
 
-/** Width of the left time gutter, in pixels. */
 const GUTTER_WIDTH = 52;
-/** Height of a single hour row, in pixels. */
 const HOUR_HEIGHT = 48;
-/** Height of the weekday/date header row, in pixels. */
 const HEADER_HEIGHT = 56;
-/** Visible day columns (a week). */
 const VISIBLE_COLUMNS = WEEK_VIEW_DAYS;
-/** Offset of the centre column from the first visible one. */
 const CENTER_OFFSET = Math.floor(VISIBLE_COLUMNS / 2);
-/** Weeks buffered on each side of the entry range, giving the strip a long,
- * effectively-continuous horizontal scroll range without recentering logic. */
+/** Weeks buffered on each side of the entry range, so the strip scrolls without recentering logic. */
 const BUFFER_WEEKS = 26;
 
 const MS_PER_DAY = 86_400_000;
 
-/** Colour of the hour rules across the grid: the column-rule token, faded so
- * the horizontal lines read as a secondary, quieter layer under the columns. */
+// Faded so the hour lines read as a quieter layer under the column rules.
 const HOUR_RULE_COLOR = "color-mix(in oklab, var(--color-border-elevated) 45%, transparent)";
 
-/** The day-column rules: a 1px line at the left edge of every column, tiled
- * one column apart. They are painted on the *viewport* boxes (the grid's
- * scroller and the header's strip viewport) rather than on the day cells, so
- * they are pinned to the visible area and run its full height — through a
- * vertical overscroll bounce too, instead of stopping at the content's edge.
- * Horizontal scrolling is followed via `--strip-scroll`, which `handleScroll`
- * keeps equal to the scroller's `scrollLeft`. Both boxes use the same column
- * width expression, so header and grid lines coincide to the pixel. */
+// Painted on the viewport boxes, not the cells, so the rules span overscroll; `--strip-scroll` keeps them following the grid.
 const COLUMN_RULES: CSSProperties = {
   backgroundImage: "linear-gradient(to right, var(--color-border-elevated) 0 1px, transparent 1px)",
   backgroundRepeat: "repeat-x",
 };
 
-/** Fades the header's column rules out toward the top, so they dissolve into
- * the toolbar above instead of meeting it at a hard corner. */
 const HEADER_RULE_FADE = "linear-gradient(to top, black 35%, transparent)";
 
-/** Depth of the grid's top and bottom edge fades, in pixels. Shallow enough
- * to stay clear of the first and last hour labels at the scroll extremes. */
 const GRID_EDGE_FADE_SIZE = 24;
 
-/** Fades the grid's scroller out at its top and bottom edges, so rules,
- * labels and the current-time line dissolve into the page background instead
- * of stopping at a hard edge. Applied to the scroller box, so it stays pinned
- * to the visible area while the content scrolls beneath it — through a
- * vertical overscroll bounce too. Vertical only: a horizontal fade would dim
- * the time gutter's labels and the outermost day column. */
+// Vertical only: a horizontal fade would dim the gutter labels and the outermost column.
 const GRID_EDGE_FADE = `linear-gradient(to bottom, transparent, black ${GRID_EDGE_FADE_SIZE}px, black calc(100% - ${GRID_EDGE_FADE_SIZE}px), transparent)`;
 
 interface WeekGridProps {
-  /** The day to centre the visible range on; drives the horizontal scroll
-   * position. Today on entry, so today sits in the middle column. */
   anchor: Date;
-  /** Reports the day now in the centre column after manual horizontal
-   * scrolling, so the pane title and paging stay in sync with the strip. */
   onCenterDayChange: (centerDay: Date) => void;
-  /** The pane's toolbar, rendered in the header card above the day row. */
   toolbar: ReactNode;
 }
 
-/**
- * The week view skeleton, modelled on qali's time strip: a pinned left time
- * gutter and a single two-axis scroller whose buffered day columns snap one
- * day at a time — so the week scrolls horizontally like qali's. The visible
- * range is a rolling seven days centred on `anchor` rather than a calendar
- * week, so "Today" puts today in the middle and paging keeps that alignment.
- * The day row lives in the header card above; it has no scroller of its own
- * and simply mirrors the grid's horizontal offset, so the two always line up.
- * Presentational only: no events; a current-time line marks today.
- */
 export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) {
   const today = useStartOfToday();
   const router = useRouter();
   const scrollerRef = useRef<HTMLDivElement>(null);
-  /** The overflow-hidden viewport around the day row, in the header card. */
   const headerStripRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number | null>(null);
   const mountedRef = useRef(false);
-  /** The scroller's vertical offset as last scrolled, so it can be put back
-   * after the router replays a cached one (see the `onRendered` effect). */
+  /** Vertical offset as last scrolled; put back after the router replays a cached one. */
   const scrollTopRef = useRef(0);
-  /** The centre day (ms, midnight) the strip is currently aligned to; guards
-   * the anchor effect from re-scrolling in response to the strip's own scroll
-   * reports. */
+  /** Centre day (ms) the strip is aligned to; keeps the anchor effect from reacting to the strip's own reports. */
   const alignedCenterMsRef = useRef<number | null>(null);
-  /** The scroller's width (px) the strip was last aligned at. Column widths
-   * are a fraction of it, so a scroll report arriving while the width differs
-   * is the strip mid-resize — its offset still belongs to the old width — and
-   * not the user paging; it is ignored and the resize observer re-aligns. */
+  /** Width (px) the strip was last aligned at; a scroll report at a different width is a resize, not paging. */
   const alignedWidthRef = useRef<number | null>(null);
 
-  // The buffered strip is centred on the range active when the grid mounts, so
-  // the entry range sits mid-buffer and paging stays inside it.
   const [stripDays] = useState(() => {
     const start = addDays(startOfVisibleWeek(anchor), -BUFFER_WEEKS * 7);
     return Array.from({ length: (BUFFER_WEEKS * 2 + 1) * 7 }, (_, index) =>
@@ -116,8 +69,7 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
   });
   const columnsTemplate = `repeat(${stripDays.length}, minmax(0, 1fr))`;
 
-  // Resolve the current-time line on the client only, so SSR and hydration
-  // agree (the server has no stable "now").
+  // Client-only so SSR and hydration agree.
   const [nowFraction, setNowFraction] = useState<number | null>(null);
   useEffect(() => {
     const update = () => {
@@ -136,8 +88,7 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
     return Math.max((el.clientWidth - GUTTER_WIDTH) / VISIBLE_COLUMNS, 1);
   }, []);
 
-  /** Mirrors the scroller's horizontal offset onto the header's day row, and
-   * into `--strip-scroll` on both boxes so their column rules follow along. */
+  /** Mirrors the scroller's horizontal offset onto the day row and into `--strip-scroll`. */
   const syncHeaderStrip = useCallback(() => {
     const scroller = scrollerRef.current;
     const headerStrip = headerStripRef.current;
@@ -148,7 +99,6 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
     headerStrip.style.setProperty("--strip-scroll", offset);
   }, []);
 
-  /** Scrolls the strip so `centerDay` (midnight) sits in the middle column. */
   const scrollToCenter = useCallback(
     (centerDay: Date, behavior: ScrollBehavior) => {
       const el = scrollerRef.current;
@@ -159,16 +109,13 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
       alignedCenterMsRef.current = centerDay.getTime();
       alignedWidthRef.current = el.clientWidth;
       el.scrollTo({ left: clamped * columnWidth(), behavior });
-      // An instant jump lands before any scroll event; mirror it right away so
-      // the header never shows a stale range, even for a frame.
+      // An instant jump fires no scroll event; mirror right away so the header never shows a stale range.
       if (behavior === "auto") syncHeaderStrip();
     },
     [columnWidth, stripDays, syncHeaderStrip],
   );
 
-  // On mount, centre the anchor day and jump down to business hours (auto, no
-  // animation); afterwards, smooth-scroll whenever the anchor moves to a
-  // different day than the strip is centred on (button paging / Today).
+  // Mount: centre the anchor and jump to business hours; afterwards, smooth-scroll on anchor moves.
   useLayoutEffect(() => {
     const centerDay = startOfDay(anchor);
     if (!mountedRef.current) {
@@ -186,15 +133,7 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
     }
   }, [anchor, scrollToCenter]);
 
-  // The router's scroll restoration replays every scrollable element's cached
-  // offsets once a navigation has rendered — this scroller's included, even
-  // though the pane stays mounted across the dashboard's child routes and its
-  // live position is the truth. The cache is sampled on a throttle, so the
-  // replayed offset can be a stale, mid-scroll one that leaves the strip off
-  // its column (snapping it onto a neighbouring day) and at a different hour.
-  // The router registers its listener when it is created, so this one runs
-  // after it: put the strip back where it was. On the first load that also
-  // re-centres on today after the last visit's offsets are replayed.
+  // The router replays cached scroll offsets after navigation; this registers after it and puts the strip back.
   useEffect(
     () =>
       router.subscribe("onRendered", () => {
@@ -207,11 +146,7 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
     [router, scrollToCenter],
   );
 
-  // Column widths are a fraction of the scroller's width, but the horizontal
-  // offset is kept in pixels — so a viewport resize would silently drift the
-  // strip to different days. Re-snap to the day the strip was centred on
-  // whenever the scroller's width changes. (`handleScroll` ignores the scroll
-  // events a resize produces, so that day is still the one the user chose.)
+  // Column widths follow the scroller's width, so a resize would drift the strip; re-snap to the centred day.
   useEffect(() => {
     const el = scrollerRef.current;
     if (!el || typeof ResizeObserver === "undefined") return;
@@ -230,8 +165,7 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
   }, [scrollToCenter]);
 
   const handleScroll = () => {
-    // Mirror synchronously — not inside the rAF below — so the header never
-    // trails the grid by a frame.
+    // Mirror synchronously, not in the rAF, so the header never trails the grid by a frame.
     syncHeaderStrip();
     const scroller = scrollerRef.current;
     if (scroller) scrollTopRef.current = scroller.scrollTop;
@@ -240,9 +174,7 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
       rafRef.current = null;
       const el = scrollerRef.current;
       if (!el) return;
-      // Mid-resize: the offset belongs to the old width, so reading it against
-      // the new one would land on a different day. The resize observer
-      // re-aligns the strip to the chosen day; don't report this one.
+      // Mid-resize offsets belong to the old width; the resize observer re-aligns the strip.
       if (el.clientWidth !== alignedWidthRef.current) return;
       const index = Math.max(
         0,
@@ -264,10 +196,8 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
 
   const dayRow = (
     <div className="flex" style={{ height: HEADER_HEIGHT }}>
-      {/* Spacer over the grid's time gutter, keeping the columns aligned. */}
       <div className="shrink-0" style={{ width: GUTTER_WIDTH }} />
       <div ref={headerStripRef} className="relative min-w-0 flex-1 overflow-hidden">
-        {/* Column rules, pinned to the viewport and faded toward the top. */}
         <div
           aria-hidden
           className="pointer-events-none absolute inset-0"
@@ -332,8 +262,6 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
           WebkitMaskImage: GRID_EDGE_FADE,
         }}
       >
-        {/* Pinned time gutter; opaque in the page colour so the columns scroll
-            under it. */}
         <div
           className="sticky left-0 z-30 shrink-0 bg-background"
           style={{ width: GUTTER_WIDTH, height: HOUR_HEIGHT * HOURS.length }}
@@ -348,7 +276,6 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
             </span>
           ))}
         </div>
-        {/* Buffered day strip: 7 columns fill the viewport, the rest overflow. */}
         <div
           className="relative grid shrink-0"
           style={{
@@ -365,10 +292,7 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
                 className="relative"
                 style={{ scrollSnapAlign: "start" }}
               >
-                {/* Hour rules, painted per cell (one strip-wide layer is too
-                    large a box for some engines to paint a background on) and
-                    starting one row down, so neither the top nor the bottom
-                    edge of the grid carries a line. */}
+                {/* Hour rules, per cell — one strip-wide background layer is too large for some engines to paint. */}
                 <div
                   aria-hidden
                   className="pointer-events-none absolute inset-x-0 bottom-0"

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -246,3 +246,18 @@ html {
     );
   }
 }
+
+/* The calendar's week/month switch runs inside a view transition (see
+   `CalendarView`). Only the named calendar groups should animate: keep the
+   root snapshot from cross-fading the whole page, and honour reduced motion. */
+::view-transition-group(root) {
+  animation-duration: 0s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
+}

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -74,6 +74,8 @@ html {
   );
   --ui-background-elevated: var(--color-white);
   --ui-border-elevated: var(--color-neutral-300);
+  /* Faded so the calendar's hour lines read as a quieter layer under its column rules. */
+  --ui-border-hour: color-mix(in oklab, var(--ui-border-elevated) 45%, transparent);
   --ui-background-inverse-hover: var(--color-neutral-800);
   --ui-background-hover: color-mix(
     in srgb,
@@ -123,6 +125,7 @@ html {
   --color-foreground-inverse-muted: var(--ui-foreground-inverse-muted);
   --color-background-elevated: var(--ui-background-elevated);
   --color-border-elevated: var(--ui-border-elevated);
+  --color-border-hour: var(--ui-border-hour);
   --color-background-inverse-hover: var(--ui-background-inverse-hover);
   --color-background-hover: var(--ui-background-hover);
   --color-destructive: var(--ui-destructive);

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -247,9 +247,7 @@ html {
   }
 }
 
-/* The calendar's week/month switch runs inside a view transition (see
-   `CalendarView`). Only the named calendar groups should animate: keep the
-   root snapshot from cross-fading the whole page, and honour reduced motion. */
+/* Only the calendar's named groups animate in its view transition; keep the root from cross-fading the page. */
 ::view-transition-group(root) {
   animation-duration: 0s;
 }

--- a/applications/web/src/routes/(dashboard)/route.tsx
+++ b/applications/web/src/routes/(dashboard)/route.tsx
@@ -53,8 +53,11 @@ function DashboardLayout() {
         <SyncProvider />
         <Outlet />
       </div>
-      {/* Calendar pane — desktop only. */}
-      <div className="hidden lg:flex lg:h-[calc(100dvh-2rem)] lg:min-w-0 lg:flex-1">
+      {/* Calendar pane — desktop only. `isolate` confines the calendar's
+          internal sticky z-indices to its own stacking context, so the header
+          and time gutter sit under the popover blur overlay (z-10) instead of
+          punching through it. */}
+      <div className="hidden lg:flex lg:h-[calc(100dvh-2rem)] lg:min-w-0 lg:flex-1 lg:isolate">
         <CalendarView />
       </div>
     </div>

--- a/applications/web/src/routes/(dashboard)/route.tsx
+++ b/applications/web/src/routes/(dashboard)/route.tsx
@@ -6,6 +6,7 @@ import * as m from "motion/react-m";
 import { popoverOverlayAtom } from "@/state/popover-overlay";
 import { SyncProvider } from "@/providers/sync-provider";
 import { resolveDashboardRedirect } from "@/lib/route-access-guards";
+import { CalendarView } from "@/features/dashboard/components/calendar-view";
 
 export const Route = createFileRoute("/(dashboard)")({
   beforeLoad: ({ context }) => {
@@ -33,8 +34,9 @@ function DashboardLayout() {
   const overlayActive = useAtomValue(popoverOverlayAtom);
 
   return (
-    <div className="relative flex flex-col items-center min-h-dvh px-4 pb-12 pt-4 xs:pt-[min(6rem,25vh)]">
-      <div className="relative flex flex-col gap-3 w-full max-w-sm">
+    <div className="relative flex min-h-dvh justify-center lg:justify-start lg:gap-4 lg:p-4">
+      {/* Sidebar — the existing centered dashboard column. */}
+      <div className="relative flex w-full max-w-sm shrink-0 flex-col gap-3 px-4 pb-12 pt-4 xs:pt-[min(6rem,25vh)] lg:h-[calc(100dvh-2rem)] lg:overflow-y-auto lg:px-1 lg:pt-6">
         <LazyMotion features={loadMotionFeatures}>
           <AnimatePresence>
             {overlayActive && (
@@ -50,6 +52,10 @@ function DashboardLayout() {
         </LazyMotion>
         <SyncProvider />
         <Outlet />
+      </div>
+      {/* Calendar pane — desktop only. */}
+      <div className="hidden lg:flex lg:h-[calc(100dvh-2rem)] lg:min-w-0 lg:flex-1">
+        <CalendarView />
       </div>
     </div>
   );

--- a/applications/web/src/routes/(dashboard)/route.tsx
+++ b/applications/web/src/routes/(dashboard)/route.tsx
@@ -35,7 +35,6 @@ function DashboardLayout() {
 
   return (
     <div className="relative flex min-h-dvh justify-center lg:justify-start lg:gap-4 lg:p-4">
-      {/* Sidebar — the existing centered dashboard column. */}
       <div className="relative flex w-full max-w-sm shrink-0 flex-col gap-3 px-4 pb-12 pt-4 xs:pt-[min(6rem,25vh)] lg:h-[calc(100dvh-2rem)] lg:overflow-y-auto lg:px-1 lg:pt-6">
         <LazyMotion features={loadMotionFeatures}>
           <AnimatePresence>
@@ -53,10 +52,7 @@ function DashboardLayout() {
         <SyncProvider />
         <Outlet />
       </div>
-      {/* Calendar pane — desktop only. `isolate` confines the calendar's
-          internal sticky z-indices to its own stacking context, so the header
-          and time gutter sit under the popover blur overlay (z-10) instead of
-          punching through it. */}
+      {/* `isolate` keeps the calendar's sticky z-indices under the popover blur overlay (z-10). */}
       <div className="hidden lg:flex lg:h-[calc(100dvh-2rem)] lg:min-w-0 lg:flex-1 lg:isolate">
         <CalendarView />
       </div>


### PR DESCRIPTION
## Summary

Adds the dashboard's calendar pane: month and week views with a shared frame, sitting beside the existing dashboard column on desktop. Layout skeleton only — events render in #938.

- **Frame** — `CalendarFrame` stacks a header card (toolbar over column labels) on a bare grid. The grid has no card of its own; like the sidebar's sync status and event graph it sits straight on the page, and each view fades its rules out toward the edges. The card, its rows and the grid carry `view-transition-name`s so the week/month switch morphs the header height instead of snapping (reduced motion opts out, and the root snapshot is kept from cross-fading the page).
- **Month view** — a 6×7 grid of day cells with the cell rules painted as one layer behind the cells, faded at all four edges. Today gets the accent dot; out-of-month days dim. Each cell reserves the space where event pills land in #938.
- **Week view** — modelled on qali's time strip: a pinned left time gutter and a single two-axis scroller whose buffered day columns (±26 weeks) snap one day at a time. The visible range is a rolling seven days centred on the anchor, so "Today" puts today in the middle column. The header's day row has no scroller of its own — it mirrors the grid's offset (and `--strip-scroll` keeps the column rules on both boxes in step). A current-time line marks today, refreshed each minute client-side.
- **Stability** — the strip re-snaps to its centred day when the viewport resizes (column widths are viewport-relative, offsets are pixels), and puts itself back after the router replays cached scroll offsets on navigation.
- **Route** — the dashboard layout becomes sidebar + desktop-only (`lg:`) calendar pane; the pane is `isolate`d so its sticky z-indices stay under the popover blur overlay.

## Verification

- `bun run lint`, `bun run types`, `bun run test` and `bun run unused` (knip) at the root.
- Live on `/dashboard`: week view enters centred on today at business hours; paging and "Today" smooth-scroll the strip; the header day row tracks the grid during swipes; month/week switch morphs the header card inside a view transition; resizing keeps the strip on its days; navigating between dashboard child routes keeps the strip in place.

## Screenshot

<img width="1548" height="978" alt="image" src="https://github.com/user-attachments/assets/4c1247b7-2ed3-4ba2-8858-200d134f7928" />


## Notes

- Stacked under #938 (`feat(web): show events in the dashboard calendar`), which fills both grids with event cards and pills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
