### PR TITLE
style(web): wrap the calendar in one frame and dissolve the header into it

### DIFF
--- a/applications/web/src/features/dashboard/components/calendar-frame.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-frame.tsx
@@ -7,13 +7,6 @@ interface CalendarFrameProps {
   children: ReactNode;
 }
 
-// Scoped to the column header rather than the whole header, so the fill starts dissolving right below the toolbar in both views.
-const HEADER_SURFACE_FADE = "linear-gradient(to bottom, black, transparent)";
-
-// The frame's 16px radius less its 1px border. View transitions lift named elements into a flat
-// overlay where the frame no longer clips them, so the filled ones have to round their own corners.
-const INNER_RADIUS = 15;
-
 export function CalendarFrame({
   toolbar,
   columnHeader,
@@ -22,34 +15,23 @@ export function CalendarFrame({
 }: CalendarFrameProps) {
   return (
     <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-border-elevated shadow-xs">
-      <header className="shrink-0" style={{ viewTransitionName: "calendar-header" }}>
-        <div
-          className="flex items-center justify-between gap-3 bg-background-elevated px-4 py-3"
-          style={{
-            viewTransitionName: "calendar-toolbar",
-            borderTopLeftRadius: INNER_RADIUS,
-            borderTopRightRadius: INNER_RADIUS,
-          }}
-        >
+      <header className="shrink-0 [view-transition-name:calendar-header]">
+        {/* View transitions lift named elements into a flat overlay where the frame no longer clips them, so the filled ones round their own corners to the frame's radius less its border. */}
+        <div className="flex items-center justify-between gap-3 rounded-t-[calc(var(--radius-2xl)-1px)] bg-background-elevated px-4 py-3 [view-transition-name:calendar-toolbar]">
           {toolbar}
         </div>
-        <div className="relative" style={{ viewTransitionName: "calendar-column-header" }}>
+        <div className="relative [view-transition-name:calendar-column-header]">
+          {/* Scoped to the column header rather than the whole header, so the fill starts dissolving right below the toolbar in both views. */}
           <div
             aria-hidden
-            className="pointer-events-none absolute inset-0 bg-background-elevated"
-            style={{ maskImage: HEADER_SURFACE_FADE, WebkitMaskImage: HEADER_SURFACE_FADE }}
+            className="pointer-events-none absolute inset-0 bg-background-elevated mask-b-from-0%"
           />
           <div className="relative">{columnHeader}</div>
         </div>
       </header>
       <div
-        className="flex min-h-0 flex-1 flex-col overflow-hidden"
-        style={{
-          maxHeight: gridMaxHeight,
-          viewTransitionName: "calendar-grid",
-          borderBottomLeftRadius: INNER_RADIUS,
-          borderBottomRightRadius: INNER_RADIUS,
-        }}
+        className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-b-[calc(var(--radius-2xl)-1px)] [view-transition-name:calendar-grid]"
+        style={{ maxHeight: gridMaxHeight }}
       >
         {children}
       </div>

--- a/applications/web/src/features/dashboard/components/calendar-frame.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-frame.tsx
@@ -7,6 +7,9 @@ interface CalendarFrameProps {
   children: ReactNode;
 }
 
+// Scoped to the column header rather than the whole header, so the fill starts dissolving right below the toolbar in both views.
+const HEADER_SURFACE_FADE = "linear-gradient(to bottom, black, transparent)";
+
 export function CalendarFrame({
   toolbar,
   columnHeader,
@@ -14,22 +17,25 @@ export function CalendarFrame({
   children,
 }: CalendarFrameProps) {
   return (
-    <div className="flex h-full min-h-0 w-full flex-col gap-1.5">
-      <header
-        className="flex shrink-0 flex-col overflow-hidden rounded-2xl border border-border-elevated bg-background-elevated shadow-xs"
-        style={{ viewTransitionName: "calendar-header" }}
-      >
+    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-border-elevated shadow-xs">
+      <header className="shrink-0" style={{ viewTransitionName: "calendar-header" }}>
         <div
-          className="flex items-center justify-between gap-3 px-4 py-3"
+          className="flex items-center justify-between gap-3 bg-background-elevated px-4 py-3"
           style={{ viewTransitionName: "calendar-toolbar" }}
         >
           {toolbar}
         </div>
-        <div style={{ viewTransitionName: "calendar-column-header" }}>{columnHeader}</div>
+        <div className="relative" style={{ viewTransitionName: "calendar-column-header" }}>
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 bg-background-elevated"
+            style={{ maskImage: HEADER_SURFACE_FADE, WebkitMaskImage: HEADER_SURFACE_FADE }}
+          />
+          <div className="relative">{columnHeader}</div>
+        </div>
       </header>
-      {/* `mx-px` insets the grid by the header card's border so their columns line up. */}
       <div
-        className="mx-px flex min-h-0 flex-1 flex-col overflow-hidden"
+        className="flex min-h-0 flex-1 flex-col overflow-hidden"
         style={{ maxHeight: gridMaxHeight, viewTransitionName: "calendar-grid" }}
       >
         {children}

--- a/applications/web/src/features/dashboard/components/calendar-frame.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-frame.tsx
@@ -10,6 +10,10 @@ interface CalendarFrameProps {
 // Scoped to the column header rather than the whole header, so the fill starts dissolving right below the toolbar in both views.
 const HEADER_SURFACE_FADE = "linear-gradient(to bottom, black, transparent)";
 
+// The frame's 16px radius less its 1px border. View transitions lift named elements into a flat
+// overlay where the frame no longer clips them, so the filled ones have to round their own corners.
+const INNER_RADIUS = 15;
+
 export function CalendarFrame({
   toolbar,
   columnHeader,
@@ -21,7 +25,11 @@ export function CalendarFrame({
       <header className="shrink-0" style={{ viewTransitionName: "calendar-header" }}>
         <div
           className="flex items-center justify-between gap-3 bg-background-elevated px-4 py-3"
-          style={{ viewTransitionName: "calendar-toolbar" }}
+          style={{
+            viewTransitionName: "calendar-toolbar",
+            borderTopLeftRadius: INNER_RADIUS,
+            borderTopRightRadius: INNER_RADIUS,
+          }}
         >
           {toolbar}
         </div>
@@ -36,7 +44,12 @@ export function CalendarFrame({
       </header>
       <div
         className="flex min-h-0 flex-1 flex-col overflow-hidden"
-        style={{ maxHeight: gridMaxHeight, viewTransitionName: "calendar-grid" }}
+        style={{
+          maxHeight: gridMaxHeight,
+          viewTransitionName: "calendar-grid",
+          borderBottomLeftRadius: INNER_RADIUS,
+          borderBottomRightRadius: INNER_RADIUS,
+        }}
       >
         {children}
       </div>

--- a/applications/web/src/features/dashboard/components/month-grid.tsx
+++ b/applications/web/src/features/dashboard/components/month-grid.tsx
@@ -14,8 +14,6 @@ import type { DayEvents } from "./event-layout";
 const COLUMNS = 7;
 const ROWS = 6;
 
-const EDGE_FADE_SIZE = 24;
-
 // Cell rules on their own layer behind the cells, so they can fade at the edges without touching the day numbers.
 const CELL_RULES: CSSProperties = {
   backgroundImage: [
@@ -24,19 +22,6 @@ const CELL_RULES: CSSProperties = {
   ].join(", "),
   backgroundSize: `calc(100% / ${COLUMNS}) 100%, 100% calc(100% / ${ROWS})`,
   backgroundRepeat: "repeat-x, repeat-y",
-};
-
-// Vertical fades at the bottom only; a top fade would wash out the band the header dissolves into.
-const EDGE_FADE = [
-  `linear-gradient(to bottom, black calc(100% - ${EDGE_FADE_SIZE}px), transparent)`,
-  `linear-gradient(to right, transparent, black ${EDGE_FADE_SIZE}px, black calc(100% - ${EDGE_FADE_SIZE}px), transparent)`,
-].join(", ");
-const RULE_LAYER_STYLE: CSSProperties = {
-  ...CELL_RULES,
-  maskImage: EDGE_FADE,
-  WebkitMaskImage: EDGE_FADE,
-  maskComposite: "intersect",
-  WebkitMaskComposite: "source-in",
 };
 
 interface MonthGridProps {
@@ -84,7 +69,12 @@ export function MonthGrid({ anchor, days, eventsByDay, toolbar }: MonthGridProps
       }
     >
       <div className="relative min-h-0 flex-1">
-        <div aria-hidden className="pointer-events-none absolute inset-0" style={RULE_LAYER_STYLE} />
+        {/* Vertical fade at the bottom only; a top fade would wash out the band the header dissolves into. */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 mask-b-from-[calc(100%-24px)] mask-x-from-[calc(100%-24px)]"
+          style={CELL_RULES}
+        />
         <div className="relative grid h-full grid-cols-7 grid-rows-6">
           {days.map((day, index) => {
             const inMonth = isSameMonth(day, anchor);

--- a/applications/web/src/features/dashboard/components/month-grid.tsx
+++ b/applications/web/src/features/dashboard/components/month-grid.tsx
@@ -26,8 +26,9 @@ const CELL_RULES: CSSProperties = {
   backgroundRepeat: "repeat-x, repeat-y",
 };
 
+// Vertical fades at the bottom only; a top fade would wash out the band the header dissolves into.
 const EDGE_FADE = [
-  `linear-gradient(to bottom, transparent, black ${EDGE_FADE_SIZE}px, black calc(100% - ${EDGE_FADE_SIZE}px), transparent)`,
+  `linear-gradient(to bottom, black calc(100% - ${EDGE_FADE_SIZE}px), transparent)`,
   `linear-gradient(to right, transparent, black ${EDGE_FADE_SIZE}px, black calc(100% - ${EDGE_FADE_SIZE}px), transparent)`,
 ].join(", ");
 const RULE_LAYER_STYLE: CSSProperties = {

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -47,8 +47,8 @@ const HEADER_RULE_FADE = "linear-gradient(to top, black 35%, transparent)";
 
 const GRID_EDGE_FADE_SIZE = 24;
 
-// Vertical only: a horizontal fade would dim the gutter labels and the outermost column.
-const GRID_EDGE_FADE = `linear-gradient(to bottom, transparent, black ${GRID_EDGE_FADE_SIZE}px, black calc(100% - ${GRID_EDGE_FADE_SIZE}px), transparent)`;
+// Bottom only: a horizontal fade would dim the gutter labels and the outermost column, and a top one would wash out the band the header dissolves into.
+const GRID_EDGE_FADE = `linear-gradient(to bottom, black calc(100% - ${GRID_EDGE_FADE_SIZE}px), transparent)`;
 
 interface DayHeaderCellProps {
   day: Date;

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -43,13 +43,6 @@ const MS_PER_DAY = 86_400_000;
 // One stable identity, so the memoised columns don't see a fresh [] each render.
 const NO_EVENTS: CalendarEvent[] = [];
 
-const HEADER_RULE_FADE = "linear-gradient(to top, black 35%, transparent)";
-
-const GRID_EDGE_FADE_SIZE = 24;
-
-// Bottom only: a horizontal fade would dim the gutter labels and the outermost column, and a top one would wash out the band the header dissolves into.
-const GRID_EDGE_FADE = `linear-gradient(to bottom, black calc(100% - ${GRID_EDGE_FADE_SIZE}px), transparent)`;
-
 interface DayHeaderCellProps {
   day: Date;
   isToday: boolean;
@@ -67,10 +60,10 @@ const DayHeaderCell = memo(function DayHeaderCell({
 
   return (
     <div className="relative flex flex-col overflow-hidden">
+      {/* Ramps upward as the header fill evaporates downward, so the rules strengthen across the seam. */}
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-y-0 left-0 w-px bg-border-elevated"
-        style={{ maskImage: HEADER_RULE_FADE, WebkitMaskImage: HEADER_RULE_FADE }}
+        className="pointer-events-none absolute inset-y-0 left-0 w-px bg-border-elevated mask-t-from-35%"
       />
       <div
         className="flex shrink-0 flex-col items-center justify-center gap-1"
@@ -303,15 +296,12 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
       columnHeader={dayRow}
       gridMaxHeight={HOUR_HEIGHT * HOURS.length}
     >
+      {/* Bottom only: a horizontal fade would dim the gutter labels and the outermost column, and a top one would wash out the band the header dissolves into. */}
       <div
         ref={scrollerRef}
         onScroll={handleScroll}
-        className="flex min-h-0 flex-1 items-start snap-x snap-mandatory overflow-auto overscroll-x-none [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-        style={{
-          scrollPaddingLeft: GUTTER_WIDTH,
-          maskImage: GRID_EDGE_FADE,
-          WebkitMaskImage: GRID_EDGE_FADE,
-        }}
+        className="flex min-h-0 flex-1 items-start snap-x snap-mandatory overflow-auto overscroll-x-none mask-b-from-[calc(100%-24px)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        style={{ scrollPaddingLeft: GUTTER_WIDTH }}
       >
         <div
           className="sticky left-0 z-30 shrink-0 bg-background"


### PR DESCRIPTION
Stacked on #938 — please merge that first.

## Why

On `/dashboard` the calendar pane reads as two unrelated components stacked on each other, and the cause is a grammar inversion between the two panes:

- **Sidebar** — flat header (`SyncStatus`, `EventGraph` sit directly on `bg-background`, no border) above a `gap-1.5` stack of `rounded-2xl` elevated cards.
- **Calendar pane** — the inverse: a `rounded-2xl` elevated *card* header floating 6px above a *bare*, edge-faded grid.

So the header was the only carded header in the app, sitting on the only bare body. The `gap-1.5` and the grid's `mx-px` border compensation were patches over that seam rather than fixes for it.

## What changed

One border now wraps the entire calendar, and inside it the toolbar band is lifted on `bg-background-elevated` and dissolves downward into the page-colored grid. The outline stops belonging to the header and starts belonging to the calendar.

- `calendar-frame.tsx` — border/rounding/shadow move from the `<header>` to the outer container, which stays transparent so its interior inherits `bg-background` and matches the sticky hour gutter. The toolbar row takes `bg-background-elevated`; the column-header row gets an `aria-hidden` masked fill layer behind it.
- `week-grid.tsx` / `month-grid.tsx` — the grids' vertical edge ramp becomes bottom-only.

Two decisions worth flagging for review:

**The fade is scoped to the column-header element, not to a percentage of the header.** The week strip's column header is `HEADER_HEIGHT + bandHeight` (it grows with the all-day band added in #938); the month grid's is unsized, ~30px. A percentage stop would land mid-toolbar in one view and below it in the other. Scoping it to the column-header row makes "dissolve from just under the toolbar" true in both, with no constant to keep in sync, and it stretches with the all-day band on its own. All-day pills render in the `relative` layer above the fill, so they stay fully opaque.

**Both grids fade at the bottom only.** Left as they were, the grid would wash *in* over its top 24px exactly where the header dissolves *out*, giving a pale dead band at the merge point. The day header's column-rule fade is deliberately untouched — its upward ramp runs opposite to the new surface fade over the same band, so the column rules strengthen as the fill evaporates. That counter-motion is the effect.

`mx-px` is gone: it existed only to compensate for the header card's own 1px border, and header and grid now share one content box inside a single border.

## Verified

`bun run types` and `bun run lint` pass. Checked live in both themes and both views, signed in with events loaded.

- **Dark, week view** — one outline encloses the calendar; the toolbar band reads as lifted and dissolves cleanly through the day header into the grid. Column rules stay continuous and aligned across the seam on all seven columns, so dropping `mx-px` did not shift them. The rules strengthen as the fill evaporates, which is the intended counter-motion.
- **Light, week and month view** — frame, rules, bottom-edge fade, month grid's horizontal edge ramp and the emerald today pill all correct.
- **All-day band** — on a week with all-day events the column header grows 56px → 78px and the fade stretches with it; pills render at full opacity above the dissolving fill, as intended.
- **Week↔month toggle** — switches cleanly in both directions with no layout break at the frame.
- **Computed styles confirm the wiring** — frame `background: transparent` with a `1px` border at `16px` radius, the toolbar on the elevated fill at a `15px` top radius, and the fill layer masked with `linear-gradient(rgb(0,0,0) 0%, rgba(0,0,0,0) 100%)` under `mask-composite: intersect`.



## Follow-up: these styles are now Tailwind, not inline

Review asked why any of this was written as inline `style={{}}` when the app is Tailwind-first (4 arbitrary-property usages in the whole codebase, and no `mask-*` utilities anywhere). There was no reason: `tailwindcss@4.2.1` was already the pinned version when the first mask constant was written, and its edge-mask utilities shipped in 4.1.

Every mask, the inner radius and the four `view-transition-name`s now use utilities. Each substitution was checked against the compiled CSS and against `getComputedStyle` on the live components:

| was | now |
| --- | --- |
| `linear-gradient(to bottom, black, transparent)` | `mask-b-from-0%` |
| `linear-gradient(to bottom, black calc(100% - 24px), transparent)` | `mask-b-from-[calc(100%-24px)]` |
| `linear-gradient(to top, black 35%, transparent)` | `mask-t-from-35%` |
| the month grid's horizontal edge ramp | `mask-x-from-[calc(100%-24px)]` |
| `borderTop/BottomRadius: 15` | `rounded-t-`/`rounded-b-[calc(var(--radius-2xl)-1px)]` |
| `viewTransitionName: "calendar-header"` | `[view-transition-name:calendar-header]` |

Two of these were worse as inline styles rather than merely different:

- `INNER_RADIUS = 15` was a magic number whose documented derivation from the frame's own radius was not enforced — change `rounded-2xl` and it goes quietly stale. `calc(var(--radius-2xl) - 1px)` keeps the derivation live, and still computes to `15px`.
- Each mask was written twice for `-webkit-`, and the month grid also hand-set `maskComposite: "intersect"` alongside the legacy `WebkitMaskComposite: "source-in"`. Tailwind emits `mask-composite: intersect` for free; there is no browserslist here and Vite's baseline target is Safari 16, while unprefixed `mask-image` landed in 15.4. Zero `-webkit-` mask properties remain on the rendered tree.

`maxHeight`, the week grid's `GUTTER_WIDTH`/`HEADER_HEIGHT` geometry and the month grid's `CELL_RULES` stay inline — the first is a runtime prop and the rest are read by JS for scroll and layout math.

Net −39 lines. `bun run types`, `bun run lint` and all 468 tests pass. Verified visually against a session-free harness rendering the real `WeekGrid` and `MonthGrid`: the frame, the header dissolve, the bottom-only fades, the month grid's horizontal ramp and the week↔month transition all render as before, with the corners staying rounded mid-transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
