### PR TITLE
feat(web): show events in the dashboard calendar

### DIFF
--- a/applications/web/src/components/ui/primitives/text.tsx
+++ b/applications/web/src/components/ui/primitives/text.tsx
@@ -17,6 +17,8 @@ const text = tv({
       inverseMuted: "text-foreground-inverse-muted",
       default: "text-foreground",
       danger: "text-red-500",
+      event: "text-event",
+      eventMuted: "text-event-muted",
     },
     align: {
       center: "text-center",
@@ -34,7 +36,7 @@ const text = tv({
 type TextProps = PropsWithChildren<{
   as?: "p" | "span";
   size?: "base" | "sm" | "xs";
-  tone?: "muted" | "disabled" | "inverse" | "inverseMuted" | "default" | "danger" | "highlight";
+  tone?: "muted" | "disabled" | "inverse" | "inverseMuted" | "default" | "danger" | "highlight" | "event" | "eventMuted";
   align?: "center" | "left" | "right";
   className?: string;
   style?: CSSProperties;

--- a/applications/web/src/components/ui/primitives/text.tsx
+++ b/applications/web/src/components/ui/primitives/text.tsx
@@ -17,8 +17,6 @@ const text = tv({
       inverseMuted: "text-foreground-inverse-muted",
       default: "text-foreground",
       danger: "text-red-500",
-      event: "text-event",
-      eventMuted: "text-event-muted",
     },
     align: {
       center: "text-center",
@@ -36,7 +34,7 @@ const text = tv({
 type TextProps = PropsWithChildren<{
   as?: "p" | "span";
   size?: "base" | "sm" | "xs";
-  tone?: "muted" | "disabled" | "inverse" | "inverseMuted" | "default" | "danger" | "highlight" | "event" | "eventMuted";
+  tone?: "muted" | "disabled" | "inverse" | "inverseMuted" | "default" | "danger" | "highlight";
   align?: "center" | "left" | "right";
   className?: string;
   style?: CSSProperties;

--- a/applications/web/src/features/dashboard/components/calendar-frame.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-frame.tsx
@@ -14,11 +14,7 @@ export function CalendarFrame({
   children,
 }: CalendarFrameProps) {
   return (
-    // `calendar-strip-scope` lets the week grid's header row follow the
-    // grid's scroll timeline (see index.css): a named scroll timeline is only
-    // visible to the scroller's descendants unless an ancestor widens its
-    // scope, and this root is the header's and the grid's nearest common one.
-    <div className="calendar-strip-scope flex h-full min-h-0 w-full flex-col gap-1.5">
+    <div className="flex h-full min-h-0 w-full flex-col gap-1.5">
       <header
         className="flex shrink-0 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs"
         style={{ viewTransitionName: "calendar-header" }}

--- a/applications/web/src/features/dashboard/components/calendar-frame.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-frame.tsx
@@ -14,7 +14,11 @@ export function CalendarFrame({
   children,
 }: CalendarFrameProps) {
   return (
-    <div className="flex h-full min-h-0 w-full flex-col gap-1.5">
+    // `calendar-strip-scope` lets the week grid's header row follow the
+    // grid's scroll timeline (see index.css): a named scroll timeline is only
+    // visible to the scroller's descendants unless an ancestor widens its
+    // scope, and this root is the header's and the grid's nearest common one.
+    <div className="calendar-strip-scope flex h-full min-h-0 w-full flex-col gap-1.5">
       <header
         className="flex shrink-0 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs"
         style={{ viewTransitionName: "calendar-header" }}

--- a/applications/web/src/features/dashboard/components/calendar-helpers.ts
+++ b/applications/web/src/features/dashboard/components/calendar-helpers.ts
@@ -26,6 +26,11 @@ export function startOfVisibleWeek(anchor: Date): Date {
   return addDays(anchor, -Math.floor(WEEK_VIEW_DAYS / 2));
 }
 
+export function startOfWeek(date: Date): Date {
+  const offset = (date.getDay() - WEEK_STARTS_ON + 7) % 7;
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() - offset);
+}
+
 export function isSameMonth(a: Date, b: Date): boolean {
   return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
 }
@@ -75,6 +80,15 @@ export function formatWeekTitle(anchor: Date): string {
     return `${startMonth} ${start.getDate()} – ${endMonth} ${end.getDate()}, ${end.getFullYear()}`;
   }
   return `${startMonth} ${start.getDate()}, ${start.getFullYear()} – ${endMonth} ${end.getDate()}, ${end.getFullYear()}`;
+}
+
+const FETCH_WEEKS_BEFORE = 1;
+const FETCH_WEEKS = 4;
+
+/** Half-open `[start, end)` quantised to calendar weeks, so a ±7-day page stays inside the previous window while the next loads. */
+export function getWeekFetchRange(anchor: Date): { start: Date; end: Date } {
+  const start = addDays(startOfWeek(startOfVisibleWeek(anchor)), -FETCH_WEEKS_BEFORE * 7);
+  return { start, end: addDays(start, FETCH_WEEKS * 7) };
 }
 
 export const HOURS = Array.from({ length: 24 }, (_, hour) => hour);

--- a/applications/web/src/features/dashboard/components/calendar-helpers.ts
+++ b/applications/web/src/features/dashboard/components/calendar-helpers.ts
@@ -79,6 +79,8 @@ export function formatWeekTitle(anchor: Date): string {
 
 export const HOURS = Array.from({ length: 24 }, (_, hour) => hour);
 
+export const HOUR_HEIGHT = 48;
+
 export function formatHourLabel(hour: number): string {
   return new Date(2023, 0, 1, hour)
     .toLocaleTimeString("en-US", { hour: "numeric" })

--- a/applications/web/src/features/dashboard/components/calendar-helpers.ts
+++ b/applications/web/src/features/dashboard/components/calendar-helpers.ts
@@ -91,6 +91,12 @@ export function getWeekFetchRange(anchor: Date): { start: Date; end: Date } {
   return { start, end: addDays(start, FETCH_WEEKS * 7) };
 }
 
+/** Half-open `[start, end)` covering exactly the 6×7 grid's days. */
+export function getMonthFetchRange(anchor: Date): { start: Date; end: Date } {
+  const days = getMonthGridDays(anchor);
+  return { start: days[0], end: addDays(days[days.length - 1], 1) };
+}
+
 export const HOURS = Array.from({ length: 24 }, (_, hour) => hour);
 
 export const HOUR_HEIGHT = 48;

--- a/applications/web/src/features/dashboard/components/calendar-view.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-view.tsx
@@ -4,14 +4,17 @@ import ChevronLeft from "lucide-react/dist/esm/icons/chevron-left";
 import ChevronRight from "lucide-react/dist/esm/icons/chevron-right";
 import { cn } from "@/utils/cn";
 import { Text } from "@/components/ui/primitives/text";
+import { useEventsInRange } from "@/hooks/use-events";
 import { MonthGrid } from "./month-grid";
 import { WeekGrid } from "./week-grid";
+import { bucketEventsByDay } from "./event-layout";
 import {
   addDays,
   addMonths,
   formatMonthTitle,
   formatWeekTitle,
   getMonthGridDays,
+  getWeekFetchRange,
 } from "./calendar-helpers";
 
 type CalendarViewMode = "week" | "month";
@@ -26,6 +29,19 @@ export function CalendarView() {
   const [anchor, setAnchor] = useState(() => new Date());
 
   const monthDays = useMemo(() => getMonthGridDays(anchor), [anchor]);
+
+  const fetchRange = getWeekFetchRange(anchor);
+  const { events } = useEventsInRange(fetchRange.start, fetchRange.end);
+  // Keyed on the window's instants rather than `anchor`: the anchor changes
+  // on every scroll step, the window only when a week boundary is crossed,
+  // and the day buckets — and so each memoised column's `events` identity —
+  // should only change with the data or the window.
+  const fetchStartMs = fetchRange.start.getTime();
+  const fetchEndMs = fetchRange.end.getTime();
+  const eventsByDay = useMemo(
+    () => bucketEventsByDay(events, new Date(fetchStartMs), new Date(fetchEndMs)),
+    [events, fetchStartMs, fetchEndMs],
+  );
 
   const title = view === "month" ? formatMonthTitle(anchor) : formatWeekTitle(anchor);
 
@@ -97,6 +113,11 @@ export function CalendarView() {
   return view === "month" ? (
     <MonthGrid anchor={anchor} days={monthDays} toolbar={toolbar} />
   ) : (
-    <WeekGrid anchor={anchor} onCenterDayChange={setAnchor} toolbar={toolbar} />
+    <WeekGrid
+      anchor={anchor}
+      eventsByDay={eventsByDay}
+      onCenterDayChange={setAnchor}
+      toolbar={toolbar}
+    />
   );
 }

--- a/applications/web/src/features/dashboard/components/calendar-view.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-view.tsx
@@ -13,6 +13,7 @@ import {
   addMonths,
   formatMonthTitle,
   formatWeekTitle,
+  getMonthFetchRange,
   getMonthGridDays,
   getWeekFetchRange,
 } from "./calendar-helpers";
@@ -30,7 +31,8 @@ export function CalendarView() {
 
   const monthDays = useMemo(() => getMonthGridDays(anchor), [anchor]);
 
-  const fetchRange = getWeekFetchRange(anchor);
+  // One fetch for the pane, windowed by the active view.
+  const fetchRange = view === "month" ? getMonthFetchRange(anchor) : getWeekFetchRange(anchor);
   const { events } = useEventsInRange(fetchRange.start, fetchRange.end);
   // Keyed on the window's instants rather than `anchor`: the anchor changes
   // on every scroll step, the window only when a week boundary is crossed,
@@ -111,7 +113,7 @@ export function CalendarView() {
   );
 
   return view === "month" ? (
-    <MonthGrid anchor={anchor} days={monthDays} toolbar={toolbar} />
+    <MonthGrid anchor={anchor} days={monthDays} eventsByDay={eventsByDay} toolbar={toolbar} />
   ) : (
     <WeekGrid
       anchor={anchor}

--- a/applications/web/src/features/dashboard/components/calendar-view.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-view.tsx
@@ -31,13 +31,9 @@ export function CalendarView() {
 
   const monthDays = useMemo(() => getMonthGridDays(anchor), [anchor]);
 
-  // One fetch for the pane, windowed by the active view.
   const fetchRange = view === "month" ? getMonthFetchRange(anchor) : getWeekFetchRange(anchor);
   const { events } = useEventsInRange(fetchRange.start, fetchRange.end);
-  // Keyed on the window's instants rather than `anchor`: the anchor changes
-  // on every scroll step, the window only when a week boundary is crossed,
-  // and the day buckets — and so each memoised column's `events` identity —
-  // should only change with the data or the window.
+  // Keyed on the window's instants, not `anchor`: the anchor moves on every scroll step, the window doesn't.
   const fetchStartMs = fetchRange.start.getTime();
   const fetchEndMs = fetchRange.end.getTime();
   const eventsByDay = useMemo(

--- a/applications/web/src/features/dashboard/components/day-column.tsx
+++ b/applications/web/src/features/dashboard/components/day-column.tsx
@@ -82,6 +82,10 @@ export const DayColumn = memo(function DayColumn({
         className="pointer-events-none absolute inset-x-0 bottom-0 bg-[linear-gradient(to_bottom,var(--color-border-hour)_0_1px,transparent_1px)]"
         style={{ top: HOUR_HEIGHT, backgroundSize: `100% ${HOUR_HEIGHT}px` }}
       />
+      {/* The column's left rule, on the cell so it scrolls with the content:
+          a rule painted on the scroller's viewport and moved from a scroll
+          event trails the cards by a frame. */}
+      <div aria-hidden className="pointer-events-none absolute inset-y-0 left-0 w-px bg-border-elevated" />
       {positioned.map((item) => (
         <EventCard
           key={item.event.id}

--- a/applications/web/src/features/dashboard/components/day-column.tsx
+++ b/applications/web/src/features/dashboard/components/day-column.tsx
@@ -88,7 +88,6 @@ export const DayColumn = memo(function DayColumn({
           event={item.event}
           past={isEventPast(item.event.endTime)}
           layout="grid"
-          className="absolute"
           style={resolveCardStyle(item)}
         />
       ))}

--- a/applications/web/src/features/dashboard/components/day-column.tsx
+++ b/applications/web/src/features/dashboard/components/day-column.tsx
@@ -1,0 +1,104 @@
+import { memo } from "react";
+import type { CSSProperties } from "react";
+import { isEventPast } from "@/lib/time";
+import type { CalendarEvent } from "@/hooks/use-events";
+import { HOUR_HEIGHT } from "./calendar-helpers";
+import { EventCard } from "./event-card";
+import { layoutDayEvents, stackIndentPx, tileBox } from "./event-layout";
+import type { PositionedEvent } from "./event-layout";
+
+/** Card insets from the column's edges, in pixels: clear of the 1px column
+ * rule on the left, and a hairline short of the next column on the right. */
+const CARD_INSET_LEFT_PX = 2;
+const CARD_INSET_RIGHT_PX = 3;
+const CARD_INSET_PX = CARD_INSET_LEFT_PX + CARD_INSET_RIGHT_PX;
+
+/** Cards stack from this z-index upward by elevation, capped so a deep
+ * cluster never climbs over the current-time line (z-20) or the sticky time
+ * gutter (z-30). Cards at the cap tie, and ties paint in DOM order — start
+ * order — so the cascade still reads. */
+const CARD_BASE_Z_INDEX = 1;
+const MAX_CARD_ELEVATION = 8;
+
+interface DayColumnProps {
+  /** Midnight on the column's day. Identity-stable (from the strip's frozen
+   * day list), so the memo holds across renders. */
+  day: Date;
+  isToday: boolean;
+  /** Today's current time as a fraction of the day; null for other days (and
+   * until the client resolves it), so only today's column re-renders on the
+   * minute tick. */
+  nowFraction: number | null;
+  /** The timed events overlapping this day. Identity-stable while unchanged. */
+  events: CalendarEvent[];
+}
+
+/** Places a laid-out event in the column: vertical by day fraction (like the
+ * current-time line), horizontal by cascade indent or tile column, with the
+ * insets applied. */
+function resolveCardStyle(item: PositionedEvent): CSSProperties {
+  let left: string;
+  let width: string;
+  if (item.tiled) {
+    const box = tileBox(item.columnIndex, item.columnCount, item.columnSpan);
+    left = `calc(${box.left * 100}% + ${CARD_INSET_LEFT_PX}px)`;
+    width = `calc(${box.width * 100}% - ${CARD_INSET_PX}px)`;
+  } else {
+    const indent = stackIndentPx(item.stackIndex);
+    left = `${CARD_INSET_LEFT_PX + indent}px`;
+    width = `calc(100% - ${CARD_INSET_PX + indent}px)`;
+  }
+  return {
+    top: `${item.topFraction * 100}%`,
+    height: `${item.heightFraction * 100}%`,
+    left,
+    width,
+    zIndex: CARD_BASE_Z_INDEX + Math.min(item.elevation, MAX_CARD_ELEVATION),
+  };
+}
+
+/**
+ * One day column of the week grid: the hour rules, the day's event cards laid
+ * out by `layoutDayEvents`, and the current-time line on today. Memoised so a
+ * scroll-driven anchor change — which re-renders the whole strip — only
+ * re-renders the columns whose events or "now" actually changed.
+ */
+export const DayColumn = memo(function DayColumn({
+  day,
+  isToday,
+  nowFraction,
+  events,
+}: DayColumnProps) {
+  const positioned = layoutDayEvents(events, day);
+
+  return (
+    <div className="relative snap-start">
+      {/* Hour rules, painted per cell (one strip-wide layer is too large a
+          box for some engines to paint a background on) and starting one row
+          down, so neither the top nor the bottom edge of the grid carries a
+          line. */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 bottom-0 bg-[linear-gradient(to_bottom,var(--color-border-hour)_0_1px,transparent_1px)]"
+        style={{ top: HOUR_HEIGHT, backgroundSize: `100% ${HOUR_HEIGHT}px` }}
+      />
+      {positioned.map((item) => (
+        <EventCard
+          key={item.event.id}
+          event={item.event}
+          past={isEventPast(item.event.endTime)}
+          layout="grid"
+          className="absolute"
+          style={resolveCardStyle(item)}
+        />
+      ))}
+      {/* Above the event cards, below the sticky time gutter. */}
+      {isToday && nowFraction != null && (
+        <div
+          className="pointer-events-none absolute inset-x-0 z-20 h-0.5 -translate-y-1/2 bg-red-500"
+          style={{ top: `${nowFraction * 100}%` }}
+        />
+      )}
+    </div>
+  );
+});

--- a/applications/web/src/features/dashboard/components/day-column.tsx
+++ b/applications/web/src/features/dashboard/components/day-column.tsx
@@ -7,35 +7,22 @@ import { EventCard } from "./event-card";
 import { layoutDayEvents, stackIndentPx, tileBox } from "./event-layout";
 import type { PositionedEvent } from "./event-layout";
 
-/** Card insets from the column's edges, in pixels: clear of the 1px column
- * rule on the left, and a hairline short of the next column on the right. */
 const CARD_INSET_LEFT_PX = 2;
 const CARD_INSET_RIGHT_PX = 3;
 const CARD_INSET_PX = CARD_INSET_LEFT_PX + CARD_INSET_RIGHT_PX;
 
-/** Cards stack from this z-index upward by elevation, capped so a deep
- * cluster never climbs over the current-time line (z-20) or the sticky time
- * gutter (z-30). Cards at the cap tie, and ties paint in DOM order — start
- * order — so the cascade still reads. */
+// Elevation is capped below the current-time line (z-20) and sticky gutter (z-30); ties paint in DOM order.
 const CARD_BASE_Z_INDEX = 1;
 const MAX_CARD_ELEVATION = 8;
 
 interface DayColumnProps {
-  /** Midnight on the column's day. Identity-stable (from the strip's frozen
-   * day list), so the memo holds across renders. */
   day: Date;
   isToday: boolean;
-  /** Today's current time as a fraction of the day; null for other days (and
-   * until the client resolves it), so only today's column re-renders on the
-   * minute tick. */
+  /** Fraction of the day; null except on today, so only today's column re-renders on the minute tick. */
   nowFraction: number | null;
-  /** The timed events overlapping this day. Identity-stable while unchanged. */
   events: CalendarEvent[];
 }
 
-/** Places a laid-out event in the column: vertical by day fraction (like the
- * current-time line), horizontal by cascade indent or tile column, with the
- * insets applied. */
 function resolveCardStyle(item: PositionedEvent): CSSProperties {
   let left: string;
   let width: string;
@@ -57,12 +44,6 @@ function resolveCardStyle(item: PositionedEvent): CSSProperties {
   };
 }
 
-/**
- * One day column of the week grid: the hour rules, the day's event cards laid
- * out by `layoutDayEvents`, and the current-time line on today. Memoised so a
- * scroll-driven anchor change — which re-renders the whole strip — only
- * re-renders the columns whose events or "now" actually changed.
- */
 export const DayColumn = memo(function DayColumn({
   day,
   isToday,
@@ -73,18 +54,12 @@ export const DayColumn = memo(function DayColumn({
 
   return (
     <div className="relative snap-start">
-      {/* Hour rules, painted per cell (one strip-wide layer is too large a
-          box for some engines to paint a background on) and starting one row
-          down, so neither the top nor the bottom edge of the grid carries a
-          line. */}
+      {/* Hour rules, per cell — one strip-wide background layer is too large for some engines to paint. */}
       <div
         aria-hidden
         className="pointer-events-none absolute inset-x-0 bottom-0 bg-[linear-gradient(to_bottom,var(--color-border-hour)_0_1px,transparent_1px)]"
         style={{ top: HOUR_HEIGHT, backgroundSize: `100% ${HOUR_HEIGHT}px` }}
       />
-      {/* The column's left rule, on the cell so it scrolls with the content:
-          a rule painted on the scroller's viewport and moved from a scroll
-          event trails the cards by a frame. */}
       <div aria-hidden className="pointer-events-none absolute inset-y-0 left-0 w-px bg-border-elevated" />
       {positioned.map((item) => (
         <EventCard
@@ -95,7 +70,6 @@ export const DayColumn = memo(function DayColumn({
           style={resolveCardStyle(item)}
         />
       ))}
-      {/* Above the event cards, below the sticky time gutter. */}
       {isToday && nowFraction != null && (
         <div
           className="pointer-events-none absolute inset-x-0 z-20 h-0.5 -translate-y-1/2 bg-red-500"

--- a/applications/web/src/features/dashboard/components/event-card.tsx
+++ b/applications/web/src/features/dashboard/components/event-card.tsx
@@ -20,7 +20,8 @@ interface EventCardProps {
    * event's duration and whose content steps down with that height — see
    * the height bands on `eventCard`. */
   layout?: EventCardLayout;
-  className?: string;
+  /** Placement for the `grid` layout: the column sets `top`/`height`/`left`/
+   * `width` and the stacking order. */
   style?: CSSProperties;
 }
 
@@ -31,31 +32,34 @@ interface EventCardProps {
  * `event-card`, and the `event-*` variants in `index.css` select on its
  * rendered height:
  *
- *   compact  < 28px   (≤ 30 min)  title (xs), centred, no padding   16px
- *   short    < 44px   (≤ 50 min)  title (sm)                        28px
- *   default  44–59px  (≤ 70 min)  time (xs) + title                 44px
- *   roomy    60–75px  (≤ 90 min)  + one description line            60px
- *   tall     ≥ 76px   (≥ 95 min)  + two description lines           76px
+ *   compact  < 27px   (≤ 30 min)  title (xs), centred, no padding   16px
+ *   short    < 43px   (≤ 50 min)  title (sm)                        28px
+ *   default  43–58px  (≤ 70 min)  time (xs) + title                 44px
+ *   roomy    59–74px  (≤ 90 min)  + one description line            60px
+ *   tall     ≥ 75px   (≥ 95 min)  + two description lines           76px
  *
- * Each band's floor equals its content height, so `overflow-hidden` only ever
- * clips padding, never glyphs. `min-h-5` floors a 15-minute card at 20px —
+ * Each band's floor sits 1px under its content height (see the variants for
+ * why), so `overflow-hidden` only ever clips a pixel of padding, never
+ * glyphs. `min-h-5` floors a 15-minute card at 20px —
  * drawn a little taller than its duration so the title still reads, the
  * trade every calendar makes for sub-hour events.
  *
- * Spacing lives on the layout variants rather than `base`: `cn` is plain
- * clsx, so two `py-*` utilities would be resolved by Tailwind's output order,
- * not by the variant chosen.
+ * Positioning and spacing live on the layout variants rather than `base`:
+ * `cn` is plain clsx, so two `position` or `py-*` utilities would be resolved
+ * by Tailwind's output order, not by the variant chosen.
  */
 const eventCard = tv({
-  base: "relative flex flex-col overflow-hidden bg-event-background before:absolute before:w-0.5 before:rounded-full before:bg-event-border",
+  base: "overflow-hidden bg-event-background before:absolute before:w-0.5 before:rounded-full before:bg-event-border",
   variants: {
     layout: {
-      list: "gap-0.5 rounded-xl py-2.5 pr-3 pl-4 before:inset-y-2 before:left-1.5",
+      list: "relative flex flex-col gap-0.5 rounded-xl py-2.5 pr-3 pl-4 before:inset-y-2 before:left-1.5",
       // `@container-[size]/event-card` makes the card the size container the
       // `event-*` variants query. Grid only: size containment detaches a
       // box's height from its content — right for a card whose height is its
       // duration, but it would collapse a content-sized list card to nothing.
-      grid: "@container-[size]/event-card min-h-5 rounded-lg py-1 pr-2 pl-3 before:inset-y-1 before:left-1 event-compact:justify-center event-compact:py-0",
+      // The card carries no padding of its own: a size container's queries
+      // measure its content box, so padding here would shrink every band.
+      grid: "absolute @container-[size]/event-card min-h-5 rounded-lg before:inset-y-1 before:left-1",
     },
     past: {
       true: "opacity-60 line-through",
@@ -76,32 +80,36 @@ export const EventCard = memo(function EventCard({
   event,
   past,
   layout = "list",
-  className,
   style,
 }: EventCardProps) {
   const title = event.title ?? event.calendarName;
-  const classes = eventCard({ layout, past, className });
+  const classes = eventCard({ layout, past });
 
   if (layout === "grid") {
     return (
       <div className={classes} style={style}>
-        <Text size="xs" tone="eventMuted" className="truncate tabular-nums event-short:hidden">
-          {formatTimeRange(event.startTime, event.endTime)}
-        </Text>
-        {/* No `leading-*` here: `event-compact:text-xs` brings the xs
-            line-height along with the size. */}
-        <Text size="sm" tone="event" className="truncate font-semibold event-compact:text-xs">
-          {title}
-        </Text>
-        {event.description && (
-          <Text
-            size="xs"
-            tone="eventMuted"
-            className="hidden event-roomy:line-clamp-1 event-tall:line-clamp-2"
-          >
-            {event.description}
+        {/* The padding and the compact band's centring sit on this body
+            rather than the card: a container's queries never match the
+            container itself, only its descendants. */}
+        <div className="flex h-full flex-col py-1 pr-2 pl-3 event-compact:justify-center event-compact:py-0">
+          <Text size="xs" tone="eventMuted" className="truncate tabular-nums event-short:hidden">
+            {formatTimeRange(event.startTime, event.endTime)}
           </Text>
-        )}
+          {/* No `leading-*` here: `event-compact:text-xs` brings the xs
+              line-height along with the size. */}
+          <Text size="sm" tone="event" className="truncate font-semibold event-compact:text-xs">
+            {title}
+          </Text>
+          {event.description && (
+            <Text
+              size="xs"
+              tone="eventMuted"
+              className="hidden event-roomy:line-clamp-1 event-tall:line-clamp-2"
+            >
+              {event.description}
+            </Text>
+          )}
+        </div>
       </div>
     );
   }

--- a/applications/web/src/features/dashboard/components/event-card.tsx
+++ b/applications/web/src/features/dashboard/components/event-card.tsx
@@ -167,3 +167,23 @@ export const EventPill = memo(function EventPill({ event, past }: EventPillProps
     </div>
   );
 });
+
+interface EventPillOverflowProps {
+  /** How many of the day's events are folded away. */
+  count: number;
+}
+
+/** The "+N more" row that stands in for the pills a day has no room for. */
+export function EventPillOverflow({ count }: EventPillOverflowProps) {
+  return (
+    <Text
+      as="span"
+      size="xs"
+      tone="muted"
+      className="flex shrink-0 items-center truncate px-1.5"
+      style={{ height: EVENT_PILL_HEIGHT_PX }}
+    >
+      +{count} more
+    </Text>
+  );
+}

--- a/applications/web/src/features/dashboard/components/event-card.tsx
+++ b/applications/web/src/features/dashboard/components/event-card.tsx
@@ -1,0 +1,58 @@
+import { memo } from "react";
+import { tv } from "tailwind-variants/lite";
+import { Text } from "@/components/ui/primitives/text";
+import { formatTime, formatTimeUntil } from "@/lib/time";
+import type { CalendarEvent } from "@/hooks/use-events";
+
+interface EventCardProps {
+  event: CalendarEvent;
+  /** Whether the event has ended, which dims and strikes the card. Owned by
+   * the parent rather than read from the clock here: the card is memoised, so
+   * a clock read inside it would freeze at first render, while the parent
+   * re-renders on whatever tick it already has (the events list on a data
+   * refresh, the week grid's today column on its minute tick). */
+  past: boolean;
+}
+
+const eventCard = tv({
+  base: "relative flex flex-col gap-0.5 overflow-hidden rounded-xl bg-event-background py-2.5 pr-3 pl-4 before:absolute before:inset-y-2 before:left-1.5 before:w-0.5 before:rounded-full before:bg-event-border",
+  variants: {
+    past: {
+      true: "opacity-60 line-through",
+      false: "",
+    },
+  },
+});
+
+/**
+ * A tinted event card: time range and relative time on the first line, a
+ * bold title (falling back to the calendar name), and the description when
+ * the calendar shares it. Shared by the events page and the calendar pane.
+ */
+export const EventCard = memo(function EventCard({ event, past }: EventCardProps) {
+  const startTime = formatTime(event.startTime);
+  const endTime = formatTime(event.endTime);
+  const timeUntil = formatTimeUntil(event.startTime);
+  const title = event.title ?? event.calendarName;
+
+  return (
+    <div className={eventCard({ past })}>
+      <div className="flex items-center justify-between gap-2">
+        <Text size="sm" tone="eventMuted" className="tabular-nums">
+          {startTime} - {endTime}
+        </Text>
+        <Text size="xs" tone="eventMuted" className="tabular-nums whitespace-nowrap">
+          {timeUntil}
+        </Text>
+      </div>
+      <Text size="sm" tone="event" className="truncate font-semibold">
+        {title}
+      </Text>
+      {event.description && (
+        <Text size="sm" tone="eventMuted" className="line-clamp-2">
+          {event.description}
+        </Text>
+      )}
+    </div>
+  );
+});

--- a/applications/web/src/features/dashboard/components/event-card.tsx
+++ b/applications/web/src/features/dashboard/components/event-card.tsx
@@ -1,8 +1,11 @@
 import { memo } from "react";
+import type { CSSProperties } from "react";
 import { tv } from "tailwind-variants/lite";
 import { Text } from "@/components/ui/primitives/text";
-import { formatTime, formatTimeUntil } from "@/lib/time";
+import { formatTime, formatTimeRange, formatTimeUntil } from "@/lib/time";
 import type { CalendarEvent } from "@/hooks/use-events";
+
+type EventCardLayout = "list" | "grid";
 
 interface EventCardProps {
   event: CalendarEvent;
@@ -12,37 +15,105 @@ interface EventCardProps {
    * re-renders on whatever tick it already has (the events list on a data
    * refresh, the week grid's today column on its minute tick). */
   past: boolean;
+  /** `list` (the default): the events page's stacked, content-sized card
+   * with the relative time. `grid`: a week-grid card whose height is its
+   * event's duration and whose content steps down with that height — see
+   * the height bands on `eventCard`. */
+  layout?: EventCardLayout;
+  className?: string;
+  style?: CSSProperties;
 }
 
+/**
+ * Height bands for the grid layout, at the week grid's 48px hour (0.8px a
+ * minute), with the card's 4px vertical padding, a 16px text-xs line and a
+ * 20px text-sm line. The grid card is a size-query container named
+ * `event-card`, and the `event-*` variants in `index.css` select on its
+ * rendered height:
+ *
+ *   compact  < 28px   (≤ 30 min)  title (xs), centred, no padding   16px
+ *   short    < 44px   (≤ 50 min)  title (sm)                        28px
+ *   default  44–59px  (≤ 70 min)  time (xs) + title                 44px
+ *   roomy    60–75px  (≤ 90 min)  + one description line            60px
+ *   tall     ≥ 76px   (≥ 95 min)  + two description lines           76px
+ *
+ * Each band's floor equals its content height, so `overflow-hidden` only ever
+ * clips padding, never glyphs. `min-h-5` floors a 15-minute card at 20px —
+ * drawn a little taller than its duration so the title still reads, the
+ * trade every calendar makes for sub-hour events.
+ *
+ * Spacing lives on the layout variants rather than `base`: `cn` is plain
+ * clsx, so two `py-*` utilities would be resolved by Tailwind's output order,
+ * not by the variant chosen.
+ */
 const eventCard = tv({
-  base: "relative flex flex-col gap-0.5 overflow-hidden rounded-xl bg-event-background py-2.5 pr-3 pl-4 before:absolute before:inset-y-2 before:left-1.5 before:w-0.5 before:rounded-full before:bg-event-border",
+  base: "relative flex flex-col overflow-hidden bg-event-background before:absolute before:w-0.5 before:rounded-full before:bg-event-border",
   variants: {
+    layout: {
+      list: "gap-0.5 rounded-xl py-2.5 pr-3 pl-4 before:inset-y-2 before:left-1.5",
+      // `@container-[size]/event-card` makes the card the size container the
+      // `event-*` variants query. Grid only: size containment detaches a
+      // box's height from its content — right for a card whose height is its
+      // duration, but it would collapse a content-sized list card to nothing.
+      grid: "@container-[size]/event-card min-h-5 rounded-lg py-1 pr-2 pl-3 before:inset-y-1 before:left-1 event-compact:justify-center event-compact:py-0",
+    },
     past: {
       true: "opacity-60 line-through",
       false: "",
     },
   },
+  defaultVariants: {
+    layout: "list",
+  },
 });
 
 /**
- * A tinted event card: time range and relative time on the first line, a
- * bold title (falling back to the calendar name), and the description when
- * the calendar shares it. Shared by the events page and the calendar pane.
+ * A tinted event card: the time range, a bold title (falling back to the
+ * calendar name), and the description when the calendar shares it. Shared by
+ * the events page (`list`) and the calendar pane (`grid`).
  */
-export const EventCard = memo(function EventCard({ event, past }: EventCardProps) {
-  const startTime = formatTime(event.startTime);
-  const endTime = formatTime(event.endTime);
-  const timeUntil = formatTimeUntil(event.startTime);
+export const EventCard = memo(function EventCard({
+  event,
+  past,
+  layout = "list",
+  className,
+  style,
+}: EventCardProps) {
   const title = event.title ?? event.calendarName;
+  const classes = eventCard({ layout, past, className });
+
+  if (layout === "grid") {
+    return (
+      <div className={classes} style={style}>
+        <Text size="xs" tone="eventMuted" className="truncate tabular-nums event-short:hidden">
+          {formatTimeRange(event.startTime, event.endTime)}
+        </Text>
+        {/* No `leading-*` here: `event-compact:text-xs` brings the xs
+            line-height along with the size. */}
+        <Text size="sm" tone="event" className="truncate font-semibold event-compact:text-xs">
+          {title}
+        </Text>
+        {event.description && (
+          <Text
+            size="xs"
+            tone="eventMuted"
+            className="hidden event-roomy:line-clamp-1 event-tall:line-clamp-2"
+          >
+            {event.description}
+          </Text>
+        )}
+      </div>
+    );
+  }
 
   return (
-    <div className={eventCard({ past })}>
+    <div className={classes} style={style}>
       <div className="flex items-center justify-between gap-2">
         <Text size="sm" tone="eventMuted" className="tabular-nums">
-          {startTime} - {endTime}
+          {formatTime(event.startTime)} - {formatTime(event.endTime)}
         </Text>
         <Text size="xs" tone="eventMuted" className="tabular-nums whitespace-nowrap">
-          {timeUntil}
+          {formatTimeUntil(event.startTime)}
         </Text>
       </div>
       <Text size="sm" tone="event" className="truncate font-semibold">

--- a/applications/web/src/features/dashboard/components/event-card.tsx
+++ b/applications/web/src/features/dashboard/components/event-card.tsx
@@ -64,10 +64,14 @@ const eventCard = tv({
       // duration, but it would collapse a content-sized list card to nothing.
       // The card carries no padding of its own: a size container's queries
       // measure its content box, so padding here would shrink every band.
-      grid: "absolute @container-[size]/event-card min-h-5 rounded-lg before:inset-y-1 before:left-1",
+      // The ring is the page colour: invisible against the grid, it cuts a
+      // card out from any card it overlaps so the stack's edges stay legible.
+      grid: "absolute @container-[size]/event-card min-h-5 rounded-lg ring-1 ring-background before:inset-y-1 before:left-1",
     },
+    // Past cards dim their content and accent bar, not the card: opacity on
+    // the card itself would let a card beneath show through in a stack.
     past: {
-      true: "opacity-60 line-through",
+      true: "line-through before:opacity-60 *:opacity-60",
       false: "",
     },
   },
@@ -159,7 +163,7 @@ const eventPill = tv({
   base: "relative flex shrink-0 items-center overflow-hidden rounded-sm bg-event-background pr-1.5 pl-3 before:absolute before:inset-y-[3px] before:left-1 before:w-0.5 before:rounded-full before:bg-event-border",
   variants: {
     past: {
-      true: "opacity-60 line-through",
+      true: "line-through before:opacity-60 *:opacity-60",
       false: "",
     },
   },

--- a/applications/web/src/features/dashboard/components/event-card.tsx
+++ b/applications/web/src/features/dashboard/components/event-card.tsx
@@ -39,6 +39,10 @@ interface EventCardProps {
  *   roomy    59–74px  (≤ 90 min)  + one description line            60px
  *   tall     ≥ 75px   (≥ 95 min)  + two description lines           76px
  *
+ * Width has one band of its own: below 72px (`event-narrow` — a two- or
+ * three-way tile in a 136px column) the time line and description go and
+ * the title tightens, since neither end of a time range would fit.
+ *
  * Each band's floor sits 1px under its content height (see the variants for
  * why), so `overflow-hidden` only ever clips a pixel of padding, never
  * glyphs. `min-h-5` floors a 15-minute card at 20px —
@@ -92,20 +96,28 @@ export const EventCard = memo(function EventCard({
         {/* The padding and the compact band's centring sit on this body
             rather than the card: a container's queries never match the
             container itself, only its descendants. */}
-        <div className="flex h-full flex-col py-1 pr-2 pl-3 event-compact:justify-center event-compact:py-0">
-          <Text size="xs" tone="eventMuted" className="truncate tabular-nums event-short:hidden">
+        <div className="flex h-full flex-col py-1 pr-2 pl-3 event-compact:justify-center event-compact:py-0 event-narrow:pr-1 event-narrow:pl-2">
+          <Text
+            size="xs"
+            tone="eventMuted"
+            className="truncate tabular-nums event-short:hidden event-narrow:hidden"
+          >
             {formatTimeRange(event.startTime, event.endTime)}
           </Text>
-          {/* No `leading-*` here: `event-compact:text-xs` brings the xs
-              line-height along with the size. */}
-          <Text size="sm" tone="event" className="truncate font-semibold event-compact:text-xs">
+          {/* No `leading-*` here: the `text-xs` steps bring the xs line-height
+              along with the size. */}
+          <Text
+            size="sm"
+            tone="event"
+            className="truncate font-semibold event-compact:text-xs event-narrow:text-xs"
+          >
             {title}
           </Text>
           {event.description && (
             <Text
               size="xs"
               tone="eventMuted"
-              className="hidden event-roomy:line-clamp-1 event-tall:line-clamp-2"
+              className="hidden event-roomy:line-clamp-1 event-tall:line-clamp-2 event-narrow:hidden"
             >
               {event.description}
             </Text>

--- a/applications/web/src/features/dashboard/components/event-card.tsx
+++ b/applications/web/src/features/dashboard/components/event-card.tsx
@@ -54,7 +54,7 @@ interface EventCardProps {
  * by Tailwind's output order, not by the variant chosen.
  */
 const eventCard = tv({
-  base: "overflow-hidden bg-event-background before:absolute before:w-0.5 before:rounded-full before:bg-event-border",
+  base: "overflow-hidden before:absolute before:w-0.5 before:rounded-full before:bg-event-border",
   variants: {
     layout: {
       list: "relative flex flex-col gap-0.5 rounded-xl py-2.5 pr-3 pl-4 before:inset-y-2 before:left-1.5",
@@ -68,11 +68,14 @@ const eventCard = tv({
       // card out from any card it overlaps so the stack's edges stay legible.
       grid: "absolute @container-[size]/event-card min-h-5 rounded-lg ring-1 ring-background before:inset-y-1 before:left-1",
     },
-    // Past cards dim their content and accent bar, not the card: opacity on
-    // the card itself would let a card beneath show through in a stack.
+    // Past cards recede on a muted (still opaque) fill with their content and
+    // accent bar dimmed — never opacity on the card itself, which would let a
+    // card beneath show through in a stack. The fill lives on both branches
+    // rather than `base`, as two `bg-*` utilities would be left to Tailwind's
+    // output order.
     past: {
-      true: "line-through before:opacity-60 *:opacity-60",
-      false: "",
+      true: "bg-event-background-muted line-through before:opacity-50 *:opacity-50",
+      false: "bg-event-background",
     },
   },
   defaultVariants: {
@@ -160,11 +163,11 @@ interface EventPillProps {
 }
 
 const eventPill = tv({
-  base: "relative flex shrink-0 items-center overflow-hidden rounded-sm bg-event-background pr-1.5 pl-3 before:absolute before:inset-y-[3px] before:left-1 before:w-0.5 before:rounded-full before:bg-event-border",
+  base: "relative flex shrink-0 items-center overflow-hidden rounded-sm pr-1.5 pl-3 before:absolute before:inset-y-[3px] before:left-1 before:w-0.5 before:rounded-full before:bg-event-border",
   variants: {
     past: {
-      true: "line-through before:opacity-60 *:opacity-60",
-      false: "",
+      true: "bg-event-background-muted line-through before:opacity-50 *:opacity-50",
+      false: "bg-event-background",
     },
   },
 });

--- a/applications/web/src/features/dashboard/components/event-card.tsx
+++ b/applications/web/src/features/dashboard/components/event-card.tsx
@@ -4,6 +4,7 @@ import { tv } from "tailwind-variants/lite";
 import { Text } from "@/components/ui/primitives/text";
 import { formatTime, formatTimeRange, formatTimeUntil } from "@/lib/time";
 import type { CalendarEvent } from "@/hooks/use-events";
+import { EVENT_PILL_HEIGHT_PX } from "./event-layout";
 
 type EventCardLayout = "list" | "grid";
 
@@ -132,6 +133,37 @@ export const EventCard = memo(function EventCard({
           {event.description}
         </Text>
       )}
+    </div>
+  );
+});
+
+interface EventPillProps {
+  event: CalendarEvent;
+  /** Whether the event has ended; see `EventCardProps.past`. */
+  past: boolean;
+}
+
+const eventPill = tv({
+  base: "relative flex shrink-0 items-center overflow-hidden rounded-sm bg-event-background pr-1.5 pl-3 before:absolute before:inset-y-[3px] before:left-1 before:w-0.5 before:rounded-full before:bg-event-border",
+  variants: {
+    past: {
+      true: "opacity-60 line-through",
+      false: "",
+    },
+  },
+});
+
+/**
+ * A one-line event pill — the card's surface and accent bar at pill height —
+ * for the week view's all-day band and the month grid's day cells.
+ */
+export const EventPill = memo(function EventPill({ event, past }: EventPillProps) {
+  return (
+    <div className={eventPill({ past })} style={{ height: EVENT_PILL_HEIGHT_PX }}>
+      {/* `min-w-0` lets the flex item shrink below its text so `truncate` bites. */}
+      <Text as="span" size="xs" tone="event" className="min-w-0 truncate font-medium">
+        {event.title ?? event.calendarName}
+      </Text>
     </div>
   );
 });

--- a/applications/web/src/features/dashboard/components/event-card.tsx
+++ b/applications/web/src/features/dashboard/components/event-card.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import type { CSSProperties } from "react";
+import type { CSSProperties, PropsWithChildren } from "react";
 import { tv } from "tailwind-variants/lite";
 import { Text } from "@/components/ui/primitives/text";
 import { formatTime, formatTimeRange, formatTimeUntil } from "@/lib/time";
@@ -7,6 +7,35 @@ import type { CalendarEvent } from "@/hooks/use-events";
 import { EVENT_PILL_HEIGHT_PX } from "./event-layout";
 
 type EventCardLayout = "list" | "grid";
+
+const eventText = tv({
+  base: "tracking-tight",
+  variants: {
+    size: {
+      sm: "text-sm",
+      xs: "text-xs",
+    },
+    muted: {
+      true: "text-event-muted",
+      false: "text-event",
+    },
+  },
+  defaultVariants: {
+    muted: false,
+  },
+});
+
+type EventTextProps = PropsWithChildren<{
+  as?: "p" | "span";
+  size: "sm" | "xs";
+  muted?: boolean;
+  className?: string;
+}>;
+
+function EventText({ as = "p", size, muted, className, children }: EventTextProps) {
+  const Element = as;
+  return <Element className={eventText({ size, muted, className })}>{children}</Element>;
+}
 
 interface EventCardProps {
   event: CalendarEvent;
@@ -104,30 +133,29 @@ export const EventCard = memo(function EventCard({
             rather than the card: a container's queries never match the
             container itself, only its descendants. */}
         <div className="flex h-full flex-col py-1 pr-2 pl-3 event-compact:justify-center event-compact:py-0 event-narrow:pr-1 event-narrow:pl-2">
-          <Text
+          <EventText
             size="xs"
-            tone="eventMuted"
+            muted
             className="truncate tabular-nums event-short:hidden event-narrow:hidden"
           >
             {formatTimeRange(event.startTime, event.endTime)}
-          </Text>
+          </EventText>
           {/* No `leading-*` here: the `text-xs` steps bring the xs line-height
               along with the size. */}
-          <Text
+          <EventText
             size="sm"
-            tone="event"
             className="truncate font-semibold event-compact:text-xs event-narrow:text-xs"
           >
             {title}
-          </Text>
+          </EventText>
           {event.description && (
-            <Text
+            <EventText
               size="xs"
-              tone="eventMuted"
+              muted
               className="hidden event-roomy:line-clamp-1 event-tall:line-clamp-2 event-narrow:hidden"
             >
               {event.description}
-            </Text>
+            </EventText>
           )}
         </div>
       </div>
@@ -137,20 +165,20 @@ export const EventCard = memo(function EventCard({
   return (
     <div className={classes} style={style}>
       <div className="flex items-center justify-between gap-2">
-        <Text size="sm" tone="eventMuted" className="tabular-nums">
+        <EventText size="sm" muted className="tabular-nums">
           {formatTime(event.startTime)} - {formatTime(event.endTime)}
-        </Text>
-        <Text size="xs" tone="eventMuted" className="tabular-nums whitespace-nowrap">
+        </EventText>
+        <EventText size="xs" muted className="tabular-nums whitespace-nowrap">
           {formatTimeUntil(event.startTime)}
-        </Text>
+        </EventText>
       </div>
-      <Text size="sm" tone="event" className="truncate font-semibold">
+      <EventText size="sm" className="truncate font-semibold">
         {title}
-      </Text>
+      </EventText>
       {event.description && (
-        <Text size="sm" tone="eventMuted" className="line-clamp-2">
+        <EventText size="sm" muted className="line-clamp-2">
           {event.description}
-        </Text>
+        </EventText>
       )}
     </div>
   );
@@ -180,9 +208,9 @@ export const EventPill = memo(function EventPill({ event, past }: EventPillProps
   return (
     <div className={eventPill({ past })} style={{ height: EVENT_PILL_HEIGHT_PX }}>
       {/* `min-w-0` lets the flex item shrink below its text so `truncate` bites. */}
-      <Text as="span" size="xs" tone="event" className="min-w-0 truncate font-medium">
+      <EventText as="span" size="xs" className="min-w-0 truncate font-medium">
         {event.title ?? event.calendarName}
-      </Text>
+      </EventText>
     </div>
   );
 });

--- a/applications/web/src/features/dashboard/components/event-card.tsx
+++ b/applications/web/src/features/dashboard/components/event-card.tsx
@@ -1,12 +1,22 @@
 import { memo } from "react";
 import type { CSSProperties, PropsWithChildren } from "react";
 import { tv } from "tailwind-variants/lite";
+import { cn } from "@/utils/cn";
 import { Text } from "@/components/ui/primitives/text";
 import { formatTime, formatTimeRange, formatTimeUntil } from "@/lib/time";
 import type { CalendarEvent } from "@/hooks/use-events";
 import { EVENT_PILL_HEIGHT_PX } from "./event-layout";
 
 type EventCardLayout = "list" | "grid";
+
+const EVENT_COLORS = {
+  blue: cn(
+    "[--event-ink:var(--color-blue-900)] [--event-surface:var(--color-blue-100)] [--event-accent:var(--color-blue-500)]",
+    "dark:[--event-ink:var(--color-blue-100)] dark:[--event-surface:color-mix(in_srgb,var(--color-blue-500)_20%,var(--color-background))] dark:[--event-accent:var(--color-blue-400)]",
+  ),
+};
+
+type EventColor = keyof typeof EVENT_COLORS;
 
 const eventText = tv({
   base: "tracking-tight",
@@ -16,8 +26,8 @@ const eventText = tv({
       xs: "text-xs",
     },
     muted: {
-      true: "text-event-muted",
-      false: "text-event",
+      true: "text-(--event-ink)/70",
+      false: "text-(--event-ink)",
     },
   },
   defaultVariants: {
@@ -53,6 +63,7 @@ interface EventCardProps {
   /** Placement for the `grid` layout: the column sets `top`/`height`/`left`/
    * `width` and the stacking order. */
   style?: CSSProperties;
+  color?: EventColor;
 }
 
 /**
@@ -83,7 +94,7 @@ interface EventCardProps {
  * by Tailwind's output order, not by the variant chosen.
  */
 const eventCard = tv({
-  base: "overflow-hidden before:absolute before:w-0.5 before:rounded-full before:bg-event-border",
+  base: "overflow-hidden before:absolute before:w-0.5 before:rounded-full before:bg-(--event-accent)",
   variants: {
     layout: {
       list: "relative flex flex-col gap-0.5 rounded-xl py-2.5 pr-3 pl-4 before:inset-y-2 before:left-1.5",
@@ -103,8 +114,8 @@ const eventCard = tv({
     // rather than `base`, as two `bg-*` utilities would be left to Tailwind's
     // output order.
     past: {
-      true: "bg-event-background-muted line-through before:opacity-50 *:opacity-50",
-      false: "bg-event-background",
+      true: "bg-[color-mix(in_srgb,var(--event-surface)_50%,var(--color-background))] line-through before:opacity-50 *:opacity-50",
+      false: "bg-(--event-surface)",
     },
   },
   defaultVariants: {
@@ -122,9 +133,10 @@ export const EventCard = memo(function EventCard({
   past,
   layout = "list",
   style,
+  color = "blue",
 }: EventCardProps) {
   const title = event.title ?? event.calendarName;
-  const classes = eventCard({ layout, past });
+  const classes = cn(eventCard({ layout, past }), EVENT_COLORS[color]);
 
   if (layout === "grid") {
     return (
@@ -188,14 +200,15 @@ interface EventPillProps {
   event: CalendarEvent;
   /** Whether the event has ended; see `EventCardProps.past`. */
   past: boolean;
+  color?: EventColor;
 }
 
 const eventPill = tv({
-  base: "relative flex shrink-0 items-center overflow-hidden rounded-sm pr-1.5 pl-3 before:absolute before:inset-y-[3px] before:left-1 before:w-0.5 before:rounded-full before:bg-event-border",
+  base: "relative flex shrink-0 items-center overflow-hidden rounded-sm pr-1.5 pl-3 before:absolute before:inset-y-[3px] before:left-1 before:w-0.5 before:rounded-full before:bg-(--event-accent)",
   variants: {
     past: {
-      true: "bg-event-background-muted line-through before:opacity-50 *:opacity-50",
-      false: "bg-event-background",
+      true: "bg-[color-mix(in_srgb,var(--event-surface)_50%,var(--color-background))] line-through before:opacity-50 *:opacity-50",
+      false: "bg-(--event-surface)",
     },
   },
 });
@@ -204,9 +217,9 @@ const eventPill = tv({
  * A one-line event pill — the card's surface and accent bar at pill height —
  * for the week view's all-day band and the month grid's day cells.
  */
-export const EventPill = memo(function EventPill({ event, past }: EventPillProps) {
+export const EventPill = memo(function EventPill({ event, past, color = "blue" }: EventPillProps) {
   return (
-    <div className={eventPill({ past })} style={{ height: EVENT_PILL_HEIGHT_PX }}>
+    <div className={cn(eventPill({ past }), EVENT_COLORS[color])} style={{ height: EVENT_PILL_HEIGHT_PX }}>
       {/* `min-w-0` lets the flex item shrink below its text so `truncate` bites. */}
       <EventText as="span" size="xs" className="min-w-0 truncate font-medium">
         {event.title ?? event.calendarName}

--- a/applications/web/src/features/dashboard/components/event-card.tsx
+++ b/applications/web/src/features/dashboard/components/event-card.tsx
@@ -49,70 +49,35 @@ function EventText({ as = "p", size, muted, className, children }: EventTextProp
 
 interface EventCardProps {
   event: CalendarEvent;
-  /** Whether the event has ended, which dims and strikes the card. Owned by
-   * the parent rather than read from the clock here: the card is memoised, so
-   * a clock read inside it would freeze at first render, while the parent
-   * re-renders on whatever tick it already has (the events list on a data
-   * refresh, the week grid's today column on its minute tick). */
+  /** Whether the event has ended (dims and strikes the card); parent-owned since the memoised card can't watch the clock. */
   past: boolean;
-  /** `list` (the default): the events page's stacked, content-sized card
-   * with the relative time. `grid`: a week-grid card whose height is its
-   * event's duration and whose content steps down with that height — see
-   * the height bands on `eventCard`. */
+  /** `list`: the events page's content-sized card; `grid`: a week-grid card sized by its event's duration. */
   layout?: EventCardLayout;
-  /** Placement for the `grid` layout: the column sets `top`/`height`/`left`/
-   * `width` and the stacking order. */
+  /** Grid placement from the column: `top`/`height`/`left`/`width` and the stacking order. */
   style?: CSSProperties;
   color?: EventColor;
 }
 
 /**
- * Height bands for the grid layout, at the week grid's 48px hour (0.8px a
- * minute), with the card's 4px vertical padding, a 16px text-xs line and a
- * 20px text-sm line. The grid card is a size-query container named
- * `event-card`, and the `event-*` variants in `index.css` select on its
- * rendered height:
- *
- *   compact  < 27px   (≤ 30 min)  title (xs), centred, no padding   16px
- *   short    < 43px   (≤ 50 min)  title (sm)                        28px
- *   default  43–58px  (≤ 70 min)  time (xs) + title                 44px
- *   roomy    59–74px  (≤ 90 min)  + one description line            60px
- *   tall     ≥ 75px   (≥ 95 min)  + two description lines           76px
- *
- * Width has one band of its own: below 72px (`event-narrow` — a two- or
- * three-way tile in a 136px column) the time line and description go and
- * the title tightens, since neither end of a time range would fit.
- *
- * Each band's floor sits 1px under its content height (see the variants for
- * why), so `overflow-hidden` only ever clips a pixel of padding, never
- * glyphs. `min-h-5` floors a 15-minute card at 20px —
- * drawn a little taller than its duration so the title still reads, the
- * trade every calendar makes for sub-hour events.
- *
- * Positioning and spacing live on the layout variants rather than `base`:
- * `cn` is plain clsx, so two `position` or `py-*` utilities would be resolved
- * by Tailwind's output order, not by the variant chosen.
+ * Height bands for the grid layout (48px hour); each floor sits 1px under its
+ * content height so percentage rounding only ever clips padding, never glyphs:
+ *   compact  < 27px   (≤ 30 min)  title (xs), centred, no padding
+ *   short    < 43px   (≤ 50 min)  title (sm)
+ *   default  43–58px  (≤ 70 min)  time (xs) + title
+ *   roomy    59–74px  (≤ 90 min)  + one description line
+ *   tall     ≥ 75px   (≥ 95 min)  + two description lines
+ *   narrow   < 72px wide          time and description go, title tightens
  */
 const eventCard = tv({
   base: "overflow-hidden before:absolute before:w-0.5 before:rounded-full before:bg-(--event-accent)",
   variants: {
     layout: {
       list: "relative flex flex-col gap-0.5 rounded-xl py-2.5 pr-3 pl-4 before:inset-y-2 before:left-1.5",
-      // `@container-[size]/event-card` makes the card the size container the
-      // `event-*` variants query. Grid only: size containment detaches a
-      // box's height from its content — right for a card whose height is its
-      // duration, but it would collapse a content-sized list card to nothing.
-      // The card carries no padding of its own: a size container's queries
-      // measure its content box, so padding here would shrink every band.
-      // The ring is the page colour: invisible against the grid, it cuts a
-      // card out from any card it overlaps so the stack's edges stay legible.
+      // Size containment is grid-only — it would collapse the content-sized list card.
+      // The page-colour ring cuts a card out of any card it overlaps.
       grid: "absolute @container-[size]/event-card min-h-5 rounded-lg ring-1 ring-background before:inset-y-1 before:left-1",
     },
-    // Past cards recede on a muted (still opaque) fill with their content and
-    // accent bar dimmed — never opacity on the card itself, which would let a
-    // card beneath show through in a stack. The fill lives on both branches
-    // rather than `base`, as two `bg-*` utilities would be left to Tailwind's
-    // output order.
+    // The muted fill stays opaque — card opacity would let a stacked card beneath show through.
     past: {
       true: "bg-[color-mix(in_srgb,var(--event-surface)_50%,var(--color-background))] line-through before:opacity-50 *:opacity-50",
       false: "bg-(--event-surface)",
@@ -123,11 +88,7 @@ const eventCard = tv({
   },
 });
 
-/**
- * A tinted event card: the time range, a bold title (falling back to the
- * calendar name), and the description when the calendar shares it. Shared by
- * the events page (`list`) and the calendar pane (`grid`).
- */
+/** A tinted event card, shared by the events page (`list`) and the calendar pane (`grid`). */
 export const EventCard = memo(function EventCard({
   event,
   past,
@@ -141,9 +102,7 @@ export const EventCard = memo(function EventCard({
   if (layout === "grid") {
     return (
       <div className={classes} style={style}>
-        {/* The padding and the compact band's centring sit on this body
-            rather than the card: a container's queries never match the
-            container itself, only its descendants. */}
+        {/* Padding and centring sit on the body: a container's queries never match the container itself. */}
         <div className="flex h-full flex-col py-1 pr-2 pl-3 event-compact:justify-center event-compact:py-0 event-narrow:pr-1 event-narrow:pl-2">
           <EventText
             size="xs"
@@ -152,8 +111,6 @@ export const EventCard = memo(function EventCard({
           >
             {formatTimeRange(event.startTime, event.endTime)}
           </EventText>
-          {/* No `leading-*` here: the `text-xs` steps bring the xs line-height
-              along with the size. */}
           <EventText
             size="sm"
             className="truncate font-semibold event-compact:text-xs event-narrow:text-xs"
@@ -213,14 +170,10 @@ const eventPill = tv({
   },
 });
 
-/**
- * A one-line event pill — the card's surface and accent bar at pill height —
- * for the week view's all-day band and the month grid's day cells.
- */
+/** A one-line event pill for the week view's all-day band and the month grid's day cells. */
 export const EventPill = memo(function EventPill({ event, past, color = "blue" }: EventPillProps) {
   return (
     <div className={cn(eventPill({ past }), EVENT_COLORS[color])} style={{ height: EVENT_PILL_HEIGHT_PX }}>
-      {/* `min-w-0` lets the flex item shrink below its text so `truncate` bites. */}
       <EventText as="span" size="xs" className="min-w-0 truncate font-medium">
         {event.title ?? event.calendarName}
       </EventText>

--- a/applications/web/src/features/dashboard/components/event-card.tsx
+++ b/applications/web/src/features/dashboard/components/event-card.tsx
@@ -49,25 +49,14 @@ function EventText({ as = "p", size, muted, className, children }: EventTextProp
 
 interface EventCardProps {
   event: CalendarEvent;
-  /** Whether the event has ended (dims and strikes the card); parent-owned since the memoised card can't watch the clock. */
+  /** Parent-owned: the memoised card can't watch the clock. */
   past: boolean;
-  /** `list`: the events page's content-sized card; `grid`: a week-grid card sized by its event's duration. */
   layout?: EventCardLayout;
-  /** Grid placement from the column: `top`/`height`/`left`/`width` and the stacking order. */
   style?: CSSProperties;
   color?: EventColor;
 }
 
-/**
- * Height bands for the grid layout (48px hour); each floor sits 1px under its
- * content height so percentage rounding only ever clips padding, never glyphs:
- *   compact  < 27px   (≤ 30 min)  title (xs), centred, no padding
- *   short    < 43px   (≤ 50 min)  title (sm)
- *   default  43–58px  (≤ 70 min)  time (xs) + title
- *   roomy    59–74px  (≤ 90 min)  + one description line
- *   tall     ≥ 75px   (≥ 95 min)  + two description lines
- *   narrow   < 72px wide          time and description go, title tightens
- */
+// Grid height bands (48px hour): each floor sits 1px under its content height so rounding never clips glyphs.
 const eventCard = tv({
   base: "overflow-hidden before:absolute before:w-0.5 before:rounded-full before:bg-(--event-accent)",
   variants: {
@@ -88,7 +77,6 @@ const eventCard = tv({
   },
 });
 
-/** A tinted event card, shared by the events page (`list`) and the calendar pane (`grid`). */
 export const EventCard = memo(function EventCard({
   event,
   past,
@@ -155,7 +143,6 @@ export const EventCard = memo(function EventCard({
 
 interface EventPillProps {
   event: CalendarEvent;
-  /** Whether the event has ended; see `EventCardProps.past`. */
   past: boolean;
   color?: EventColor;
 }
@@ -170,7 +157,6 @@ const eventPill = tv({
   },
 });
 
-/** A one-line event pill for the week view's all-day band and the month grid's day cells. */
 export const EventPill = memo(function EventPill({ event, past, color = "blue" }: EventPillProps) {
   return (
     <div className={cn(eventPill({ past }), EVENT_COLORS[color])} style={{ height: EVENT_PILL_HEIGHT_PX }}>
@@ -182,11 +168,9 @@ export const EventPill = memo(function EventPill({ event, past, color = "blue" }
 });
 
 interface EventPillOverflowProps {
-  /** How many of the day's events are folded away. */
   count: number;
 }
 
-/** The "+N more" row that stands in for the pills a day has no room for. */
 export function EventPillOverflow({ count }: EventPillOverflowProps) {
   return (
     <Text

--- a/applications/web/src/features/dashboard/components/event-layout.ts
+++ b/applications/web/src/features/dashboard/components/event-layout.ts
@@ -71,16 +71,21 @@ export function tileBox(
   return { left: columnIndex / columnCount, width: columnSpan / columnCount };
 }
 
-/** Position of an instant within its day as a fraction of the day's 24 rows,
- * read from the local wall clock rather than elapsed milliseconds: a DST day
- * has 23 or 25 hours, and dividing elapsed time by 86 400 000 would slide
- * every afternoon event a row off its hour. An instant at or past the day's
- * end maps to 1. */
-function wallClockFraction(ms: number, dayEndMs: number): number {
-  if (ms >= dayEndMs) return 1;
-  const date = new Date(ms);
+/** Where an instant falls in its day, as a 0–1 fraction of the day's 24
+ * rows, read from the local wall clock rather than elapsed milliseconds: a
+ * DST day has 23 or 25 hours, and dividing elapsed time by 86 400 000 would
+ * slide every afternoon instant a row off its hour. Shared by the event
+ * cards and the current-time line, so both agree on where an hour sits. */
+export function timeOfDayFraction(date: Date): number {
   const minutes = date.getHours() * 60 + date.getMinutes() + date.getSeconds() / 60;
   return minutes / MINUTES_PER_DAY;
+}
+
+/** `timeOfDayFraction` for a laid-out instant, with one at or past the
+ * day's end mapping to 1. */
+function wallClockFraction(ms: number, dayEndMs: number): number {
+  if (ms >= dayEndMs) return 1;
+  return timeOfDayFraction(new Date(ms));
 }
 
 interface LayoutItem {

--- a/applications/web/src/features/dashboard/components/event-layout.ts
+++ b/applications/web/src/features/dashboard/components/event-layout.ts
@@ -1,0 +1,209 @@
+import type { CalendarEvent } from "@/hooks/use-events";
+import { addDays } from "./calendar-helpers";
+
+const MS_PER_MINUTE = 60_000;
+const MINUTES_PER_DAY = 24 * 60;
+
+/** Shortest span an event is laid out with. A five-minute event still takes
+ * a fifteen-minute slot so it registers on the grid; the card's `min-h`
+ * floors the rendered height too, but this floors the *time* geometry, so
+ * the overlap and lane decisions see the same box the user does. */
+export const MIN_EVENT_SPAN_MS = 15 * MS_PER_MINUTE;
+
+/** When two time-overlapping events start within this window, the cascade's
+ * later card would land on the earlier one's header and hide its time and
+ * title, so the whole cluster tiles into equal columns instead. qali's
+ * week-view value: week columns are narrow and a cascaded card's exposed
+ * left sliver is thin, so tiling is preferred eagerly. */
+export const TILE_MAX_STAGGER_MS = 45 * MS_PER_MINUTE;
+
+/** Horizontal shift, in pixels, per level of the overlap cascade. */
+const STACK_INDENT_PX = 14;
+/** Levels that get the full indent before it stops growing. */
+const STACK_MAX_LEVELS = 3;
+/** Thin residual indent per level past the cap, so deep cards still peek out. */
+const STACK_DEEP_STEP_PX = 4;
+
+export interface PositionedEvent {
+  event: CalendarEvent;
+  /** Distance from the top of the day, as a 0–1 fraction of its height. */
+  topFraction: number;
+  /** Share of the day's height, 0–1. */
+  heightFraction: number;
+  /** Cascade depth: how many earlier events in the cluster are still running
+   * at this event's start. 0 is the leftmost card; deeper cards indent
+   * further right. Drives the horizontal indent only, not the paint order. */
+  stackIndex: number;
+  /** Paint order within the cluster (0 = earliest start). Higher sits on top,
+   * so a later-starting event is never buried under an earlier, longer one. */
+  elevation: number;
+  /** Column (lane) this event occupies when its cluster tiles. 0 is leftmost. */
+  columnIndex: number;
+  /** Columns the event's cluster splits into (1 when it stands alone). */
+  columnCount: number;
+  /** How many columns the card fills once it expands right into free space
+   * (at least 1). `columnIndex + columnSpan <= columnCount`. */
+  columnSpan: number;
+  /** Whether the cluster tiles into equal, non-overlapping columns rather
+   * than cascading — see `TILE_MAX_STAGGER_MS`. */
+  tiled: boolean;
+}
+
+/** Left indent (px) for a card at `stackIndex`, capped so the front cards
+ * stay wide in deep overlaps while every card behind still exposes a visible
+ * left sliver (the residual keeps the indent monotonic past the cap). */
+export function stackIndentPx(stackIndex: number): number {
+  const capped = Math.min(stackIndex, STACK_MAX_LEVELS);
+  const overflow = Math.max(0, stackIndex - STACK_MAX_LEVELS);
+  return capped * STACK_INDENT_PX + overflow * STACK_DEEP_STEP_PX;
+}
+
+/** Horizontal box (`left`/`width` as 0–1 fractions of the column) for an
+ * event in a tiled cluster: equal columns, with a card widening across
+ * `columnSpan` of them when it can expand right into free space. */
+export function tileBox(
+  columnIndex: number,
+  columnCount: number,
+  columnSpan: number,
+): { left: number; width: number } {
+  if (columnCount <= 1) return { left: 0, width: 1 };
+  return { left: columnIndex / columnCount, width: columnSpan / columnCount };
+}
+
+/** Position of an instant within its day as a fraction of the day's 24 rows,
+ * read from the local wall clock rather than elapsed milliseconds: a DST day
+ * has 23 or 25 hours, and dividing elapsed time by 86 400 000 would slide
+ * every afternoon event a row off its hour. An instant at or past the day's
+ * end maps to 1. */
+function wallClockFraction(ms: number, dayEndMs: number): number {
+  if (ms >= dayEndMs) return 1;
+  const date = new Date(ms);
+  const minutes = date.getHours() * 60 + date.getMinutes() + date.getSeconds() / 60;
+  return minutes / MINUTES_PER_DAY;
+}
+
+interface LayoutItem {
+  event: CalendarEvent;
+  /** The event's span clamped to the day and floored to `MIN_EVENT_SPAN_MS`, in ms. */
+  start: number;
+  end: number;
+  stackIndex: number;
+  elevation: number;
+  columnIndex: number;
+  columnCount: number;
+  columnSpan: number;
+  tiled: boolean;
+}
+
+const overlaps = (first: LayoutItem, second: LayoutItem): boolean =>
+  first.start < second.end && second.start < first.end;
+
+/** Lays out one cluster of transitively overlapping events: first-fit lane
+ * packing, right-expansion into free lanes, and the cascade-or-tile decision
+ * for the cluster as a whole. */
+function layoutCluster(cluster: LayoutItem[]): void {
+  // Greedy first-fit into lanes: each event reuses the first lane free at
+  // its start, or opens a new one.
+  const laneEnds: number[] = [];
+  for (const item of cluster) {
+    let lane = laneEnds.findIndex((end) => end <= item.start);
+    if (lane === -1) lane = laneEnds.length;
+    laneEnds[lane] = item.end;
+    item.columnIndex = lane;
+  }
+  const columnCount = laneEnds.length;
+
+  // Expand each card right into free lanes: stop at the first later-lane
+  // event it overlaps in time.
+  for (const item of cluster) {
+    item.columnCount = columnCount;
+    let span = columnCount - item.columnIndex;
+    for (const other of cluster) {
+      if (other === item || other.columnIndex <= item.columnIndex) continue;
+      if (overlaps(item, other)) span = Math.min(span, other.columnIndex - item.columnIndex);
+    }
+    item.columnSpan = Math.max(span, 1);
+  }
+
+  // The cascade reads well when a comfortable stagger keeps every earlier
+  // card's header above the next card's top edge. When two overlapping cards
+  // start within TILE_MAX_STAGGER_MS the later one would bury the earlier
+  // one's header, so the whole cluster tiles into clean columns instead.
+  const tiled = cluster.some((item, index) =>
+    cluster
+      .slice(index + 1)
+      .some(
+        (other) => overlaps(item, other) && Math.abs(item.start - other.start) < TILE_MAX_STAGGER_MS,
+      ),
+  );
+  for (const item of cluster) item.tiled = tiled;
+}
+
+/**
+ * Positions a day's timed events, modelled on qali's week view: clamp each
+ * to the day, then group transitively overlapping events into clusters. A
+ * cluster cascades — each event indents past the earlier events still
+ * running at its start (`stackIndex`) and paints in start order
+ * (`elevation`), so a later, shorter event sits on top of the earlier ones it
+ * overlaps instead of being buried under them — unless two of its events
+ * start too close together to stagger legibly, in which case it tiles into
+ * equal columns (`columnIndex`/`columnCount`/`columnSpan`).
+ */
+export function layoutDayEvents(events: CalendarEvent[], day: Date): PositionedEvent[] {
+  const dayStartMs = day.getTime();
+  // The local next midnight, so a DST day keeps its 23 or 25 hours.
+  const dayEndMs = addDays(day, 1).getTime();
+
+  const items: LayoutItem[] = events
+    .map((event) => {
+      const start = Math.max(event.startTime.getTime(), dayStartMs);
+      const end = Math.min(Math.max(event.endTime.getTime(), start + MIN_EVENT_SPAN_MS), dayEndMs);
+      return {
+        event,
+        start,
+        end,
+        stackIndex: 0,
+        elevation: 0,
+        columnIndex: 0,
+        columnCount: 1,
+        columnSpan: 1,
+        tiled: false,
+      };
+    })
+    // Start ascending, then longer first, so the widest card anchors a cluster.
+    .sort(
+      (first, second) =>
+        first.start - second.start || second.end - second.start - (first.end - first.start),
+    );
+
+  // Walk events in start order, grouping transitively overlapping ones into
+  // clusters (a run of events chained by overlap); each cluster is laid out
+  // independently.
+  let cluster: LayoutItem[] = [];
+  let clusterEnd = Number.NEGATIVE_INFINITY;
+  for (const item of items) {
+    if (item.start >= clusterEnd) {
+      layoutCluster(cluster);
+      cluster = [];
+    }
+    // Indent past every earlier cluster member still running at our start.
+    item.stackIndex = cluster.filter((previous) => previous.end > item.start).length;
+    // Paint order: later starts sit on top of earlier ones in the cluster.
+    item.elevation = cluster.length;
+    cluster.push(item);
+    clusterEnd = Math.max(clusterEnd, item.end);
+  }
+  layoutCluster(cluster);
+
+  return items.map((item) => ({
+    event: item.event,
+    topFraction: wallClockFraction(item.start, dayEndMs),
+    heightFraction: wallClockFraction(item.end, dayEndMs) - wallClockFraction(item.start, dayEndMs),
+    stackIndex: item.stackIndex,
+    elevation: item.elevation,
+    columnIndex: item.columnIndex,
+    columnCount: item.columnCount,
+    columnSpan: item.columnSpan,
+    tiled: item.tiled,
+  }));
+}

--- a/applications/web/src/features/dashboard/components/event-layout.ts
+++ b/applications/web/src/features/dashboard/components/event-layout.ts
@@ -240,6 +240,9 @@ const getDayEvents = (buckets: Map<number, DayEvents>, dayKey: number): DayEvent
  * days are read in UTC and mapped onto local days by index — comparing them
  * with a local midnight would shift them by the zone offset and spill a
  * single-day event into a neighbour.
+ *
+ * Each day's lists come back in start order, so a consumer can show them as
+ * they fall without sorting again.
  */
 export function bucketEventsByDay(
   events: CalendarEvent[],
@@ -282,8 +285,15 @@ export function bucketEventsByDay(
     }
   }
 
+  for (const bucket of buckets.values()) {
+    bucket.timed.sort(byStartTime);
+    bucket.allDay.sort(byStartTime);
+  }
   return buckets;
 }
+
+const byStartTime = (first: CalendarEvent, second: CalendarEvent): number =>
+  first.startTime.getTime() - second.startTime.getTime();
 
 /** Height of a one-line event pill (the all-day band and the month grid), and
  * the gap between stacked pills, in pixels. */
@@ -300,4 +310,11 @@ export function resolveVisiblePillCount(
   const visibleCount =
     eventCount <= availableRows ? eventCount : Math.max(availableRows - 1, 0);
   return { visibleCount, hiddenCount: eventCount - visibleCount };
+}
+
+/** How many pill rows fit in `availableHeight` pixels of a month cell, each
+ * row after the first paying for its gap. */
+export function resolvePillRows(availableHeight: number): number {
+  const rowPitch = EVENT_PILL_HEIGHT_PX + EVENT_PILL_GAP_PX;
+  return Math.max(Math.floor((availableHeight + EVENT_PILL_GAP_PX) / rowPitch), 0);
 }

--- a/applications/web/src/features/dashboard/components/event-layout.ts
+++ b/applications/web/src/features/dashboard/components/event-layout.ts
@@ -284,3 +284,20 @@ export function bucketEventsByDay(
 
   return buckets;
 }
+
+/** Height of a one-line event pill (the all-day band and the month grid), and
+ * the gap between stacked pills, in pixels. */
+export const EVENT_PILL_HEIGHT_PX = 18;
+export const EVENT_PILL_GAP_PX = 2;
+
+/** How many of a day's pills to show in `availableRows`: all of them when
+ * they fit, otherwise one row fewer, with the last row given over to a
+ * "+N more" count so the overflow is never silent. */
+export function resolveVisiblePillCount(
+  eventCount: number,
+  availableRows: number,
+): { visibleCount: number; hiddenCount: number } {
+  const visibleCount =
+    eventCount <= availableRows ? eventCount : Math.max(availableRows - 1, 0);
+  return { visibleCount, hiddenCount: eventCount - visibleCount };
+}

--- a/applications/web/src/features/dashboard/components/event-layout.ts
+++ b/applications/web/src/features/dashboard/components/event-layout.ts
@@ -1,8 +1,9 @@
 import type { CalendarEvent } from "@/hooks/use-events";
-import { addDays } from "./calendar-helpers";
+import { addDays, startOfDay } from "./calendar-helpers";
 
 const MS_PER_MINUTE = 60_000;
 const MINUTES_PER_DAY = 24 * 60;
+const MS_PER_DAY = 86_400_000;
 
 /** Shortest span an event is laid out with. A five-minute event still takes
  * a fifteen-minute slot so it registers on the grid; the card's `min-h`
@@ -206,4 +207,80 @@ export function layoutDayEvents(events: CalendarEvent[], day: Date): PositionedE
     columnSpan: item.columnSpan,
     tiled: item.tiled,
   }));
+}
+
+/** A day's events, split by how the calendar shows them: timed events in the
+ * time grid, all-day events in the band above it. */
+export interface DayEvents {
+  timed: CalendarEvent[];
+  allDay: CalendarEvent[];
+}
+
+const getDayEvents = (buckets: Map<number, DayEvents>, dayKey: number): DayEvents => {
+  let bucket = buckets.get(dayKey);
+  if (!bucket) {
+    bucket = { timed: [], allDay: [] };
+    buckets.set(dayKey, bucket);
+  }
+  return bucket;
+};
+
+/**
+ * Groups events by the local calendar days they overlap inside
+ * `[rangeStart, rangeEnd)`, keyed by each day's midnight `getTime()` — the
+ * key the grids use for their day cells, all built with `new Date(y, m, d)`.
+ * Only the window's days are visited, never the strip's full buffer.
+ *
+ * Timed events are walked day by day with `addDays`, not in 86 400 000-ms
+ * steps, so daylight-saving days stay aligned. The end is exclusive: an event
+ * ending at midnight belongs to the day it ends on, not the next, and a
+ * zero-length event still lands on its start day.
+ *
+ * All-day events carry UTC-midnight bounds (a date, not an instant), so their
+ * days are read in UTC and mapped onto local days by index — comparing them
+ * with a local midnight would shift them by the zone offset and spill a
+ * single-day event into a neighbour.
+ */
+export function bucketEventsByDay(
+  events: CalendarEvent[],
+  rangeStart: Date,
+  rangeEnd: Date,
+): Map<number, DayEvents> {
+  const rangeStartMs = rangeStart.getTime();
+  const rangeEndMs = rangeEnd.getTime();
+  const rangeDayCount = Math.round((rangeEndMs - rangeStartMs) / MS_PER_DAY);
+  const utcBase = Date.UTC(rangeStart.getFullYear(), rangeStart.getMonth(), rangeStart.getDate());
+  const buckets = new Map<number, DayEvents>();
+
+  for (const event of events) {
+    const startMs = event.startTime.getTime();
+    const endMs = event.endTime.getTime();
+
+    if (event.isAllDay) {
+      const firstIndex = Math.max(Math.round((startMs - utcBase) / MS_PER_DAY), 0);
+      const lastIndex = Math.min(
+        Math.round((endMs - MS_PER_DAY - utcBase) / MS_PER_DAY),
+        rangeDayCount - 1,
+      );
+      for (let index = firstIndex; index <= lastIndex; index++) {
+        getDayEvents(buckets, addDays(rangeStart, index).getTime()).allDay.push(event);
+      }
+      continue;
+    }
+
+    // A zero-length event occupies an instant; give it a millisecond so it
+    // still claims its start day under the exclusive end below.
+    const occupiedEndMs = Math.max(endMs, startMs + 1);
+    if (occupiedEndMs <= rangeStartMs || startMs >= rangeEndMs) continue;
+    const lastMs = Math.min(occupiedEndMs, rangeEndMs);
+    for (
+      let day = startOfDay(new Date(Math.max(startMs, rangeStartMs)));
+      day.getTime() < lastMs;
+      day = addDays(day, 1)
+    ) {
+      getDayEvents(buckets, day.getTime()).timed.push(event);
+    }
+  }
+
+  return buckets;
 }

--- a/applications/web/src/features/dashboard/components/event-layout.ts
+++ b/applications/web/src/features/dashboard/components/event-layout.ts
@@ -5,63 +5,36 @@ const MS_PER_MINUTE = 60_000;
 const MINUTES_PER_DAY = 24 * 60;
 const MS_PER_DAY = 86_400_000;
 
-/** Shortest span an event is laid out with. A five-minute event still takes
- * a fifteen-minute slot so it registers on the grid; the card's `min-h`
- * floors the rendered height too, but this floors the *time* geometry, so
- * the overlap and lane decisions see the same box the user does. */
+/** Floors the time geometry, so overlap and lane decisions see the same box the user does. */
 export const MIN_EVENT_SPAN_MS = 15 * MS_PER_MINUTE;
 
-/** When two time-overlapping events start within this window, the cascade's
- * later card would land on the earlier one's header and hide its time and
- * title, so the whole cluster tiles into equal columns instead. qali's
- * week-view value: week columns are narrow and a cascaded card's exposed
- * left sliver is thin, so tiling is preferred eagerly. */
+/** Overlapping events starting within this window tile into columns instead of cascading. */
 export const TILE_MAX_STAGGER_MS = 45 * MS_PER_MINUTE;
 
-/** Horizontal shift, in pixels, per level of the overlap cascade. */
 const STACK_INDENT_PX = 14;
-/** Levels that get the full indent before it stops growing. */
 const STACK_MAX_LEVELS = 3;
-/** Thin residual indent per level past the cap, so deep cards still peek out. */
 const STACK_DEEP_STEP_PX = 4;
 
 export interface PositionedEvent {
   event: CalendarEvent;
-  /** Distance from the top of the day, as a 0–1 fraction of its height. */
   topFraction: number;
-  /** Share of the day's height, 0–1. */
   heightFraction: number;
-  /** Cascade depth: how many earlier events in the cluster are still running
-   * at this event's start. 0 is the leftmost card; deeper cards indent
-   * further right. Drives the horizontal indent only, not the paint order. */
+  /** Cascade indent depth; drives the horizontal indent only, not the paint order. */
   stackIndex: number;
-  /** Paint order within the cluster (0 = earliest start). Higher sits on top,
-   * so a later-starting event is never buried under an earlier, longer one. */
+  /** Paint order within the cluster; later starts sit on top. */
   elevation: number;
-  /** Column (lane) this event occupies when its cluster tiles. 0 is leftmost. */
   columnIndex: number;
-  /** Columns the event's cluster splits into (1 when it stands alone). */
   columnCount: number;
-  /** How many columns the card fills once it expands right into free space
-   * (at least 1). `columnIndex + columnSpan <= columnCount`. */
   columnSpan: number;
-  /** Whether the cluster tiles into equal, non-overlapping columns rather
-   * than cascading — see `TILE_MAX_STAGGER_MS`. */
   tiled: boolean;
 }
 
-/** Left indent (px) for a card at `stackIndex`, capped so the front cards
- * stay wide in deep overlaps while every card behind still exposes a visible
- * left sliver (the residual keeps the indent monotonic past the cap). */
 export function stackIndentPx(stackIndex: number): number {
   const capped = Math.min(stackIndex, STACK_MAX_LEVELS);
   const overflow = Math.max(0, stackIndex - STACK_MAX_LEVELS);
   return capped * STACK_INDENT_PX + overflow * STACK_DEEP_STEP_PX;
 }
 
-/** Horizontal box (`left`/`width` as 0–1 fractions of the column) for an
- * event in a tiled cluster: equal columns, with a card widening across
- * `columnSpan` of them when it can expand right into free space. */
 export function tileBox(
   columnIndex: number,
   columnCount: number,
@@ -71,18 +44,12 @@ export function tileBox(
   return { left: columnIndex / columnCount, width: columnSpan / columnCount };
 }
 
-/** Where an instant falls in its day, as a 0–1 fraction of the day's 24
- * rows, read from the local wall clock rather than elapsed milliseconds: a
- * DST day has 23 or 25 hours, and dividing elapsed time by 86 400 000 would
- * slide every afternoon instant a row off its hour. Shared by the event
- * cards and the current-time line, so both agree on where an hour sits. */
+// Wall-clock minutes, not elapsed ms: a DST day has 23 or 25 hours.
 export function timeOfDayFraction(date: Date): number {
   const minutes = date.getHours() * 60 + date.getMinutes() + date.getSeconds() / 60;
   return minutes / MINUTES_PER_DAY;
 }
 
-/** `timeOfDayFraction` for a laid-out instant, with one at or past the
- * day's end mapping to 1. */
 function wallClockFraction(ms: number, dayEndMs: number): number {
   if (ms >= dayEndMs) return 1;
   return timeOfDayFraction(new Date(ms));
@@ -90,7 +57,7 @@ function wallClockFraction(ms: number, dayEndMs: number): number {
 
 interface LayoutItem {
   event: CalendarEvent;
-  /** The event's span clamped to the day and floored to `MIN_EVENT_SPAN_MS`, in ms. */
+  /** Clamped to the day and floored to `MIN_EVENT_SPAN_MS`, in ms. */
   start: number;
   end: number;
   stackIndex: number;
@@ -104,12 +71,8 @@ interface LayoutItem {
 const overlaps = (first: LayoutItem, second: LayoutItem): boolean =>
   first.start < second.end && second.start < first.end;
 
-/** Lays out one cluster of transitively overlapping events: first-fit lane
- * packing, right-expansion into free lanes, and the cascade-or-tile decision
- * for the cluster as a whole. */
 function layoutCluster(cluster: LayoutItem[]): void {
-  // Greedy first-fit into lanes: each event reuses the first lane free at
-  // its start, or opens a new one.
+  // First-fit lanes: reuse the first lane free at the start, else open one.
   const laneEnds: number[] = [];
   for (const item of cluster) {
     let lane = laneEnds.findIndex((end) => end <= item.start);
@@ -119,8 +82,7 @@ function layoutCluster(cluster: LayoutItem[]): void {
   }
   const columnCount = laneEnds.length;
 
-  // Expand each card right into free lanes: stop at the first later-lane
-  // event it overlaps in time.
+  // Expand each card right until the first later-lane event it overlaps.
   for (const item of cluster) {
     item.columnCount = columnCount;
     let span = columnCount - item.columnIndex;
@@ -131,10 +93,7 @@ function layoutCluster(cluster: LayoutItem[]): void {
     item.columnSpan = Math.max(span, 1);
   }
 
-  // The cascade reads well when a comfortable stagger keeps every earlier
-  // card's header above the next card's top edge. When two overlapping cards
-  // start within TILE_MAX_STAGGER_MS the later one would bury the earlier
-  // one's header, so the whole cluster tiles into clean columns instead.
+  // Starts within TILE_MAX_STAGGER_MS would bury the earlier card's header, so the cluster tiles.
   const tiled = cluster.some((item, index) =>
     cluster
       .slice(index + 1)
@@ -145,16 +104,6 @@ function layoutCluster(cluster: LayoutItem[]): void {
   for (const item of cluster) item.tiled = tiled;
 }
 
-/**
- * Positions a day's timed events, modelled on qali's week view: clamp each
- * to the day, then group transitively overlapping events into clusters. A
- * cluster cascades — each event indents past the earlier events still
- * running at its start (`stackIndex`) and paints in start order
- * (`elevation`), so a later, shorter event sits on top of the earlier ones it
- * overlaps instead of being buried under them — unless two of its events
- * start too close together to stagger legibly, in which case it tiles into
- * equal columns (`columnIndex`/`columnCount`/`columnSpan`).
- */
 export function layoutDayEvents(events: CalendarEvent[], day: Date): PositionedEvent[] {
   const dayStartMs = day.getTime();
   // The local next midnight, so a DST day keeps its 23 or 25 hours.
@@ -182,9 +131,7 @@ export function layoutDayEvents(events: CalendarEvent[], day: Date): PositionedE
         first.start - second.start || second.end - second.start - (first.end - first.start),
     );
 
-  // Walk events in start order, grouping transitively overlapping ones into
-  // clusters (a run of events chained by overlap); each cluster is laid out
-  // independently.
+  // Group transitively overlapping events into clusters; each is laid out independently.
   let cluster: LayoutItem[] = [];
   let clusterEnd = Number.NEGATIVE_INFINITY;
   for (const item of items) {
@@ -214,8 +161,6 @@ export function layoutDayEvents(events: CalendarEvent[], day: Date): PositionedE
   }));
 }
 
-/** A day's events, split by how the calendar shows them: timed events in the
- * time grid, all-day events in the band above it. */
 export interface DayEvents {
   timed: CalendarEvent[];
   allDay: CalendarEvent[];
@@ -230,25 +175,7 @@ const getDayEvents = (buckets: Map<number, DayEvents>, dayKey: number): DayEvent
   return bucket;
 };
 
-/**
- * Groups events by the local calendar days they overlap inside
- * `[rangeStart, rangeEnd)`, keyed by each day's midnight `getTime()` — the
- * key the grids use for their day cells, all built with `new Date(y, m, d)`.
- * Only the window's days are visited, never the strip's full buffer.
- *
- * Timed events are walked day by day with `addDays`, not in 86 400 000-ms
- * steps, so daylight-saving days stay aligned. The end is exclusive: an event
- * ending at midnight belongs to the day it ends on, not the next, and a
- * zero-length event still lands on its start day.
- *
- * All-day events carry UTC-midnight bounds (a date, not an instant), so their
- * days are read in UTC and mapped onto local days by index — comparing them
- * with a local midnight would shift them by the zone offset and spill a
- * single-day event into a neighbour.
- *
- * Each day's lists come back in start order, so a consumer can show them as
- * they fall without sorting again.
- */
+// Buckets by local-midnight getTime() key; ends are exclusive, so an event ending at midnight stays on the day it ends.
 export function bucketEventsByDay(
   events: CalendarEvent[],
   rangeStart: Date,
@@ -265,6 +192,7 @@ export function bucketEventsByDay(
     const endMs = event.endTime.getTime();
 
     if (event.isAllDay) {
+      // All-day bounds are UTC midnights; map onto local days by index, never by comparing instants.
       const firstIndex = Math.max(Math.round((startMs - utcBase) / MS_PER_DAY), 0);
       const lastIndex = Math.min(
         Math.round((endMs - MS_PER_DAY - utcBase) / MS_PER_DAY),
@@ -276,8 +204,7 @@ export function bucketEventsByDay(
       continue;
     }
 
-    // A zero-length event occupies an instant; give it a millisecond so it
-    // still claims its start day under the exclusive end below.
+    // A zero-length event still claims its start day under the exclusive end.
     const occupiedEndMs = Math.max(endMs, startMs + 1);
     if (occupiedEndMs <= rangeStartMs || startMs >= rangeEndMs) continue;
     const lastMs = Math.min(occupiedEndMs, rangeEndMs);
@@ -300,14 +227,10 @@ export function bucketEventsByDay(
 const byStartTime = (first: CalendarEvent, second: CalendarEvent): number =>
   first.startTime.getTime() - second.startTime.getTime();
 
-/** Height of a one-line event pill (the all-day band and the month grid), and
- * the gap between stacked pills, in pixels. */
 export const EVENT_PILL_HEIGHT_PX = 18;
 export const EVENT_PILL_GAP_PX = 2;
 
-/** How many of a day's pills to show in `availableRows`: all of them when
- * they fit, otherwise one row fewer, with the last row given over to a
- * "+N more" count so the overflow is never silent. */
+/** All pills when they fit, else one row fewer with the last row spent on "+N more". */
 export function resolveVisiblePillCount(
   eventCount: number,
   availableRows: number,
@@ -317,8 +240,6 @@ export function resolveVisiblePillCount(
   return { visibleCount, hiddenCount: eventCount - visibleCount };
 }
 
-/** How many pill rows fit in `availableHeight` pixels of a month cell, each
- * row after the first paying for its gap. */
 export function resolvePillRows(availableHeight: number): number {
   const rowPitch = EVENT_PILL_HEIGHT_PX + EVENT_PILL_GAP_PX;
   return Math.max(Math.floor((availableHeight + EVENT_PILL_GAP_PX) / rowPitch), 0);

--- a/applications/web/src/features/dashboard/components/month-grid.tsx
+++ b/applications/web/src/features/dashboard/components/month-grid.tsx
@@ -1,9 +1,15 @@
+import { useLayoutEffect, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import { cn } from "@/utils/cn";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
+import { isEventPast } from "@/lib/time";
+import type { CalendarEvent } from "@/hooks/use-events";
 import { Text } from "@/components/ui/primitives/text";
 import { CalendarFrame } from "./calendar-frame";
 import { isSameDay, isSameMonth, WEEKDAY_LABELS } from "./calendar-helpers";
+import { EventPill, EventPillOverflow } from "./event-card";
+import { EVENT_PILL_GAP_PX, resolvePillRows, resolveVisiblePillCount } from "./event-layout";
+import type { DayEvents } from "./event-layout";
 
 const COLUMNS = 7;
 const ROWS = 6;
@@ -35,11 +41,32 @@ const RULE_LAYER_STYLE: CSSProperties = {
 interface MonthGridProps {
   anchor: Date;
   days: Date[];
+  /** Keyed by local-midnight `getTime()` (see `bucketEventsByDay`); days outside the window are absent. */
+  eventsByDay: Map<number, DayEvents>;
   toolbar: ReactNode;
 }
 
-export function MonthGrid({ anchor, days, toolbar }: MonthGridProps) {
+const NO_EVENTS: CalendarEvent[] = [];
+
+export function MonthGrid({ anchor, days, eventsByDay, toolbar }: MonthGridProps) {
   const today = useStartOfToday();
+  /** The first cell's pill area. Every cell is the same height, so one
+   * measurement sets the row budget for all of them. */
+  const pillAreaRef = useRef<HTMLDivElement>(null);
+  const [pillRows, setPillRows] = useState(0);
+
+  // Measure the row budget once the grid is laid out, and again whenever the
+  // pane resizes. The observer reports once on `observe`, so the first read
+  // happens in its callback rather than as a synchronous set in the effect.
+  useLayoutEffect(() => {
+    const pillArea = pillAreaRef.current;
+    if (!pillArea || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry) setPillRows(resolvePillRows(entry.contentRect.height));
+    });
+    observer.observe(pillArea);
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <CalendarFrame
@@ -63,9 +90,14 @@ export function MonthGrid({ anchor, days, toolbar }: MonthGridProps) {
       <div className="relative min-h-0 flex-1">
         <div aria-hidden className="pointer-events-none absolute inset-0" style={RULE_LAYER_STYLE} />
         <div className="relative grid h-full grid-cols-7 grid-rows-6">
-          {days.map((day) => {
+          {days.map((day, index) => {
             const inMonth = isSameMonth(day, anchor);
             const isToday = isSameDay(day, today);
+            const dayEvents = eventsByDay.get(day.getTime());
+            // All-day first, then the timed events as they fall (the buckets
+            // keep each list in start order).
+            const pills = dayEvents ? [...dayEvents.allDay, ...dayEvents.timed] : NO_EVENTS;
+            const { visibleCount, hiddenCount } = resolveVisiblePillCount(pills.length, pillRows);
             return (
               <div
                 key={day.getTime()}
@@ -81,8 +113,16 @@ export function MonthGrid({ anchor, days, toolbar }: MonthGridProps) {
                 >
                   {day.getDate()}
                 </span>
-                {/* Event pills will render here in a later stage. */}
-                <div className="min-h-0 flex-1" />
+                <div
+                  ref={index === 0 ? pillAreaRef : undefined}
+                  className="flex min-h-0 flex-1 flex-col overflow-hidden"
+                  style={{ gap: EVENT_PILL_GAP_PX }}
+                >
+                  {pills.slice(0, visibleCount).map((event) => (
+                    <EventPill key={event.id} event={event} past={isEventPast(event.endTime)} />
+                  ))}
+                  {hiddenCount > 0 && <EventPillOverflow count={hiddenCount} />}
+                </div>
               </div>
             );
           })}

--- a/applications/web/src/features/dashboard/components/month-grid.tsx
+++ b/applications/web/src/features/dashboard/components/month-grid.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import { cn } from "@/utils/cn";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
@@ -50,16 +50,17 @@ const NO_EVENTS: CalendarEvent[] = [];
 
 export function MonthGrid({ anchor, days, eventsByDay, toolbar }: MonthGridProps) {
   const today = useStartOfToday();
-  /** The first cell's pill area. Every cell is the same height, so one
-   * measurement sets the row budget for all of them. */
-  const pillAreaRef = useRef<HTMLDivElement>(null);
   const [pillRows, setPillRows] = useState(0);
 
-  // Measure the row budget once the grid is laid out, and again whenever the
-  // pane resizes. The observer reports once on `observe`, so the first read
-  // happens in its callback rather than as a synchronous set in the effect.
-  useLayoutEffect(() => {
-    const pillArea = pillAreaRef.current;
+  // Measures the row budget from the first cell's pill area (every cell is
+  // the same height, so one measurement serves all), and keeps measuring
+  // through resizes. A callback ref rather than a mount effect: the cells are
+  // keyed by day, so paging the month mounts a new first cell, and an
+  // observer attached once on mount would be left watching the old, detached
+  // node — which reports a zero height, folding every cell to "+N more". The
+  // ref runs again for each new node, and its cleanup disconnects the old
+  // observer. The observer reports once on `observe`, which is the first read.
+  const observePillArea = useCallback((pillArea: HTMLDivElement | null) => {
     if (!pillArea || typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(([entry]) => {
       if (entry) setPillRows(resolvePillRows(entry.contentRect.height));
@@ -114,7 +115,7 @@ export function MonthGrid({ anchor, days, eventsByDay, toolbar }: MonthGridProps
                   {day.getDate()}
                 </span>
                 <div
-                  ref={index === 0 ? pillAreaRef : undefined}
+                  ref={index === 0 ? observePillArea : undefined}
                   className="flex min-h-0 flex-1 flex-col overflow-hidden"
                   style={{ gap: EVENT_PILL_GAP_PX }}
                 >

--- a/applications/web/src/features/dashboard/components/month-grid.tsx
+++ b/applications/web/src/features/dashboard/components/month-grid.tsx
@@ -52,14 +52,8 @@ export function MonthGrid({ anchor, days, eventsByDay, toolbar }: MonthGridProps
   const today = useStartOfToday();
   const [pillRows, setPillRows] = useState(0);
 
-  // Measures the row budget from the first cell's pill area (every cell is
-  // the same height, so one measurement serves all), and keeps measuring
-  // through resizes. A callback ref rather than a mount effect: the cells are
-  // keyed by day, so paging the month mounts a new first cell, and an
-  // observer attached once on mount would be left watching the old, detached
-  // node — which reports a zero height, folding every cell to "+N more". The
-  // ref runs again for each new node, and its cleanup disconnects the old
-  // observer. The observer reports once on `observe`, which is the first read.
+  // A callback ref, not a mount effect: paging mounts a new first cell, and an observer
+  // left on the detached node would report zero height and fold every cell to "+N more".
   const observePillArea = useCallback((pillArea: HTMLDivElement | null) => {
     if (!pillArea || typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(([entry]) => {
@@ -95,8 +89,6 @@ export function MonthGrid({ anchor, days, eventsByDay, toolbar }: MonthGridProps
             const inMonth = isSameMonth(day, anchor);
             const isToday = isSameDay(day, today);
             const dayEvents = eventsByDay.get(day.getTime());
-            // All-day first, then the timed events as they fall (the buckets
-            // keep each list in start order).
             const pills = dayEvents ? [...dayEvents.allDay, ...dayEvents.timed] : NO_EVENTS;
             const { visibleCount, hiddenCount } = resolveVisiblePillCount(pills.length, pillRows);
             return (

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -7,6 +7,7 @@ import type { CalendarEvent } from "@/hooks/use-events";
 import { Text } from "@/components/ui/primitives/text";
 import { CalendarFrame } from "./calendar-frame";
 import { DayColumn } from "./day-column";
+import type { DayEvents } from "./event-layout";
 import {
   addDays,
   formatHourLabel,
@@ -45,11 +46,13 @@ const GRID_EDGE_FADE = `linear-gradient(to bottom, transparent, black ${GRID_EDG
 
 interface WeekGridProps {
   anchor: Date;
+  /** Keyed by local-midnight `getTime()` (see `bucketEventsByDay`); days outside the window are absent. */
+  eventsByDay: Map<number, DayEvents>;
   onCenterDayChange: (centerDay: Date) => void;
   toolbar: ReactNode;
 }
 
-export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) {
+export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: WeekGridProps) {
   const today = useStartOfToday();
   const router = useRouter();
   const scrollerRef = useRef<HTMLDivElement>(null);
@@ -293,7 +296,7 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
                 day={day}
                 isToday={isToday}
                 nowFraction={isToday ? nowFraction : null}
-                events={NO_EVENTS}
+                events={eventsByDay.get(day.getTime())?.timed ?? NO_EVENTS}
               />
             );
           })}

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -3,11 +3,14 @@ import type { CSSProperties, ReactNode } from "react";
 import { useRouter } from "@tanstack/react-router";
 import { cn } from "@/utils/cn";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
+import type { CalendarEvent } from "@/hooks/use-events";
 import { Text } from "@/components/ui/primitives/text";
 import { CalendarFrame } from "./calendar-frame";
+import { DayColumn } from "./day-column";
 import {
   addDays,
   formatHourLabel,
+  HOUR_HEIGHT,
   HOURS,
   isSameDay,
   startOfDay,
@@ -16,7 +19,6 @@ import {
 } from "./calendar-helpers";
 
 const GUTTER_WIDTH = 52;
-const HOUR_HEIGHT = 48;
 const HEADER_HEIGHT = 56;
 const VISIBLE_COLUMNS = WEEK_VIEW_DAYS;
 const CENTER_OFFSET = Math.floor(VISIBLE_COLUMNS / 2);
@@ -24,6 +26,9 @@ const CENTER_OFFSET = Math.floor(VISIBLE_COLUMNS / 2);
 const BUFFER_WEEKS = 26;
 
 const MS_PER_DAY = 86_400_000;
+
+// One stable identity, so the memoised columns don't see a fresh [] each render.
+const NO_EVENTS: CalendarEvent[] = [];
 
 // Painted on the viewport boxes, not the cells, so the rules span overscroll; `--strip-scroll` keeps them following the grid.
 const COLUMN_RULES: CSSProperties = {
@@ -283,21 +288,13 @@ export function WeekGrid({ anchor, onCenterDayChange, toolbar }: WeekGridProps) 
           {stripDays.map((day) => {
             const isToday = isSameDay(day, today);
             return (
-              <div key={day.getTime()} className="relative snap-start">
-                {/* Hour rules, per cell — one strip-wide background layer is too large for some engines to paint. */}
-                <div
-                  aria-hidden
-                  className="pointer-events-none absolute inset-x-0 bottom-0 bg-[linear-gradient(to_bottom,var(--color-border-hour)_0_1px,transparent_1px)]"
-                  style={{ top: HOUR_HEIGHT, backgroundSize: `100% ${HOUR_HEIGHT}px` }}
-                />
-                {/* Event blocks will render here in a later stage. */}
-                {isToday && nowFraction != null && (
-                  <div
-                    className="pointer-events-none absolute inset-x-0 z-10 h-0.5 -translate-y-1/2 bg-red-500"
-                    style={{ top: `${nowFraction * 100}%` }}
-                  />
-                )}
-              </div>
+              <DayColumn
+                key={day.getTime()}
+                day={day}
+                isToday={isToday}
+                nowFraction={isToday ? nowFraction : null}
+                events={NO_EVENTS}
+              />
             );
           })}
         </div>

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -1,6 +1,8 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import type { CSSProperties, ReactNode } from "react";
+import type { ReactNode } from "react";
 import { useRouter } from "@tanstack/react-router";
+import { scroll } from "motion";
+import { animate } from "motion/mini";
 import { cn } from "@/utils/cn";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
 import { isEventPast } from "@/lib/time";
@@ -40,14 +42,6 @@ const MS_PER_DAY = 86_400_000;
 
 // One stable identity, so the memoised columns don't see a fresh [] each render.
 const NO_EVENTS: CalendarEvent[] = [];
-
-/** Whether the header's day row can follow the grid's scroll through a CSS
- * scroll timeline (see `.calendar-strip-row` in index.css). The same feature
- * the stylesheet gates on, so the JS mirror below only runs where the CSS
- * does not — both moving the row would scroll it twice. Resolved once: it
- * only varies by engine, and on the server it is false without effect. */
-const HEADER_FOLLOWS_SCROLL_TIMELINE =
-  typeof CSS !== "undefined" && CSS.supports("animation-timeline", "scroll()");
 
 const HEADER_RULE_FADE = "linear-gradient(to top, black 35%, transparent)";
 
@@ -126,7 +120,7 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
   const today = useStartOfToday();
   const router = useRouter();
   const scrollerRef = useRef<HTMLDivElement>(null);
-  const headerStripRef = useRef<HTMLDivElement>(null);
+  const rowRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number | null>(null);
   const mountedRef = useRef(false);
   /** Vertical offset as last scrolled; put back after the router replays a cached one. */
@@ -159,17 +153,6 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
     return Math.max((el.clientWidth - GUTTER_WIDTH) / VISIBLE_COLUMNS, 1);
   }, []);
 
-  /** Fallback for engines without scroll timelines: mirrors the scroller's
-   * horizontal offset onto the header strip from the scroll event, a frame
-   * behind the grid. A no-op where the row follows the timeline in CSS. */
-  const syncHeaderStrip = useCallback(() => {
-    if (HEADER_FOLLOWS_SCROLL_TIMELINE) return;
-    const scroller = scrollerRef.current;
-    const headerStrip = headerStripRef.current;
-    if (!scroller || !headerStrip) return;
-    headerStrip.scrollLeft = scroller.scrollLeft;
-  }, []);
-
   const scrollToCenter = useCallback(
     (centerDay: Date, behavior: ScrollBehavior) => {
       const el = scrollerRef.current;
@@ -180,10 +163,8 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
       alignedCenterMsRef.current = centerDay.getTime();
       alignedWidthRef.current = el.clientWidth;
       el.scrollTo({ left: clamped * columnWidth(), behavior });
-      // An instant jump fires no scroll event; mirror right away so the header never shows a stale range.
-      if (behavior === "auto") syncHeaderStrip();
     },
-    [columnWidth, stripDays, syncHeaderStrip],
+    [columnWidth, stripDays],
   );
 
   // Mount: centre the anchor and jump to business hours; afterwards, smooth-scroll on anchor moves.
@@ -203,6 +184,24 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
       scrollToCenter(centerDay, "smooth");
     }
   }, [anchor, scrollToCenter]);
+
+  // The day row follows the grid via Motion's ScrollTimeline — a scrollLeft mirror trails compositor scrolling by a frame.
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    const row = rowRef.current;
+    if (!scroller || !row) return;
+    const travel = (-100 * (stripDays.length - VISIBLE_COLUMNS)) / stripDays.length;
+    const animation = animate(
+      row,
+      { transform: ["translateX(0%)", `translateX(${travel}%)`] },
+      { ease: "linear" },
+    );
+    const cancel = scroll(animation, { container: scroller, axis: "x" });
+    return () => {
+      cancel();
+      animation.cancel();
+    };
+  }, [stripDays]);
 
   // The router replays cached scroll offsets after navigation; this registers after it and puts the strip back.
   useEffect(
@@ -236,8 +235,6 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
   }, [scrollToCenter]);
 
   const handleScroll = () => {
-    // Mirror synchronously, not in the rAF, so the header never trails the grid by a frame.
-    syncHeaderStrip();
     const scroller = scrollerRef.current;
     if (scroller) scrollTopRef.current = scroller.scrollTop;
     if (rafRef.current !== null) return;
@@ -287,20 +284,14 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
       style={{ height: HEADER_HEIGHT + bandHeight }}
     >
       <div className="shrink-0" style={{ width: GUTTER_WIDTH }} />
-      <div ref={headerStripRef} className="relative min-w-0 flex-1 overflow-hidden">
+      <div className="relative min-w-0 flex-1 overflow-hidden">
         <div
-          className="calendar-strip-row relative grid h-full"
-          style={
-            {
-              gridTemplateColumns: columnsTemplate,
-              width: `calc(${stripDays.length} * 100% / ${VISIBLE_COLUMNS})`,
-              // How far the row travels at full scroll — its own width less
-              // the viewport's, as a share of its width — for the scroll
-              // timeline in index.css. The same ratio as the grid's scroll
-              // range, so the two coincide to the pixel at every offset.
-              "--calendar-strip-travel": `calc(-100% * ${stripDays.length - VISIBLE_COLUMNS} / ${stripDays.length})`,
-            } as CSSProperties
-          }
+          ref={rowRef}
+          className="relative grid h-full"
+          style={{
+            gridTemplateColumns: columnsTemplate,
+            width: `calc(${stripDays.length} * 100% / ${VISIBLE_COLUMNS})`,
+          }}
         >
           {stripDays.map((day) => (
             <DayHeaderCell
@@ -325,7 +316,7 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
       <div
         ref={scrollerRef}
         onScroll={handleScroll}
-        className="calendar-strip-scroller flex min-h-0 flex-1 items-start snap-x snap-mandatory overflow-auto overscroll-x-none [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="flex min-h-0 flex-1 items-start snap-x snap-mandatory overflow-auto overscroll-x-none [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         style={{
           scrollPaddingLeft: GUTTER_WIDTH,
           maskImage: GRID_EDGE_FADE,

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -3,10 +3,13 @@ import type { CSSProperties, ReactNode } from "react";
 import { useRouter } from "@tanstack/react-router";
 import { cn } from "@/utils/cn";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
+import { isEventPast } from "@/lib/time";
 import type { CalendarEvent } from "@/hooks/use-events";
 import { Text } from "@/components/ui/primitives/text";
 import { CalendarFrame } from "./calendar-frame";
 import { DayColumn } from "./day-column";
+import { EventPill } from "./event-card";
+import { EVENT_PILL_GAP_PX, EVENT_PILL_HEIGHT_PX, resolveVisiblePillCount } from "./event-layout";
 import type { DayEvents } from "./event-layout";
 import {
   addDays,
@@ -21,6 +24,8 @@ import {
 
 const GUTTER_WIDTH = 52;
 const HEADER_HEIGHT = 56;
+const ALL_DAY_MAX_ROWS = 2;
+const ALL_DAY_BAND_PADDING_BOTTOM = 4;
 const VISIBLE_COLUMNS = WEEK_VIEW_DAYS;
 const CENTER_OFFSET = Math.floor(VISIBLE_COLUMNS / 2);
 /** Weeks buffered on each side of the entry range, so the strip scrolls without recentering logic. */
@@ -199,8 +204,27 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
     [],
   );
 
+  // The band's rows follow the visible days, so the header only grows when
+  // a day with all-day events is on screen; the height eases between sizes.
+  const visibleStart = startOfVisibleWeek(anchor);
+  let mostAllDay = 0;
+  for (let index = 0; index < VISIBLE_COLUMNS; index++) {
+    const allDayCount = eventsByDay.get(addDays(visibleStart, index).getTime())?.allDay.length ?? 0;
+    mostAllDay = Math.max(mostAllDay, allDayCount);
+  }
+  const bandRows = Math.min(mostAllDay, ALL_DAY_MAX_ROWS);
+  const bandHeight =
+    bandRows === 0
+      ? 0
+      : bandRows * EVENT_PILL_HEIGHT_PX +
+        (bandRows - 1) * EVENT_PILL_GAP_PX +
+        ALL_DAY_BAND_PADDING_BOTTOM;
+
   const dayRow = (
-    <div className="flex" style={{ height: HEADER_HEIGHT }}>
+    <div
+      className="flex transition-[height] duration-200 motion-reduce:transition-none"
+      style={{ height: HEADER_HEIGHT + bandHeight }}
+    >
       <div className="shrink-0" style={{ width: GUTTER_WIDTH }} />
       <div ref={headerStripRef} className="relative min-w-0 flex-1 overflow-hidden">
         <div
@@ -223,22 +247,44 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
         >
           {stripDays.map((day) => {
             const isToday = isSameDay(day, today);
+            const allDay = eventsByDay.get(day.getTime())?.allDay ?? NO_EVENTS;
+            const { visibleCount, hiddenCount } = resolveVisiblePillCount(allDay.length, bandRows);
             return (
-              <div
-                key={day.getTime()}
-                className="flex flex-col items-center justify-center gap-1"
-              >
-                <Text as="span" size="xs" tone="muted" className="font-medium uppercase tracking-wide">
-                  {day.toLocaleDateString("en-US", { weekday: "short" })}
-                </Text>
-                <span
-                  className={cn(
-                    "flex size-6 items-center justify-center text-xs font-medium tabular-nums",
-                    isToday ? "rounded-full bg-emerald-400 text-neutral-950" : "text-foreground",
-                  )}
+              <div key={day.getTime()} className="flex flex-col overflow-hidden">
+                <div
+                  className="flex shrink-0 flex-col items-center justify-center gap-1"
+                  style={{ height: HEADER_HEIGHT }}
                 >
-                  {day.getDate()}
-                </span>
+                  <Text as="span" size="xs" tone="muted" className="font-medium uppercase tracking-wide">
+                    {day.toLocaleDateString("en-US", { weekday: "short" })}
+                  </Text>
+                  <span
+                    className={cn(
+                      "flex size-6 items-center justify-center text-xs font-medium tabular-nums",
+                      isToday ? "rounded-full bg-emerald-400 text-neutral-950" : "text-foreground",
+                    )}
+                  >
+                    {day.getDate()}
+                  </span>
+                </div>
+                {allDay.length > 0 && (
+                  <div className="flex flex-col px-0.5" style={{ gap: EVENT_PILL_GAP_PX }}>
+                    {allDay.slice(0, visibleCount).map((event) => (
+                      <EventPill key={event.id} event={event} past={isEventPast(event.endTime)} />
+                    ))}
+                    {hiddenCount > 0 && (
+                      <Text
+                        as="span"
+                        size="xs"
+                        tone="muted"
+                        className="flex shrink-0 items-center truncate px-1.5"
+                        style={{ height: EVENT_PILL_HEIGHT_PX }}
+                      >
+                        +{hiddenCount} more
+                      </Text>
+                    )}
+                  </div>
+                )}
               </div>
             );
           })}

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -72,9 +72,8 @@ const DayHeaderCell = memo(function DayHeaderCell({
 
   return (
     <div className="relative flex flex-col overflow-hidden">
-      {/* The column's left rule, faded toward the top so it dissolves into the
-          toolbar above instead of meeting it at a hard corner. On the cell,
-          so it moves with the row. */}
+      {/* The column's left rule, faded toward the top; on the cell so it
+          moves with the row. */}
       <div
         aria-hidden
         className="pointer-events-none absolute inset-y-0 left-0 w-px bg-border-elevated"

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import { useRouter } from "@tanstack/react-router";
 import { cn } from "@/utils/cn";
@@ -41,11 +41,13 @@ const MS_PER_DAY = 86_400_000;
 // One stable identity, so the memoised columns don't see a fresh [] each render.
 const NO_EVENTS: CalendarEvent[] = [];
 
-// Painted on the viewport boxes, not the cells, so the rules span overscroll; `--strip-scroll` keeps them following the grid.
-const COLUMN_RULES: CSSProperties = {
-  backgroundImage: "linear-gradient(to right, var(--color-border-elevated) 0 1px, transparent 1px)",
-  backgroundRepeat: "repeat-x",
-};
+/** Whether the header's day row can follow the grid's scroll through a CSS
+ * scroll timeline (see `.calendar-strip-row` in index.css). The same feature
+ * the stylesheet gates on, so the JS mirror below only runs where the CSS
+ * does not — both moving the row would scroll it twice. Resolved once: it
+ * only varies by engine, and on the server it is false without effect. */
+const HEADER_FOLLOWS_SCROLL_TIMELINE =
+  typeof CSS !== "undefined" && CSS.supports("animation-timeline", "scroll()");
 
 const HEADER_RULE_FADE = "linear-gradient(to top, black 35%, transparent)";
 
@@ -53,6 +55,64 @@ const GRID_EDGE_FADE_SIZE = 24;
 
 // Vertical only: a horizontal fade would dim the gutter labels and the outermost column.
 const GRID_EDGE_FADE = `linear-gradient(to bottom, transparent, black ${GRID_EDGE_FADE_SIZE}px, black calc(100% - ${GRID_EDGE_FADE_SIZE}px), transparent)`;
+
+interface DayHeaderCellProps {
+  day: Date;
+  isToday: boolean;
+  /** The day's all-day events, identity-stable while unchanged. */
+  allDay: CalendarEvent[];
+  /** Rows the band currently shows; a day with more folds the rest away. */
+  bandRows: number;
+}
+
+/** One day of the header row: the weekday and date over the day's all-day
+ * pills. Memoised so a scroll-driven anchor change only re-renders the cells
+ * whose events or band actually changed. */
+const DayHeaderCell = memo(function DayHeaderCell({
+  day,
+  isToday,
+  allDay,
+  bandRows,
+}: DayHeaderCellProps) {
+  const { visibleCount, hiddenCount } = resolveVisiblePillCount(allDay.length, bandRows);
+
+  return (
+    <div className="relative flex flex-col overflow-hidden">
+      {/* The column's left rule, faded toward the top so it dissolves into the
+          toolbar above instead of meeting it at a hard corner. On the cell,
+          so it moves with the row. */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-y-0 left-0 w-px bg-border-elevated"
+        style={{ maskImage: HEADER_RULE_FADE, WebkitMaskImage: HEADER_RULE_FADE }}
+      />
+      <div
+        className="flex shrink-0 flex-col items-center justify-center gap-1"
+        style={{ height: HEADER_HEIGHT }}
+      >
+        <Text as="span" size="xs" tone="muted" className="font-medium uppercase tracking-wide">
+          {day.toLocaleDateString("en-US", { weekday: "short" })}
+        </Text>
+        <span
+          className={cn(
+            "flex size-6 items-center justify-center text-xs font-medium tabular-nums",
+            isToday ? "rounded-full bg-emerald-400 text-neutral-950" : "text-foreground",
+          )}
+        >
+          {day.getDate()}
+        </span>
+      </div>
+      {allDay.length > 0 && (
+        <div className="flex flex-col px-0.5" style={{ gap: EVENT_PILL_GAP_PX }}>
+          {allDay.slice(0, visibleCount).map((event) => (
+            <EventPill key={event.id} event={event} past={isEventPast(event.endTime)} />
+          ))}
+          {hiddenCount > 0 && <EventPillOverflow count={hiddenCount} />}
+        </div>
+      )}
+    </div>
+  );
+});
 
 interface WeekGridProps {
   anchor: Date;
@@ -99,15 +159,15 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
     return Math.max((el.clientWidth - GUTTER_WIDTH) / VISIBLE_COLUMNS, 1);
   }, []);
 
-  /** Mirrors the scroller's horizontal offset onto the day row and into `--strip-scroll`. */
+  /** Fallback for engines without scroll timelines: mirrors the scroller's
+   * horizontal offset onto the header strip from the scroll event, a frame
+   * behind the grid. A no-op where the row follows the timeline in CSS. */
   const syncHeaderStrip = useCallback(() => {
+    if (HEADER_FOLLOWS_SCROLL_TIMELINE) return;
     const scroller = scrollerRef.current;
     const headerStrip = headerStripRef.current;
     if (!scroller || !headerStrip) return;
     headerStrip.scrollLeft = scroller.scrollLeft;
-    const offset = `${scroller.scrollLeft}px`;
-    scroller.style.setProperty("--strip-scroll", offset);
-    headerStrip.style.setProperty("--strip-scroll", offset);
   }, []);
 
   const scrollToCenter = useCallback(
@@ -229,56 +289,28 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
       <div className="shrink-0" style={{ width: GUTTER_WIDTH }} />
       <div ref={headerStripRef} className="relative min-w-0 flex-1 overflow-hidden">
         <div
-          aria-hidden
-          className="pointer-events-none absolute inset-0"
-          style={{
-            ...COLUMN_RULES,
-            backgroundSize: `calc(100% / ${VISIBLE_COLUMNS}) 100%`,
-            backgroundPositionX: "calc(0px - var(--strip-scroll, 0px))",
-            maskImage: HEADER_RULE_FADE,
-            WebkitMaskImage: HEADER_RULE_FADE,
-          }}
-        />
-        <div
-          className="relative grid h-full"
-          style={{
-            gridTemplateColumns: columnsTemplate,
-            width: `calc(${stripDays.length} * 100% / ${VISIBLE_COLUMNS})`,
-          }}
+          className="calendar-strip-row relative grid h-full"
+          style={
+            {
+              gridTemplateColumns: columnsTemplate,
+              width: `calc(${stripDays.length} * 100% / ${VISIBLE_COLUMNS})`,
+              // How far the row travels at full scroll — its own width less
+              // the viewport's, as a share of its width — for the scroll
+              // timeline in index.css. The same ratio as the grid's scroll
+              // range, so the two coincide to the pixel at every offset.
+              "--calendar-strip-travel": `calc(-100% * ${stripDays.length - VISIBLE_COLUMNS} / ${stripDays.length})`,
+            } as CSSProperties
+          }
         >
-          {stripDays.map((day) => {
-            const isToday = isSameDay(day, today);
-            const allDay = eventsByDay.get(day.getTime())?.allDay ?? NO_EVENTS;
-            const { visibleCount, hiddenCount } = resolveVisiblePillCount(allDay.length, bandRows);
-            return (
-              <div key={day.getTime()} className="flex flex-col overflow-hidden">
-                <div
-                  className="flex shrink-0 flex-col items-center justify-center gap-1"
-                  style={{ height: HEADER_HEIGHT }}
-                >
-                  <Text as="span" size="xs" tone="muted" className="font-medium uppercase tracking-wide">
-                    {day.toLocaleDateString("en-US", { weekday: "short" })}
-                  </Text>
-                  <span
-                    className={cn(
-                      "flex size-6 items-center justify-center text-xs font-medium tabular-nums",
-                      isToday ? "rounded-full bg-emerald-400 text-neutral-950" : "text-foreground",
-                    )}
-                  >
-                    {day.getDate()}
-                  </span>
-                </div>
-                {allDay.length > 0 && (
-                  <div className="flex flex-col px-0.5" style={{ gap: EVENT_PILL_GAP_PX }}>
-                    {allDay.slice(0, visibleCount).map((event) => (
-                      <EventPill key={event.id} event={event} past={isEventPast(event.endTime)} />
-                    ))}
-                    {hiddenCount > 0 && <EventPillOverflow count={hiddenCount} />}
-                  </div>
-                )}
-              </div>
-            );
-          })}
+          {stripDays.map((day) => (
+            <DayHeaderCell
+              key={day.getTime()}
+              day={day}
+              isToday={isSameDay(day, today)}
+              allDay={eventsByDay.get(day.getTime())?.allDay ?? NO_EVENTS}
+              bandRows={bandRows}
+            />
+          ))}
         </div>
       </div>
     </div>
@@ -293,11 +325,8 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
       <div
         ref={scrollerRef}
         onScroll={handleScroll}
-        className="flex min-h-0 flex-1 items-start snap-x snap-mandatory overflow-auto overscroll-x-none [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="calendar-strip-scroller flex min-h-0 flex-1 items-start snap-x snap-mandatory overflow-auto overscroll-x-none [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         style={{
-          ...COLUMN_RULES,
-          backgroundSize: `calc((100% - ${GUTTER_WIDTH}px) / ${VISIBLE_COLUMNS}) 100%`,
-          backgroundPositionX: `calc(${GUTTER_WIDTH}px - var(--strip-scroll, 0px))`,
           scrollPaddingLeft: GUTTER_WIDTH,
           maskImage: GRID_EDGE_FADE,
           WebkitMaskImage: GRID_EDGE_FADE,

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -8,7 +8,7 @@ import type { CalendarEvent } from "@/hooks/use-events";
 import { Text } from "@/components/ui/primitives/text";
 import { CalendarFrame } from "./calendar-frame";
 import { DayColumn } from "./day-column";
-import { EventPill } from "./event-card";
+import { EventPill, EventPillOverflow } from "./event-card";
 import { EVENT_PILL_GAP_PX, EVENT_PILL_HEIGHT_PX, resolveVisiblePillCount } from "./event-layout";
 import type { DayEvents } from "./event-layout";
 import {
@@ -272,17 +272,7 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
                     {allDay.slice(0, visibleCount).map((event) => (
                       <EventPill key={event.id} event={event} past={isEventPast(event.endTime)} />
                     ))}
-                    {hiddenCount > 0 && (
-                      <Text
-                        as="span"
-                        size="xs"
-                        tone="muted"
-                        className="flex shrink-0 items-center truncate px-1.5"
-                        style={{ height: EVENT_PILL_HEIGHT_PX }}
-                      >
-                        +{hiddenCount} more
-                      </Text>
-                    )}
+                    {hiddenCount > 0 && <EventPillOverflow count={hiddenCount} />}
                   </div>
                 )}
               </div>

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -9,7 +9,12 @@ import { Text } from "@/components/ui/primitives/text";
 import { CalendarFrame } from "./calendar-frame";
 import { DayColumn } from "./day-column";
 import { EventPill, EventPillOverflow } from "./event-card";
-import { EVENT_PILL_GAP_PX, EVENT_PILL_HEIGHT_PX, resolveVisiblePillCount } from "./event-layout";
+import {
+  EVENT_PILL_GAP_PX,
+  EVENT_PILL_HEIGHT_PX,
+  resolveVisiblePillCount,
+  timeOfDayFraction,
+} from "./event-layout";
 import type { DayEvents } from "./event-layout";
 import {
   addDays,
@@ -79,14 +84,10 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
   });
   const columnsTemplate = `repeat(${stripDays.length}, minmax(0, 1fr))`;
 
-  // Client-only so SSR and hydration agree.
+  // Client-only so SSR and hydration agree; wall-clock placed so the line holds its hour through DST days.
   const [nowFraction, setNowFraction] = useState<number | null>(null);
   useEffect(() => {
-    const update = () => {
-      const now = new Date();
-      const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-      setNowFraction((now.getTime() - startOfDay.getTime()) / MS_PER_DAY);
-    };
+    const update = () => setNowFraction(timeOfDayFraction(new Date()));
     update();
     const interval = globalThis.setInterval(update, 60_000);
     return () => globalThis.clearInterval(interval);

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -53,15 +53,10 @@ const GRID_EDGE_FADE = `linear-gradient(to bottom, transparent, black ${GRID_EDG
 interface DayHeaderCellProps {
   day: Date;
   isToday: boolean;
-  /** The day's all-day events, identity-stable while unchanged. */
   allDay: CalendarEvent[];
-  /** Rows the band currently shows; a day with more folds the rest away. */
   bandRows: number;
 }
 
-/** One day of the header row: the weekday and date over the day's all-day
- * pills. Memoised so a scroll-driven anchor change only re-renders the cells
- * whose events or band actually changed. */
 const DayHeaderCell = memo(function DayHeaderCell({
   day,
   isToday,
@@ -72,8 +67,6 @@ const DayHeaderCell = memo(function DayHeaderCell({
 
   return (
     <div className="relative flex flex-col overflow-hidden">
-      {/* The column's left rule, faded toward the top; on the cell so it
-          moves with the row. */}
       <div
         aria-hidden
         className="pointer-events-none absolute inset-y-0 left-0 w-px bg-border-elevated"
@@ -261,8 +254,6 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
     [],
   );
 
-  // The band's rows follow the visible days, so the header only grows when
-  // a day with all-day events is on screen; the height eases between sizes.
   const visibleStart = startOfVisibleWeek(anchor);
   let mostAllDay = 0;
   for (let index = 0; index < VISIBLE_COLUMNS; index++) {

--- a/applications/web/src/hooks/use-events.ts
+++ b/applications/web/src/hooks/use-events.ts
@@ -6,6 +6,8 @@ import type { ApiEvent } from "@/types/api";
 export interface CalendarEvent {
   id: string;
   eventStateId: string | null;
+  title: string | null;
+  description: string | null;
   startTime: Date;
   endTime: Date;
   calendarId: string;
@@ -29,6 +31,8 @@ const fetchEvents = async (url: string): Promise<CalendarEvent[]> => {
   return data.map((event) => ({
     id: event.id,
     eventStateId: event.eventStateId,
+    title: event.title ?? null,
+    description: event.description ?? null,
     startTime: new Date(event.startTime),
     endTime: new Date(event.endTime),
     calendarId: event.calendarId,

--- a/applications/web/src/hooks/use-events.ts
+++ b/applications/web/src/hooks/use-events.ts
@@ -10,6 +10,8 @@ export interface CalendarEvent {
   description: string | null;
   startTime: Date;
   endTime: Date;
+  /** Whole-day event: `startTime`/`endTime` are the UTC-midnight day bounds. */
+  isAllDay: boolean;
   calendarId: string;
   calendarName: string;
   calendarProvider: string;
@@ -35,6 +37,7 @@ const fetchEvents = async (url: string): Promise<CalendarEvent[]> => {
     description: event.description ?? null,
     startTime: new Date(event.startTime),
     endTime: new Date(event.endTime),
+    isAllDay: event.isAllDay,
     calendarId: event.calendarId,
     calendarName: event.calendarName,
     calendarProvider: event.calendarProvider,

--- a/applications/web/src/hooks/use-events.ts
+++ b/applications/web/src/hooks/use-events.ts
@@ -1,3 +1,4 @@
+import useSWR from "swr";
 import useSWRInfinite from "swr/infinite";
 import { fetcher } from "@/lib/fetcher";
 import { useStartOfToday } from "./use-start-of-today";
@@ -20,6 +21,10 @@ export interface CalendarEvent {
 
 const DAYS_PER_PAGE = 7;
 
+/** Relative, so the key is the same string on the server and in the browser.
+ * Bun defines no `globalThis.location`; SWR swallows a *key function* that
+ * throws (which is how `useEvents` survived server rendering with the old
+ * absolute URL), but a plain string key built eagerly would not be caught. */
 const buildEventsUrl = (from: Date, to: Date): string => {
   const params = new URLSearchParams({
     from: from.toISOString(),
@@ -73,6 +78,34 @@ export function useEvents() {
   };
 
   return { events, error, isLoading, isValidating, hasMore, loadMore };
+}
+
+const NO_EVENTS: CalendarEvent[] = [];
+
+/** The API treats `to` as inclusive (see the read window in services/api).
+ * Callers pass a half-open `[start, end)` so day boundaries compose, and the
+ * hook steps the end back by a millisecond. */
+const INCLUSIVE_END_MS = 1;
+
+interface EventsInRange {
+  events: CalendarEvent[];
+  error: Error | undefined;
+  isLoading: boolean;
+}
+
+/**
+ * The events overlapping `[start, end)`, for a view that can look anywhere in
+ * time (the calendar pane) rather than page forward from today. The previous
+ * range's events stay on screen while a new one loads, so a window shift
+ * never blanks the grid.
+ */
+export function useEventsInRange(start: Date, end: Date): EventsInRange {
+  const url = buildEventsUrl(start, new Date(end.getTime() - INCLUSIVE_END_MS));
+  const { data, error, isLoading } = useSWR<CalendarEvent[], Error>(url, fetchEvents, {
+    keepPreviousData: true,
+  });
+
+  return { events: data ?? NO_EVENTS, error, isLoading };
 }
 
 const deduplicateEvents = (events: CalendarEvent[]): CalendarEvent[] => [

--- a/applications/web/src/hooks/use-events.ts
+++ b/applications/web/src/hooks/use-events.ts
@@ -21,10 +21,7 @@ export interface CalendarEvent {
 
 const DAYS_PER_PAGE = 7;
 
-/** Relative, so the key is the same string on the server and in the browser.
- * Bun defines no `globalThis.location`; SWR swallows a *key function* that
- * throws (which is how `useEvents` survived server rendering with the old
- * absolute URL), but a plain string key built eagerly would not be caught. */
+// Relative: Bun has no `globalThis.location`, and an eagerly built absolute key would throw in SSR.
 const buildEventsUrl = (from: Date, to: Date): string => {
   const params = new URLSearchParams({
     from: from.toISOString(),
@@ -82,9 +79,7 @@ export function useEvents() {
 
 const NO_EVENTS: CalendarEvent[] = [];
 
-/** The API treats `to` as inclusive (see the read window in services/api).
- * Callers pass a half-open `[start, end)` so day boundaries compose, and the
- * hook steps the end back by a millisecond. */
+/** The API's `to` is inclusive; callers pass half-open `[start, end)`, so the end steps back 1ms. */
 const INCLUSIVE_END_MS = 1;
 
 interface EventsInRange {
@@ -93,12 +88,6 @@ interface EventsInRange {
   isLoading: boolean;
 }
 
-/**
- * The events overlapping `[start, end)`, for a view that can look anywhere in
- * time (the calendar pane) rather than page forward from today. The previous
- * range's events stay on screen while a new one loads, so a window shift
- * never blanks the grid.
- */
 export function useEventsInRange(start: Date, end: Date): EventsInRange {
   const url = buildEventsUrl(start, new Date(end.getTime() - INCLUSIVE_END_MS));
   const { data, error, isLoading } = useSWR<CalendarEvent[], Error>(url, fetchEvents, {

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -19,6 +19,12 @@
 @custom-variant event-short (@container event-card (height < 43px));
 @custom-variant event-roomy (@container event-card (59px <= height < 75px));
 @custom-variant event-tall (@container event-card (height >= 75px));
+/* Narrow cards — overlapping events tiled three across in a week column —
+   can't show a time range's both ends, so the time line goes and the title
+   tightens instead. Declared last on purpose: custom variants emit in
+   declaration order, so `event-narrow:hidden` outranks the roomy/tall
+   description clamps on the same element. */
+@custom-variant event-narrow (@container event-card (width < 72px));
 
 html {
   @apply w-full min-h-full bg-background overflow-x-hidden;

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -2,6 +2,21 @@
 
 @custom-variant pointer-hover (@media (hover: hover));
 
+/* Calendar event cards are sized by their event's duration, so their content
+   steps down as the card gets shorter. A grid card is a size-query container
+   named `event-card` (see the grid layout in `EventCard`); these variants
+   select on its rendered height. The thresholds assume the week grid's 48px
+   hour, Tailwind's 16px text-xs and 20px text-sm lines and the grid card's
+   4px vertical padding — the band table in `event-card.tsx` has the fit
+   arithmetic. The container is named deliberately: height queries need a
+   `size` container, and an unnamed query binds to whichever ancestor happens
+   to be one, so a future size container around the card could silently
+   capture these. */
+@custom-variant event-compact (@container event-card (height < 28px));
+@custom-variant event-short (@container event-card (height < 44px));
+@custom-variant event-roomy (@container event-card (60px <= height < 76px));
+@custom-variant event-tall (@container event-card (height >= 76px));
+
 html {
   @apply w-full min-h-full bg-background overflow-x-hidden;
   -webkit-font-smoothing: antialiased;

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -8,14 +8,17 @@
    select on its rendered height. The thresholds assume the week grid's 48px
    hour, Tailwind's 16px text-xs and 20px text-sm lines and the grid card's
    4px vertical padding — the band table in `event-card.tsx` has the fit
-   arithmetic. The container is named deliberately: height queries need a
-   `size` container, and an unnamed query binds to whichever ancestor happens
-   to be one, so a future size container around the card could silently
-   capture these. */
-@custom-variant event-compact (@container event-card (height < 28px));
-@custom-variant event-short (@container event-card (height < 44px));
-@custom-variant event-roomy (@container event-card (60px <= height < 76px));
-@custom-variant event-tall (@container event-card (height >= 76px));
+   arithmetic. Each floor sits 1px under its band's content height: a card's
+   height is a percentage of the day, which can land a hair under the exact
+   pixel and would otherwise drop the card into the band below; the 1px it
+   may clip is padding, never glyphs. The container is named deliberately:
+   height queries need a `size` container, and an unnamed query binds to
+   whichever ancestor happens to be one, so a future size container around
+   the card could silently capture these. */
+@custom-variant event-compact (@container event-card (height < 27px));
+@custom-variant event-short (@container event-card (height < 43px));
+@custom-variant event-roomy (@container event-card (59px <= height < 75px));
+@custom-variant event-tall (@container event-card (height >= 75px));
 
 html {
   @apply w-full min-h-full bg-background overflow-x-hidden;

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -89,6 +89,10 @@ html {
   --ui-ring: var(--color-blue-500);
   --ui-template: var(--color-purple-600);
   --ui-template-muted: color-mix(in srgb, var(--ui-template), transparent 50%);
+  --ui-event: var(--color-blue-900);
+  --ui-event-muted: color-mix(in srgb, var(--ui-event), transparent 30%);
+  --ui-event-background: var(--color-blue-100);
+  --ui-event-border: var(--color-blue-500);
 }
 
 @font-face {
@@ -135,6 +139,10 @@ html {
   --color-ring: var(--ui-ring);
   --color-template: var(--ui-template);
   --color-template-muted: var(--ui-template-muted);
+  --color-event: var(--ui-event);
+  --color-event-muted: var(--ui-event-muted);
+  --color-event-background: var(--ui-event-background);
+  --color-event-border: var(--ui-event-border);
 
   --font-sans: "Geist Sans", system-ui, sans-serif;
   --font-lora: "Lora", Georgia, serif;
@@ -247,6 +255,14 @@ html {
       var(--ui-template),
       transparent 40%
     );
+    --ui-event: var(--color-blue-100);
+    --ui-event-muted: color-mix(in srgb, var(--ui-event), transparent 30%);
+    --ui-event-background: color-mix(
+      in srgb,
+      var(--color-blue-500),
+      transparent 80%
+    );
+    --ui-event-border: var(--color-blue-400);
   }
 }
 

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -2,19 +2,12 @@
 
 @custom-variant pointer-hover (@media (hover: hover));
 
-/* Event cards are sized by their event's duration; these variants select on
-   the card's rendered height (the band table in `event-card.tsx` has the fit
-   arithmetic — each floor sits 1px under its band so percentage-height
-   rounding can't drop a card into the band below). The container is named
-   because an unnamed height query would bind to whichever ancestor happens
-   to be a size container. */
+/* Height bands for grid event cards; the band table in `event-card.tsx` has the fit arithmetic. */
 @custom-variant event-compact (@container event-card (height < 27px));
 @custom-variant event-short (@container event-card (height < 43px));
 @custom-variant event-roomy (@container event-card (59px <= height < 75px));
 @custom-variant event-tall (@container event-card (height >= 75px));
-/* Narrow cards drop the time line and tighten the title. Declared last:
-   custom variants emit in declaration order, so `event-narrow:` utilities
-   outrank the height bands on the same element. */
+/* Declared last so `event-narrow:` utilities outrank the height bands on the same element. */
 @custom-variant event-narrow (@container event-card (width < 72px));
 
 html {

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -116,6 +116,13 @@ html {
   --ui-event: var(--color-blue-900);
   --ui-event-muted: color-mix(in srgb, var(--ui-event), transparent 30%);
   --ui-event-background: var(--color-blue-100);
+  /* The fill of a past event: half of the way from the event fill back to
+     the page, so it recedes yet stays opaque for the calendar's stacks. */
+  --ui-event-background-muted: color-mix(
+    in srgb,
+    var(--ui-event-background) 50%,
+    var(--ui-background)
+  );
   --ui-event-border: var(--color-blue-500);
 }
 
@@ -166,6 +173,7 @@ html {
   --color-event: var(--ui-event);
   --color-event-muted: var(--ui-event-muted);
   --color-event-background: var(--ui-event-background);
+  --color-event-background-muted: var(--ui-event-background-muted);
   --color-event-border: var(--ui-event-border);
 
   --font-sans: "Geist Sans", system-ui, sans-serif;
@@ -287,6 +295,11 @@ html {
     --ui-event-background: color-mix(
       in srgb,
       var(--color-blue-500) 20%,
+      var(--ui-background)
+    );
+    --ui-event-background-muted: color-mix(
+      in srgb,
+      var(--ui-event-background) 50%,
       var(--ui-background)
     );
     --ui-event-border: var(--color-blue-400);

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -281,10 +281,13 @@ html {
     );
     --ui-event: var(--color-blue-100);
     --ui-event-muted: color-mix(in srgb, var(--ui-event), transparent 30%);
+    /* Mixed against the page colour rather than transparent: event cards
+       overlap in the calendar's week grid, and a translucent fill lets the
+       card beneath show through the one on top. */
     --ui-event-background: color-mix(
       in srgb,
-      var(--color-blue-500),
-      transparent 80%
+      var(--color-blue-500) 20%,
+      var(--ui-background)
     );
     --ui-event-border: var(--color-blue-400);
   }

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -2,7 +2,7 @@
 
 @custom-variant pointer-hover (@media (hover: hover));
 
-/* Height bands for grid event cards; the band table in `event-card.tsx` has the fit arithmetic. */
+/* Height bands for grid event cards (48px hour); each floor sits 1px under its band's content height. */
 @custom-variant event-compact (@container event-card (height < 27px));
 @custom-variant event-short (@container event-card (height < 43px));
 @custom-variant event-roomy (@container event-card (59px <= height < 75px));

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -104,17 +104,6 @@ html {
   --ui-ring: var(--color-blue-500);
   --ui-template: var(--color-purple-600);
   --ui-template-muted: color-mix(in srgb, var(--ui-template), transparent 50%);
-  --ui-event: var(--color-blue-900);
-  --ui-event-muted: color-mix(in srgb, var(--ui-event), transparent 30%);
-  --ui-event-background: var(--color-blue-100);
-  /* The fill of a past event: half of the way from the event fill back to
-     the page, so it recedes yet stays opaque for the calendar's stacks. */
-  --ui-event-background-muted: color-mix(
-    in srgb,
-    var(--ui-event-background) 50%,
-    var(--ui-background)
-  );
-  --ui-event-border: var(--color-blue-500);
 }
 
 @font-face {
@@ -161,11 +150,6 @@ html {
   --color-ring: var(--ui-ring);
   --color-template: var(--ui-template);
   --color-template-muted: var(--ui-template-muted);
-  --color-event: var(--ui-event);
-  --color-event-muted: var(--ui-event-muted);
-  --color-event-background: var(--ui-event-background);
-  --color-event-background-muted: var(--ui-event-background-muted);
-  --color-event-border: var(--ui-event-border);
 
   --font-sans: "Geist Sans", system-ui, sans-serif;
   --font-lora: "Lora", Georgia, serif;
@@ -278,22 +262,6 @@ html {
       var(--ui-template),
       transparent 40%
     );
-    --ui-event: var(--color-blue-100);
-    --ui-event-muted: color-mix(in srgb, var(--ui-event), transparent 30%);
-    /* Mixed against the page colour rather than transparent: event cards
-       overlap in the calendar's week grid, and a translucent fill lets the
-       card beneath show through the one on top. */
-    --ui-event-background: color-mix(
-      in srgb,
-      var(--color-blue-500) 20%,
-      var(--ui-background)
-    );
-    --ui-event-background-muted: color-mix(
-      in srgb,
-      var(--ui-event-background) 50%,
-      var(--ui-background)
-    );
-    --ui-event-border: var(--color-blue-400);
   }
 }
 

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -306,41 +306,6 @@ html {
   }
 }
 
-/* The week grid's day row lives in the header card, outside the grid's
-   scroller, and has to follow its horizontal scroll to the pixel. Mirroring
-   `scrollLeft` from a scroll event lands a frame or more behind compositor
-   scrolling — the event cards in the grid visibly lead the day labels on
-   every swipe — so where scroll-driven animations exist the row follows a
-   scroll timeline instead: the scroller publishes its inline-axis progress
-   as `--calendar-strip`, scoped up to the frame so the header can see it,
-   and the row translates from rest to `--calendar-strip-travel` (its own
-   width less the viewport's, set inline by `WeekGrid`) in step with it, on
-   the compositor. `WeekGrid` keeps the `scrollLeft` mirror as the fallback
-   for engines without scroll timelines. */
-.calendar-strip-scope {
-  timeline-scope: --calendar-strip;
-}
-
-.calendar-strip-scroller {
-  scroll-timeline: --calendar-strip x;
-}
-
-@supports (animation-timeline: scroll()) {
-  .calendar-strip-row {
-    animation: calendar-strip-follow linear both;
-    animation-timeline: --calendar-strip;
-  }
-}
-
-@keyframes calendar-strip-follow {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(var(--calendar-strip-travel));
-  }
-}
-
 /* Only the calendar's named groups animate in its view transition; keep the root from cross-fading the page. */
 ::view-transition-group(root) {
   animation-duration: 0s;

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -2,28 +2,19 @@
 
 @custom-variant pointer-hover (@media (hover: hover));
 
-/* Calendar event cards are sized by their event's duration, so their content
-   steps down as the card gets shorter. A grid card is a size-query container
-   named `event-card` (see the grid layout in `EventCard`); these variants
-   select on its rendered height. The thresholds assume the week grid's 48px
-   hour, Tailwind's 16px text-xs and 20px text-sm lines and the grid card's
-   4px vertical padding — the band table in `event-card.tsx` has the fit
-   arithmetic. Each floor sits 1px under its band's content height: a card's
-   height is a percentage of the day, which can land a hair under the exact
-   pixel and would otherwise drop the card into the band below; the 1px it
-   may clip is padding, never glyphs. The container is named deliberately:
-   height queries need a `size` container, and an unnamed query binds to
-   whichever ancestor happens to be one, so a future size container around
-   the card could silently capture these. */
+/* Event cards are sized by their event's duration; these variants select on
+   the card's rendered height (the band table in `event-card.tsx` has the fit
+   arithmetic — each floor sits 1px under its band so percentage-height
+   rounding can't drop a card into the band below). The container is named
+   because an unnamed height query would bind to whichever ancestor happens
+   to be a size container. */
 @custom-variant event-compact (@container event-card (height < 27px));
 @custom-variant event-short (@container event-card (height < 43px));
 @custom-variant event-roomy (@container event-card (59px <= height < 75px));
 @custom-variant event-tall (@container event-card (height >= 75px));
-/* Narrow cards — overlapping events tiled three across in a week column —
-   can't show a time range's both ends, so the time line goes and the title
-   tightens instead. Declared last on purpose: custom variants emit in
-   declaration order, so `event-narrow:hidden` outranks the roomy/tall
-   description clamps on the same element. */
+/* Narrow cards drop the time line and tighten the title. Declared last:
+   custom variants emit in declaration order, so `event-narrow:` utilities
+   outrank the height bands on the same element. */
 @custom-variant event-narrow (@container event-card (width < 72px));
 
 html {

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -290,6 +290,41 @@ html {
   }
 }
 
+/* The week grid's day row lives in the header card, outside the grid's
+   scroller, and has to follow its horizontal scroll to the pixel. Mirroring
+   `scrollLeft` from a scroll event lands a frame or more behind compositor
+   scrolling — the event cards in the grid visibly lead the day labels on
+   every swipe — so where scroll-driven animations exist the row follows a
+   scroll timeline instead: the scroller publishes its inline-axis progress
+   as `--calendar-strip`, scoped up to the frame so the header can see it,
+   and the row translates from rest to `--calendar-strip-travel` (its own
+   width less the viewport's, set inline by `WeekGrid`) in step with it, on
+   the compositor. `WeekGrid` keeps the `scrollLeft` mirror as the fallback
+   for engines without scroll timelines. */
+.calendar-strip-scope {
+  timeline-scope: --calendar-strip;
+}
+
+.calendar-strip-scroller {
+  scroll-timeline: --calendar-strip x;
+}
+
+@supports (animation-timeline: scroll()) {
+  .calendar-strip-row {
+    animation: calendar-strip-follow linear both;
+    animation-timeline: --calendar-strip;
+  }
+}
+
+@keyframes calendar-strip-follow {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(var(--calendar-strip-travel));
+  }
+}
+
 /* Only the calendar's named groups animate in its view transition; keep the root from cross-fading the page. */
 ::view-transition-group(root) {
   animation-duration: 0s;

--- a/applications/web/src/lib/time.ts
+++ b/applications/web/src/lib/time.ts
@@ -37,13 +37,28 @@ const resolvePeriod = (hours: number): string => {
   return "AM";
 };
 
-export const formatTime = (date: Date): string => {
+/** The 12-hour clock without its period, e.g. "9:30". */
+const formatClock = (date: Date): string => {
   const hours = date.getHours();
   const minutes = date.getMinutes();
-  const period = resolvePeriod(hours);
   const displayHours = hours % 12 || 12;
 
-  return `${displayHours}:${minutes.toString().padStart(2, "0")} ${period}`;
+  return `${displayHours}:${minutes.toString().padStart(2, "0")}`;
+};
+
+export const formatTime = (date: Date): string =>
+  `${formatClock(date)} ${resolvePeriod(date.getHours())}`;
+
+/**
+ * A compact time range for the calendar grid, e.g. "9:00 – 10:00 AM": the
+ * start's period is dropped when both ends share it and kept when the range
+ * crosses noon ("11:30 AM – 1:00 PM"), so the text fits a week column.
+ */
+export const formatTimeRange = (start: Date, end: Date): string => {
+  const samePeriod = resolvePeriod(start.getHours()) === resolvePeriod(end.getHours());
+  const startLabel = samePeriod ? formatClock(start) : formatTime(start);
+
+  return `${startLabel} – ${formatTime(end)}`;
 };
 
 export const formatDate = (date: string | Date): string =>

--- a/applications/web/src/lib/time.ts
+++ b/applications/web/src/lib/time.ts
@@ -37,7 +37,6 @@ const resolvePeriod = (hours: number): string => {
   return "AM";
 };
 
-/** The 12-hour clock without its period, e.g. "9:30". */
 const formatClock = (date: Date): string => {
   const hours = date.getHours();
   const minutes = date.getMinutes();
@@ -49,11 +48,7 @@ const formatClock = (date: Date): string => {
 export const formatTime = (date: Date): string =>
   `${formatClock(date)} ${resolvePeriod(date.getHours())}`;
 
-/**
- * A compact time range for the calendar grid, e.g. "9:00 – 10:00 AM": the
- * start's period is dropped when both ends share it and kept when the range
- * crosses noon ("11:30 AM – 1:00 PM"), so the text fits a week column.
- */
+// The start's period is dropped when both ends share it, e.g. "9:00 – 10:00 AM".
 export const formatTimeRange = (start: Date, end: Date): string => {
   const samePeriod = resolvePeriod(start.getHours()) === resolvePeriod(end.getHours());
   const startLabel = samePeriod ? formatClock(start) : formatTime(start);

--- a/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
@@ -125,7 +125,7 @@ const DaySection = memo(function DaySection({ label, events }: DaySectionProps) 
   return (
     <div className="flex flex-col px-0.5">
       <DashboardHeading2>{label}</DashboardHeading2>
-      <div className="flex flex-col">
+      <div className="flex flex-col gap-2 pt-1">
         {events.map((event) => (
           <EventCard key={event.id} event={event} />
         ))}

--- a/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, memo } from "react";
 import { createFileRoute } from "@tanstack/react-router";
+import { tv } from "tailwind-variants/lite";
 import LoaderCircle from "lucide-react/dist/esm/icons/loader-circle";
 import { BackButton } from "@/components/ui/primitives/back-button";
 import { ErrorState } from "@/components/ui/primitives/error-state";
@@ -7,7 +8,6 @@ import { DashboardHeading1, DashboardHeading2 } from "@/components/ui/primitives
 import { Text } from "@/components/ui/primitives/text";
 import { formatTime, formatTimeUntil, isEventPast, formatDayHeader } from "@/lib/time";
 import { useEvents, type CalendarEvent } from "@/hooks/use-events";
-import { cn } from "@/utils/cn";
 
 export const Route = createFileRoute("/(dashboard)/dashboard/events/")({
   component: EventsPage,
@@ -23,7 +23,7 @@ interface DaySectionProps {
   events: CalendarEvent[];
 }
 
-interface EventRowProps {
+interface EventCardProps {
   event: CalendarEvent;
 }
 
@@ -127,45 +127,48 @@ const DaySection = memo(function DaySection({ label, events }: DaySectionProps) 
       <DashboardHeading2>{label}</DashboardHeading2>
       <div className="flex flex-col">
         {events.map((event) => (
-          <EventRow key={event.id} event={event} />
+          <EventCard key={event.id} event={event} />
         ))}
       </div>
     </div>
   );
 });
 
-function resolveEventRowClassName(past: boolean): string {
-  return cn("flex items-center justify-between gap-2 py-1.5", past && "line-through");
-}
+const eventCard = tv({
+  base: "relative flex flex-col gap-0.5 overflow-hidden rounded-xl bg-event-background py-2.5 pr-3 pl-4 before:absolute before:inset-y-2 before:left-1.5 before:w-0.5 before:rounded-full before:bg-event-border",
+  variants: {
+    past: {
+      true: "opacity-60 line-through",
+      false: "",
+    },
+  },
+});
 
-const EventRow = memo(function EventRow({ event }: EventRowProps) {
+const EventCard = memo(function EventCard({ event }: EventCardProps) {
   const past = isEventPast(event.endTime);
   const startTime = formatTime(event.startTime);
   const endTime = formatTime(event.endTime);
   const timeUntil = formatTimeUntil(event.startTime);
+  const title = event.title ?? event.calendarName;
 
   return (
-    <div className={resolveEventRowClassName(past)}>
-      <div className="flex items-center gap-1 min-w-0">
-        <Text size="sm" tone="muted" className="truncate">
-          {event.calendarName}
+    <div className={eventCard({ past })}>
+      <div className="flex items-center justify-between gap-2">
+        <Text size="sm" tone="eventMuted" className="tabular-nums">
+          {startTime} - {endTime}
         </Text>
-        <Text size="sm" tone="muted" className="shrink-0">
-          from
-        </Text>
-        <Text size="sm" tone="default" className="font-medium tabular-nums shrink-0">
-          {startTime}
-        </Text>
-        <Text size="sm" tone="muted" className="shrink-0">
-          to
-        </Text>
-        <Text size="sm" tone="default" className="font-medium tabular-nums shrink-0">
-          {endTime}
+        <Text size="xs" tone="eventMuted" className="tabular-nums whitespace-nowrap">
+          {timeUntil}
         </Text>
       </div>
-      <Text size="sm" tone="muted" className="tabular-nums shrink-0 whitespace-nowrap">
-        {timeUntil}
+      <Text size="sm" tone="event" className="truncate font-semibold">
+        {title}
       </Text>
+      {event.description && (
+        <Text size="sm" tone="eventMuted" className="line-clamp-2">
+          {event.description}
+        </Text>
+      )}
     </div>
   );
 });

--- a/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useRef, memo } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import { tv } from "tailwind-variants/lite";
 import LoaderCircle from "lucide-react/dist/esm/icons/loader-circle";
 import { BackButton } from "@/components/ui/primitives/back-button";
 import { ErrorState } from "@/components/ui/primitives/error-state";
 import { DashboardHeading1, DashboardHeading2 } from "@/components/ui/primitives/dashboard-heading";
 import { Text } from "@/components/ui/primitives/text";
-import { formatTime, formatTimeUntil, isEventPast, formatDayHeader } from "@/lib/time";
+import { isEventPast, formatDayHeader } from "@/lib/time";
+import { EventCard } from "@/features/dashboard/components/event-card";
 import { useEvents, type CalendarEvent } from "@/hooks/use-events";
 
 export const Route = createFileRoute("/(dashboard)/dashboard/events/")({
@@ -21,10 +21,6 @@ interface DayGroup {
 interface DaySectionProps {
   label: string;
   events: CalendarEvent[];
-}
-
-interface EventCardProps {
-  event: CalendarEvent;
 }
 
 interface LoadMoreSentinelProps {
@@ -127,48 +123,9 @@ const DaySection = memo(function DaySection({ label, events }: DaySectionProps) 
       <DashboardHeading2>{label}</DashboardHeading2>
       <div className="flex flex-col gap-2 pt-1">
         {events.map((event) => (
-          <EventCard key={event.id} event={event} />
+          <EventCard key={event.id} event={event} past={isEventPast(event.endTime)} />
         ))}
       </div>
-    </div>
-  );
-});
-
-const eventCard = tv({
-  base: "relative flex flex-col gap-0.5 overflow-hidden rounded-xl bg-event-background py-2.5 pr-3 pl-4 before:absolute before:inset-y-2 before:left-1.5 before:w-0.5 before:rounded-full before:bg-event-border",
-  variants: {
-    past: {
-      true: "opacity-60 line-through",
-      false: "",
-    },
-  },
-});
-
-const EventCard = memo(function EventCard({ event }: EventCardProps) {
-  const past = isEventPast(event.endTime);
-  const startTime = formatTime(event.startTime);
-  const endTime = formatTime(event.endTime);
-  const timeUntil = formatTimeUntil(event.startTime);
-  const title = event.title ?? event.calendarName;
-
-  return (
-    <div className={eventCard({ past })}>
-      <div className="flex items-center justify-between gap-2">
-        <Text size="sm" tone="eventMuted" className="tabular-nums">
-          {startTime} - {endTime}
-        </Text>
-        <Text size="xs" tone="eventMuted" className="tabular-nums whitespace-nowrap">
-          {timeUntil}
-        </Text>
-      </div>
-      <Text size="sm" tone="event" className="truncate font-semibold">
-        {title}
-      </Text>
-      {event.description && (
-        <Text size="sm" tone="eventMuted" className="line-clamp-2">
-          {event.description}
-        </Text>
-      )}
     </div>
   );
 });

--- a/applications/web/src/types/api.ts
+++ b/applications/web/src/types/api.ts
@@ -76,6 +76,8 @@ export interface ApiEvent {
   description: string | null;
   startTime: string;
   endTime: string;
+  /** Whole-day event: `startTime`/`endTime` are the UTC-midnight day bounds. */
+  isAllDay: boolean;
   calendarId: string;
   calendarName: string;
   calendarProvider: string;

--- a/applications/web/src/types/api.ts
+++ b/applications/web/src/types/api.ts
@@ -72,6 +72,8 @@ export interface CalendarDetail {
 export interface ApiEvent {
   id: string;
   eventStateId: string | null;
+  title: string | null;
+  description: string | null;
   startTime: string;
   endTime: string;
   calendarId: string;

--- a/applications/web/tests/features/dashboard/components/calendar-helpers.test.ts
+++ b/applications/web/tests/features/dashboard/components/calendar-helpers.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  addDays,
+  getWeekFetchRange,
+  startOfVisibleWeek,
+  WEEK_STARTS_ON,
+  WEEK_VIEW_DAYS,
+} from "../../../../src/features/dashboard/components/calendar-helpers";
+
+const MS_PER_DAY = 86_400_000;
+
+const visibleDays = (anchor: Date): Date[] =>
+  Array.from({ length: WEEK_VIEW_DAYS }, (_, index) => addDays(startOfVisibleWeek(anchor), index));
+
+const contains = (range: { start: Date; end: Date }, day: Date): boolean =>
+  day.getTime() >= range.start.getTime() && day.getTime() < range.end.getTime();
+
+describe("getWeekFetchRange", () => {
+  it("starts at midnight on the first weekday and spans four weeks", () => {
+    const { start, end } = getWeekFetchRange(new Date(2026, 7, 22, 15, 30));
+
+    expect(start.getDay()).toBe(WEEK_STARTS_ON);
+    expect([start.getHours(), start.getMinutes()]).toEqual([0, 0]);
+    expect(Math.round((end.getTime() - start.getTime()) / MS_PER_DAY)).toBe(28);
+  });
+
+  it("covers the visible week, and the weeks a step or a page away, on every day", () => {
+    // Two years of anchors cover daylight-saving changes and a year boundary.
+    const last = new Date(2027, 11, 31);
+    const uncovered: string[] = [];
+    for (let anchor = new Date(2026, 0, 1); anchor <= last; anchor = addDays(anchor, 1)) {
+      const range = getWeekFetchRange(anchor);
+      for (const offset of [0, 1, -1, WEEK_VIEW_DAYS, -WEEK_VIEW_DAYS]) {
+        for (const day of visibleDays(addDays(anchor, offset))) {
+          if (!contains(range, day)) uncovered.push(`${anchor.toDateString()} ${offset}`);
+        }
+      }
+    }
+
+    expect(uncovered).toEqual([]);
+  });
+});

--- a/applications/web/tests/features/dashboard/components/calendar-helpers.test.ts
+++ b/applications/web/tests/features/dashboard/components/calendar-helpers.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   addDays,
+  getMonthFetchRange,
+  getMonthGridDays,
   getWeekFetchRange,
   startOfVisibleWeek,
   WEEK_STARTS_ON,
@@ -38,5 +40,17 @@ describe("getWeekFetchRange", () => {
     }
 
     expect(uncovered).toEqual([]);
+  });
+});
+
+describe("getMonthFetchRange", () => {
+  it("spans exactly the month grid's 42 days", () => {
+    const anchor = new Date(2026, 7, 22);
+    const days = getMonthGridDays(anchor);
+    const { start, end } = getMonthFetchRange(anchor);
+
+    expect(start.getTime()).toBe(days[0].getTime());
+    expect(end.getTime()).toBe(addDays(days[41], 1).getTime());
+    expect(Math.round((end.getTime() - start.getTime()) / MS_PER_DAY)).toBe(42);
   });
 });

--- a/applications/web/tests/features/dashboard/components/event-layout.test.ts
+++ b/applications/web/tests/features/dashboard/components/event-layout.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+import type { CalendarEvent } from "../../../../src/hooks/use-events";
+import {
+  layoutDayEvents,
+  MIN_EVENT_SPAN_MS,
+  stackIndentPx,
+  tileBox,
+} from "../../../../src/features/dashboard/components/event-layout";
+import type { PositionedEvent } from "../../../../src/features/dashboard/components/event-layout";
+
+const MS_PER_DAY = 86_400_000;
+
+const day = new Date(2026, 0, 5);
+const at = (hour: number, minute = 0): Date => new Date(2026, 0, 5, hour, minute);
+
+const timedEvent = (id: string, startTime: Date, endTime: Date): CalendarEvent => ({
+  id,
+  eventStateId: null,
+  title: id,
+  description: null,
+  startTime,
+  endTime,
+  calendarId: "calendar",
+  calendarName: "Calendar",
+  calendarProvider: "google",
+  calendarUrl: "https://calendar.example",
+});
+
+const byId = (layout: PositionedEvent[]): Record<string, PositionedEvent> =>
+  Object.fromEntries(layout.map((item) => [item.event.id, item]));
+
+describe("layoutDayEvents geometry", () => {
+  it("positions an event by its share of the day", () => {
+    const [item] = layoutDayEvents([timedEvent("meeting", at(9), at(10))], day);
+
+    expect(item.topFraction).toBeCloseTo(9 / 24);
+    expect(item.heightFraction).toBeCloseTo(1 / 24);
+  });
+
+  it("clamps an event to the day at both ends", () => {
+    const layout = byId(
+      layoutDayEvents(
+        [
+          timedEvent("late", at(22), new Date(2026, 0, 6, 2)),
+          timedEvent("early", new Date(2026, 0, 4, 22), at(2)),
+        ],
+        day,
+      ),
+    );
+
+    expect(layout.late.topFraction).toBeCloseTo(22 / 24);
+    expect(layout.late.heightFraction).toBeCloseTo(2 / 24);
+    expect(layout.early.topFraction).toBe(0);
+    expect(layout.early.heightFraction).toBeCloseTo(2 / 24);
+  });
+
+  it("floors short and zero-length events to the minimum span", () => {
+    const layout = byId(
+      layoutDayEvents(
+        [timedEvent("brief", at(9), at(9, 5)), timedEvent("instant", at(11), at(11))],
+        day,
+      ),
+    );
+    const minimum = MIN_EVENT_SPAN_MS / MS_PER_DAY;
+
+    expect(layout.brief.heightFraction).toBeCloseTo(minimum);
+    expect(layout.instant.heightFraction).toBeCloseTo(minimum);
+  });
+
+  it("runs an event that ends at midnight to the bottom of the day", () => {
+    const [item] = layoutDayEvents([timedEvent("last", at(23), new Date(2026, 0, 6, 0))], day);
+
+    expect(item.topFraction + item.heightFraction).toBeCloseTo(1);
+  });
+
+  it("positions by the wall clock on a daylight-saving day", () => {
+    // US clocks spring forward on 2026-03-08; noon must still sit halfway
+    // down the day, not 11/23 of the way (passes in any zone, pins the
+    // behaviour where the day is 23 hours long).
+    const dstDay = new Date(2026, 2, 8);
+    const [item] = layoutDayEvents(
+      [timedEvent("noon", new Date(2026, 2, 8, 12), new Date(2026, 2, 8, 13))],
+      dstDay,
+    );
+
+    expect(item.topFraction).toBeCloseTo(0.5);
+  });
+});
+
+describe("layoutDayEvents clusters", () => {
+  it("keeps sequential events in a single column", () => {
+    const layout = layoutDayEvents(
+      [timedEvent("first", at(9), at(10)), timedEvent("second", at(10), at(11))],
+      day,
+    );
+
+    for (const item of layout) {
+      expect(item.columnCount).toBe(1);
+      expect(item.stackIndex).toBe(0);
+      expect(item.elevation).toBe(0);
+      expect(item.tiled).toBe(false);
+    }
+  });
+
+  it("tiles concurrent events into side-by-side columns", () => {
+    const layout = byId(
+      layoutDayEvents(
+        [timedEvent("first", at(9), at(10)), timedEvent("second", at(9), at(10))],
+        day,
+      ),
+    );
+
+    expect(layout.first.columnIndex).toBe(0);
+    expect(layout.second.columnIndex).toBe(1);
+    expect(layout.first.columnCount).toBe(2);
+    expect(layout.first.tiled).toBe(true);
+    expect(layout.second.tiled).toBe(true);
+  });
+
+  it("cascades a transitive chain and reuses a freed lane", () => {
+    // a and c never overlap, but both overlap b, so all three share a cluster.
+    const layout = byId(
+      layoutDayEvents(
+        [
+          timedEvent("a", at(9), at(10, 30)),
+          timedEvent("b", at(10), at(12)),
+          timedEvent("c", at(11, 30), at(13)),
+        ],
+        day,
+      ),
+    );
+
+    expect(layout.a.columnIndex).toBe(0);
+    expect(layout.b.columnIndex).toBe(1);
+    expect(layout.c.columnIndex).toBe(0);
+    expect(layout.a.columnCount).toBe(2);
+    expect([layout.a.stackIndex, layout.b.stackIndex, layout.c.stackIndex]).toEqual([0, 1, 1]);
+    expect([layout.a.elevation, layout.b.elevation, layout.c.elevation]).toEqual([0, 1, 2]);
+    expect(layout.a.tiled).toBe(false);
+  });
+
+  it("expands a card right across free columns", () => {
+    const layout = byId(
+      layoutDayEvents(
+        [
+          timedEvent("long", at(9), at(11)),
+          timedEvent("b", at(9), at(9, 30)),
+          timedEvent("c", at(9), at(9, 30)),
+          timedEvent("d", at(10), at(10, 30)),
+        ],
+        day,
+      ),
+    );
+
+    expect(layout.long.columnSpan).toBe(1);
+    expect(layout.d.columnIndex).toBe(1);
+    expect(layout.d.columnSpan).toBe(2);
+    expect(layout.d.columnCount).toBe(3);
+  });
+
+  it("keeps the cascade for a comfortable stagger", () => {
+    const layout = byId(
+      layoutDayEvents(
+        [timedEvent("outer", at(11), at(14)), timedEvent("inner", at(12), at(13))],
+        day,
+      ),
+    );
+
+    expect(layout.outer.tiled).toBe(false);
+    expect(layout.inner.stackIndex).toBe(1);
+    expect(layout.inner.elevation).toBe(1);
+  });
+
+  it("tiles a close stagger but not one at the threshold", () => {
+    const close = byId(
+      layoutDayEvents(
+        [timedEvent("a", at(9), at(10)), timedEvent("b", at(9, 40), at(10, 30))],
+        day,
+      ),
+    );
+    const threshold = byId(
+      layoutDayEvents(
+        [timedEvent("a", at(9), at(10)), timedEvent("b", at(9, 45), at(10, 30))],
+        day,
+      ),
+    );
+
+    expect(close.a.tiled).toBe(true);
+    expect(threshold.a.tiled).toBe(false);
+  });
+
+  it("tiles the whole cluster when any overlapping pair starts too close", () => {
+    const layout = layoutDayEvents(
+      [
+        timedEvent("a", at(9), at(12)),
+        timedEvent("b", at(10), at(12)),
+        timedEvent("c", at(10, 10), at(12)),
+      ],
+      day,
+    );
+
+    expect(layout.every((item) => item.tiled)).toBe(true);
+    expect(layout[0].columnCount).toBe(3);
+  });
+
+  it("never clusters back-to-back events", () => {
+    const layout = byId(
+      layoutDayEvents(
+        [timedEvent("a", at(9), at(9, 30)), timedEvent("b", at(9, 30), at(10))],
+        day,
+      ),
+    );
+
+    expect(layout.a.columnCount).toBe(1);
+    expect(layout.b.columnCount).toBe(1);
+    expect(layout.b.stackIndex).toBe(0);
+    expect(layout.b.tiled).toBe(false);
+  });
+});
+
+describe("stackIndentPx", () => {
+  it("indents fully for the first levels and thinly past the cap", () => {
+    expect(stackIndentPx(0)).toBe(0);
+    expect(stackIndentPx(1)).toBe(14);
+    expect(stackIndentPx(3)).toBe(42);
+    expect(stackIndentPx(5)).toBe(50);
+  });
+});
+
+describe("tileBox", () => {
+  it("fills the column for a lone event", () => {
+    expect(tileBox(0, 1, 1)).toEqual({ left: 0, width: 1 });
+  });
+
+  it("splits the column into equal tiles", () => {
+    expect(tileBox(0, 2, 1)).toEqual({ left: 0, width: 0.5 });
+    expect(tileBox(1, 2, 1)).toEqual({ left: 0.5, width: 0.5 });
+  });
+
+  it("widens a spanning card across its columns", () => {
+    expect(tileBox(0, 2, 2)).toEqual({ left: 0, width: 1 });
+  });
+});

--- a/applications/web/tests/features/dashboard/components/event-layout.test.ts
+++ b/applications/web/tests/features/dashboard/components/event-layout.test.ts
@@ -4,6 +4,7 @@ import {
   bucketEventsByDay,
   layoutDayEvents,
   MIN_EVENT_SPAN_MS,
+  resolvePillRows,
   resolveVisiblePillCount,
   stackIndentPx,
   tileBox,
@@ -327,6 +328,23 @@ describe("bucketEventsByDay", () => {
     expect(daysHolding(buckets, "holiday", "timed")).toEqual([]);
   });
 
+  it("returns each day's lists in start order", () => {
+    const buckets = bucketEventsByDay(
+      [
+        timedEvent("noon", at(12), at(13)),
+        timedEvent("morning", at(9), at(10)),
+        allDayEvent("later", "2026-01-05T00:00:00.000Z", "2026-01-07T00:00:00.000Z"),
+        allDayEvent("sooner", "2026-01-04T00:00:00.000Z", "2026-01-06T00:00:00.000Z"),
+      ],
+      rangeStart,
+      rangeEnd,
+    );
+    const monday = buckets.get(day.getTime());
+
+    expect(monday?.timed.map((event) => event.id)).toEqual(["morning", "noon"]);
+    expect(monday?.allDay.map((event) => event.id)).toEqual(["sooner", "later"]);
+  });
+
   it("clamps an all-day span to the window", () => {
     const buckets = bucketEventsByDay(
       [allDayEvent("fortnight", "2026-01-01T00:00:00.000Z", "2026-01-15T00:00:00.000Z")],
@@ -351,5 +369,16 @@ describe("resolveVisiblePillCount", () => {
 
   it("hides everything when there is no row at all", () => {
     expect(resolveVisiblePillCount(3, 0)).toEqual({ visibleCount: 0, hiddenCount: 3 });
+  });
+});
+
+describe("resolvePillRows", () => {
+  it("counts whole rows, each after the first paying for its gap", () => {
+    expect(resolvePillRows(0)).toBe(0);
+    expect(resolvePillRows(17)).toBe(0);
+    expect(resolvePillRows(18)).toBe(1);
+    expect(resolvePillRows(37)).toBe(1);
+    expect(resolvePillRows(38)).toBe(2);
+    expect(resolvePillRows(100)).toBe(5);
   });
 });

--- a/applications/web/tests/features/dashboard/components/event-layout.test.ts
+++ b/applications/web/tests/features/dashboard/components/event-layout.test.ts
@@ -8,6 +8,7 @@ import {
   resolveVisiblePillCount,
   stackIndentPx,
   tileBox,
+  timeOfDayFraction,
 } from "../../../../src/features/dashboard/components/event-layout";
 import type {
   DayEvents,
@@ -380,5 +381,17 @@ describe("resolvePillRows", () => {
     expect(resolvePillRows(37)).toBe(1);
     expect(resolvePillRows(38)).toBe(2);
     expect(resolvePillRows(100)).toBe(5);
+  });
+});
+
+describe("timeOfDayFraction", () => {
+  it("reads the wall clock", () => {
+    expect(timeOfDayFraction(at(0))).toBe(0);
+    expect(timeOfDayFraction(at(12))).toBe(0.5);
+    expect(timeOfDayFraction(at(18, 30))).toBeCloseTo(18.5 / 24);
+  });
+
+  it("keeps noon halfway down a daylight-saving day", () => {
+    expect(timeOfDayFraction(new Date(2026, 2, 8, 12))).toBe(0.5);
   });
 });

--- a/applications/web/tests/features/dashboard/components/event-layout.test.ts
+++ b/applications/web/tests/features/dashboard/components/event-layout.test.ts
@@ -20,6 +20,7 @@ const timedEvent = (id: string, startTime: Date, endTime: Date): CalendarEvent =
   description: null,
   startTime,
   endTime,
+  isAllDay: false,
   calendarId: "calendar",
   calendarName: "Calendar",
   calendarProvider: "google",

--- a/applications/web/tests/features/dashboard/components/event-layout.test.ts
+++ b/applications/web/tests/features/dashboard/components/event-layout.test.ts
@@ -4,6 +4,7 @@ import {
   bucketEventsByDay,
   layoutDayEvents,
   MIN_EVENT_SPAN_MS,
+  resolveVisiblePillCount,
   stackIndentPx,
   tileBox,
 } from "../../../../src/features/dashboard/components/event-layout";
@@ -334,5 +335,21 @@ describe("bucketEventsByDay", () => {
     );
 
     expect(daysHolding(buckets, "fortnight", "allDay")).toEqual([4, 5, 6, 7, 8, 9, 10]);
+  });
+});
+
+describe("resolveVisiblePillCount", () => {
+  it("shows every pill when they fit", () => {
+    expect(resolveVisiblePillCount(2, 2)).toEqual({ visibleCount: 2, hiddenCount: 0 });
+    expect(resolveVisiblePillCount(0, 2)).toEqual({ visibleCount: 0, hiddenCount: 0 });
+  });
+
+  it("gives the last row to the overflow count when they do not", () => {
+    expect(resolveVisiblePillCount(3, 2)).toEqual({ visibleCount: 1, hiddenCount: 2 });
+    expect(resolveVisiblePillCount(5, 1)).toEqual({ visibleCount: 0, hiddenCount: 5 });
+  });
+
+  it("hides everything when there is no row at all", () => {
+    expect(resolveVisiblePillCount(3, 0)).toEqual({ visibleCount: 0, hiddenCount: 3 });
   });
 });

--- a/applications/web/tests/features/dashboard/components/event-layout.test.ts
+++ b/applications/web/tests/features/dashboard/components/event-layout.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from "vitest";
 import type { CalendarEvent } from "../../../../src/hooks/use-events";
 import {
+  bucketEventsByDay,
   layoutDayEvents,
   MIN_EVENT_SPAN_MS,
   stackIndentPx,
   tileBox,
 } from "../../../../src/features/dashboard/components/event-layout";
-import type { PositionedEvent } from "../../../../src/features/dashboard/components/event-layout";
+import type {
+  DayEvents,
+  PositionedEvent,
+} from "../../../../src/features/dashboard/components/event-layout";
 
 const MS_PER_DAY = 86_400_000;
 
@@ -25,6 +29,11 @@ const timedEvent = (id: string, startTime: Date, endTime: Date): CalendarEvent =
   calendarName: "Calendar",
   calendarProvider: "google",
   calendarUrl: "https://calendar.example",
+});
+
+const allDayEvent = (id: string, startIso: string, endIso: string): CalendarEvent => ({
+  ...timedEvent(id, new Date(startIso), new Date(endIso)),
+  isAllDay: true,
 });
 
 const byId = (layout: PositionedEvent[]): Record<string, PositionedEvent> =>
@@ -240,5 +249,90 @@ describe("tileBox", () => {
 
   it("widens a spanning card across its columns", () => {
     expect(tileBox(0, 2, 2)).toEqual({ left: 0, width: 1 });
+  });
+});
+
+describe("bucketEventsByDay", () => {
+  // A Sunday-to-Sunday window, so day-of-month doubles as the day key.
+  const rangeStart = new Date(2026, 0, 4);
+  const rangeEnd = new Date(2026, 0, 11);
+
+  const daysHolding = (buckets: Map<number, DayEvents>, id: string, kind: keyof DayEvents): number[] =>
+    [...buckets.entries()]
+      .filter(([, bucket]) => bucket[kind].some((event) => event.id === id))
+      .map(([key]) => new Date(key).getDate())
+      .sort((first, second) => first - second);
+
+  it("keys a single-day event under its local midnight", () => {
+    const buckets = bucketEventsByDay([timedEvent("meeting", at(9), at(10))], rangeStart, rangeEnd);
+
+    expect([...buckets.keys()]).toEqual([new Date(2026, 0, 5).getTime()]);
+    expect(buckets.get(day.getTime())?.timed.map((event) => event.id)).toEqual(["meeting"]);
+    expect(buckets.get(day.getTime())?.allDay).toEqual([]);
+  });
+
+  it("spreads a multi-day event over every day it overlaps", () => {
+    const buckets = bucketEventsByDay(
+      [timedEvent("trip", at(22), new Date(2026, 0, 7, 2))],
+      rangeStart,
+      rangeEnd,
+    );
+
+    expect(daysHolding(buckets, "trip", "timed")).toEqual([5, 6, 7]);
+  });
+
+  it("keeps an event ending at midnight on the day it ends", () => {
+    const buckets = bucketEventsByDay(
+      [timedEvent("late", at(22), new Date(2026, 0, 6, 0))],
+      rangeStart,
+      rangeEnd,
+    );
+
+    expect(daysHolding(buckets, "late", "timed")).toEqual([5]);
+  });
+
+  it("lands a zero-length event on its start day", () => {
+    const buckets = bucketEventsByDay([timedEvent("ping", at(9), at(9))], rangeStart, rangeEnd);
+
+    expect(daysHolding(buckets, "ping", "timed")).toEqual([5]);
+  });
+
+  it("only visits days inside the window", () => {
+    const buckets = bucketEventsByDay(
+      [
+        timedEvent("long", new Date(2026, 0, 3, 22), new Date(2026, 0, 12, 2)),
+        timedEvent("before", new Date(2026, 0, 3, 22), new Date(2026, 0, 4, 0)),
+      ],
+      rangeStart,
+      rangeEnd,
+    );
+
+    expect(daysHolding(buckets, "long", "timed")).toEqual([4, 5, 6, 7, 8, 9, 10]);
+    expect(daysHolding(buckets, "before", "timed")).toEqual([]);
+  });
+
+  it("places an all-day event on its calendar days in any zone", () => {
+    const buckets = bucketEventsByDay(
+      [
+        allDayEvent("holiday", "2026-01-05T00:00:00.000Z", "2026-01-06T00:00:00.000Z"),
+        allDayEvent("offsite", "2026-01-07T00:00:00.000Z", "2026-01-10T00:00:00.000Z"),
+      ],
+      rangeStart,
+      rangeEnd,
+    );
+
+    expect(daysHolding(buckets, "holiday", "allDay")).toEqual([5]);
+    expect(daysHolding(buckets, "offsite", "allDay")).toEqual([7, 8, 9]);
+    expect(daysHolding(buckets, "holiday", "timed")).toEqual([]);
+  });
+
+  it("clamps an all-day span to the window", () => {
+    const buckets = bucketEventsByDay(
+      [allDayEvent("fortnight", "2026-01-01T00:00:00.000Z", "2026-01-15T00:00:00.000Z")],
+      rangeStart,
+      rangeEnd,
+    );
+
+    expect(daysHolding(buckets, "fortnight", "allDay")).toEqual([4, 5, 6, 7, 8, 9, 10]);
   });
 });

--- a/applications/web/tests/features/dashboard/components/event-layout.test.ts
+++ b/applications/web/tests/features/dashboard/components/event-layout.test.ts
@@ -87,9 +87,7 @@ describe("layoutDayEvents geometry", () => {
   });
 
   it("positions by the wall clock on a daylight-saving day", () => {
-    // US clocks spring forward on 2026-03-08; noon must still sit halfway
-    // down the day, not 11/23 of the way (passes in any zone, pins the
-    // behaviour where the day is 23 hours long).
+    // US clocks spring forward on 2026-03-08; noon must sit halfway down the day, not 11/23 of the way.
     const dstDay = new Date(2026, 2, 8);
     const [item] = layoutDayEvents(
       [timedEvent("noon", new Date(2026, 2, 8, 12), new Date(2026, 2, 8, 13))],

--- a/applications/web/tests/lib/time.test.ts
+++ b/applications/web/tests/lib/time.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { formatTimeRange } from "../../src/lib/time";
+
+const at = (hour: number, minute = 0): Date => new Date(2026, 0, 5, hour, minute);
+
+describe("formatTimeRange", () => {
+  it("drops the start's period when both ends share it", () => {
+    expect(formatTimeRange(at(9), at(10))).toBe("9:00 – 10:00 AM");
+  });
+
+  it("keeps both periods when the range crosses noon", () => {
+    expect(formatTimeRange(at(11, 30), at(13))).toBe("11:30 AM – 1:00 PM");
+  });
+
+  it("labels noon as 12 PM", () => {
+    expect(formatTimeRange(at(12), at(12, 30))).toBe("12:00 – 12:30 PM");
+  });
+
+  it("keeps both periods when the range ends at midnight", () => {
+    expect(formatTimeRange(at(22), new Date(2026, 0, 6, 0, 0))).toBe("10:00 PM – 12:00 AM");
+  });
+});

--- a/services/api/src/queries/event-read-model.ts
+++ b/services/api/src/queries/event-read-model.ts
@@ -3,6 +3,7 @@ import {
   overlapsRepresentableTimeWindow,
   parseStoredRecurrenceForMaterialization,
   REPRESENTABLE_RANGE_SLACK_MS,
+  resolveIsAllDayEvent,
   resolveRepresentableTimeRange,
 } from "@keeper.sh/calendar";
 import type { MaterializedSyncableEvent, SyncableEvent } from "@keeper.sh/calendar";
@@ -58,6 +59,7 @@ interface KeeperEventProjection {
   endTime: Date;
   eventStateId: string | null;
   id: string;
+  isAllDay: boolean;
   location: string | null;
   startTime: Date;
   title: string | null;
@@ -169,25 +171,31 @@ const toSyncedProjection = (
     description: occurrence.description ?? null,
     eventStateId,
     id,
+    isAllDay: resolveIsAllDayEvent(occurrence),
     location: occurrence.location ?? null,
     title: occurrence.summary || null,
     ...resolveRepresentableTimeRange(occurrence),
   };
 };
 
-const toUserProjection = (row: UserEventRow): KeeperEventProjection => ({
-  calendarId: row.calendarId,
-  description: row.description,
-  eventStateId: null,
-  id: row.id,
-  location: row.location,
-  title: row.title,
-  ...resolveRepresentableTimeRange({
+const toUserProjection = (row: UserEventRow): KeeperEventProjection => {
+  const timeRange = {
     endTime: row.endTime,
     startTime: row.startTime,
     ...(row.isAllDay !== null && { isAllDay: row.isAllDay }),
-  }),
-});
+  };
+
+  return {
+    calendarId: row.calendarId,
+    description: row.description,
+    eventStateId: null,
+    id: row.id,
+    isAllDay: resolveIsAllDayEvent(timeRange),
+    location: row.location,
+    title: row.title,
+    ...resolveRepresentableTimeRange(timeRange),
+  };
+};
 
 const isIncludedByFilters = (
   occurrence: MaterializedSyncableEvent,
@@ -259,6 +267,7 @@ const toKeeperEvent = (
   endTime: event.endTime.toISOString(),
   eventStateId: event.eventStateId,
   id: event.id,
+  isAllDay: event.isAllDay,
   location: event.location,
   startTime: event.startTime.toISOString(),
   title: event.title,

--- a/services/api/src/queries/get-event.ts
+++ b/services/api/src/queries/get-event.ts
@@ -5,7 +5,7 @@ import {
   userEventsTable,
 } from "@keeper.sh/database/schema";
 import { and, eq } from "drizzle-orm";
-import { resolveRepresentableTimeRange } from "@keeper.sh/calendar";
+import { resolveIsAllDayEvent, resolveRepresentableTimeRange } from "@keeper.sh/calendar";
 
 import type { KeeperDatabase, KeeperEvent } from "@/types";
 import {
@@ -138,19 +138,24 @@ const getSeriesRows = (
     );
 };
 
-const toPersistedSyncedProjection = (row: SyncedEventRow): KeeperEventProjection => ({
-  calendarId: row.calendarId,
-  description: row.description,
-  eventStateId: row.id,
-  id: row.id,
-  location: row.location,
-  title: row.title,
-  ...resolveRepresentableTimeRange({
+const toPersistedSyncedProjection = (row: SyncedEventRow): KeeperEventProjection => {
+  const timeRange = {
     endTime: row.endTime,
     startTime: row.startTime,
     ...(row.isAllDay !== null && { isAllDay: row.isAllDay }),
-  }),
-});
+  };
+
+  return {
+    calendarId: row.calendarId,
+    description: row.description,
+    eventStateId: row.id,
+    id: row.id,
+    isAllDay: resolveIsAllDayEvent(timeRange),
+    location: row.location,
+    title: row.title,
+    ...resolveRepresentableTimeRange(timeRange),
+  };
+};
 
 const resolveEventReadModel = async (
   repository: EventReadRepository,

--- a/services/api/src/types.ts
+++ b/services/api/src/types.ts
@@ -40,6 +40,8 @@ interface KeeperEvent {
   eventStateId: string | null;
   startTime: string;
   endTime: string;
+  /** Whole-day event: `startTime`/`endTime` are the UTC-midnight day bounds. */
+  isAllDay: boolean;
   title: string | null;
   description: string | null;
   location: string | null;

--- a/services/api/tests/queries/get-event.test.ts
+++ b/services/api/tests/queries/get-event.test.ts
@@ -174,6 +174,7 @@ describe("resolveEventReadModel", () => {
       endTime: "2026-03-02T11:00:00.000Z",
       eventStateId: null,
       id: USER_EVENT_ID,
+      isAllDay: false,
       location: null,
       startTime: "2026-03-02T10:00:00.000Z",
       title: "User event",

--- a/services/api/tests/queries/get-events-in-range.test.ts
+++ b/services/api/tests/queries/get-events-in-range.test.ts
@@ -156,6 +156,13 @@ describe("flattenSyncedEvents", () => {
     expect(flatten({ availability: ["free"] }).map((event) => event.title)).toEqual(["Override"]);
   });
 
+  it("projects whether each event is all-day", () => {
+    expect(flatten().map((event) => ({ isAllDay: event.isAllDay, title: event.title }))).toEqual([
+      { isAllDay: false, title: "Master" },
+      { isAllDay: true, title: "Override" },
+    ]);
+  });
+
   it("reconciles detached overrides before applying all-day filters", () => {
     expect(flatten({ isAllDay: false }).map((event) => event.title)).toEqual(["Master"]);
     expect(flatten({ isAllDay: true }).map((event) => event.title)).toEqual(["Override"]);


### PR DESCRIPTION
## Summary

Events now render in the dashboard's calendar pane, in the same card style as the `/dashboard/events` page, with stacking and height-responsive content modelled on qali's week view.

- **Shared event card** — `EventCard` moves out of the events route into `features/dashboard/components/event-card.tsx` with a `list` layout (events page, unchanged) and a `grid` layout for the calendar.
- **Week grid** — each day is a memoised `DayColumn` that lays out its events by day fraction. Overlapping events cascade (indent right, later start paints on top) and tile into equal columns when two start within 45 min (`event-layout.ts`, ported from qali). Positions come from the local wall clock, so DST days keep noon on the noon rule.
- **Height-adaptive cards** — the grid card is a CSS size container; `event-compact/short/roomy/tall` custom variants step the content down with the card's height (title only at 15–30 min, time + title at 1 h, description from 75 min), plus `event-narrow` for tiles too thin for a time range.
- **Data** — `useEventsInRange` with a week-quantised window (`getWeekFetchRange`), so scrolling inside it never refetches and a page in either direction stays covered by the previous window; `bucketEventsByDay` groups the window's events by local day.
- **All-day events** — `feat(api)` exposes `isAllDay` on the event response; the web keeps all-day events out of the time grid and shows them as pills in a band under the day row (0–2 rows, "+N more").
- **Month view** — day cells list pills (all-day first) in as many rows as fit, folding the rest into "+N more".
- **Scroll sync** — column rules are painted on the day cells and the header's day row follows the grid through a CSS scroll timeline (with the `scrollLeft` mirror as a fallback), so cards, rules and day labels move as one during a swipe.
- **Opaque fills** — the dark-mode event background mixes against the page colour instead of transparent; past cards dim their content rather than the element, on a muted fill, so stacks stay legible.

## Verification

- Per commit: `bun run lint`, `bun run types`, `bun run test` (web: 466 tests, incl. layout, bucketing, fetch-window and time-format suites; api: 702) and `bun run unused` (knip) at the root.
- Live on `/dashboard`: cards sit on their hour rules; bands resolve on real durations; overlaps cascade/tile; all-day events appear only in the band; one `/api/events` request per window, none while scrolling inside it; month switch fetches exactly the 42 grid days; header row translate equals `-scrollLeft` to the sub-pixel at multiple offsets.

## Before/After

| Before | After |
|:---:|:---:|
| <img width="420" alt="events as plain rows" src="https://github.com/user-attachments/assets/b68c07e0-e936-4d65-b184-0407f550cd18" /> | <img width="420" alt="events as cards" src="https://github.com/user-attachments/assets/3939e09a-6563-47cc-a6b9-c92418da5e69" /> |
<img width="1550" height="968" alt="image" src="https://github.com/user-attachments/assets/69b5fac9-5978-48b7-b095-d1759559ae0a" />


## Notes

- Scroll-timeline fallback (engines without `animation-timeline`) is the previous `scrollLeft` mirror and wasn't exercised here.
- Column rules no longer run through a vertical overscroll bounce (they end at the content edge, under the existing edge fade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
