### PR TITLE
chore(cron): drop the comment left on the rate limiter resolver

### DIFF
--- a/services/cron/src/jobs/ingest-sources.ts
+++ b/services/cron/src/jobs/ingest-sources.ts
@@ -664,12 +664,6 @@ const resolveTargetHost = (target: string | null): string | null => {
   }
 };
 
-/*
- * Per-request pacing, not per-run: a permit is taken before each Graph request and given back
- * when it settles, so the account's capacity bounds requests in flight against the mailbox
- * across every replica, every calendar and every concurrent series-master expansion. Nothing a
- * run holds outlives its request, so the lease TTL is request-scale and no run parks a slot.
- */
 const resolveRateLimiter = (
   provider: string,
   source: RateLimiterSourceContext,


### PR DESCRIPTION
#926 replaced the comment above `resolveRateLimiter` — the old one described the per-run lease invariant, which stopped being true when the permit became request-scoped, and leaving a comment that states a false invariant is worse than having none.

The replacement should not have stayed. Removing it.

No behaviour change; the deletion is the whole diff. Gate: `bunx turbo run test lint types --force --continue` → 45/45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)