### PR TITLE
fix(web): keep homepage Latest on busy-block how-tos

### DIFF
--- a/applications/web/src/lib/article-library.ts
+++ b/applications/web/src/lib/article-library.ts
@@ -1,6 +1,6 @@
 import { blogPosts, type BlogPost } from "./blog-posts";
 import { comparePages } from "./compare-pages";
-import { selectLatestArticles, type ArticleSummary } from "./related-articles";
+import { selectHomepageLatestArticles, type ArticleSummary } from "./related-articles";
 
 const LATEST_ARTICLE_COUNT = 6;
 
@@ -23,9 +23,7 @@ export const articleLibrary: ArticleSummary[] = [
   ...comparePages.map((comparePage) => toArticleSummary(comparePage, "/compare")),
 ];
 
-const COMPARE_PATH_PREFIX = "/compare/";
-
-export const latestArticles: ArticleSummary[] = selectLatestArticles(
-  articleLibrary.filter((article) => !article.path.startsWith(COMPARE_PATH_PREFIX)),
+export const latestArticles: ArticleSummary[] = selectHomepageLatestArticles(
+  articleLibrary,
   LATEST_ARTICLE_COUNT,
 );

--- a/applications/web/src/lib/related-articles.ts
+++ b/applications/web/src/lib/related-articles.ts
@@ -7,6 +7,7 @@ export interface ArticleSummary {
 }
 
 const RELATED_ARTICLE_COUNT = 3;
+const COMPARE_PATH_PREFIX = "/compare/";
 
 function countSharedTags(tags: string[], otherTags: string[]): number {
   return tags.filter((tag) => otherTags.includes(tag)).length;
@@ -16,11 +17,58 @@ function byRecency(article: ArticleSummary, other: ArticleSummary): number {
   return other.createdAt.localeCompare(article.createdAt);
 }
 
+function pathContains(article: ArticleSummary, fragment: string): boolean {
+  return article.path.toLowerCase().includes(fragment);
+}
+
+function isCompareArticle(article: ArticleSummary): boolean {
+  return article.path.startsWith(COMPARE_PATH_PREFIX);
+}
+
+/* Claude/MCP funnel posts (and any future path with mcp/claude, or mcp tag)
+ * stay off the homepage Latest roll. /docs/mcp is a static page, not a blog
+ * post, so it never enters this picker. */
+function isMcpFunnelArticle(article: ArticleSummary): boolean {
+  return (
+    pathContains(article, "mcp") ||
+    pathContains(article, "claude") ||
+    article.tags.some((tag) => tag.toLowerCase().includes("mcp"))
+  );
+}
+
+function isFastmailArticle(article: ArticleSummary): boolean {
+  return pathContains(article, "fastmail");
+}
+
 export function selectLatestArticles(
   articles: ArticleSummary[],
   count: number,
 ): ArticleSummary[] {
   return [...articles].sort(byRecency).slice(0, count);
+}
+
+export function selectHomepageLatestArticles(
+  articles: ArticleSummary[],
+  count: number,
+): ArticleSummary[] {
+  const eligible = articles.filter(
+    (article) => !isCompareArticle(article) && !isMcpFunnelArticle(article),
+  );
+  const latest = selectLatestArticles(eligible, count);
+
+  if (latest.some(isFastmailArticle)) {
+    return latest;
+  }
+
+  const [newestFastmail] = selectLatestArticles(
+    eligible.filter(isFastmailArticle),
+    1,
+  );
+  if (!newestFastmail) {
+    return latest;
+  }
+
+  return [...latest.slice(0, -1), newestFastmail];
 }
 
 export function selectRelatedArticles(

--- a/applications/web/tests/lib/related-articles.test.ts
+++ b/applications/web/tests/lib/related-articles.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  selectHomepageLatestArticles,
   selectLatestArticles,
   selectRelatedArticles,
   type ArticleSummary,
@@ -34,6 +35,31 @@ const articles: ArticleSummary[] = [
     tags: ["google", "outlook"],
     title: "How To Sync Google Calendar With Outlook",
   },
+];
+
+function summary(path: string, createdAt: string, tags: string[] = []): ArticleSummary {
+  return {
+    blurb: path,
+    createdAt,
+    path,
+    tags,
+    title: path,
+  };
+}
+
+const homepageLibrary: ArticleSummary[] = [
+  summary("/blog/how-to-give-claude-access-to-your-calendar-mcp", "2026-08-20", ["mcp"]),
+  summary("/blog/what-an-ai-agent-can-do-with-your-calendar", "2026-08-19", ["mcp"]),
+  summary("/compare/calendarbridge-alternative", "2026-08-18", ["comparison"]),
+  summary("/blog/how-to-sync-google-calendar-with-outlook", "2026-08-17"),
+  summary("/blog/how-to-sync-icloud-calendar-with-google", "2026-08-16"),
+  summary("/blog/how-to-block-time-on-another-calendar", "2026-08-15"),
+  summary("/blog/how-to-sync-outlook-with-icloud", "2026-08-14"),
+  summary("/blog/how-to-keep-two-calendars-busy", "2026-08-13"),
+  summary("/blog/how-to-sync-google-calendar-with-icloud", "2026-08-12"),
+  summary("/blog/sync-fastmail-calendar-with-google-calendar", "2026-08-11"),
+  summary("/blog/sync-fastmail-calendar-with-outlook", "2026-08-09"),
+  summary("/docs/mcp", "2026-08-21", ["docs"]),
 ];
 
 describe("selectRelatedArticles", () => {
@@ -74,5 +100,85 @@ describe("selectLatestArticles", () => {
       "/compare/onecal-alternative",
     ]);
     expect(articles[0].path).toBe("/compare/calendarbridge-alternative");
+  });
+});
+
+describe("selectHomepageLatestArticles", () => {
+  it("keeps six newest non-MCP blog posts and promotes Fastmail when missing", () => {
+    const latest = selectHomepageLatestArticles(homepageLibrary, 6);
+
+    expect(latest.map((article) => article.path)).toEqual([
+      "/blog/how-to-sync-google-calendar-with-outlook",
+      "/blog/how-to-sync-icloud-calendar-with-google",
+      "/blog/how-to-block-time-on-another-calendar",
+      "/blog/how-to-sync-outlook-with-icloud",
+      "/blog/how-to-keep-two-calendars-busy",
+      "/blog/sync-fastmail-calendar-with-google-calendar",
+    ]);
+  });
+
+  it("keeps MCP funnel posts, compare pages, and /docs/mcp off the roll", () => {
+    const latest = selectHomepageLatestArticles(homepageLibrary, 6);
+    const paths = latest.map((article) => article.path);
+
+    expect(paths).not.toContain("/blog/how-to-give-claude-access-to-your-calendar-mcp");
+    expect(paths).not.toContain("/blog/what-an-ai-agent-can-do-with-your-calendar");
+    expect(paths).not.toContain("/compare/calendarbridge-alternative");
+    expect(paths).not.toContain("/docs/mcp");
+  });
+
+  it("excludes future blog paths that contain mcp or claude", () => {
+    const latest = selectHomepageLatestArticles(
+      [
+        summary("/blog/future-mcp-calendar-guide", "2026-08-22"),
+        summary("/blog/connect-claude-to-your-calendar", "2026-08-21"),
+        summary("/blog/how-to-sync-google-calendar-with-outlook", "2026-08-17"),
+      ],
+      6,
+    );
+
+    expect(latest.map((article) => article.path)).toEqual([
+      "/blog/how-to-sync-google-calendar-with-outlook",
+    ]);
+  });
+
+  it("leaves Fastmail in place when it already ranks in the newest posts", () => {
+    const latest = selectHomepageLatestArticles(
+      [
+        summary("/blog/sync-fastmail-calendar-with-google-calendar", "2026-08-18"),
+        summary("/blog/how-to-sync-google-calendar-with-outlook", "2026-08-17"),
+        summary("/blog/how-to-sync-icloud-calendar-with-google", "2026-08-16"),
+        summary("/blog/older-busy-block-guide", "2026-08-10"),
+      ],
+      3,
+    );
+
+    expect(latest.map((article) => article.path)).toEqual([
+      "/blog/sync-fastmail-calendar-with-google-calendar",
+      "/blog/how-to-sync-google-calendar-with-outlook",
+      "/blog/how-to-sync-icloud-calendar-with-google",
+    ]);
+  });
+
+  it("does not invent a Fastmail post when the library has none", () => {
+    const latest = selectHomepageLatestArticles(
+      [
+        summary("/blog/how-to-sync-google-calendar-with-outlook", "2026-08-17"),
+        summary("/blog/how-to-sync-icloud-calendar-with-google", "2026-08-16"),
+        summary("/blog/how-to-give-claude-access-to-your-calendar-mcp", "2026-08-20", ["mcp"]),
+      ],
+      6,
+    );
+
+    expect(latest.map((article) => article.path)).toEqual([
+      "/blog/how-to-sync-google-calendar-with-outlook",
+      "/blog/how-to-sync-icloud-calendar-with-google",
+    ]);
+  });
+
+  it("does not mutate the library", () => {
+    const originalOrder = homepageLibrary.map((article) => article.path);
+    selectHomepageLatestArticles(homepageLibrary, 6);
+    expect(homepageLibrary.map((article) => article.path)).toEqual(originalOrder);
   });
 });


### PR DESCRIPTION
Homepage Latest content keeps busy-block how-tos, includes Fastmail when present, excludes MCP funnel. Separate from presence-hygiene schema/sitemap PR.