### PR TITLE
feat(web): run the current-time line across the week grid with a clock pill in the gutter

### DIFF
--- a/applications/web/src/features/dashboard/components/day-column.tsx
+++ b/applications/web/src/features/dashboard/components/day-column.tsx
@@ -17,6 +17,8 @@ const MAX_CARD_ELEVATION = 8;
 
 interface DayColumnProps {
   day: Date;
+  /** Null except on today, so only today's column re-renders on the minute tick. */
+  now: Date | null;
   events: CalendarEvent[];
 }
 
@@ -41,7 +43,7 @@ function resolveCardStyle(item: PositionedEvent): CSSProperties {
   };
 }
 
-export const DayColumn = memo(function DayColumn({ day, events }: DayColumnProps) {
+export const DayColumn = memo(function DayColumn({ day, now, events }: DayColumnProps) {
   const positioned = layoutDayEvents(events, day);
 
   return (
@@ -57,7 +59,7 @@ export const DayColumn = memo(function DayColumn({ day, events }: DayColumnProps
         <EventCard
           key={item.event.id}
           event={item.event}
-          past={isEventPast(item.event.endTime)}
+          past={isEventPast(item.event.endTime, now?.getTime())}
           layout="grid"
           style={resolveCardStyle(item)}
         />

--- a/applications/web/src/features/dashboard/components/day-column.tsx
+++ b/applications/web/src/features/dashboard/components/day-column.tsx
@@ -11,15 +11,12 @@ const CARD_INSET_LEFT_PX = 2;
 const CARD_INSET_RIGHT_PX = 3;
 const CARD_INSET_PX = CARD_INSET_LEFT_PX + CARD_INSET_RIGHT_PX;
 
-// Elevation is capped below the current-time line (z-20) and sticky gutter (z-30); ties paint in DOM order.
+// Elevation is capped below the current-time line (z-20, now-indicator.tsx) and sticky gutter (z-30); ties paint in DOM order.
 const CARD_BASE_Z_INDEX = 1;
 const MAX_CARD_ELEVATION = 8;
 
 interface DayColumnProps {
   day: Date;
-  isToday: boolean;
-  /** Fraction of the day; null except on today, so only today's column re-renders on the minute tick. */
-  nowFraction: number | null;
   events: CalendarEvent[];
 }
 
@@ -44,12 +41,7 @@ function resolveCardStyle(item: PositionedEvent): CSSProperties {
   };
 }
 
-export const DayColumn = memo(function DayColumn({
-  day,
-  isToday,
-  nowFraction,
-  events,
-}: DayColumnProps) {
+export const DayColumn = memo(function DayColumn({ day, events }: DayColumnProps) {
   const positioned = layoutDayEvents(events, day);
 
   return (
@@ -70,12 +62,6 @@ export const DayColumn = memo(function DayColumn({
           style={resolveCardStyle(item)}
         />
       ))}
-      {isToday && nowFraction != null && (
-        <div
-          className="pointer-events-none absolute inset-x-0 z-20 h-0.5 -translate-y-1/2 bg-red-500"
-          style={{ top: `${nowFraction * 100}%` }}
-        />
-      )}
     </div>
   );
 });

--- a/applications/web/src/features/dashboard/components/now-indicator.tsx
+++ b/applications/web/src/features/dashboard/components/now-indicator.tsx
@@ -1,45 +1,42 @@
-import { formatClock } from "@/lib/time";
+import { NOW_PILL_HEIGHT_PX } from "./now-layout";
 import type { NowLayout } from "./now-layout";
 
 interface NowIndicatorProps {
   layout: NowLayout;
-  columnCount: number;
 }
 
-export function NowIndicator({ layout, columnCount }: NowIndicatorProps) {
+export function NowIndicator({ layout }: NowIndicatorProps) {
   return (
     <div
       aria-hidden
       className="pointer-events-none absolute inset-x-0 z-20"
       style={{ top: `${layout.topFraction * 100}%` }}
     >
-      <div className="absolute inset-x-0 h-px -translate-y-1/2 bg-red-400/25" />
-      {layout.todayIndex >= 0 && (
+      <div className="absolute inset-x-0 h-px bg-red-400/25" />
+      {layout.today && (
         <div
           className="absolute h-0.5 -translate-y-1/2 bg-red-400"
-          style={{
-            left: `${(layout.todayIndex / columnCount) * 100}%`,
-            width: `${(1 / columnCount) * 100}%`,
-          }}
+          style={{ left: `${layout.today.left * 100}%`, width: `${layout.today.width * 100}%` }}
         />
       )}
     </div>
   );
 }
 
-interface NowPillProps {
-  now: Date;
-  topFraction: number;
-}
+// Clamped to its own half-height, so the pill isn't cut off at the scroller's top edge around midnight.
+export function NowPill({ layout }: NowIndicatorProps) {
+  const halfHeight = NOW_PILL_HEIGHT_PX / 2;
 
-export function NowPill({ now, topFraction }: NowPillProps) {
   return (
     <span
       aria-hidden
-      className="pointer-events-none absolute right-0 -translate-y-1/2 rounded-full bg-red-400 px-1.5 py-0.5 text-[10px] font-medium leading-none tabular-nums text-neutral-950"
-      style={{ top: `${topFraction * 100}%` }}
+      className="pointer-events-none absolute right-0 flex -translate-y-1/2 items-center rounded-full bg-red-400 px-1.5 text-[10px] font-medium leading-none tabular-nums text-neutral-950"
+      style={{
+        height: NOW_PILL_HEIGHT_PX,
+        top: `clamp(${halfHeight}px, ${layout.topFraction * 100}%, calc(100% - ${halfHeight}px))`,
+      }}
     >
-      {formatClock(now)}
+      {layout.label}
     </span>
   );
 }

--- a/applications/web/src/features/dashboard/components/now-indicator.tsx
+++ b/applications/web/src/features/dashboard/components/now-indicator.tsx
@@ -40,7 +40,6 @@ export function NowPill({ now, topFraction }: NowPillProps) {
       style={{ top: `${topFraction * 100}%` }}
     >
       {formatClock(now)}
-      <span className="absolute top-1/2 left-full h-0.5 w-1.5 -translate-y-1/2 bg-red-400" />
     </span>
   );
 }

--- a/applications/web/src/features/dashboard/components/now-indicator.tsx
+++ b/applications/web/src/features/dashboard/components/now-indicator.tsx
@@ -36,7 +36,7 @@ export function NowPill({ now, topFraction }: NowPillProps) {
   return (
     <span
       aria-hidden
-      className="pointer-events-none absolute right-1.5 -translate-y-1/2 rounded-full bg-red-400 px-1.5 py-0.5 text-[10px] font-medium leading-none tabular-nums text-neutral-950"
+      className="pointer-events-none absolute right-0 -translate-y-1/2 rounded-full bg-red-400 px-1.5 py-0.5 text-[10px] font-medium leading-none tabular-nums text-neutral-950"
       style={{ top: `${topFraction * 100}%` }}
     >
       {formatClock(now)}

--- a/applications/web/src/features/dashboard/components/now-indicator.tsx
+++ b/applications/web/src/features/dashboard/components/now-indicator.tsx
@@ -1,0 +1,46 @@
+import { formatClock } from "@/lib/time";
+import type { NowLayout } from "./now-layout";
+
+interface NowIndicatorProps {
+  layout: NowLayout;
+  columnCount: number;
+}
+
+export function NowIndicator({ layout, columnCount }: NowIndicatorProps) {
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-x-0 z-20"
+      style={{ top: `${layout.topFraction * 100}%` }}
+    >
+      <div className="absolute inset-x-0 h-px -translate-y-1/2 bg-red-500/25" />
+      {layout.todayIndex >= 0 && (
+        <div
+          className="absolute h-0.5 -translate-y-1/2 bg-red-500"
+          style={{
+            left: `${(layout.todayIndex / columnCount) * 100}%`,
+            width: `${(1 / columnCount) * 100}%`,
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+interface NowPillProps {
+  now: Date;
+  topFraction: number;
+}
+
+export function NowPill({ now, topFraction }: NowPillProps) {
+  return (
+    <span
+      aria-hidden
+      className="pointer-events-none absolute right-1.5 -translate-y-1/2 rounded-full bg-red-500 px-1.5 py-0.5 text-[10px] font-semibold leading-none tabular-nums text-white"
+      style={{ top: `${topFraction * 100}%` }}
+    >
+      {formatClock(now)}
+      <span className="absolute top-1/2 left-full h-0.5 w-1.5 -translate-y-1/2 bg-red-500" />
+    </span>
+  );
+}

--- a/applications/web/src/features/dashboard/components/now-indicator.tsx
+++ b/applications/web/src/features/dashboard/components/now-indicator.tsx
@@ -13,10 +13,10 @@ export function NowIndicator({ layout, columnCount }: NowIndicatorProps) {
       className="pointer-events-none absolute inset-x-0 z-20"
       style={{ top: `${layout.topFraction * 100}%` }}
     >
-      <div className="absolute inset-x-0 h-px -translate-y-1/2 bg-red-500/25" />
+      <div className="absolute inset-x-0 h-px -translate-y-1/2 bg-red-400/25" />
       {layout.todayIndex >= 0 && (
         <div
-          className="absolute h-0.5 -translate-y-1/2 bg-red-500"
+          className="absolute h-0.5 -translate-y-1/2 bg-red-400"
           style={{
             left: `${(layout.todayIndex / columnCount) * 100}%`,
             width: `${(1 / columnCount) * 100}%`,
@@ -36,11 +36,11 @@ export function NowPill({ now, topFraction }: NowPillProps) {
   return (
     <span
       aria-hidden
-      className="pointer-events-none absolute right-1.5 -translate-y-1/2 rounded-full bg-red-500 px-1.5 py-0.5 text-[10px] font-semibold leading-none tabular-nums text-white"
+      className="pointer-events-none absolute right-1.5 -translate-y-1/2 rounded-full bg-red-400 px-1.5 py-0.5 text-[10px] font-medium leading-none tabular-nums text-neutral-950"
       style={{ top: `${topFraction * 100}%` }}
     >
       {formatClock(now)}
-      <span className="absolute top-1/2 left-full h-0.5 w-1.5 -translate-y-1/2 bg-red-500" />
+      <span className="absolute top-1/2 left-full h-0.5 w-1.5 -translate-y-1/2 bg-red-400" />
     </span>
   );
 }

--- a/applications/web/src/features/dashboard/components/now-layout.ts
+++ b/applications/web/src/features/dashboard/components/now-layout.ts
@@ -1,12 +1,16 @@
+import { formatClock } from "@/lib/time";
 import { HOUR_HEIGHT, HOURS, isSameDay } from "./calendar-helpers";
 import { timeOfDayFraction } from "./event-layout";
 
-/** Pill half-height plus label half-height: a label the pill would only half-cover is hidden instead. */
-const NOW_PILL_CLEARANCE_PX = 12;
+export const NOW_PILL_HEIGHT_PX = 14;
+const HOUR_LABEL_HEIGHT_PX = 10;
+/** A label the pill would only half-cover is hidden instead. */
+const NOW_PILL_CLEARANCE_PX = (NOW_PILL_HEIGHT_PX + HOUR_LABEL_HEIGHT_PX) / 2;
 
 export interface NowLayout {
+  label: string;
   topFraction: number;
-  todayIndex: number;
+  today: { left: number; width: number } | null;
   coveredHour: number | null;
 }
 
@@ -15,10 +19,12 @@ export function resolveNowLayout(days: Date[], now: Date): NowLayout {
   const hourPosition = topFraction * HOURS.length;
   const nearestHour = Math.round(hourPosition);
   const covered = Math.abs(hourPosition - nearestHour) * HOUR_HEIGHT < NOW_PILL_CLEARANCE_PX;
+  const todayIndex = days.findIndex((day) => isSameDay(day, now));
 
   return {
+    label: formatClock(now),
     topFraction,
-    todayIndex: days.findIndex((day) => isSameDay(day, now)),
+    today: todayIndex === -1 ? null : { left: todayIndex / days.length, width: 1 / days.length },
     coveredHour: covered ? nearestHour : null,
   };
 }

--- a/applications/web/src/features/dashboard/components/now-layout.ts
+++ b/applications/web/src/features/dashboard/components/now-layout.ts
@@ -1,0 +1,24 @@
+import { HOUR_HEIGHT, HOURS, isSameDay } from "./calendar-helpers";
+import { timeOfDayFraction } from "./event-layout";
+
+/** Pill half-height plus label half-height: a label the pill would only half-cover is hidden instead. */
+const NOW_PILL_CLEARANCE_PX = 12;
+
+export interface NowLayout {
+  topFraction: number;
+  todayIndex: number;
+  coveredHour: number | null;
+}
+
+export function resolveNowLayout(days: Date[], now: Date): NowLayout {
+  const topFraction = timeOfDayFraction(now);
+  const hourPosition = topFraction * HOURS.length;
+  const nearestHour = Math.round(hourPosition);
+  const covered = Math.abs(hourPosition - nearestHour) * HOUR_HEIGHT < NOW_PILL_CLEARANCE_PX;
+
+  return {
+    topFraction,
+    todayIndex: days.findIndex((day) => isSameDay(day, now)),
+    coveredHour: covered ? nearestHour : null,
+  };
+}

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -7,6 +7,7 @@ import { animate } from "motion/mini";
 import { cn } from "@/utils/cn";
 import { eventDetailAtom } from "@/state/event-detail";
 import { useSetPopoverOverlay } from "@/hooks/use-popover-overlay";
+import { useNowMinute } from "@/hooks/use-now-minute";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
 import { isEventPast } from "@/lib/time";
 import type { CalendarEvent } from "@/hooks/use-events";
@@ -15,12 +16,9 @@ import { CalendarFrame } from "./calendar-frame";
 import { DayColumn } from "./day-column";
 import { EventPill, EventPillOverflow } from "./event-card";
 import { EventDetailPopover } from "./event-detail-popover";
-import {
-  EVENT_PILL_GAP_PX,
-  EVENT_PILL_HEIGHT_PX,
-  resolveVisiblePillCount,
-  timeOfDayFraction,
-} from "./event-layout";
+import { NowIndicator, NowPill } from "./now-indicator";
+import { resolveNowLayout } from "./now-layout";
+import { EVENT_PILL_GAP_PX, EVENT_PILL_HEIGHT_PX, resolveVisiblePillCount } from "./event-layout";
 import type { DayEvents } from "./event-layout";
 import {
   addDays,
@@ -127,14 +125,8 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
   });
   const columnsTemplate = `repeat(${stripDays.length}, minmax(0, 1fr))`;
 
-  // Client-only so SSR and hydration agree; wall-clock placed so the line holds its hour through DST days.
-  const [nowFraction, setNowFraction] = useState<number | null>(null);
-  useEffect(() => {
-    const update = () => setNowFraction(timeOfDayFraction(new Date()));
-    update();
-    const interval = globalThis.setInterval(update, 60_000);
-    return () => globalThis.clearInterval(interval);
-  }, []);
+  const now = useNowMinute();
+  const nowLayout = now && resolveNowLayout(stripDays, now);
 
   const columnWidth = useCallback(() => {
     const el = scrollerRef.current;
@@ -370,12 +362,16 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
           {HOURS.slice(1).map((hour) => (
             <span
               key={hour}
-              className="absolute right-1.5 -translate-y-1/2 text-[10px] tabular-nums text-foreground-muted"
+              className={cn(
+                "absolute right-1.5 -translate-y-1/2 text-[10px] tabular-nums text-foreground-muted",
+                hour === nowLayout?.coveredHour && "invisible",
+              )}
               style={{ top: hour * HOUR_HEIGHT }}
             >
               {formatHourLabel(hour)}
             </span>
           ))}
+          {now && nowLayout && <NowPill now={now} topFraction={nowLayout.topFraction} />}
         </div>
         <div
           onClick={handleEventClick}
@@ -386,18 +382,14 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
             height: HOUR_HEIGHT * HOURS.length,
           }}
         >
-          {stripDays.map((day) => {
-            const isToday = isSameDay(day, today);
-            return (
-              <DayColumn
-                key={day.getTime()}
-                day={day}
-                isToday={isToday}
-                nowFraction={isToday ? nowFraction : null}
-                events={eventsByDay.get(day.getTime())?.timed ?? NO_EVENTS}
-              />
-            );
-          })}
+          {stripDays.map((day) => (
+            <DayColumn
+              key={day.getTime()}
+              day={day}
+              events={eventsByDay.get(day.getTime())?.timed ?? NO_EVENTS}
+            />
+          ))}
+          {nowLayout && <NowIndicator layout={nowLayout} columnCount={stripDays.length} />}
         </div>
       </div>
       <EventDetailPopover onClose={closeDetail} />

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -371,7 +371,7 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
               {formatHourLabel(hour)}
             </span>
           ))}
-          {now && nowLayout && <NowPill now={now} topFraction={nowLayout.topFraction} />}
+          {nowLayout && <NowPill layout={nowLayout} />}
         </div>
         <div
           onClick={handleEventClick}
@@ -386,10 +386,11 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
             <DayColumn
               key={day.getTime()}
               day={day}
+              now={isSameDay(day, today) ? now : null}
               events={eventsByDay.get(day.getTime())?.timed ?? NO_EVENTS}
             />
           ))}
-          {nowLayout && <NowIndicator layout={nowLayout} columnCount={stripDays.length} />}
+          {nowLayout && <NowIndicator layout={nowLayout} />}
         </div>
       </div>
       <EventDetailPopover onClose={closeDetail} />

--- a/applications/web/src/hooks/use-now-minute.ts
+++ b/applications/web/src/hooks/use-now-minute.ts
@@ -2,6 +2,9 @@ import { useEffect, useState } from "react";
 
 const MS_PER_MINUTE = 60_000;
 
+const sameMinute = (a: Date, b: Date): boolean =>
+  Math.floor(a.getTime() / MS_PER_MINUTE) === Math.floor(b.getTime() / MS_PER_MINUTE);
+
 /** Null until mounted so SSR and hydration agree; re-read on focus since throttled tabs deliver late ticks. */
 export function useNowMinute(): Date | null {
   const [now, setNow] = useState<Date | null>(null);
@@ -9,7 +12,8 @@ export function useNowMinute(): Date | null {
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout>;
     const tick = () => {
-      setNow(new Date());
+      const next = new Date();
+      setNow((previous) => (previous && sameMinute(previous, next) ? previous : next));
       timeoutId = globalThis.setTimeout(tick, MS_PER_MINUTE - (Date.now() % MS_PER_MINUTE));
     };
     const resync = () => {

--- a/applications/web/src/hooks/use-now-minute.ts
+++ b/applications/web/src/hooks/use-now-minute.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+
+const MS_PER_MINUTE = 60_000;
+
+/** Null until mounted so SSR and hydration agree; re-read on focus since throttled tabs deliver late ticks. */
+export function useNowMinute(): Date | null {
+  const [now, setNow] = useState<Date | null>(null);
+
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const tick = () => {
+      setNow(new Date());
+      timeoutId = globalThis.setTimeout(tick, MS_PER_MINUTE - (Date.now() % MS_PER_MINUTE));
+    };
+    const resync = () => {
+      if (document.visibilityState !== "visible") return;
+      globalThis.clearTimeout(timeoutId);
+      tick();
+    };
+    tick();
+    document.addEventListener("visibilitychange", resync);
+    globalThis.addEventListener("focus", resync);
+
+    return () => {
+      globalThis.clearTimeout(timeoutId);
+      document.removeEventListener("visibilitychange", resync);
+      globalThis.removeEventListener("focus", resync);
+    };
+  }, []);
+
+  return now;
+}

--- a/applications/web/src/hooks/use-start-of-today.ts
+++ b/applications/web/src/hooks/use-start-of-today.ts
@@ -13,16 +13,26 @@ function resolveMillisecondsUntilTomorrow(): number {
   return tomorrow.getTime() - now.getTime();
 }
 
+/** Re-read on focus like `useNowMinute`, so the today badge and the now line cross midnight together after sleep. */
 export function useStartOfToday(): Date {
   const [todayStart, setTodayStart] = useState(resolveStartOfToday);
 
   useEffect(() => {
-    const timeoutId = globalThis.setTimeout(() => {
-      setTodayStart(resolveStartOfToday());
-    }, resolveMillisecondsUntilTomorrow());
+    const refresh = () => {
+      const next = resolveStartOfToday();
+      setTodayStart((previous) => (previous.getTime() === next.getTime() ? previous : next));
+    };
+    const resync = () => {
+      if (document.visibilityState === "visible") refresh();
+    };
+    const timeoutId = globalThis.setTimeout(refresh, resolveMillisecondsUntilTomorrow());
+    document.addEventListener("visibilitychange", resync);
+    globalThis.addEventListener("focus", resync);
 
     return () => {
       globalThis.clearTimeout(timeoutId);
+      document.removeEventListener("visibilitychange", resync);
+      globalThis.removeEventListener("focus", resync);
     };
   }, [todayStart]);
 

--- a/applications/web/src/lib/time.ts
+++ b/applications/web/src/lib/time.ts
@@ -37,7 +37,7 @@ const resolvePeriod = (hours: number): string => {
   return "AM";
 };
 
-const formatClock = (date: Date): string => {
+export const formatClock = (date: Date): string => {
   const hours = date.getHours();
   const minutes = date.getMinutes();
   const displayHours = hours % 12 || 12;

--- a/applications/web/src/lib/time.ts
+++ b/applications/web/src/lib/time.ts
@@ -29,8 +29,8 @@ export const formatTimeUntil = (date: Date): string => {
   return `${prefix}${days}d${suffix}`;
 };
 
-export const isEventPast = (endTime: Date): boolean =>
-  endTime.getTime() < Date.now();
+export const isEventPast = (endTime: Date, nowMs = Date.now()): boolean =>
+  endTime.getTime() < nowMs;
 
 const resolvePeriod = (hours: number): string => {
   if (hours >= 12) return "PM";

--- a/applications/web/tests/features/dashboard/components/event-layout.test.ts
+++ b/applications/web/tests/features/dashboard/components/event-layout.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { CalendarEvent } from "../../../../src/hooks/use-events";
+import { at } from "../../../helpers/clock";
 import {
   bucketEventsByDay,
   layoutDayEvents,
@@ -18,7 +19,6 @@ import type {
 const MS_PER_DAY = 86_400_000;
 
 const day = new Date(2026, 0, 5);
-const at = (hour: number, minute = 0): Date => new Date(2026, 0, 5, hour, minute);
 
 const timedEvent = (id: string, startTime: Date, endTime: Date): CalendarEvent => ({
   id,

--- a/applications/web/tests/features/dashboard/components/now-layout.test.ts
+++ b/applications/web/tests/features/dashboard/components/now-layout.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { resolveNowLayout } from "../../../../src/features/dashboard/components/now-layout";
+
+const at = (hour: number, minute = 0): Date => new Date(2026, 0, 5, hour, minute);
+
+const days = [new Date(2026, 0, 4), new Date(2026, 0, 5), new Date(2026, 0, 6)];
+
+describe("resolveNowLayout", () => {
+  it("places the line by wall-clock fraction and finds today's column", () => {
+    const layout = resolveNowLayout(days, at(10, 42));
+
+    expect(layout.topFraction).toBeCloseTo((10 * 60 + 42) / 1440);
+    expect(layout.todayIndex).toBe(1);
+  });
+
+  it("reports -1 when today is outside the strip", () => {
+    expect(resolveNowLayout(days, new Date(2026, 0, 9, 10)).todayIndex).toBe(-1);
+  });
+
+  it("covers the nearest hour label only within the pill's clearance", () => {
+    expect(resolveNowLayout(days, at(10)).coveredHour).toBe(10);
+    expect(resolveNowLayout(days, at(10, 14)).coveredHour).toBe(10);
+    expect(resolveNowLayout(days, at(9, 46)).coveredHour).toBe(10);
+    expect(resolveNowLayout(days, at(10, 15)).coveredHour).toBeNull();
+    expect(resolveNowLayout(days, at(10, 30)).coveredHour).toBeNull();
+  });
+});

--- a/applications/web/tests/features/dashboard/components/now-layout.test.ts
+++ b/applications/web/tests/features/dashboard/components/now-layout.test.ts
@@ -1,20 +1,20 @@
 import { describe, expect, it } from "vitest";
 import { resolveNowLayout } from "../../../../src/features/dashboard/components/now-layout";
-
-const at = (hour: number, minute = 0): Date => new Date(2026, 0, 5, hour, minute);
+import { at } from "../../../helpers/clock";
 
 const days = [new Date(2026, 0, 4), new Date(2026, 0, 5), new Date(2026, 0, 6)];
 
 describe("resolveNowLayout", () => {
-  it("places the line by wall-clock fraction and finds today's column", () => {
+  it("labels the clock, places the line by wall-clock fraction, and boxes today's column", () => {
     const layout = resolveNowLayout(days, at(10, 42));
 
+    expect(layout.label).toBe("10:42");
     expect(layout.topFraction).toBeCloseTo((10 * 60 + 42) / 1440);
-    expect(layout.todayIndex).toBe(1);
+    expect(layout.today).toEqual({ left: 1 / 3, width: 1 / 3 });
   });
 
-  it("reports -1 when today is outside the strip", () => {
-    expect(resolveNowLayout(days, new Date(2026, 0, 9, 10)).todayIndex).toBe(-1);
+  it("drops today's box when today is outside the strip", () => {
+    expect(resolveNowLayout(days, new Date(2026, 0, 9, 10)).today).toBeNull();
   });
 
   it("covers the nearest hour label only within the pill's clearance", () => {

--- a/applications/web/tests/helpers/clock.ts
+++ b/applications/web/tests/helpers/clock.ts
@@ -1,0 +1,1 @@
+export const at = (hour: number, minute = 0): Date => new Date(2026, 0, 5, hour, minute);

--- a/applications/web/tests/helpers/mount-hook.ts
+++ b/applications/web/tests/helpers/mount-hook.ts
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+import { parseHTML } from "linkedom";
+
+const INJECTED_GLOBALS = [
+  "window",
+  "document",
+  "navigator",
+  "HTMLElement",
+  "Element",
+  "Node",
+  "Text",
+  "Event",
+  "MutationObserver",
+  "IS_REACT_ACT_ENVIRONMENT",
+] as const;
+
+export interface MountedHook<T> {
+  latest: () => T;
+  unmount: () => void;
+}
+
+/** Renders the hook in a linkedom document swapped into the globals; `unmount` puts them back. */
+export function mountHook<T>(useHook: () => T): MountedHook<T> {
+  const { window } = parseHTML("<html><body><div id='root'></div></body></html>");
+  const previous = Object.fromEntries(
+    INJECTED_GLOBALS.map((key) => [key, (globalThis as Record<string, unknown>)[key]]),
+  );
+  Object.assign(globalThis, {
+    window,
+    document: window.document,
+    navigator: window.navigator,
+    HTMLElement: window.HTMLElement,
+    Element: window.Element,
+    Node: window.Node,
+    Text: window.Text,
+    Event: window.Event,
+    MutationObserver: class {
+      observe() {}
+      disconnect() {}
+    },
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+
+  const container = window.document.getElementById("root") as unknown as Element;
+  const root = createRoot(container);
+  const renders: T[] = [];
+
+  const Probe = () => {
+    renders.push(useHook());
+    return null;
+  };
+
+  React.act(() => {
+    root.render(React.createElement(Probe));
+  });
+
+  return {
+    latest: () => {
+      if (renders.length === 0) {
+        throw new Error("Hook never rendered");
+      }
+      return renders[renders.length - 1];
+    },
+    unmount: () => {
+      React.act(() => {
+        root.unmount();
+      });
+      for (const key of INJECTED_GLOBALS) {
+        if (previous[key] === undefined) {
+          delete (globalThis as Record<string, unknown>)[key];
+          continue;
+        }
+        (globalThis as Record<string, unknown>)[key] = previous[key];
+      }
+    },
+  };
+}

--- a/applications/web/tests/hooks/use-copied-state.test.tsx
+++ b/applications/web/tests/hooks/use-copied-state.test.tsx
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as React from "react";
-import { createRoot } from "react-dom/client";
-import { parseHTML } from "linkedom";
 import { useCopiedState } from "../../src/hooks/use-copied-state";
+import { mountHook } from "../helpers/mount-hook";
 
 const RESET_MS = 2000;
 
@@ -12,88 +11,15 @@ interface Harness {
   unmount: () => void;
 }
 
-const INJECTED_GLOBALS = [
-  "window",
-  "document",
-  "navigator",
-  "HTMLElement",
-  "Element",
-  "Node",
-  "Text",
-  "Event",
-  "MutationObserver",
-  "IS_REACT_ACT_ENVIRONMENT",
-] as const;
-
-let restoreDom = (): void => undefined;
-
-const setupDom = () => {
-  const { window } = parseHTML("<html><body><div id='root'></div></body></html>");
-  const previous = Object.fromEntries(
-    INJECTED_GLOBALS.map((key) => [key, (globalThis as Record<string, unknown>)[key]]),
-  );
-  Object.assign(globalThis, {
-    window,
-    document: window.document,
-    navigator: window.navigator,
-    HTMLElement: window.HTMLElement,
-    Element: window.Element,
-    Node: window.Node,
-    Text: window.Text,
-    Event: window.Event,
-    MutationObserver: class {
-      observe() {}
-      disconnect() {}
-    },
-    IS_REACT_ACT_ENVIRONMENT: true,
-  });
-  restoreDom = () => {
-    for (const key of INJECTED_GLOBALS) {
-      if (previous[key] === undefined) {
-        delete (globalThis as Record<string, unknown>)[key];
-        continue;
-      }
-      (globalThis as Record<string, unknown>)[key] = previous[key];
-    }
-  };
-  return window;
-};
-
 const mountHarness = (): Harness => {
-  const window = setupDom();
-  const container = window.document.getElementById("root") as unknown as Element;
-  const root = createRoot(container);
-
-  const renders: ReturnType<typeof useCopiedState>[] = [];
-
-  const Probe = () => {
-    renders.push(useCopiedState(RESET_MS));
-    return null;
-  };
-
-  const latest = () => {
-    const state = renders[renders.length - 1];
-    if (!state) {
-      throw new Error("Harness never rendered");
-    }
-    return state;
-  };
-
-  React.act(() => {
-    root.render(React.createElement(Probe));
-  });
+  const hook = mountHook(() => useCopiedState(RESET_MS));
 
   return {
-    copied: () => latest().copied,
+    copied: () => hook.latest().copied,
     copy: () => React.act(() => {
-      latest().markCopied();
+      hook.latest().markCopied();
     }),
-    unmount: () => {
-      React.act(() => {
-        root.unmount();
-      });
-      restoreDom();
-    },
+    unmount: hook.unmount,
   };
 };
 

--- a/applications/web/tests/hooks/use-countdown.test.tsx
+++ b/applications/web/tests/hooks/use-countdown.test.tsx
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as React from "react";
-import { createRoot } from "react-dom/client";
-import { parseHTML } from "linkedom";
 import { useCountdown } from "../../src/hooks/use-countdown";
+import { mountHook } from "../helpers/mount-hook";
 
 const SECOND_MS = 1000;
 
@@ -12,88 +11,15 @@ interface Harness {
   unmount: () => void;
 }
 
-const INJECTED_GLOBALS = [
-  "window",
-  "document",
-  "navigator",
-  "HTMLElement",
-  "Element",
-  "Node",
-  "Text",
-  "Event",
-  "MutationObserver",
-  "IS_REACT_ACT_ENVIRONMENT",
-] as const;
-
-let restoreDom = (): void => undefined;
-
-const setupDom = () => {
-  const { window } = parseHTML("<html><body><div id='root'></div></body></html>");
-  const previous = Object.fromEntries(
-    INJECTED_GLOBALS.map((key) => [key, (globalThis as Record<string, unknown>)[key]]),
-  );
-  Object.assign(globalThis, {
-    window,
-    document: window.document,
-    navigator: window.navigator,
-    HTMLElement: window.HTMLElement,
-    Element: window.Element,
-    Node: window.Node,
-    Text: window.Text,
-    Event: window.Event,
-    MutationObserver: class {
-      observe() {}
-      disconnect() {}
-    },
-    IS_REACT_ACT_ENVIRONMENT: true,
-  });
-  restoreDom = () => {
-    for (const key of INJECTED_GLOBALS) {
-      if (previous[key] === undefined) {
-        delete (globalThis as Record<string, unknown>)[key];
-        continue;
-      }
-      (globalThis as Record<string, unknown>)[key] = previous[key];
-    }
-  };
-  return window;
-};
-
 const mountHarness = (): Harness => {
-  const window = setupDom();
-  const container = window.document.getElementById("root") as unknown as Element;
-  const root = createRoot(container);
-
-  const renders: ReturnType<typeof useCountdown>[] = [];
-
-  const Probe = () => {
-    renders.push(useCountdown());
-    return null;
-  };
-
-  const latest = () => {
-    const state = renders[renders.length - 1];
-    if (!state) {
-      throw new Error("Harness never rendered");
-    }
-    return state;
-  };
-
-  React.act(() => {
-    root.render(React.createElement(Probe));
-  });
+  const hook = mountHook(useCountdown);
 
   return {
-    secondsRemaining: () => latest().secondsRemaining,
+    secondsRemaining: () => hook.latest().secondsRemaining,
     start: (seconds: number) => React.act(() => {
-      latest().start(seconds);
+      hook.latest().start(seconds);
     }),
-    unmount: () => {
-      React.act(() => {
-        root.unmount();
-      });
-      restoreDom();
-    },
+    unmount: hook.unmount,
   };
 };
 

--- a/applications/web/tests/hooks/use-now-minute.test.tsx
+++ b/applications/web/tests/hooks/use-now-minute.test.tsx
@@ -1,88 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as React from "react";
-import { createRoot } from "react-dom/client";
-import { parseHTML } from "linkedom";
 import { useNowMinute } from "../../src/hooks/use-now-minute";
+import { mountHook } from "../helpers/mount-hook";
 
 const SECOND_MS = 1000;
+const NativeEvent = globalThis.Event;
 
-interface Harness {
-  now: () => Date | null;
-  unmount: () => void;
-}
-
-const INJECTED_GLOBALS = [
-  "window",
-  "document",
-  "navigator",
-  "HTMLElement",
-  "Element",
-  "Node",
-  "Text",
-  "Event",
-  "MutationObserver",
-  "IS_REACT_ACT_ENVIRONMENT",
-] as const;
-
-let restoreDom = (): void => undefined;
-
-const setupDom = () => {
-  const { window } = parseHTML("<html><body><div id='root'></div></body></html>");
-  const previous = Object.fromEntries(
-    INJECTED_GLOBALS.map((key) => [key, (globalThis as Record<string, unknown>)[key]]),
-  );
-  Object.assign(globalThis, {
-    window,
-    document: window.document,
-    navigator: window.navigator,
-    HTMLElement: window.HTMLElement,
-    Element: window.Element,
-    Node: window.Node,
-    Text: window.Text,
-    Event: window.Event,
-    MutationObserver: class {
-      observe() {}
-      disconnect() {}
-    },
-    IS_REACT_ACT_ENVIRONMENT: true,
-  });
-  restoreDom = () => {
-    for (const key of INJECTED_GLOBALS) {
-      if (previous[key] === undefined) {
-        delete (globalThis as Record<string, unknown>)[key];
-        continue;
-      }
-      (globalThis as Record<string, unknown>)[key] = previous[key];
-    }
-  };
-  return window;
-};
-
-const mountHarness = (): Harness => {
-  const window = setupDom();
-  const container = window.document.getElementById("root") as unknown as Element;
-  const root = createRoot(container);
-
-  const renders: (Date | null)[] = [];
-
-  const Probe = () => {
-    renders.push(useNowMinute());
-    return null;
-  };
-
-  React.act(() => {
-    root.render(React.createElement(Probe));
-  });
-
-  return {
-    now: () => renders[renders.length - 1] ?? null,
-    unmount: () => {
-      React.act(() => {
-        root.unmount();
-      });
-      restoreDom();
-    },
-  };
+const setVisibility = (state: DocumentVisibilityState) => {
+  Object.defineProperty(document, "visibilityState", { value: state, configurable: true });
 };
 
 describe("useNowMinute", () => {
@@ -96,27 +21,60 @@ describe("useNowMinute", () => {
   });
 
   it("reads the clock on mount and ticks on the next minute boundary", () => {
-    const harness = mountHarness();
-    expect(harness.now()?.getMinutes()).toBe(42);
+    const hook = mountHook(useNowMinute);
+    expect(hook.latest()?.getMinutes()).toBe(42);
 
     React.act(() => {
       vi.advanceTimersByTime(29 * SECOND_MS);
     });
-    expect(harness.now()?.getMinutes()).toBe(42);
+    expect(hook.latest()?.getMinutes()).toBe(42);
 
     React.act(() => {
       vi.advanceTimersByTime(SECOND_MS);
     });
-    expect(harness.now()?.getMinutes()).toBe(43);
-    expect(harness.now()?.getSeconds()).toBe(0);
+    expect(hook.latest()?.getMinutes()).toBe(43);
+    expect(hook.latest()?.getSeconds()).toBe(0);
 
-    harness.unmount();
+    hook.unmount();
+  });
+
+  it("re-reads a stale clock when the tab becomes visible, not while hidden", () => {
+    const hook = mountHook(useNowMinute);
+    vi.setSystemTime(new Date(2026, 0, 5, 10, 45, 10));
+
+    setVisibility("hidden");
+    React.act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(hook.latest()?.getMinutes()).toBe(42);
+
+    setVisibility("visible");
+    React.act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(hook.latest()?.getMinutes()).toBe(45);
+
+    hook.unmount();
+  });
+
+  it("keeps the same Date when focus lands inside the current minute", () => {
+    const hook = mountHook(useNowMinute);
+    const before = hook.latest();
+    setVisibility("visible");
+
+    React.act(() => {
+      globalThis.dispatchEvent(new NativeEvent("focus"));
+    });
+    expect(hook.latest()).toBe(before);
+
+    hook.unmount();
   });
 
   it("stops ticking when the component unmounts", () => {
-    const harness = mountHarness();
-    harness.unmount();
+    const hook = mountHook(useNowMinute);
+    expect(vi.getTimerCount()).toBe(1);
 
+    hook.unmount();
     expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/applications/web/tests/hooks/use-now-minute.test.tsx
+++ b/applications/web/tests/hooks/use-now-minute.test.tsx
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import { useNowMinute } from "../../src/hooks/use-now-minute";
+
+const SECOND_MS = 1000;
+
+interface Harness {
+  now: () => Date | null;
+  unmount: () => void;
+}
+
+const INJECTED_GLOBALS = [
+  "window",
+  "document",
+  "navigator",
+  "HTMLElement",
+  "Element",
+  "Node",
+  "Text",
+  "Event",
+  "MutationObserver",
+  "IS_REACT_ACT_ENVIRONMENT",
+] as const;
+
+let restoreDom = (): void => undefined;
+
+const setupDom = () => {
+  const { window } = parseHTML("<html><body><div id='root'></div></body></html>");
+  const previous = Object.fromEntries(
+    INJECTED_GLOBALS.map((key) => [key, (globalThis as Record<string, unknown>)[key]]),
+  );
+  Object.assign(globalThis, {
+    window,
+    document: window.document,
+    navigator: window.navigator,
+    HTMLElement: window.HTMLElement,
+    Element: window.Element,
+    Node: window.Node,
+    Text: window.Text,
+    Event: window.Event,
+    MutationObserver: class {
+      observe() {}
+      disconnect() {}
+    },
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  restoreDom = () => {
+    for (const key of INJECTED_GLOBALS) {
+      if (previous[key] === undefined) {
+        delete (globalThis as Record<string, unknown>)[key];
+        continue;
+      }
+      (globalThis as Record<string, unknown>)[key] = previous[key];
+    }
+  };
+  return window;
+};
+
+const mountHarness = (): Harness => {
+  const window = setupDom();
+  const container = window.document.getElementById("root") as unknown as Element;
+  const root = createRoot(container);
+
+  const renders: (Date | null)[] = [];
+
+  const Probe = () => {
+    renders.push(useNowMinute());
+    return null;
+  };
+
+  React.act(() => {
+    root.render(React.createElement(Probe));
+  });
+
+  return {
+    now: () => renders[renders.length - 1] ?? null,
+    unmount: () => {
+      React.act(() => {
+        root.unmount();
+      });
+      restoreDom();
+    },
+  };
+};
+
+describe("useNowMinute", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 5, 10, 42, 30));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reads the clock on mount and ticks on the next minute boundary", () => {
+    const harness = mountHarness();
+    expect(harness.now()?.getMinutes()).toBe(42);
+
+    React.act(() => {
+      vi.advanceTimersByTime(29 * SECOND_MS);
+    });
+    expect(harness.now()?.getMinutes()).toBe(42);
+
+    React.act(() => {
+      vi.advanceTimersByTime(SECOND_MS);
+    });
+    expect(harness.now()?.getMinutes()).toBe(43);
+    expect(harness.now()?.getSeconds()).toBe(0);
+
+    harness.unmount();
+  });
+
+  it("stops ticking when the component unmounts", () => {
+    const harness = mountHarness();
+    harness.unmount();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/applications/web/tests/lib/time.test.ts
+++ b/applications/web/tests/lib/time.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { formatTimeRange } from "../../src/lib/time";
+import { formatClock, formatTimeRange } from "../../src/lib/time";
 
 const at = (hour: number, minute = 0): Date => new Date(2026, 0, 5, hour, minute);
+
+describe("formatClock", () => {
+  it("drops the period and pads minutes", () => {
+    expect(formatClock(at(10, 42))).toBe("10:42");
+    expect(formatClock(at(0, 5))).toBe("12:05");
+    expect(formatClock(at(13))).toBe("1:00");
+  });
+});
 
 describe("formatTimeRange", () => {
   it("drops the start's period when both ends share it", () => {

--- a/applications/web/tests/lib/time.test.ts
+++ b/applications/web/tests/lib/time.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { formatClock, formatTimeRange } from "../../src/lib/time";
-
-const at = (hour: number, minute = 0): Date => new Date(2026, 0, 5, hour, minute);
+import { at } from "../helpers/clock";
 
 describe("formatClock", () => {
   it("drops the period and pads minutes", () => {


### PR DESCRIPTION
Stacked on #982.

## Summary

- The current-time line now spans every column of the week grid at 25% opacity and brightens over today's column, instead of stopping at today's edges.
- A pill in the time gutter shows the current time (`10:42`), styled like the header's today badge (dark text on a `red-400` fill, `rounded-full`, medium weight) and butted against the grid line.
- The hour label the pill would half-cover is hidden, so no sliver peeks out between roughly 5 and 13 minutes past the hour.
- The clock ticks on wall-clock minute boundaries and resyncs on focus and visibility change, so the printed minutes stay true in a throttled tab.
- The line and its props leave `DayColumn`, so the memoised columns no longer re-render on the tick.

## Files

- `now-indicator.tsx` — stateless `NowIndicator` (grid overlay) and `NowPill` (gutter).
- `now-layout.ts` — pure `resolveNowLayout`: day fraction, today's column index, and the covered hour.
- `hooks/use-now-minute.ts` — minute-aligned clock hook.
- `lib/time.ts` — exports `formatClock`.

## Screenshots
<img width="1720" height="1096" alt="45229" src="https://github.com/user-attachments/assets/4054c690-b899-4b5c-9178-f031e2b17941" />
<img width="1424" height="832" alt="58006" src="https://github.com/user-attachments/assets/5f6bb371-5dcd-47b1-9bdc-637d27664dd6" />


## Test plan

- [x] `bun run lint`, `bun run types`, `bun run test`, `bun run unused`
- [x] New tests for `resolveNowLayout`, `useNowMinute`, and `formatClock`
- [x] Rendered the real components in a Vite harness at 10:42, 10:05 (covered label), and 12:45 (widest text) in light and dark; pill and line centres coincide, the pill's right edge meets the line, and the solid segment matches today's column bounds
- [x] Check on the signed-in dashboard that the pill paints over event cards under the sticky gutter

🤖 Generated with [Claude Code](https://claude.com/claude-code)