### PR TITLE
fix(web): Keeper.sh presence hygiene

### DIFF
--- a/applications/web/plugins/sitemap.ts
+++ b/applications/web/plugins/sitemap.ts
@@ -4,6 +4,7 @@ import type { Plugin } from "vite";
 import { CONTENT_DIRECTORIES } from "../src/lib/content-paths";
 import { XMLBuilder } from "fast-xml-parser";
 import { parse as parseYaml } from "yaml";
+import { extraSitemapPaths } from "../src/lib/extra-sitemap-paths";
 import { staticPageMetadata } from "../src/lib/page-metadata";
 import {
   assertIndexableRoutesCovered,
@@ -23,6 +24,16 @@ const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 interface SitemapEntry {
   path: string;
   lastmod?: string;
+}
+
+function extraStaticSitemapEntries(root: string): SitemapEntry[] {
+  return extraSitemapPaths.map((path) => {
+    const filePath = join(root, "public", path);
+    if (!existsSync(filePath)) {
+      throw new Error(`Sitemap static file "${path}" is missing from public/.`);
+    }
+    return { path };
+  });
 }
 
 function readStaticEntries(): SitemapEntry[] {
@@ -127,6 +138,7 @@ function buildSitemapXml(entries: SitemapEntry[]): string {
 }
 
 export function sitemapPlugin(): Plugin {
+  let projectRoot: string;
   let blogDir: string;
   let compareDir: string;
   let changelogDir: string;
@@ -140,6 +152,7 @@ export function sitemapPlugin(): Plugin {
     apply: "build",
 
     configResolved(config) {
+      projectRoot = config.root;
       blogDir = resolve(config.root, CONTENT_DIRECTORIES.blog);
       compareDir = resolve(config.root, CONTENT_DIRECTORIES.compare);
       changelogDir = resolve(config.root, CONTENT_DIRECTORIES.changelog);
@@ -192,6 +205,7 @@ export function sitemapPlugin(): Plugin {
         recipesIndexEntry,
         ...recipesEntries,
         ...buildChangelogEntries(changelogDir),
+        ...extraStaticSitemapEntries(projectRoot),
       ];
 
       this.emitFile({

--- a/applications/web/src/lib/extra-sitemap-paths.ts
+++ b/applications/web/src/lib/extra-sitemap-paths.ts
@@ -1,0 +1,6 @@
+/**
+ * Public static files that are not HTML routes. `plugins/sitemap.ts` appends
+ * these after the indexable-route check, so they can ship without a matching
+ * TanStack route or HTML cache entry.
+ */
+export const extraSitemapPaths = ["/llms.txt"] as const;

--- a/applications/web/src/lib/seo.ts
+++ b/applications/web/src/lib/seo.ts
@@ -162,7 +162,7 @@ export function faqPageSchema(
   return {
     "@context": "https://schema.org",
     "@type": "FAQPage",
-    "@id": `${canonicalUrl(path)}/#faqpage`,
+    "@id": entityId(path, "faqpage"),
     mainEntity: questions.map((entry) => ({
       "@type": "Question",
       name: entry.question,
@@ -206,6 +206,20 @@ export function softwareApplicationSchema() {
         description:
           "For more than two calendar accounts, or when you need updates within the minute.",
       },
+      {
+        "@type": "Offer",
+        name: "Pro",
+        price: "45.00",
+        priceCurrency: "USD",
+        priceSpecification: {
+          "@type": "UnitPriceSpecification",
+          price: "45.00",
+          priceCurrency: "USD",
+          billingDuration: "P1Y",
+        },
+        description:
+          "For more than two calendar accounts, or when you need updates within the minute.",
+      },
     ],
     provider: { "@id": `${SITE_URL}/#organization` },
   };
@@ -218,7 +232,7 @@ export function offerCatalogSchema(
   return {
     "@context": "https://schema.org",
     "@type": "OfferCatalog",
-    "@id": `${canonicalUrl(path)}/#offercatalog`,
+    "@id": entityId(path, "offercatalog"),
     name: `${SITE_NAME} Plans`,
     url: canonicalUrl(path),
     itemListElement: offers.map((offer) => ({
@@ -245,7 +259,7 @@ export function faqSchema(
   return {
     "@context": "https://schema.org",
     "@type": "FAQPage",
-    "@id": `${canonicalUrl(path)}/#faq`,
+    "@id": entityId(path, "faq"),
     isPartOf: { "@id": `${SITE_URL}/#website` },
     mainEntity: items.map((item) => {
       const question = item.question.trim();

--- a/applications/web/tests/lib/extra-sitemap-paths.test.ts
+++ b/applications/web/tests/lib/extra-sitemap-paths.test.ts
@@ -1,0 +1,18 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { extraSitemapPaths } from "../../src/lib/extra-sitemap-paths";
+
+const PUBLIC_ROOT = join(import.meta.dirname, "../../public");
+
+describe("extraSitemapPaths", () => {
+  it("includes the live llms.txt file", () => {
+    expect([...extraSitemapPaths]).toEqual(["/llms.txt"]);
+  });
+
+  it("points at files that exist in public/", () => {
+    for (const path of extraSitemapPaths) {
+      expect(existsSync(join(PUBLIC_ROOT, path))).toBe(true);
+    }
+  });
+});

--- a/applications/web/tests/lib/seo.test.ts
+++ b/applications/web/tests/lib/seo.test.ts
@@ -4,11 +4,15 @@ import {
   blogPostingSchema,
   canonicalUrl,
   collectionPageSchema,
+  faqPageSchema,
+  faqSchema,
   jsonLdScript,
+  offerCatalogSchema,
   organizationSchema,
   personSchema,
   seoHead,
   seoMeta,
+  softwareApplicationSchema,
   webPageSchema,
 } from "@/lib/seo";
 
@@ -275,5 +279,87 @@ describe("collectionPageSchema", () => {
     expect(schema.mainEntity.itemListElement[0].url).toBe(
       "https://www.keeper.sh/compare/onecal-alternative",
     );
+  });
+});
+
+describe("faqSchema", () => {
+  const items = [{ question: "Can I cancel?", answer: "Yes." }];
+
+  it("builds a homepage fragment identifier without a double slash", () => {
+    expect(faqSchema("/", items)["@id"]).toBe("https://www.keeper.sh/#faq");
+    expect(faqSchema("", items)["@id"]).toBe("https://www.keeper.sh/#faq");
+  });
+
+  it("keeps the published identifier for nested pages", () => {
+    expect(faqSchema("/pricing", items)["@id"]).toBe("https://www.keeper.sh/pricing/#faq");
+  });
+});
+
+describe("faqPageSchema", () => {
+  const questions = [{ question: "Can I cancel?", answer: "Yes." }];
+
+  it("builds a homepage fragment identifier without a double slash", () => {
+    expect(faqPageSchema("/", questions)["@id"]).toBe("https://www.keeper.sh/#faqpage");
+  });
+
+  it("keeps the published identifier for nested pages", () => {
+    expect(faqPageSchema("/blog/why-keeper", questions)["@id"]).toBe(
+      "https://www.keeper.sh/blog/why-keeper/#faqpage",
+    );
+  });
+});
+
+describe("offerCatalogSchema", () => {
+  it("builds a homepage fragment identifier without a double slash", () => {
+    expect(offerCatalogSchema("/", [])["@id"]).toBe("https://www.keeper.sh/#offercatalog");
+  });
+});
+
+describe("softwareApplicationSchema", () => {
+  it("offers Free, monthly Pro, and annual Pro at $45", () => {
+    const { offers } = softwareApplicationSchema();
+
+    expect(offers).toEqual([
+      {
+        "@type": "Offer",
+        name: "Free",
+        price: "0",
+        priceCurrency: "USD",
+        description:
+          "For keeping two calendar accounts from double-booking each other.",
+      },
+      {
+        "@type": "Offer",
+        name: "Pro",
+        price: "5.00",
+        priceCurrency: "USD",
+        priceSpecification: {
+          "@type": "UnitPriceSpecification",
+          price: "5.00",
+          priceCurrency: "USD",
+          billingDuration: "P1M",
+        },
+        description:
+          "For more than two calendar accounts, or when you need updates within the minute.",
+      },
+      {
+        "@type": "Offer",
+        name: "Pro",
+        price: "45.00",
+        priceCurrency: "USD",
+        priceSpecification: {
+          "@type": "UnitPriceSpecification",
+          price: "45.00",
+          priceCurrency: "USD",
+          billingDuration: "P1Y",
+        },
+        description:
+          "For more than two calendar accounts, or when you need updates within the minute.",
+      },
+    ]);
+  });
+
+  it("does not invent an aggregate rating", () => {
+    expect(softwareApplicationSchema()).not.toHaveProperty("aggregateRating");
   });
 });


### PR DESCRIPTION
## Summary
- Fix FAQPage JSON-LD `@id` on the homepage from `https://www.keeper.sh//#faq` to `https://www.keeper.sh/#faq` (same origin-join bug also fixed for FAQPage and OfferCatalog `@id`s).
- Add an annual SoftwareApplication Offer for Pro at **$45/year USD**, keeping Free $0 and monthly Pro $5. Polar billed name stays **Keeper Pro**. No aggregateRating and no invented ratings or reviews.
- Add `/llms.txt` to sitemap.xml generation as a public static file (not an HTML route). robots.txt and the footer do not already link similar static files, so no new footer/robots copy.

## Test plan
- [x] `applications/web` unit tests for FAQ `@id`s, the three-offer list at $45 not $42, and extra sitemap paths
- [x] `bun run types` in `applications/web`
- [ ] CI checks on this PR