### PR TITLE
fix(web): hydrate the events page cleanly on full loads

### DIFF
--- a/applications/web/src/hooks/use-events.ts
+++ b/applications/web/src/hooks/use-events.ts
@@ -16,11 +16,15 @@ export interface CalendarEvent {
 
 const DAYS_PER_PAGE = 7;
 
+// Keep the key a relative path: an absolute URL via `globalThis.location`
+// throws during SSR, which SWR swallows into a null key, so the server would
+// render the page as loaded while the client's first render is still loading.
 const buildEventsUrl = (from: Date, to: Date): string => {
-  const url = new URL("/api/events", globalThis.location.origin);
-  url.searchParams.set("from", from.toISOString());
-  url.searchParams.set("to", to.toISOString());
-  return url.toString();
+  const params = new URLSearchParams({
+    from: from.toISOString(),
+    to: to.toISOString(),
+  });
+  return `/api/events?${params.toString()}`;
 };
 
 const fetchEvents = async (url: string): Promise<CalendarEvent[]> => {

--- a/applications/web/src/hooks/use-events.ts
+++ b/applications/web/src/hooks/use-events.ts
@@ -16,9 +16,6 @@ export interface CalendarEvent {
 
 const DAYS_PER_PAGE = 7;
 
-// Keep the key a relative path: an absolute URL via `globalThis.location`
-// throws during SSR, which SWR swallows into a null key, so the server would
-// render the page as loaded while the client's first render is still loading.
 const buildEventsUrl = (from: Date, to: Date): string => {
   const params = new URLSearchParams({
     from: from.toISOString(),

--- a/applications/web/src/routes/__root.tsx
+++ b/applications/web/src/routes/__root.tsx
@@ -63,8 +63,10 @@ function ViteScriptTag({ script }: { script: ViteScript }) {
 function RootComponent() {
   const { runtimeConfig, viteAssets } = Route.useRouteContext();
 
+  // The inline client-state script stamps data-* attributes on <html> before
+  // hydration, so the server markup never matches the element exactly.
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <HeadContent />
         <script

--- a/applications/web/src/routes/__root.tsx
+++ b/applications/web/src/routes/__root.tsx
@@ -63,8 +63,6 @@ function ViteScriptTag({ script }: { script: ViteScript }) {
 function RootComponent() {
   const { runtimeConfig, viteAssets } = Route.useRouteContext();
 
-  // The inline client-state script stamps data-* attributes on <html> before
-  // hydration, so the server markup never matches the element exactly.
   return (
     <html lang="en" suppressHydrationWarning>
       <head>


### PR DESCRIPTION
## Summary

A full page load of `/dashboard/events` (authenticated) logged two React 19 hydration errors on every load. Pre-existing on `main`; unrelated to the event-card work.

1. **`<html>` attribute mismatch** — the inline client-state script stamps `data-session` (and sometimes `data-consent`) on `<html>` before hydration, which the root component never renders. Fixed by marking `<html>` with `suppressHydrationWarning` (element-scoped; children still validate).
2. **"Hydration failed" in `EventsContent`** — the events SWR key was built with `new URL("/api/events", globalThis.location.origin)`, which throws on the server. `useSWRInfinite` swallows key-function errors into a null key, so the server rendered the page as loaded (heading + empty sentinel) while the client's first render, with a valid key, showed the loading spinner. Fixed by building a relative `/api/events?from=…&to=…` key, matching how `event-graph.tsx` and the other `/api/...` SWR keys already work.

## Verification

- Captured the full hydration diff by hooking `window.error`/`console.error` before hydration; the differing node was `<LoadingIndicator>` (`flex justify-center py-6`) vs the server's `flex flex-col gap-2` wrapper.
- After the fix the SSR HTML renders the spinner, and repeated full reloads produce no console errors; the page still populates with day sections client-side.
- `bun run types`, `bun run lint`, `bun run test` (428 passed, 9 skipped) in `applications/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)