### PR TITLE
test(web): load the calendar detail route at collection, not inside the test

### DIFF
--- a/applications/web/tests/routes/dashboard/calendar-delete-affordance.test.tsx
+++ b/applications/web/tests/routes/dashboard/calendar-delete-affordance.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { CalendarAccount, CalendarDetail } from "../../../src/types/api";
+import "../../../src/routes/(dashboard)/dashboard/accounts/$accountId.$calendarId";
 
 const ACCOUNT_ID = "account-1";
 const CALENDAR_ID = "calendar-1";
@@ -95,13 +96,11 @@ const makeCalendar = (capabilities: string[]): CalendarDetail => ({
   url: null,
 });
 
-const renderPage = async (capabilities: string[]): Promise<string> => {
+const renderPage = (capabilities: string[]): string => {
   swrData.clear();
   swrData.set(`/api/accounts/${ACCOUNT_ID}`, account);
   swrData.set(`/api/sources/${CALENDAR_ID}`, makeCalendar(capabilities));
   swrData.set("/api/sources", []);
-
-  await import("../../../src/routes/(dashboard)/dashboard/accounts/$accountId.$calendarId");
 
   const Page = captured.component;
   if (!Page) throw new Error("Calendar detail route did not register a component");
@@ -109,14 +108,14 @@ const renderPage = async (capabilities: string[]): Promise<string> => {
 };
 
 describe("calendar detail page delete affordance", () => {
-  it("offers removal for a calendar keeper only pulls from", async () => {
-    const markup = await renderPage(["pull"]);
+  it("offers removal for a calendar keeper only pulls from", () => {
+    const markup = renderPage(["pull"]);
 
     expect(markup).toContain("Delete Calendar");
   });
 
-  it("hides removal for a calendar keeper pushes events to", async () => {
-    const markup = await renderPage(["pull", "push"]);
+  it("hides removal for a calendar keeper pushes events to", () => {
+    const markup = renderPage(["pull", "push"]);
 
     expect(markup.includes("Delete Calendar")).toBe(false);
     expect(markup.includes("Remove Calendar")).toBe(false);


### PR DESCRIPTION
`calendar-delete-affordance.test.tsx` (added in #928) does the route module's dynamic import **inside the test body**, so loading that entire module graph is charged against vitest's 5s per-test timeout.

In isolation it takes ~1.2s and passes. Under a loaded parallel gate it took 6465ms and failed:

```
× offers removal for a calendar keeper only pulls from  6465ms
Error: Test timed out in 5000ms.
```

Nothing is wrong with the code under test — the test simply had a duration it could lose against.

`vi.mock` is hoisted, so a static top-level import receives the same mocks while moving the load to collection time, outside any per-test budget.

**Test body: 1176ms → 13ms.** The 297ms import now happens once during collection.

`bun run test` → 48 passed | 5 skipped. `lint` and `types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)