### PR TITLE
feat(web): open week-grid events in a morphing detail popover

### DIFF
--- a/applications/web/src/components/ui/composites/navigation-menu/navigation-menu-popover.tsx
+++ b/applications/web/src/components/ui/composites/navigation-menu/navigation-menu-popover.tsx
@@ -1,11 +1,10 @@
 import { use, useCallback, useEffect, useRef, useState, type PropsWithChildren, type ReactNode } from "react";
-import { useSetAtom } from "jotai";
 import { AnimatePresence, LazyMotion } from "motion/react";
 import { loadMotionFeatures } from "@/lib/motion-features";
 import * as m from "motion/react-m";
 import ChevronsUpDown from "lucide-react/dist/esm/icons/chevrons-up-down";
 import { cn } from "@/utils/cn";
-import { popoverOverlayAtom } from "@/state/popover-overlay";
+import { useSetPopoverOverlay } from "@/hooks/use-popover-overlay";
 import {
   InsidePopoverContext,
   ItemDisabledContext,
@@ -46,7 +45,7 @@ export function NavigationMenuPopover({
   const [expanded, setExpanded] = useState(false);
   const [present, setPresent] = useState(false);
   const containerRef = useRef<HTMLLIElement>(null);
-  const setOverlay = useSetAtom(popoverOverlayAtom);
+  const setOverlay = useSetPopoverOverlay();
   const variant = use(MenuVariantContext);
 
   const close = useCallback(() => {

--- a/applications/web/src/components/ui/primitives/modal.tsx
+++ b/applications/web/src/components/ui/primitives/modal.tsx
@@ -1,10 +1,9 @@
 import type { PropsWithChildren } from "react";
 import { createContext, use, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { useSetAtom } from "jotai";
 import { Heading3 } from "./heading";
 import { Text } from "./text";
-import { popoverOverlayAtom } from "@/state/popover-overlay";
+import { useSetPopoverOverlay } from "@/hooks/use-popover-overlay";
 
 interface ModalContextValue {
   open: boolean;
@@ -42,7 +41,7 @@ export function Modal({ children, open: controlledOpen, onOpenChange }: ModalPro
 export function ModalContent({ children }: PropsWithChildren) {
   const { open, setOpen } = useModal();
   const contentRef = useRef<HTMLDivElement>(null);
-  const setOverlay = useSetAtom(popoverOverlayAtom);
+  const setOverlay = useSetPopoverOverlay();
 
   useEffect(() => {
     if (!open) return;

--- a/applications/web/src/features/dashboard/components/event-card.styles.ts
+++ b/applications/web/src/features/dashboard/components/event-card.styles.ts
@@ -1,0 +1,10 @@
+import { cn } from "@/utils/cn";
+
+export const EVENT_COLORS = {
+  blue: cn(
+    "[--event-ink:var(--color-blue-900)] [--event-surface:var(--color-blue-100)] [--event-accent:var(--color-blue-500)]",
+    "dark:[--event-ink:var(--color-blue-100)] dark:[--event-surface:color-mix(in_srgb,var(--color-blue-500)_20%,var(--color-background))] dark:[--event-accent:var(--color-blue-400)]",
+  ),
+};
+
+export type EventColor = keyof typeof EVENT_COLORS;

--- a/applications/web/src/features/dashboard/components/event-card.tsx
+++ b/applications/web/src/features/dashboard/components/event-card.tsx
@@ -5,18 +5,11 @@ import { cn } from "@/utils/cn";
 import { Text } from "@/components/ui/primitives/text";
 import { formatTime, formatTimeRange, formatTimeUntil } from "@/lib/time";
 import type { CalendarEvent } from "@/hooks/use-events";
+import { EVENT_COLORS } from "./event-card.styles";
+import type { EventColor } from "./event-card.styles";
 import { EVENT_PILL_HEIGHT_PX } from "./event-layout";
 
 type EventCardLayout = "list" | "grid";
-
-const EVENT_COLORS = {
-  blue: cn(
-    "[--event-ink:var(--color-blue-900)] [--event-surface:var(--color-blue-100)] [--event-accent:var(--color-blue-500)]",
-    "dark:[--event-ink:var(--color-blue-100)] dark:[--event-surface:color-mix(in_srgb,var(--color-blue-500)_20%,var(--color-background))] dark:[--event-accent:var(--color-blue-400)]",
-  ),
-};
-
-type EventColor = keyof typeof EVENT_COLORS;
 
 const eventText = tv({
   base: "tracking-tight",
@@ -42,7 +35,7 @@ type EventTextProps = PropsWithChildren<{
   className?: string;
 }>;
 
-function EventText({ as = "p", size, muted, className, children }: EventTextProps) {
+export function EventText({ as = "p", size, muted, className, children }: EventTextProps) {
   const Element = as;
   return <Element className={eventText({ size, muted, className })}>{children}</Element>;
 }
@@ -88,8 +81,17 @@ export const EventCard = memo(function EventCard({
   const classes = cn(eventCard({ layout, past }), EVENT_COLORS[color]);
 
   if (layout === "grid") {
+    // Clicks are delegated via `data-event-id` in WeekGrid, so the memoised tree never sees a handler.
     return (
-      <div className={classes} style={style}>
+      <button
+        type="button"
+        data-event-id={event.id}
+        className={cn(
+          classes,
+          "cursor-pointer text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        )}
+        style={style}
+      >
         {/* Padding and centring sit on the body: a container's queries never match the container itself. */}
         <div className="flex h-full flex-col py-1 pr-2 pl-3 event-compact:justify-center event-compact:py-0 event-narrow:pr-1 event-narrow:pl-2">
           <EventText
@@ -115,7 +117,7 @@ export const EventCard = memo(function EventCard({
             </EventText>
           )}
         </div>
-      </div>
+      </button>
     );
   }
 

--- a/applications/web/src/features/dashboard/components/event-card.tsx
+++ b/applications/web/src/features/dashboard/components/event-card.tsx
@@ -49,15 +49,49 @@ interface EventCardProps {
   color?: EventColor;
 }
 
+/** Grid card body, shared with the detail popover's ghost so the morph starts pixel-identical. */
+export function EventCardGridBody({ event }: { event: CalendarEvent }) {
+  const title = event.title ?? event.calendarName;
+  // Padding and centring sit on the body: a container's queries never match the container itself.
+  return (
+    <span className="flex h-full flex-col py-1 pr-2 pl-3 event-compact:justify-center event-compact:py-0 event-narrow:pr-1 event-narrow:pl-2">
+      <EventText
+        as="span"
+        size="xs"
+        muted
+        className="truncate tabular-nums event-short:hidden event-narrow:hidden"
+      >
+        {formatTimeRange(event.startTime, event.endTime)}
+      </EventText>
+      <EventText
+        as="span"
+        size="sm"
+        className="truncate font-semibold event-compact:text-xs event-narrow:text-xs"
+      >
+        {title}
+      </EventText>
+      {event.description && (
+        <EventText
+          as="span"
+          size="xs"
+          muted
+          className="hidden event-roomy:line-clamp-1 event-tall:line-clamp-2 event-narrow:hidden"
+        >
+          {event.description}
+        </EventText>
+      )}
+    </span>
+  );
+}
+
 // Grid height bands (48px hour): each floor sits 1px under its content height so rounding never clips glyphs.
 const eventCard = tv({
   base: "overflow-hidden before:absolute before:w-0.5 before:rounded-full before:bg-(--event-accent)",
   variants: {
     layout: {
       list: "relative flex flex-col gap-0.5 rounded-xl py-2.5 pr-3 pl-4 before:inset-y-2 before:left-1.5",
-      // Size containment is grid-only — it would collapse the content-sized list card.
       // The page-colour ring cuts a card out of any card it overlaps.
-      grid: "absolute @container-[size]/event-card min-h-5 rounded-lg ring-1 ring-background before:inset-y-1 before:left-1",
+      grid: "absolute min-h-5 rounded-lg ring-1 ring-background before:inset-y-1 before:left-1",
     },
     // The muted fill stays opaque — card opacity would let a stacked card beneath show through.
     past: {
@@ -86,37 +120,17 @@ export const EventCard = memo(function EventCard({
       <button
         type="button"
         data-event-id={event.id}
+        aria-label={`${title}, ${formatTimeRange(event.startTime, event.endTime)}`}
         className={cn(
           classes,
           "cursor-pointer text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         )}
         style={style}
       >
-        {/* Padding and centring sit on the body: a container's queries never match the container itself. */}
-        <div className="flex h-full flex-col py-1 pr-2 pl-3 event-compact:justify-center event-compact:py-0 event-narrow:pr-1 event-narrow:pl-2">
-          <EventText
-            size="xs"
-            muted
-            className="truncate tabular-nums event-short:hidden event-narrow:hidden"
-          >
-            {formatTimeRange(event.startTime, event.endTime)}
-          </EventText>
-          <EventText
-            size="sm"
-            className="truncate font-semibold event-compact:text-xs event-narrow:text-xs"
-          >
-            {title}
-          </EventText>
-          {event.description && (
-            <EventText
-              size="xs"
-              muted
-              className="hidden event-roomy:line-clamp-1 event-tall:line-clamp-2 event-narrow:hidden"
-            >
-              {event.description}
-            </EventText>
-          )}
-        </div>
+        {/* Size containment sits on an inner span: it's spec-ambiguous on form controls (CSSWG #7947), and it would collapse the content-sized list card. */}
+        <span className="block size-full @container-[size]/event-card">
+          <EventCardGridBody event={event} />
+        </span>
       </button>
     );
   }

--- a/applications/web/src/features/dashboard/components/event-detail-popover.tsx
+++ b/applications/web/src/features/dashboard/components/event-detail-popover.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useAtomValue } from "jotai";
 import { AnimatePresence, LazyMotion } from "motion/react";
 import * as m from "motion/react-m";
 import MapPin from "lucide-react/dist/esm/icons/map-pin";
@@ -7,8 +8,9 @@ import { cn } from "@/utils/cn";
 import { loadMotionFeatures } from "@/lib/motion-features";
 import { ProviderIcon } from "@/components/ui/primitives/provider-icon";
 import { formatDayHeader, formatTimeRange } from "@/lib/time";
-import type { CalendarEvent } from "@/hooks/use-events";
-import { EventText } from "./event-card";
+import { eventDetailAtom } from "@/state/event-detail";
+import type { EventDetailSelection } from "@/state/event-detail";
+import { EventCardGridBody, EventText } from "./event-card";
 import { EVENT_COLORS } from "./event-card.styles";
 
 const PANEL_WIDTH = 320;
@@ -25,53 +27,37 @@ const CONTENT_ANIMATE = { height: "fit-content" as const, filter: "blur(0)", opa
 const CONTENT_EXIT = { height: 0, filter: "blur(4px)", opacity: 0 };
 const DETAIL_MAX_HEIGHT = { maxHeight: "16rem" } as const;
 
-interface AnchorRect {
-  top: number;
-  left: number;
-  width: number;
-  height: number;
-}
-
-interface FrameRect {
-  top: number;
-  left: number;
-  right: number;
-  bottom: number;
-}
-
-export interface EventDetailSelection {
-  event: CalendarEvent;
-  /** Clicked card's rect, viewport coordinates. */
-  anchor: AnchorRect;
-  /** Bounds the panel is nudged to stay within. */
-  frame: FrameRect;
-}
-
 interface EventDetailPopoverProps {
-  selection: EventDetailSelection | null;
   onClose: () => void;
 }
 
-export function EventDetailPopover({ selection, onClose }: EventDetailPopoverProps) {
-  const lastEventIdRef = useRef<string | null>(null);
+export function EventDetailPopover({ onClose }: EventDetailPopoverProps) {
+  const selection = useAtomValue(eventDetailAtom);
+  const lastSelectionRef = useRef<EventDetailSelection | null>(null);
 
   useEffect(() => {
-    if (selection) lastEventIdRef.current = selection.event.id;
+    if (selection) lastSelectionRef.current = selection;
   }, [selection]);
 
   // Portals can't render during SSR; the panel only ever opens from a client click.
   if (typeof document === "undefined") return null;
 
   const restoreFocus = () => {
-    const id = lastEventIdRef.current;
-    if (!id) return;
-    document.querySelector<HTMLElement>(`[data-event-id="${CSS.escape(id)}"]`)?.focus();
+    const last = lastSelectionRef.current;
+    if (!last) return;
+    // A multi-day event renders one card per spanned day; the stored trigger is the one clicked.
+    const target = last.trigger.isConnected
+      ? last.trigger
+      : document.querySelector<HTMLElement>(`[data-event-id="${CSS.escape(last.event.id)}"]`);
+    target?.focus({ preventScroll: true });
   };
 
   return createPortal(
     <LazyMotion features={loadMotionFeatures}>
       <AnimatePresence onExitComplete={restoreFocus}>
-        {selection && <EventDetailPanel selection={selection} onClose={onClose} />}
+        {selection && (
+          <EventDetailPanel key={selection.event.id} selection={selection} onClose={onClose} />
+        )}
       </AnimatePresence>
     </LazyMotion>,
     document.body,
@@ -109,6 +95,11 @@ function EventDetailPanel({ selection, onClose }: EventDetailPanelProps) {
   useEffect(() => {
     const onKeyDown = (keyEvent: KeyboardEvent) => {
       if (keyEvent.key === "Escape") onClose();
+      // No focusable descendants: keep Tab inside the dialog.
+      if (keyEvent.key === "Tab") {
+        keyEvent.preventDefault();
+        panelRef.current?.focus();
+      }
     };
     const onPointerDown = (pointerEvent: PointerEvent) => {
       if (
@@ -127,11 +118,30 @@ function EventDetailPanel({ selection, onClose }: EventDetailPanelProps) {
     };
   }, [onClose]);
 
+  // Any outside scroll or resize stales the captured anchor; close rather than drift.
+  useEffect(() => {
+    const onScroll = (scrollEvent: Event) => {
+      if (
+        scrollEvent.target instanceof Node
+        && panelRef.current?.contains(scrollEvent.target)
+      ) {
+        return;
+      }
+      onClose();
+    };
+    document.addEventListener("scroll", onScroll, true);
+    globalThis.addEventListener("resize", onClose);
+    return () => {
+      document.removeEventListener("scroll", onScroll, true);
+      globalThis.removeEventListener("resize", onClose);
+    };
+  }, [onClose]);
+
   const title = event.title ?? event.calendarName;
 
   return (
     <m.div
-      className="pointer-events-none fixed z-50"
+      className="fixed z-50"
       style={{ top: anchor.top, left: anchor.left }}
       initial={{ x: 0, y: 0 }}
       animate={{ x: nudge.x, y: nudge.y }}
@@ -140,10 +150,11 @@ function EventDetailPanel({ selection, onClose }: EventDetailPanelProps) {
       <m.div
         ref={panelRef}
         role="dialog"
+        aria-modal="true"
         aria-label={title}
         tabIndex={-1}
         className={cn(
-          "pointer-events-auto overflow-hidden rounded-lg bg-(--event-surface) ring-1 ring-background focus-visible:outline-none",
+          "overflow-hidden rounded-lg bg-(--event-surface) ring-1 ring-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           EVENT_COLORS.blue,
         )}
         initial={{ ...SHADOW_HIDDEN, width: anchor.width }}
@@ -156,17 +167,12 @@ function EventDetailPanel({ selection, onClose }: EventDetailPanelProps) {
           animate={GHOST_ANIMATE}
           exit={{ height: anchor.height, filter: "blur(0)", opacity: 1 }}
         >
-          {/* Pixel-matches the card at t=0 so the panel appears to grow out of it. */}
+          {/* The card's own body inside a same-named size container, so the morph starts pixel-identical. */}
           <div
-            className="relative flex flex-col py-1 pr-2 pl-3 before:absolute before:inset-y-1 before:left-1 before:w-0.5 before:rounded-full before:bg-(--event-accent)"
+            className="relative @container-[size]/event-card before:absolute before:inset-y-1 before:left-1 before:w-0.5 before:rounded-full before:bg-(--event-accent)"
             style={{ width: anchor.width, height: anchor.height }}
           >
-            <EventText size="xs" muted className="truncate tabular-nums">
-              {formatTimeRange(event.startTime, event.endTime)}
-            </EventText>
-            <EventText size="sm" className="truncate font-semibold">
-              {title}
-            </EventText>
+            <EventCardGridBody event={event} />
           </div>
         </m.div>
         <m.div

--- a/applications/web/src/features/dashboard/components/event-detail-popover.tsx
+++ b/applications/web/src/features/dashboard/components/event-detail-popover.tsx
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, LazyMotion } from "motion/react";
+import * as m from "motion/react-m";
+import MapPin from "lucide-react/dist/esm/icons/map-pin";
+import { cn } from "@/utils/cn";
+import { loadMotionFeatures } from "@/lib/motion-features";
+import { ProviderIcon } from "@/components/ui/primitives/provider-icon";
+import { formatDayHeader, formatTimeRange } from "@/lib/time";
+import type { CalendarEvent } from "@/hooks/use-events";
+import { EventText } from "./event-card";
+import { EVENT_COLORS } from "./event-card.styles";
+
+const PANEL_WIDTH = 320;
+const FRAME_MARGIN = 8;
+
+// Animation constants mirror NavigationMenuPopoverPanel so both morphs feel identical.
+const SHADOW_HIDDEN = { boxShadow: "0 0 0 0 rgba(0,0,0,0)" } as const;
+const SHADOW_VISIBLE = {
+  boxShadow: "0 20px 25px -5px rgba(0,0,0,0.1), 0 8px 10px -6px rgba(0,0,0,0.1)",
+} as const;
+const GHOST_ANIMATE = { height: 0, filter: "blur(0)", opacity: 0 };
+const CONTENT_INITIAL = { height: 0, filter: "blur(0)", opacity: 0 };
+const CONTENT_ANIMATE = { height: "fit-content" as const, filter: "blur(0)", opacity: 1 };
+const CONTENT_EXIT = { height: 0, filter: "blur(4px)", opacity: 0 };
+const DETAIL_MAX_HEIGHT = { maxHeight: "16rem" } as const;
+
+interface AnchorRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+interface FrameRect {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+}
+
+export interface EventDetailSelection {
+  event: CalendarEvent;
+  /** Clicked card's rect, viewport coordinates. */
+  anchor: AnchorRect;
+  /** Bounds the panel is nudged to stay within. */
+  frame: FrameRect;
+}
+
+interface EventDetailPopoverProps {
+  selection: EventDetailSelection | null;
+  onClose: () => void;
+}
+
+export function EventDetailPopover({ selection, onClose }: EventDetailPopoverProps) {
+  const lastEventIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (selection) lastEventIdRef.current = selection.event.id;
+  }, [selection]);
+
+  // Portals can't render during SSR; the panel only ever opens from a client click.
+  if (typeof document === "undefined") return null;
+
+  const restoreFocus = () => {
+    const id = lastEventIdRef.current;
+    if (!id) return;
+    document.querySelector<HTMLElement>(`[data-event-id="${CSS.escape(id)}"]`)?.focus();
+  };
+
+  return createPortal(
+    <LazyMotion features={loadMotionFeatures}>
+      <AnimatePresence onExitComplete={restoreFocus}>
+        {selection && <EventDetailPanel selection={selection} onClose={onClose} />}
+      </AnimatePresence>
+    </LazyMotion>,
+    document.body,
+  );
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+interface EventDetailPanelProps {
+  selection: EventDetailSelection;
+  onClose: () => void;
+}
+
+function EventDetailPanel({ selection, onClose }: EventDetailPanelProps) {
+  const { event, anchor, frame } = selection;
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [detailHeight, setDetailHeight] = useState(0);
+
+  // Measured via callback ref: the final box is only known once the detail content lays out.
+  const measureDetail = useCallback((node: HTMLDivElement | null) => {
+    if (node) setDetailHeight(node.offsetHeight);
+  }, []);
+
+  const maxLeft = Math.max(frame.right - PANEL_WIDTH - FRAME_MARGIN, frame.left + FRAME_MARGIN);
+  const maxTop = Math.max(frame.bottom - detailHeight - FRAME_MARGIN, frame.top + FRAME_MARGIN);
+  const nudge = {
+    x: clamp(anchor.left, frame.left + FRAME_MARGIN, maxLeft) - anchor.left,
+    y: clamp(anchor.top, frame.top + FRAME_MARGIN, maxTop) - anchor.top,
+  };
+
+  useEffect(() => {
+    panelRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const onKeyDown = (keyEvent: KeyboardEvent) => {
+      if (keyEvent.key === "Escape") onClose();
+    };
+    const onPointerDown = (pointerEvent: PointerEvent) => {
+      if (
+        panelRef.current
+        && pointerEvent.target instanceof Node
+        && !panelRef.current.contains(pointerEvent.target)
+      ) {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("pointerdown", onPointerDown);
+    };
+  }, [onClose]);
+
+  const title = event.title ?? event.calendarName;
+
+  return (
+    <m.div
+      className="pointer-events-none fixed z-50"
+      style={{ top: anchor.top, left: anchor.left }}
+      initial={{ x: 0, y: 0 }}
+      animate={{ x: nudge.x, y: nudge.y }}
+      exit={{ x: 0, y: 0 }}
+    >
+      <m.div
+        ref={panelRef}
+        role="dialog"
+        aria-label={title}
+        tabIndex={-1}
+        className={cn(
+          "pointer-events-auto overflow-hidden rounded-lg bg-(--event-surface) ring-1 ring-background focus-visible:outline-none",
+          EVENT_COLORS.blue,
+        )}
+        initial={{ ...SHADOW_HIDDEN, width: anchor.width }}
+        animate={{ ...SHADOW_VISIBLE, width: PANEL_WIDTH }}
+        exit={{ ...SHADOW_HIDDEN, width: anchor.width }}
+      >
+        <m.div
+          className="flex flex-col justify-end"
+          initial={{ height: anchor.height, filter: "blur(4px)", opacity: 1 }}
+          animate={GHOST_ANIMATE}
+          exit={{ height: anchor.height, filter: "blur(0)", opacity: 1 }}
+        >
+          {/* Pixel-matches the card at t=0 so the panel appears to grow out of it. */}
+          <div
+            className="relative flex flex-col py-1 pr-2 pl-3 before:absolute before:inset-y-1 before:left-1 before:w-0.5 before:rounded-full before:bg-(--event-accent)"
+            style={{ width: anchor.width, height: anchor.height }}
+          >
+            <EventText size="xs" muted className="truncate tabular-nums">
+              {formatTimeRange(event.startTime, event.endTime)}
+            </EventText>
+            <EventText size="sm" className="truncate font-semibold">
+              {title}
+            </EventText>
+          </div>
+        </m.div>
+        <m.div
+          className="overflow-hidden"
+          initial={CONTENT_INITIAL}
+          animate={CONTENT_ANIMATE}
+          exit={CONTENT_EXIT}
+        >
+          <div ref={measureDetail} className="overflow-y-auto" style={{ ...DETAIL_MAX_HEIGHT, width: PANEL_WIDTH }}>
+            <div className="relative flex flex-col gap-1.5 py-3 pr-4 pl-5 before:absolute before:inset-y-3 before:left-2 before:w-0.5 before:rounded-full before:bg-(--event-accent)">
+              <EventText size="sm" className="font-semibold">
+                {title}
+              </EventText>
+              <EventText size="xs" muted className="tabular-nums">
+                {formatDayHeader(event.startTime)} · {formatTimeRange(event.startTime, event.endTime)}
+              </EventText>
+              <div className="flex items-center gap-1.5">
+                <ProviderIcon provider={event.calendarProvider} size={13} />
+                <EventText as="span" size="xs" muted className="truncate">
+                  {event.calendarName}
+                </EventText>
+              </div>
+              {event.location && (
+                <div className="flex items-start gap-1.5">
+                  <MapPin size={13} className="mt-0.5 shrink-0 text-(--event-ink)/70" />
+                  <EventText as="span" size="xs" muted>
+                    {event.location}
+                  </EventText>
+                </div>
+              )}
+              {event.description && (
+                <EventText size="xs" muted className="whitespace-pre-line">
+                  {event.description}
+                </EventText>
+              )}
+            </div>
+          </div>
+        </m.div>
+      </m.div>
+    </m.div>
+  );
+}

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -5,7 +5,8 @@ import { useSetAtom } from "jotai";
 import { scroll } from "motion";
 import { animate } from "motion/mini";
 import { cn } from "@/utils/cn";
-import { popoverOverlayAtom } from "@/state/popover-overlay";
+import { eventDetailAtom } from "@/state/event-detail";
+import { useSetPopoverOverlay } from "@/hooks/use-popover-overlay";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
 import { isEventPast } from "@/lib/time";
 import type { CalendarEvent } from "@/hooks/use-events";
@@ -14,7 +15,6 @@ import { CalendarFrame } from "./calendar-frame";
 import { DayColumn } from "./day-column";
 import { EventPill, EventPillOverflow } from "./event-card";
 import { EventDetailPopover } from "./event-detail-popover";
-import type { EventDetailSelection } from "./event-detail-popover";
 import {
   EVENT_PILL_GAP_PX,
   EVENT_PILL_HEIGHT_PX,
@@ -223,30 +223,43 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
     return () => observer.disconnect();
   }, [scrollToCenter]);
 
-  const [detail, setDetail] = useState<EventDetailSelection | null>(null);
-  const setOverlay = useSetAtom(popoverOverlayAtom);
+  // Write-only: subscribing would reconcile all 742 memoised day cells on every open/close.
+  const setDetail = useSetAtom(eventDetailAtom);
+  const setOverlay = useSetPopoverOverlay();
 
   const closeDetail = useCallback(() => {
     setDetail(null);
     setOverlay(false);
-  }, [setOverlay]);
+  }, [setDetail, setOverlay]);
 
-  useEffect(() => () => setOverlay(false), [setOverlay]);
+  useEffect(
+    () => () => {
+      setDetail(null);
+      setOverlay(false);
+    },
+    [setDetail, setOverlay],
+  );
 
-  // The anchor rect goes stale on resize; the overlay already blocks scrolling while open.
+  // A refetch replaces event objects; swap the fresh one into an open panel.
   useEffect(() => {
-    if (!detail) return;
-    globalThis.addEventListener("resize", closeDetail);
-    return () => globalThis.removeEventListener("resize", closeDetail);
-  }, [detail, closeDetail]);
+    setDetail((prev) => {
+      if (!prev) return prev;
+      for (const day of eventsByDay.values()) {
+        const fresh = day.timed.find((candidate) => candidate.id === prev.event.id);
+        if (fresh) return fresh === prev.event ? prev : { ...prev, event: fresh };
+      }
+      return prev;
+    });
+  }, [eventsByDay, setDetail]);
 
   const handleEventClick = (clickEvent: ReactMouseEvent) => {
     const target = (clickEvent.target as Element).closest<HTMLElement>("[data-event-id]");
     const scroller = scrollerRef.current;
     if (!target || !scroller) return;
+    const id = target.dataset.eventId;
     let event: CalendarEvent | undefined;
     for (const day of eventsByDay.values()) {
-      event = day.timed.find((candidate) => candidate.id === target.dataset.eventId);
+      event = day.timed.find((candidate) => candidate.id === id);
       if (event) break;
     }
     if (!event) return;
@@ -254,7 +267,8 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
     const frameRect = scroller.getBoundingClientRect();
     setDetail({
       event,
-      anchor: { top: rect.top, left: rect.left, width: rect.width, height: rect.height },
+      trigger: target,
+      anchor: rect,
       frame: {
         top: frameRect.top,
         left: frameRect.left + GUTTER_WIDTH,
@@ -386,7 +400,7 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
           })}
         </div>
       </div>
-      <EventDetailPopover selection={detail} onClose={closeDetail} />
+      <EventDetailPopover onClose={closeDetail} />
     </CalendarFrame>
   );
 }

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -1,9 +1,11 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import type { ReactNode } from "react";
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { useRouter } from "@tanstack/react-router";
+import { useSetAtom } from "jotai";
 import { scroll } from "motion";
 import { animate } from "motion/mini";
 import { cn } from "@/utils/cn";
+import { popoverOverlayAtom } from "@/state/popover-overlay";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
 import { isEventPast } from "@/lib/time";
 import type { CalendarEvent } from "@/hooks/use-events";
@@ -11,6 +13,8 @@ import { Text } from "@/components/ui/primitives/text";
 import { CalendarFrame } from "./calendar-frame";
 import { DayColumn } from "./day-column";
 import { EventPill, EventPillOverflow } from "./event-card";
+import { EventDetailPopover } from "./event-detail-popover";
+import type { EventDetailSelection } from "./event-detail-popover";
 import {
   EVENT_PILL_GAP_PX,
   EVENT_PILL_HEIGHT_PX,
@@ -219,6 +223,48 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
     return () => observer.disconnect();
   }, [scrollToCenter]);
 
+  const [detail, setDetail] = useState<EventDetailSelection | null>(null);
+  const setOverlay = useSetAtom(popoverOverlayAtom);
+
+  const closeDetail = useCallback(() => {
+    setDetail(null);
+    setOverlay(false);
+  }, [setOverlay]);
+
+  useEffect(() => () => setOverlay(false), [setOverlay]);
+
+  // The anchor rect goes stale on resize; the overlay already blocks scrolling while open.
+  useEffect(() => {
+    if (!detail) return;
+    globalThis.addEventListener("resize", closeDetail);
+    return () => globalThis.removeEventListener("resize", closeDetail);
+  }, [detail, closeDetail]);
+
+  const handleEventClick = (clickEvent: ReactMouseEvent) => {
+    const target = (clickEvent.target as Element).closest<HTMLElement>("[data-event-id]");
+    const scroller = scrollerRef.current;
+    if (!target || !scroller) return;
+    let event: CalendarEvent | undefined;
+    for (const day of eventsByDay.values()) {
+      event = day.timed.find((candidate) => candidate.id === target.dataset.eventId);
+      if (event) break;
+    }
+    if (!event) return;
+    const rect = target.getBoundingClientRect();
+    const frameRect = scroller.getBoundingClientRect();
+    setDetail({
+      event,
+      anchor: { top: rect.top, left: rect.left, width: rect.width, height: rect.height },
+      frame: {
+        top: frameRect.top,
+        left: frameRect.left + GUTTER_WIDTH,
+        right: frameRect.right,
+        bottom: frameRect.bottom,
+      },
+    });
+    setOverlay(true);
+  };
+
   const handleScroll = () => {
     const scroller = scrollerRef.current;
     if (scroller) scrollTopRef.current = scroller.scrollTop;
@@ -318,6 +364,7 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
           ))}
         </div>
         <div
+          onClick={handleEventClick}
           className="relative grid shrink-0"
           style={{
             gridTemplateColumns: columnsTemplate,
@@ -339,6 +386,7 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
           })}
         </div>
       </div>
+      <EventDetailPopover selection={detail} onClose={closeDetail} />
     </CalendarFrame>
   );
 }

--- a/applications/web/src/hooks/use-events.ts
+++ b/applications/web/src/hooks/use-events.ts
@@ -9,6 +9,7 @@ export interface CalendarEvent {
   eventStateId: string | null;
   title: string | null;
   description: string | null;
+  location: string | null;
   startTime: Date;
   endTime: Date;
   /** Whole-day event: `startTime`/`endTime` are the UTC-midnight day bounds. */
@@ -37,6 +38,7 @@ const fetchEvents = async (url: string): Promise<CalendarEvent[]> => {
     eventStateId: event.eventStateId,
     title: event.title ?? null,
     description: event.description ?? null,
+    location: event.location ?? null,
     startTime: new Date(event.startTime),
     endTime: new Date(event.endTime),
     isAllDay: event.isAllDay,

--- a/applications/web/src/hooks/use-popover-overlay.ts
+++ b/applications/web/src/hooks/use-popover-overlay.ts
@@ -1,0 +1,10 @@
+import { useCallback, useId } from "react";
+import { useSetAtom } from "jotai";
+import { popoverOverlayOwnerAtom } from "@/state/popover-overlay";
+
+/** Drop-in `setOverlay(active)` scoped to this component instance. */
+export function useSetPopoverOverlay() {
+  const owner = useId();
+  const write = useSetAtom(popoverOverlayOwnerAtom);
+  return useCallback((active: boolean) => write(owner, active), [write, owner]);
+}

--- a/applications/web/src/state/event-detail.ts
+++ b/applications/web/src/state/event-detail.ts
@@ -1,0 +1,28 @@
+import { atom } from "jotai";
+import type { CalendarEvent } from "@/hooks/use-events";
+
+interface AnchorRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+interface FrameRect {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+}
+
+export interface EventDetailSelection {
+  event: CalendarEvent;
+  /** The clicked card, for focus restore on close. */
+  trigger: HTMLElement;
+  /** Clicked card's rect, viewport coordinates. */
+  anchor: AnchorRect;
+  /** Bounds the panel is nudged to stay within. */
+  frame: FrameRect;
+}
+
+export const eventDetailAtom = atom<EventDetailSelection | null>(null);

--- a/applications/web/src/state/popover-overlay.ts
+++ b/applications/web/src/state/popover-overlay.ts
@@ -1,3 +1,19 @@
 import { atom } from "jotai";
 
-export const popoverOverlayAtom = atom(false);
+const overlayOwnersAtom = atom<ReadonlySet<string>>(new Set<string>());
+
+/** True while any owner holds the overlay open. */
+export const popoverOverlayAtom = atom((get) => get(overlayOwnersAtom).size > 0);
+
+/** Owner-scoped writes: one popover closing can't drop the blur another still holds. */
+export const popoverOverlayOwnerAtom = atom(
+  null,
+  (get, set, owner: string, active: boolean) => {
+    const owners = get(overlayOwnersAtom);
+    if (owners.has(owner) === active) return;
+    const next = new Set(owners);
+    if (active) next.add(owner);
+    else next.delete(owner);
+    set(overlayOwnersAtom, next);
+  },
+);

--- a/applications/web/src/types/api.ts
+++ b/applications/web/src/types/api.ts
@@ -74,6 +74,7 @@ export interface ApiEvent {
   eventStateId: string | null;
   title: string | null;
   description: string | null;
+  location: string | null;
   startTime: string;
   endTime: string;
   /** Whole-day event: `startTime`/`endTime` are the UTC-midnight day bounds. */

--- a/applications/web/tests/features/dashboard/components/event-layout.test.ts
+++ b/applications/web/tests/features/dashboard/components/event-layout.test.ts
@@ -25,6 +25,7 @@ const timedEvent = (id: string, startTime: Date, endTime: Date): CalendarEvent =
   eventStateId: null,
   title: id,
   description: null,
+  location: null,
   startTime,
   endTime,
   isAllDay: false,


### PR DESCRIPTION
Stacked on #956.

Clicking an event card in the week grid now opens a detail popover using the same animation language as the sidebar navigation menus: the dashboard-wide backdrop blur fades in (via `popoverOverlayAtom`), and the panel grows out of the clicked card in place — a ghost of the card row blurs out and collapses while the detail content expands, reusing the navigation-menu popover's variants verbatim. The panel stays anchored to the card and is only nudged when it would overflow the grid area.

- Week-grid cards become buttons (`data-event-id`); clicks are delegated from the day-columns container so the memoised `EventCard`/`DayColumn` trees stay intact.
- New `EventDetailPopover` portals to `document.body` above the z-10 overlay (the calendar pane's `lg:isolate` keeps everything inside it below the blur) and shows title, day + time range, calendar with provider icon, location, and description.
- `location` is now carried through `ApiEvent` → `CalendarEvent` (the API already returned it; the web layer dropped it).
- `EVENT_COLORS` moved to `event-card.styles.ts` so the popover can share the surface variables without tripping react-refresh.
- Dismissal matches the sidebar: Escape, pointer-down outside, plus close-on-resize since the anchor rect goes stale; focus returns to the originating card on exit.

Month pills and the events list page stay inert by design.

## Preview

<img width="800" height="450" alt="export-1787905786861" src="https://github.com/user-attachments/assets/6ac1c365-3c1a-4803-9c5a-cc295c768747" />


**Verification status**: types, lint, and unit tests pass. Browser verification is still pending a signed-in session — flagging one open question from a scratchpad harness: `AnimatePresence` exit animations there ran but never unmounted (even for a minimal inline `m.div`, the exact sidebar pattern), which points at the harness's Vite dep-optimizer duplicating motion internals rather than at this code, but it should be confirmed against the real dashboard before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)