### PR TITLE
fix(caldav): never resolve a create conflict by deleting a stranger's event

### DIFF
--- a/packages/calendar/src/providers/caldav/destination/provider.ts
+++ b/packages/calendar/src/providers/caldav/destination/provider.ts
@@ -120,6 +120,19 @@ const recoverCreateConflict = async (
     return;
   }
 
+  /*
+   * Our object names are derived from the source event, so two customers mirroring the same event
+   * into one shared calendar land on the same href. The object already standing there is only ours
+   * to replace if it says so: anything else is somebody else's event, and deleting it to make room
+   * destroys a copy we were never asked to manage. Failing here costs us a mirror we could not
+   * write; the alternative costs them the event itself.
+   */
+  if (remoteEvent?.uid !== uid) {
+    throw new Error(
+      `CalDAV object ${uid}.ics carries uid ${remoteEvent?.uid ?? "none"}, so it is not this event's mirror`,
+    );
+  }
+
   if (!existing.etag) {
     throw new Error(`CalDAV event ${uid} already exists but has no ETag for a safe recreation`);
   }

--- a/packages/calendar/src/providers/caldav/destination/provider.ts
+++ b/packages/calendar/src/providers/caldav/destination/provider.ts
@@ -120,13 +120,6 @@ const recoverCreateConflict = async (
     return;
   }
 
-  /*
-   * Our object names are derived from the source event, so two customers mirroring the same event
-   * into one shared calendar land on the same href. The object already standing there is only ours
-   * to replace if it says so: anything else is somebody else's event, and deleting it to make room
-   * destroys a copy we were never asked to manage. Failing here costs us a mirror we could not
-   * write; the alternative costs them the event itself.
-   */
   if (remoteEvent?.uid !== uid) {
     throw new Error(
       `CalDAV object ${uid}.ics carries uid ${remoteEvent?.uid ?? "none"}, so it is not this event's mirror`,

--- a/packages/calendar/tests/providers/caldav/destination/a-create-conflict-never-overwrites-a-stranger.test.ts
+++ b/packages/calendar/tests/providers/caldav/destination/a-create-conflict-never-overwrites-a-stranger.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateDeterministicEventUid } from "../../../../src/core/events/identity";
+import type { MaterializedSyncableEvent } from "../../../../src/core/types";
+import { createCalDAVSyncProvider } from "../../../../src/providers/caldav/destination/provider";
+import { CalDAVCreateConflictError } from "../../../../src/providers/caldav/shared/client";
+import { eventToICalString } from "../../../../src/providers/caldav/shared/ics";
+
+/*
+ * Our object names are deterministic from the source event, so two keeper customers mirroring the
+ * same source event into the same shared calendar derive the same UID and therefore the same href.
+ * The second one's create conflicts, and the recovery then decided what to do about an object it
+ * did not put there. Deleting it and writing ours in its place destroys the first customer's event
+ * and reports conflictResolved. The same fall-through catches an object we merely could not parse.
+ */
+const clientMocks = vi.hoisted(() => ({
+  createCalendarObject: vi.fn(),
+  deleteCalendarObject: vi.fn(),
+  deleteCalendarObjectByUrl: vi.fn(),
+  fetchCalendarObject: vi.fn(),
+  fetchCalendarObjects: vi.fn(),
+  resolveCalendarUrl: vi.fn(),
+}));
+
+vi.mock("../../../../src/providers/caldav/shared/client", () => {
+  class MockCalDAVHttpError extends Error {
+    status: number;
+
+    constructor(response: Response) {
+      super(`CalDAV request failed: ${response.status}`);
+      this.name = "CalDAVHttpError";
+      this.status = response.status;
+    }
+  }
+
+  class MockCalDAVCreateConflictError extends MockCalDAVHttpError {
+    constructor(response: Response) {
+      super(response);
+      this.name = "CalDAVCreateConflictError";
+    }
+  }
+
+  class CalDAVClient {
+    createCalendarObject = clientMocks.createCalendarObject;
+    deleteCalendarObject = clientMocks.deleteCalendarObject;
+    deleteCalendarObjectByUrl = clientMocks.deleteCalendarObjectByUrl;
+    fetchCalendarObject = clientMocks.fetchCalendarObject;
+    fetchCalendarObjects = clientMocks.fetchCalendarObjects;
+    resolveCalendarUrl = clientMocks.resolveCalendarUrl;
+  }
+
+  return {
+    CalDAVClient,
+    CalDAVCreateConflictError: MockCalDAVCreateConflictError,
+    CalDAVHttpError: MockCalDAVHttpError,
+  };
+});
+
+const ourEvent = (): MaterializedSyncableEvent => ({
+  calendarId: "source-calendar-id",
+  calendarName: "Source",
+  calendarUrl: null,
+  endTime: new Date("2026-03-08T15:00:00.000Z"),
+  id: "event-state-id-1",
+  sourceEventUid: "source-event-uid-1",
+  startTime: new Date("2026-03-08T14:00:00.000Z"),
+  summary: "Our meeting",
+});
+
+const strangersEvent = (): MaterializedSyncableEvent => ({
+  calendarId: "someone-elses-calendar",
+  calendarName: "Theirs",
+  calendarUrl: null,
+  endTime: new Date("2026-03-08T15:00:00.000Z"),
+  id: "event-state-id-belonging-to-someone-else",
+  sourceEventUid: "their-source-uid",
+  startTime: new Date("2026-03-08T14:00:00.000Z"),
+  summary: "Their meeting",
+});
+
+const createProvider = () =>
+  createCalDAVSyncProvider({
+    calendarUrl: "https://caldav.example.com/calendar/",
+    password: "pass",
+    serverUrl: "https://caldav.example.com",
+    username: "user",
+  });
+
+const conflictOnCreate = (): void => {
+  clientMocks.createCalendarObject.mockRejectedValueOnce(
+    new CalDAVCreateConflictError(new Response(null, { status: 412 })),
+  );
+};
+
+describe("a create conflict never overwrites a stranger", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clientMocks.resolveCalendarUrl.mockImplementation((url: string) => Promise.resolve(url));
+    clientMocks.createCalendarObject.mockResolvedValue(null);
+    clientMocks.deleteCalendarObject.mockResolvedValue(null);
+  });
+
+  it("does not delete an object carrying a uid that is not this event's", async () => {
+    const theirUid = generateDeterministicEventUid(strangersEvent().id);
+    conflictOnCreate();
+    clientMocks.fetchCalendarObject.mockResolvedValueOnce({
+      data: eventToICalString(strangersEvent(), theirUid),
+      etag: "\"their-etag\"",
+      url: "https://caldav.example.com/calendar/whatever.ics",
+    });
+
+    const [result] = await createProvider().pushEvents([ourEvent()]);
+
+    expect(clientMocks.deleteCalendarObject).not.toHaveBeenCalled();
+    expect(result?.success).toBe(false);
+  });
+
+  it("does not delete an object it could not parse at all", async () => {
+    conflictOnCreate();
+    clientMocks.fetchCalendarObject.mockResolvedValueOnce({
+      data: "this is not a calendar object",
+      etag: "\"unreadable-etag\"",
+      url: "https://caldav.example.com/calendar/whatever.ics",
+    });
+
+    const [result] = await createProvider().pushEvents([ourEvent()]);
+
+    expect(clientMocks.deleteCalendarObject).not.toHaveBeenCalled();
+    expect(result?.success).toBe(false);
+  });
+
+  it("still replaces our own object when its content has drifted", async () => {
+    const ourUid = generateDeterministicEventUid(ourEvent().id);
+    conflictOnCreate();
+    clientMocks.fetchCalendarObject.mockResolvedValueOnce({
+      data: eventToICalString({ ...ourEvent(), summary: "Our meeting, older title" }, ourUid),
+      etag: "\"our-etag\"",
+      url: "https://caldav.example.com/calendar/whatever.ics",
+    });
+
+    const [result] = await createProvider().pushEvents([ourEvent()]);
+
+    expect(clientMocks.deleteCalendarObject).toHaveBeenCalledTimes(1);
+    expect(result?.success).toBe(true);
+    expect(result?.conflictResolved).toBe(true);
+  });
+});

--- a/packages/calendar/tests/providers/caldav/destination/a-create-conflict-never-overwrites-a-stranger.test.ts
+++ b/packages/calendar/tests/providers/caldav/destination/a-create-conflict-never-overwrites-a-stranger.test.ts
@@ -5,13 +5,6 @@ import { createCalDAVSyncProvider } from "../../../../src/providers/caldav/desti
 import { CalDAVCreateConflictError } from "../../../../src/providers/caldav/shared/client";
 import { eventToICalString } from "../../../../src/providers/caldav/shared/ics";
 
-/*
- * Our object names are deterministic from the source event, so two keeper customers mirroring the
- * same source event into the same shared calendar derive the same UID and therefore the same href.
- * The second one's create conflicts, and the recovery then decided what to do about an object it
- * did not put there. Deleting it and writing ours in its place destroys the first customer's event
- * and reports conflictResolved. The same fall-through catches an object we merely could not parse.
- */
 const clientMocks = vi.hoisted(() => ({
   createCalendarObject: vi.fn(),
   deleteCalendarObject: vi.fn(),


### PR DESCRIPTION
Our CalDAV object names are derived from the source event, so two customers mirroring the same event into one shared calendar land on the same href. When the second create conflicts, `recoverCreateConflict` fetched whatever was already standing at that href and — unless it was byte-for-byte the mirror we were about to write — **deleted it with its own ETag** and put ours in its place, then returned `conflictResolved: true, success: true`.

On a shared calendar that destroys the other customer's event, and each side does it to the other on every pass. The push reports success either way.

## What changed

The object already there now has to carry this event's uid before anything is removed. Anything else fails the push and leaves both copies alone.

Failing costs us a mirror we could not write, which the next cycle reports and an operator can see. The alternative cost somebody their event, silently, and told us it had worked.

## Why it went unnoticed

This path had **no test at all** — the three files mentioning `CalDAVCreateConflictError` only construct the error, never the recovery. It is unchanged from `main` and independent of the #875 churn work, which is why fourteen rounds of review on that branch never reached it: every round attacked the code that branch changed.

## Verification

Three cases, red-first against `main`:

- an object carrying a uid that is not this event's — **was deleted**, now is not
- an object we could not parse at all — left alone
- our own object whose content has drifted — still replaced, `conflictResolved: true`

Mutation-controlled: removing the guard turns the first case red again.

Workspace gate: `bunx turbo run test lint types --force` → **45/45**.