### PR TITLE
fix(web): FAQ JSON-LD slash, Pro $45/year Offer, llms.txt sitemap

### DIFF
--- a/applications/web/plugins/sitemap.ts
+++ b/applications/web/plugins/sitemap.ts
@@ -25,6 +25,9 @@ interface SitemapEntry {
   lastmod?: string;
 }
 
+/** Public static files that are not HTML marketing pages. Kept out of staticPageMetadata so they skip the HTML cache. */
+export const staticAssetSitemapPaths = ["/llms.txt"] as const;
+
 function readStaticEntries(): SitemapEntry[] {
   return staticPageMetadata.map(({ path, updatedAt }) => {
     if (!ISO_DATE_PATTERN.test(updatedAt)) {
@@ -192,6 +195,7 @@ export function sitemapPlugin(): Plugin {
         recipesIndexEntry,
         ...recipesEntries,
         ...buildChangelogEntries(changelogDir),
+        ...staticAssetSitemapPaths.map((path) => ({ path })),
       ];
 
       this.emitFile({

--- a/applications/web/plugins/sitemap.ts
+++ b/applications/web/plugins/sitemap.ts
@@ -10,6 +10,7 @@ import {
   parseIndexableRoutePaths,
 } from "../src/lib/indexable-routes";
 import { processChangelogDirectory } from "../src/lib/changelog-content";
+import { staticAssetSitemapPaths } from "../src/lib/static-asset-sitemap-paths";
 
 const SITE_URL = "https://www.keeper.sh";
 const BLOG_BASE_PATH = "/blog";
@@ -24,9 +25,6 @@ interface SitemapEntry {
   path: string;
   lastmod?: string;
 }
-
-/** Public static files that are not HTML marketing pages. Kept out of staticPageMetadata so they skip the HTML cache. */
-export const staticAssetSitemapPaths = ["/llms.txt"] as const;
 
 function readStaticEntries(): SitemapEntry[] {
   return staticPageMetadata.map(({ path, updatedAt }) => {

--- a/applications/web/src/lib/seo.ts
+++ b/applications/web/src/lib/seo.ts
@@ -162,7 +162,7 @@ export function faqPageSchema(
   return {
     "@context": "https://schema.org",
     "@type": "FAQPage",
-    "@id": `${canonicalUrl(path)}/#faqpage`,
+    "@id": entityId(path, "faqpage"),
     mainEntity: questions.map((entry) => ({
       "@type": "Question",
       name: entry.question,
@@ -206,6 +206,20 @@ export function softwareApplicationSchema() {
         description:
           "For more than two calendar accounts, or when you need updates within the minute.",
       },
+      {
+        "@type": "Offer",
+        name: "Pro",
+        price: "45.00",
+        priceCurrency: "USD",
+        priceSpecification: {
+          "@type": "UnitPriceSpecification",
+          price: "45.00",
+          priceCurrency: "USD",
+          billingDuration: "P1Y",
+        },
+        description:
+          "For more than two calendar accounts, or when you need updates within the minute.",
+      },
     ],
     provider: { "@id": `${SITE_URL}/#organization` },
   };
@@ -218,7 +232,7 @@ export function offerCatalogSchema(
   return {
     "@context": "https://schema.org",
     "@type": "OfferCatalog",
-    "@id": `${canonicalUrl(path)}/#offercatalog`,
+    "@id": entityId(path, "offercatalog"),
     name: `${SITE_NAME} Plans`,
     url: canonicalUrl(path),
     itemListElement: offers.map((offer) => ({
@@ -245,7 +259,7 @@ export function faqSchema(
   return {
     "@context": "https://schema.org",
     "@type": "FAQPage",
-    "@id": `${canonicalUrl(path)}/#faq`,
+    "@id": entityId(path, "faq"),
     isPartOf: { "@id": `${SITE_URL}/#website` },
     mainEntity: items.map((item) => {
       const question = item.question.trim();

--- a/applications/web/src/lib/static-asset-sitemap-paths.ts
+++ b/applications/web/src/lib/static-asset-sitemap-paths.ts
@@ -1,0 +1,5 @@
+/**
+ * Public static files that are not HTML marketing pages. Kept out of
+ * staticPageMetadata / staticPagePaths so they skip the HTML cache.
+ */
+export const staticAssetSitemapPaths = ["/llms.txt"] as const;

--- a/applications/web/tests/lib/seo.test.ts
+++ b/applications/web/tests/lib/seo.test.ts
@@ -4,11 +4,15 @@ import {
   blogPostingSchema,
   canonicalUrl,
   collectionPageSchema,
+  faqPageSchema,
+  faqSchema,
   jsonLdScript,
+  offerCatalogSchema,
   organizationSchema,
   personSchema,
   seoHead,
   seoMeta,
+  softwareApplicationSchema,
   webPageSchema,
 } from "@/lib/seo";
 
@@ -275,5 +279,73 @@ describe("collectionPageSchema", () => {
     expect(schema.mainEntity.itemListElement[0].url).toBe(
       "https://www.keeper.sh/compare/onecal-alternative",
     );
+  });
+});
+
+const FAQ_ITEM = [{ question: "What is this?", answer: "A calendar syncing tool." }];
+
+describe("faqSchema", () => {
+  it("builds a fragment identifier without a double slash", () => {
+    expect(faqSchema("/", FAQ_ITEM)["@id"]).toBe("https://www.keeper.sh/#faq");
+    expect(faqSchema("", FAQ_ITEM)["@id"]).toBe("https://www.keeper.sh/#faq");
+  });
+
+  it("keeps the published identifier for nested pages", () => {
+    expect(faqSchema("/pricing", FAQ_ITEM)["@id"]).toBe("https://www.keeper.sh/pricing/#faq");
+  });
+});
+
+describe("faqPageSchema", () => {
+  it("builds a fragment identifier without a double slash", () => {
+    expect(faqPageSchema("/", FAQ_ITEM)["@id"]).toBe("https://www.keeper.sh/#faqpage");
+    expect(faqPageSchema("", FAQ_ITEM)["@id"]).toBe("https://www.keeper.sh/#faqpage");
+  });
+});
+
+describe("offerCatalogSchema", () => {
+  it("builds a fragment identifier without a double slash", () => {
+    expect(offerCatalogSchema("/", [])["@id"]).toBe("https://www.keeper.sh/#offercatalog");
+    expect(offerCatalogSchema("", [])["@id"]).toBe("https://www.keeper.sh/#offercatalog");
+  });
+});
+
+describe("softwareApplicationSchema", () => {
+  it("offers Free, monthly Pro, and yearly Pro at 45 USD", () => {
+    const { offers } = softwareApplicationSchema();
+
+    expect(offers).toEqual([
+      expect.objectContaining({
+        "@type": "Offer",
+        name: "Free",
+        price: "0",
+        priceCurrency: "USD",
+      }),
+      expect.objectContaining({
+        "@type": "Offer",
+        name: "Pro",
+        price: "5.00",
+        priceCurrency: "USD",
+        priceSpecification: expect.objectContaining({
+          billingDuration: "P1M",
+          price: "5.00",
+          priceCurrency: "USD",
+        }),
+      }),
+      expect.objectContaining({
+        "@type": "Offer",
+        name: "Pro",
+        price: "45.00",
+        priceCurrency: "USD",
+        priceSpecification: expect.objectContaining({
+          billingDuration: "P1Y",
+          price: "45.00",
+          priceCurrency: "USD",
+        }),
+      }),
+    ]);
+  });
+
+  it("does not invent an aggregate rating", () => {
+    expect(softwareApplicationSchema()).not.toHaveProperty("aggregateRating");
   });
 });

--- a/applications/web/tests/lib/static-page-paths.test.ts
+++ b/applications/web/tests/lib/static-page-paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { staticAssetSitemapPaths } from "../../plugins/sitemap";
+import { staticAssetSitemapPaths } from "../../src/lib/static-asset-sitemap-paths";
 import { staticPageMetadata } from "../../src/lib/page-metadata";
 import { staticPagePaths } from "../../src/lib/static-page-paths";
 

--- a/applications/web/tests/lib/static-page-paths.test.ts
+++ b/applications/web/tests/lib/static-page-paths.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { staticAssetSitemapPaths } from "../../plugins/sitemap";
 import { staticPageMetadata } from "../../src/lib/page-metadata";
 import { staticPagePaths } from "../../src/lib/static-page-paths";
 
@@ -11,5 +12,12 @@ describe("staticPagePaths", () => {
 
   it("lists each path once", () => {
     expect(new Set(staticPagePaths).size).toBe(staticPagePaths.length);
+  });
+});
+
+describe("staticAssetSitemapPaths", () => {
+  it("publishes llms.txt in the sitemap without putting it on the HTML cache list", () => {
+    expect([...staticAssetSitemapPaths]).toEqual(["/llms.txt"]);
+    expect(staticPagePaths).not.toContain("/llms.txt");
   });
 });


### PR DESCRIPTION
## Summary
- Fix homepage FAQ JSON-LD `@id` (and the same `canonicalUrl(path)/#fragment` join on FAQPage/OfferCatalog) so it is `https://www.keeper.sh/#faq`, not a double slash.
- Add a SoftwareApplication yearly Pro Offer at $45/year USD beside Free $0 and monthly Pro $5. No aggregateRating.
- Include `/llms.txt` in sitemap generation as a static asset, not as a marketing HTML cache page. robots.txt and the footer do not already link similar static files, so no extra marketing copy there.

## Test plan
- [x] `applications/web` vitest: `tests/lib/seo.test.ts`, `tests/lib/static-page-paths.test.ts`
- [ ] CI on this PR