### PR TITLE
feat(web): Flatten the sidebar and animate its pages

### DIFF
--- a/applications/web/src/components/ui/composites/navigation-menu/navigation-menu.styles.ts
+++ b/applications/web/src/components/ui/composites/navigation-menu/navigation-menu.styles.ts
@@ -4,7 +4,7 @@ export const navigationMenuStyle = tv({
   base: "flex flex-col rounded-2xl p-0.5",
   variants: {
     variant: {
-      default: "bg-background-elevated border border-border-elevated shadow-xs",
+      default: "bg-background border border-interactive-border shadow-xs",
       highlight: "relative before:absolute before:top-0.5 before:inset-x-0 before:h-px before:bg-linear-to-r before:mx-4 before:z-10 before:from-transparent before:to-transparent dark:bg-blue-700 dark:before:via-blue-400 bg-blue-500 before:via-blue-300"
     },
   },

--- a/applications/web/src/components/ui/primitives/back-button.tsx
+++ b/applications/web/src/components/ui/primitives/back-button.tsx
@@ -11,7 +11,7 @@ interface BackButtonProps {
 
 export function BackButton({
   fallback = "/dashboard",
-  variant = "elevated",
+  variant = "border",
   size = "compact",
   className = "aspect-square",
 }: BackButtonProps) {

--- a/applications/web/src/components/ui/primitives/error-state.tsx
+++ b/applications/web/src/components/ui/primitives/error-state.tsx
@@ -16,7 +16,7 @@ export function ErrorState({
         {message}
       </Text>
       {onRetry && (
-        <Button variant="elevated" size="compact" onClick={onRetry}>
+        <Button variant="border" size="compact" onClick={onRetry}>
           <ButtonText>Retry</ButtonText>
         </Button>
       )}

--- a/applications/web/src/components/ui/primitives/page-body.tsx
+++ b/applications/web/src/components/ui/primitives/page-body.tsx
@@ -5,7 +5,7 @@ import { ScrollFader } from "./scroll-fader";
 // At lg the page fills the column and this body scrolls instead, so the header above it never rides an elastic bounce.
 export function PageBody({ children, className }: PropsWithChildren<{ className?: string }>) {
   return (
-    <div className="lg:-mx-1 lg:-mb-12 lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-y-contain lg:px-1 lg:pb-12">
+    <div data-page-scroller className="lg:-mx-1 lg:-mb-12 lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-y-contain lg:px-1 lg:pb-12">
       <ScrollFader>
         <div className={cn("flex flex-col", className)}>{children}</div>
       </ScrollFader>

--- a/applications/web/src/components/ui/primitives/page-body.tsx
+++ b/applications/web/src/components/ui/primitives/page-body.tsx
@@ -1,0 +1,14 @@
+import type { PropsWithChildren } from "react";
+import { cn } from "@/utils/cn";
+import { ScrollFader } from "./scroll-fader";
+
+// At lg the page fills the column and this body scrolls instead, so the header above it never rides an elastic bounce.
+export function PageBody({ children, className }: PropsWithChildren<{ className?: string }>) {
+  return (
+    <div className="lg:-mx-1 lg:-mb-12 lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-y-contain lg:px-1 lg:pb-12">
+      <ScrollFader>
+        <div className={cn("flex flex-col", className)}>{children}</div>
+      </ScrollFader>
+    </div>
+  );
+}

--- a/applications/web/src/components/ui/primitives/page-body.tsx
+++ b/applications/web/src/components/ui/primitives/page-body.tsx
@@ -5,7 +5,7 @@ import { ScrollFader } from "./scroll-fader";
 // At lg the page fills the column and this body scrolls instead, so the header above it never rides an elastic bounce.
 export function PageBody({ children, className }: PropsWithChildren<{ className?: string }>) {
   return (
-    <div data-page-scroller className="lg:-mx-1 lg:-mb-12 lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-y-contain lg:px-1 lg:pb-12">
+    <div data-page-scroller className="lg:-mx-(--sidebar-pad-x) lg:-mb-(--sidebar-pad-b) lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-y-contain lg:px-(--sidebar-pad-x) lg:pb-(--sidebar-pad-b)">
       <ScrollFader>
         <div className={cn("flex flex-col", className)}>{children}</div>
       </ScrollFader>

--- a/applications/web/src/components/ui/primitives/pagination.tsx
+++ b/applications/web/src/components/ui/primitives/pagination.tsx
@@ -17,7 +17,7 @@ export function PaginationPrevious({ to, onMouseEnter }: { to?: string; onMouseE
   }
 
   return (
-    <LinkButton to={to} replace variant="border" size="compact" className="aspect-square" onMouseEnter={onMouseEnter}>
+    <LinkButton to={to} replace state={{ sidebarDirection: "back" }} variant="border" size="compact" className="aspect-square" onMouseEnter={onMouseEnter}>
       <ButtonIcon><ChevronLeft size={16} /></ButtonIcon>
     </LinkButton>
   );
@@ -33,7 +33,7 @@ export function PaginationNext({ to, onMouseEnter }: { to?: string; onMouseEnter
   }
 
   return (
-    <LinkButton to={to} replace variant="border" size="compact" className="aspect-square" onMouseEnter={onMouseEnter}>
+    <LinkButton to={to} replace state={{ sidebarDirection: "forward" }} variant="border" size="compact" className="aspect-square" onMouseEnter={onMouseEnter}>
       <ButtonIcon><ChevronRight size={16} /></ButtonIcon>
     </LinkButton>
   );

--- a/applications/web/src/components/ui/primitives/pagination.tsx
+++ b/applications/web/src/components/ui/primitives/pagination.tsx
@@ -10,14 +10,14 @@ export function Pagination({ children }: PropsWithChildren) {
 export function PaginationPrevious({ to, onMouseEnter }: { to?: string; onMouseEnter?: () => void }) {
   if (!to) {
     return (
-      <Button variant="elevated" size="compact" className="aspect-square" disabled>
+      <Button variant="border" size="compact" className="aspect-square" disabled>
         <ButtonIcon><ChevronLeft size={16} /></ButtonIcon>
       </Button>
     );
   }
 
   return (
-    <LinkButton to={to} replace variant="elevated" size="compact" className="aspect-square" onMouseEnter={onMouseEnter}>
+    <LinkButton to={to} replace variant="border" size="compact" className="aspect-square" onMouseEnter={onMouseEnter}>
       <ButtonIcon><ChevronLeft size={16} /></ButtonIcon>
     </LinkButton>
   );
@@ -26,14 +26,14 @@ export function PaginationPrevious({ to, onMouseEnter }: { to?: string; onMouseE
 export function PaginationNext({ to, onMouseEnter }: { to?: string; onMouseEnter?: () => void }) {
   if (!to) {
     return (
-      <Button variant="elevated" size="compact" className="aspect-square" disabled>
+      <Button variant="border" size="compact" className="aspect-square" disabled>
         <ButtonIcon><ChevronRight size={16} /></ButtonIcon>
       </Button>
     );
   }
 
   return (
-    <LinkButton to={to} replace variant="elevated" size="compact" className="aspect-square" onMouseEnter={onMouseEnter}>
+    <LinkButton to={to} replace variant="border" size="compact" className="aspect-square" onMouseEnter={onMouseEnter}>
       <ButtonIcon><ChevronRight size={16} /></ButtonIcon>
     </LinkButton>
   );

--- a/applications/web/src/components/ui/primitives/provider-icon-stack.tsx
+++ b/applications/web/src/components/ui/primitives/provider-icon-stack.tsx
@@ -12,7 +12,7 @@ interface ProviderIconStackProps {
 
 function ProviderIconStackItem({ provider, calendarType }: { provider?: string; calendarType?: string }) {
   return (
-    <div className="size-6 rounded-full bg-background-elevated border border-border-elevated flex items-center justify-center">
+    <div className="size-6 rounded-full bg-background border border-interactive-border flex items-center justify-center">
       <ProviderIcon provider={provider} calendarType={calendarType} size={12} />
     </div>
   );
@@ -57,7 +57,7 @@ function ProviderIconStack({ providers, max = 4, animate = false }: ProviderIcon
                 exit={HIDDEN}
                 className="max-w-3 flex justify-start"
             >
-              <div className="size-6 min-w-6 grid place-items-center bg-background-elevated border border-border-elevated rounded-full">
+              <div className="size-6 min-w-6 grid place-items-center bg-background border border-interactive-border rounded-full">
                   <Text size="xs" tone="muted" className="tabular-nums text-[0.625rem]">+{overflow}</Text>
                 </div>
               </m.div>

--- a/applications/web/src/components/ui/primitives/scroll-fader.tsx
+++ b/applications/web/src/components/ui/primitives/scroll-fader.tsx
@@ -72,7 +72,7 @@ export function ScrollFader({ children }: PropsWithChildren) {
   const band = (
     <div
       ref={bandRef}
-      className="pointer-events-none fixed z-10 bg-linear-to-t from-background to-transparent opacity-0"
+      className="pointer-events-none fixed z-[5] bg-linear-to-t from-background to-transparent opacity-0"
       style={{ height: BAND_HEIGHT_PX }}
     />
   );

--- a/applications/web/src/components/ui/primitives/scroll-fader.tsx
+++ b/applications/web/src/components/ui/primitives/scroll-fader.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useSyncExternalStore, type PropsWithChildren } from "react";
+import { createPortal } from "react-dom";
+import { resolveScrollParent } from "@/lib/scroll-parent";
+
+const FADE_DISTANCE_PX = 48;
+const BAND_HEIGHT_PX = 96;
+const BLEED_PX = 16;
+
+const clamp01 = (value: number): number => Math.min(Math.max(value, 0), 1);
+
+const subscribeNever = () => () => {};
+const isClient = () => true;
+const isServer = () => false;
+
+// Offsets ignore transforms, so a page still sliding in through the sidebar transition measures at rest.
+function resolveViewportLeft(element: HTMLElement): number {
+  let left = -window.scrollX;
+  for (let node: HTMLElement | null = element; node; node = node.offsetParent as HTMLElement | null) {
+    left += node.offsetLeft + (node.offsetParent?.clientLeft ?? 0);
+  }
+  return left;
+}
+
+function resolveScrollportBottom(element: HTMLElement): number {
+  const parent = resolveScrollParent(element);
+  return parent ? parent.getBoundingClientRect().bottom : window.innerHeight;
+}
+
+export function ScrollFader({ children }: PropsWithChildren) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const bandRef = useRef<HTMLDivElement>(null);
+  const mounted = useSyncExternalStore(subscribeNever, isClient, isServer);
+
+  useEffect(() => {
+    let frame = 0;
+
+    const update = () => {
+      frame = 0;
+      const wrapper = wrapperRef.current;
+      const anchor = anchorRef.current;
+      const sentinel = sentinelRef.current;
+      const band = bandRef.current;
+      if (!wrapper || !anchor || !sentinel || !band) return;
+      const remaining = sentinel.getBoundingClientRect().top - anchor.getBoundingClientRect().top;
+      band.style.opacity = String(clamp01(remaining / FADE_DISTANCE_PX));
+      band.style.left = `${resolveViewportLeft(wrapper) - BLEED_PX}px`;
+      band.style.width = `${wrapper.offsetWidth + BLEED_PX * 2}px`;
+      band.style.top = `${resolveScrollportBottom(wrapper) - BAND_HEIGHT_PX}px`;
+    };
+
+    const schedule = () => {
+      if (frame === 0) frame = requestAnimationFrame(update);
+    };
+
+    update();
+    const resizeObserver = new ResizeObserver(schedule);
+    if (wrapperRef.current) resizeObserver.observe(wrapperRef.current);
+    // Scroll events don't bubble, so the capture phase is what sees the column or the window scrolling.
+    window.addEventListener("scroll", schedule, { capture: true, passive: true });
+    window.addEventListener("resize", schedule);
+    return () => {
+      cancelAnimationFrame(frame);
+      resizeObserver.disconnect();
+      window.removeEventListener("scroll", schedule, { capture: true });
+      window.removeEventListener("resize", schedule);
+    };
+  }, [mounted]);
+
+  // The band lives outside the scroll column so it can bleed past the content edges without clipping.
+  const band = (
+    <div
+      ref={bandRef}
+      className="pointer-events-none fixed z-10 bg-linear-to-t from-background to-transparent opacity-0"
+      style={{ height: BAND_HEIGHT_PX }}
+    />
+  );
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      {children}
+      <div ref={sentinelRef} />
+      <div ref={anchorRef} className="sticky bottom-0 h-0" />
+      {mounted && createPortal(band, document.body)}
+    </div>
+  );
+}

--- a/applications/web/src/components/ui/primitives/sticky-page-header.tsx
+++ b/applications/web/src/components/ui/primitives/sticky-page-header.tsx
@@ -6,7 +6,7 @@ export function StickyPageHeader({ children, className }: PropsWithChildren<{ cl
   return (
     <div
       className={cn(
-        "sticky top-0 z-[5] flex flex-col bg-background pb-1 after:pointer-events-none after:absolute after:inset-x-0 after:top-full after:h-6 after:bg-linear-to-b after:from-background after:to-transparent lg:-top-6 lg:-mx-1 lg:-mt-6 lg:px-1 lg:pt-6",
+        "sticky top-0 z-[5] flex flex-col bg-background pb-1 after:pointer-events-none after:absolute after:inset-x-0 after:top-full after:h-6 after:bg-linear-to-b after:from-background after:to-transparent lg:-top-(--sidebar-pad-t) lg:-mx-(--sidebar-pad-x) lg:-mt-(--sidebar-pad-t) lg:px-(--sidebar-pad-x) lg:pt-(--sidebar-pad-t)",
         className,
       )}
     >

--- a/applications/web/src/components/ui/primitives/sticky-page-header.tsx
+++ b/applications/web/src/components/ui/primitives/sticky-page-header.tsx
@@ -6,7 +6,7 @@ export function StickyPageHeader({ children, className }: PropsWithChildren<{ cl
   return (
     <div
       className={cn(
-        "sticky top-0 z-[5] flex flex-col bg-background pb-1 after:absolute after:inset-x-0 after:top-full after:h-6 after:bg-linear-to-b after:from-background after:to-transparent lg:-top-6 lg:-mx-1 lg:-mt-6 lg:px-1 lg:pt-6",
+        "sticky top-0 z-[5] flex flex-col bg-background pb-1 after:pointer-events-none after:absolute after:inset-x-0 after:top-full after:h-6 after:bg-linear-to-b after:from-background after:to-transparent lg:-top-6 lg:-mx-1 lg:-mt-6 lg:px-1 lg:pt-6",
         className,
       )}
     >

--- a/applications/web/src/components/ui/primitives/sticky-page-header.tsx
+++ b/applications/web/src/components/ui/primitives/sticky-page-header.tsx
@@ -1,0 +1,16 @@
+import type { PropsWithChildren } from "react";
+import { cn } from "@/utils/cn";
+
+// Sits under the popover blur overlay (z-10) but above page content, and reaches up over the column's top padding at lg.
+export function StickyPageHeader({ children, className }: PropsWithChildren<{ className?: string }>) {
+  return (
+    <div
+      className={cn(
+        "sticky top-0 z-[5] flex flex-col bg-background pb-1 after:absolute after:inset-x-0 after:top-full after:h-6 after:bg-linear-to-b after:from-background after:to-transparent lg:-top-6 lg:-mx-1 lg:-mt-6 lg:px-1 lg:pt-6",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/applications/web/src/features/dashboard/components/sidebar-page-transition.tsx
+++ b/applications/web/src/features/dashboard/components/sidebar-page-transition.tsx
@@ -13,6 +13,7 @@ import {
 const NUDGE = 32;
 const TRANSITION = { duration: 0.22, ease: [0.2, 0, 0, 1] as const };
 const INSTANT = { duration: 0 };
+const PAGE_SCROLLER_SELECTOR = "[data-page-scroller]";
 
 const pageVariants: Variants = {
   enter: (direction: SidebarDirection) => ({ x: direction === "forward" ? NUDGE : -NUDGE, opacity: 0 }),
@@ -25,10 +26,18 @@ interface TrackedLocation {
   direction: SidebarDirection | null;
 }
 
+interface Box {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
 interface DetachedPage {
   node: HTMLElement;
-  height: number;
-  scrollOffset: number;
+  box: Box;
+  scrollport: Box;
+  innerScrollTop: number;
 }
 
 interface ExitingPage extends DetachedPage {
@@ -36,9 +45,12 @@ interface ExitingPage extends DetachedPage {
   direction: SidebarDirection;
 }
 
-function resolveScrollTop(element: HTMLElement): number {
+const toBox = ({ top, left, width, height }: DOMRect): Box => ({ top, left, width, height });
+
+function resolveScrollportBox(element: HTMLElement): Box {
   const parent = resolveScrollParent(element);
-  return parent ? parent.scrollTop : window.scrollY;
+  if (parent) return toBox(parent.getBoundingClientRect());
+  return { top: 0, left: 0, width: window.innerWidth, height: window.innerHeight };
 }
 
 function scrollToTop(element: HTMLElement): void {
@@ -47,23 +59,33 @@ function scrollToTop(element: HTMLElement): void {
   else window.scrollTo(0, 0);
 }
 
+// Pinned to the viewport where it last stood, so scrolling or restoring the live page cannot drag it along.
 function ExitingPageLayer({ page, onDone }: { page: ExitingPage; onDone: () => void }) {
   const attach = useCallback((element: HTMLDivElement | null) => {
-    element?.replaceChildren(page.node);
-  }, [page.node]);
+    if (!element) return;
+    element.replaceChildren(page.node);
+    const scroller = page.node.querySelector<HTMLElement>(PAGE_SCROLLER_SELECTOR);
+    if (scroller) scroller.scrollTop = page.innerScrollTop;
+  }, [page]);
+  const { box, scrollport } = page;
 
   return (
-    <m.div
-      className="pointer-events-none absolute inset-x-0"
-      style={{ top: -page.scrollOffset, height: page.height }}
-      custom={page.direction}
-      variants={pageVariants}
-      initial="center"
-      animate="exit"
-      transition={TRANSITION}
-      onAnimationComplete={onDone}
-      ref={attach}
-    />
+    <div
+      className="pointer-events-none fixed overflow-hidden"
+      style={{ top: scrollport.top, left: scrollport.left, width: scrollport.width, height: scrollport.height }}
+    >
+      <m.div
+        className="absolute"
+        style={{ top: box.top - scrollport.top, left: box.left - scrollport.left, width: box.width, height: box.height }}
+        custom={page.direction}
+        variants={pageVariants}
+        initial="center"
+        animate="exit"
+        transition={TRANSITION}
+        onAnimationComplete={onDone}
+        ref={attach}
+      />
+    </div>
   );
 }
 
@@ -92,19 +114,20 @@ export function SidebarPageTransition({ children }: PropsWithChildren) {
     return () => {
       detachedRef.current = {
         node: element,
-        height: element.offsetHeight,
-        scrollOffset: resolveScrollTop(element),
+        box: toBox(element.getBoundingClientRect()),
+        scrollport: resolveScrollportBox(element),
+        innerScrollTop: element.querySelector<HTMLElement>(PAGE_SCROLLER_SELECTOR)?.scrollTop ?? 0,
       };
     };
   }, []);
 
-  // The new page starts at the top; the outgoing one is offset so it keeps the spot it had on screen.
+  // Forward navigation starts the new page at the top; going back leaves the position to the router's restoration.
   useLayoutEffect(() => {
     const detached = detachedRef.current;
     const container = containerRef.current;
     detachedRef.current = null;
     if (!detached || !container || !tracked.direction) return;
-    scrollToTop(container);
+    if (tracked.direction === "forward") scrollToTop(container);
     if (reduceMotion) return;
     const { pathname: to, index: at } = tracked.location;
     setExiting({ ...detached, key: `${to}:${at}`, direction: tracked.direction });

--- a/applications/web/src/features/dashboard/components/sidebar-page-transition.tsx
+++ b/applications/web/src/features/dashboard/components/sidebar-page-transition.tsx
@@ -95,6 +95,7 @@ export function SidebarPageTransition({ children }: PropsWithChildren) {
     select: (state) => state.matches[state.matches.length - 1]?.pathname ?? state.location.pathname,
   });
   const index = useLocation({ select: (location) => location.state.__TSR_index });
+  const declared = useLocation({ select: (location) => location.state.sidebarDirection });
   const reduceMotion = useReducedMotion() ?? false;
   const [tracked, setTracked] = useState<TrackedLocation>({ location: { pathname, index }, direction: null });
   const [exiting, setExiting] = useState<ExitingPage | null>(null);
@@ -103,7 +104,7 @@ export function SidebarPageTransition({ children }: PropsWithChildren) {
 
   if (tracked.location.pathname !== pathname) {
     const location = { pathname, index };
-    setTracked({ location, direction: resolveSidebarDirection(tracked.location, location) });
+    setTracked({ location, direction: resolveSidebarDirection(tracked.location, location, declared) });
   }
 
   // The router cannot keep an exited match rendered, so the outgoing page animates as its retained DOM node.

--- a/applications/web/src/features/dashboard/components/sidebar-page-transition.tsx
+++ b/applications/web/src/features/dashboard/components/sidebar-page-transition.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useLayoutEffect, useRef, useState, type PropsWithChildren } from "react";
+import { useLocation, useRouterState } from "@tanstack/react-router";
+import { LazyMotion, useReducedMotion, type Variants } from "motion/react";
+import * as m from "motion/react-m";
+import { loadMotionFeatures } from "@/lib/motion-features";
+import { resolveScrollParent } from "@/lib/scroll-parent";
+import {
+  resolveSidebarDirection,
+  type SidebarDirection,
+  type SidebarLocation,
+} from "@/lib/sidebar-transition";
+
+const NUDGE = 32;
+const TRANSITION = { duration: 0.22, ease: [0.2, 0, 0, 1] as const };
+const INSTANT = { duration: 0 };
+
+const pageVariants: Variants = {
+  enter: (direction: SidebarDirection) => ({ x: direction === "forward" ? NUDGE : -NUDGE, opacity: 0 }),
+  center: { x: 0, opacity: 1 },
+  exit: (direction: SidebarDirection) => ({ x: direction === "forward" ? -NUDGE : NUDGE, opacity: 0 }),
+};
+
+interface TrackedLocation {
+  location: SidebarLocation;
+  direction: SidebarDirection | null;
+}
+
+interface DetachedPage {
+  node: HTMLElement;
+  height: number;
+  scrollOffset: number;
+}
+
+interface ExitingPage extends DetachedPage {
+  key: string;
+  direction: SidebarDirection;
+}
+
+function resolveScrollTop(element: HTMLElement): number {
+  const parent = resolveScrollParent(element);
+  return parent ? parent.scrollTop : window.scrollY;
+}
+
+function scrollToTop(element: HTMLElement): void {
+  const parent = resolveScrollParent(element);
+  if (parent) parent.scrollTop = 0;
+  else window.scrollTo(0, 0);
+}
+
+function ExitingPageLayer({ page, onDone }: { page: ExitingPage; onDone: () => void }) {
+  const attach = useCallback((element: HTMLDivElement | null) => {
+    element?.replaceChildren(page.node);
+  }, [page.node]);
+
+  return (
+    <m.div
+      className="pointer-events-none absolute inset-x-0"
+      style={{ top: -page.scrollOffset, height: page.height }}
+      custom={page.direction}
+      variants={pageVariants}
+      initial="center"
+      animate="exit"
+      transition={TRANSITION}
+      onAnimationComplete={onDone}
+      ref={attach}
+    />
+  );
+}
+
+export function SidebarPageTransition({ children }: PropsWithChildren) {
+  // Matches swap when the loader resolves, later than `location`; keying on them keeps the outgoing DOM intact.
+  const pathname = useRouterState({
+    select: (state) => state.matches[state.matches.length - 1]?.pathname ?? state.location.pathname,
+  });
+  const index = useLocation({ select: (location) => location.state.__TSR_index });
+  const reduceMotion = useReducedMotion() ?? false;
+  const [tracked, setTracked] = useState<TrackedLocation>({ location: { pathname, index }, direction: null });
+  const [exiting, setExiting] = useState<ExitingPage | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const detachedRef = useRef<DetachedPage | null>(null);
+
+  if (tracked.location.pathname !== pathname) {
+    const location = { pathname, index };
+    setTracked({ location, direction: resolveSidebarDirection(tracked.location, location) });
+  }
+
+  // The router cannot keep an exited match rendered, so the outgoing page animates as its retained DOM node.
+  const capturePage = useCallback((element: HTMLDivElement | null) => {
+    if (!element) return;
+    // StrictMode re-attaches the same element after a simulated cleanup; that is not a departure.
+    if (detachedRef.current?.node === element) detachedRef.current = null;
+    return () => {
+      detachedRef.current = {
+        node: element,
+        height: element.offsetHeight,
+        scrollOffset: resolveScrollTop(element),
+      };
+    };
+  }, []);
+
+  // The new page starts at the top; the outgoing one is offset so it keeps the spot it had on screen.
+  useLayoutEffect(() => {
+    const detached = detachedRef.current;
+    const container = containerRef.current;
+    detachedRef.current = null;
+    if (!detached || !container || !tracked.direction) return;
+    scrollToTop(container);
+    if (reduceMotion) return;
+    const { pathname: to, index: at } = tracked.location;
+    setExiting({ ...detached, key: `${to}:${at}`, direction: tracked.direction });
+  }, [tracked, reduceMotion]);
+
+  const clearExiting = useCallback(() => setExiting(null), []);
+
+  return (
+    <LazyMotion features={loadMotionFeatures}>
+      <div ref={containerRef} className="relative">
+        {exiting && <ExitingPageLayer key={exiting.key} page={exiting} onDone={clearExiting} />}
+        <m.div
+          key={pathname}
+          custom={tracked.direction}
+          variants={pageVariants}
+          initial={tracked.direction ? "enter" : false}
+          animate="center"
+          transition={reduceMotion ? INSTANT : TRANSITION}
+          ref={capturePage}
+        >
+          {children}
+        </m.div>
+      </div>
+    </LazyMotion>
+  );
+}

--- a/applications/web/src/features/dashboard/components/sidebar-page-transition.tsx
+++ b/applications/web/src/features/dashboard/components/sidebar-page-transition.tsx
@@ -114,10 +114,11 @@ export function SidebarPageTransition({ children }: PropsWithChildren) {
 
   return (
     <LazyMotion features={loadMotionFeatures}>
-      <div ref={containerRef} className="relative">
+      <div ref={containerRef} className="relative lg:h-full">
         {exiting && <ExitingPageLayer key={exiting.key} page={exiting} onDone={clearExiting} />}
         <m.div
           key={pathname}
+          className="lg:h-full"
           custom={tracked.direction}
           variants={pageVariants}
           initial={tracked.direction ? "enter" : false}

--- a/applications/web/src/index.css
+++ b/applications/web/src/index.css
@@ -23,6 +23,17 @@ body {
   overflow-x: hidden;
 }
 
+/* The colour inherits from the root; the width does not, so every scroller sets it in the base layer, where utilities such as `[scrollbar-width:none]` still win. */
+@layer base {
+  html {
+    scrollbar-color: var(--ui-interactive-border) transparent;
+  }
+
+  * {
+    scrollbar-width: thin;
+  }
+}
+
 @media (width < 48rem) {
   body:has(#marketing-header-menu) {
     overflow-y: hidden;

--- a/applications/web/src/lib/scroll-parent.ts
+++ b/applications/web/src/lib/scroll-parent.ts
@@ -1,0 +1,7 @@
+export function resolveScrollParent(element: HTMLElement): HTMLElement | null {
+  for (let node = element.parentElement; node; node = node.parentElement) {
+    const { overflowY } = getComputedStyle(node);
+    if (overflowY === "auto" || overflowY === "scroll") return node;
+  }
+  return null;
+}

--- a/applications/web/src/lib/sidebar-transition.ts
+++ b/applications/web/src/lib/sidebar-transition.ts
@@ -10,7 +10,19 @@ const normalizePath = (pathname: string): string => pathname.replace(/\/+$/, "")
 const isAncestorPath = (ancestor: string, pathname: string): boolean =>
   pathname.startsWith(`${ancestor}/`);
 
-export function resolveSidebarDirection(from: SidebarLocation, to: SidebarLocation): SidebarDirection {
+declare module "@tanstack/history" {
+  interface HistoryState {
+    sidebarDirection?: SidebarDirection;
+  }
+}
+
+// A replace keeps the history index, so siblings (previous/next) declare their own direction via link state.
+export function resolveSidebarDirection(
+  from: SidebarLocation,
+  to: SidebarLocation,
+  declared?: SidebarDirection,
+): SidebarDirection {
+  if (declared && to.index === from.index) return declared;
   const popped = to.index < from.index;
   if (popped || isAncestorPath(normalizePath(to.pathname), normalizePath(from.pathname))) return "back";
   return "forward";

--- a/applications/web/src/lib/sidebar-transition.ts
+++ b/applications/web/src/lib/sidebar-transition.ts
@@ -1,0 +1,17 @@
+export interface SidebarLocation {
+  pathname: string;
+  index: number;
+}
+
+export type SidebarDirection = "forward" | "back";
+
+const normalizePath = (pathname: string): string => pathname.replace(/\/+$/, "") || "/";
+
+const isAncestorPath = (ancestor: string, pathname: string): boolean =>
+  pathname.startsWith(`${ancestor}/`);
+
+export function resolveSidebarDirection(from: SidebarLocation, to: SidebarLocation): SidebarDirection {
+  const popped = to.index < from.index;
+  if (popped || isAncestorPath(normalizePath(to.pathname), normalizePath(from.pathname))) return "back";
+  return "forward";
+}

--- a/applications/web/src/routes/(dashboard)/dashboard/accounts/$accountId.$calendarId.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/accounts/$accountId.$calendarId.tsx
@@ -6,6 +6,8 @@ import { useAtomValue, useStore } from "jotai";
 import type { SyncRange } from "@keeper.sh/data-schemas";
 import { useEntitlements, useMutateEntitlements, canAddMore } from "@/hooks/use-entitlements";
 import { BackButton } from "@/components/ui/primitives/back-button";
+import { ScrollFader } from "@/components/ui/primitives/scroll-fader";
+import { StickyPageHeader } from "@/components/ui/primitives/sticky-page-header";
 import { UpgradeHint, PremiumFeatureGate } from "@/components/ui/primitives/upgrade-hint";
 import { Pagination, PaginationPrevious, PaginationNext } from "@/components/ui/primitives/pagination";
 import { RouteShell } from "@/components/ui/shells/route-shell";
@@ -156,29 +158,33 @@ function CalendarDetailPage() {
   const isPushCapable = canPush(calendar);
 
   return (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex items-center justify-between">
-        <BackButton fallback={`/dashboard/accounts/${accountId}`} />
-        <CalendarPrevNext calendarId={calendarId} />
+    <ScrollFader>
+      <div className="flex flex-col gap-1.5">
+        <StickyPageHeader className="gap-1.5">
+          <div className="flex items-center justify-between">
+            <BackButton fallback={`/dashboard/accounts/${accountId}`} />
+            <CalendarPrevNext calendarId={calendarId} />
+          </div>
+          <CalendarHeader account={account} />
+        </StickyPageHeader>
+        <ProviderMissingNotice />
+        <RenameSection calendarId={calendarId} />
+        {isPullCapable && (
+          <>
+            <DashboardSection
+              title="Send Events to Calendars"
+              description="Select which calendars should receive events from this calendar."
+            />
+            <DestinationsSection calendarId={calendarId} />
+          </>
+        )}
+        {isPushCapable && <SyncWindowSection calendarId={calendarId} />}
+        {isPullCapable && <SyncSettingsSection calendarId={calendarId} />}
+        {isPullCapable && <ExclusionsSection calendarId={calendarId} provider={calendar.provider} />}
+        <CalendarInfoSection account={account} accountId={accountId} />
+        {!isPushCapable && <DeleteCalendarSection accountId={accountId} calendarId={calendarId} />}
       </div>
-      <CalendarHeader account={account} />
-      <ProviderMissingNotice />
-      <RenameSection calendarId={calendarId} />
-      {isPullCapable && (
-        <>
-          <DashboardSection
-            title="Send Events to Calendars"
-            description="Select which calendars should receive events from this calendar."
-          />
-          <DestinationsSection calendarId={calendarId} />
-        </>
-      )}
-      {isPushCapable && <SyncWindowSection calendarId={calendarId} />}
-      {isPullCapable && <SyncSettingsSection calendarId={calendarId} />}
-      {isPullCapable && <ExclusionsSection calendarId={calendarId} provider={calendar.provider} />}
-      <CalendarInfoSection account={account} accountId={accountId} />
-      {!isPushCapable && <DeleteCalendarSection accountId={accountId} calendarId={calendarId} />}
-    </div>
+    </ScrollFader>
   );
 }
 

--- a/applications/web/src/routes/(dashboard)/dashboard/accounts/$accountId.$calendarId.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/accounts/$accountId.$calendarId.tsx
@@ -6,7 +6,7 @@ import { useAtomValue, useStore } from "jotai";
 import type { SyncRange } from "@keeper.sh/data-schemas";
 import { useEntitlements, useMutateEntitlements, canAddMore } from "@/hooks/use-entitlements";
 import { BackButton } from "@/components/ui/primitives/back-button";
-import { ScrollFader } from "@/components/ui/primitives/scroll-fader";
+import { PageBody } from "@/components/ui/primitives/page-body";
 import { StickyPageHeader } from "@/components/ui/primitives/sticky-page-header";
 import { UpgradeHint, PremiumFeatureGate } from "@/components/ui/primitives/upgrade-hint";
 import { Pagination, PaginationPrevious, PaginationNext } from "@/components/ui/primitives/pagination";
@@ -158,15 +158,15 @@ function CalendarDetailPage() {
   const isPushCapable = canPush(calendar);
 
   return (
-    <ScrollFader>
-      <div className="flex flex-col gap-1.5">
-        <StickyPageHeader className="gap-1.5">
-          <div className="flex items-center justify-between">
-            <BackButton fallback={`/dashboard/accounts/${accountId}`} />
-            <CalendarPrevNext calendarId={calendarId} />
-          </div>
-          <CalendarHeader account={account} />
-        </StickyPageHeader>
+    <div className="flex flex-col gap-1.5 lg:h-full">
+      <StickyPageHeader className="gap-1.5">
+        <div className="flex items-center justify-between">
+          <BackButton fallback={`/dashboard/accounts/${accountId}`} />
+          <CalendarPrevNext calendarId={calendarId} />
+        </div>
+        <CalendarHeader account={account} />
+      </StickyPageHeader>
+      <PageBody className="gap-1.5">
         <ProviderMissingNotice />
         <RenameSection calendarId={calendarId} />
         {isPullCapable && (
@@ -183,8 +183,8 @@ function CalendarDetailPage() {
         {isPullCapable && <ExclusionsSection calendarId={calendarId} provider={calendar.provider} />}
         <CalendarInfoSection account={account} accountId={accountId} />
         {!isPushCapable && <DeleteCalendarSection accountId={accountId} calendarId={calendarId} />}
-      </div>
-    </ScrollFader>
+      </PageBody>
+    </div>
   );
 }
 

--- a/applications/web/src/routes/(dashboard)/dashboard/accounts/$accountId.index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/accounts/$accountId.index.tsx
@@ -4,6 +4,8 @@ import useSWR, { preload, useSWRConfig } from "swr";
 import Calendar from "lucide-react/dist/esm/icons/calendar";
 import Trash2 from "lucide-react/dist/esm/icons/trash-2";
 import { BackButton } from "@/components/ui/primitives/back-button";
+import { ScrollFader } from "@/components/ui/primitives/scroll-fader";
+import { StickyPageHeader } from "@/components/ui/primitives/sticky-page-header";
 import { Pagination, PaginationPrevious, PaginationNext } from "@/components/ui/primitives/pagination";
 import { RouteShell } from "@/components/ui/shells/route-shell";
 import { Text } from "@/components/ui/primitives/text";
@@ -146,54 +148,58 @@ function AccountDetailPage() {
   );
 
   return (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex items-center justify-between">
-        <BackButton />
-        <AccountPrevNext accountId={accountId} />
+    <ScrollFader>
+      <div className="flex flex-col gap-1.5">
+        <StickyPageHeader>
+          <div className="flex items-center justify-between">
+            <BackButton />
+            <AccountPrevNext accountId={accountId} />
+          </div>
+        </StickyPageHeader>
+        <DashboardSection
+          title="Account Information"
+          description="View details about the account and its calendars."
+        />
+        <NavigationMenu>
+          <MetadataRow label="Resource Type" value="Account" />
+          <MetadataRow label="Calendar Count" value={String(calendars.length)} />
+          <MetadataRow label="Identifier" value={account.accountIdentifier ?? ""} truncate />
+          <MetadataRow label="Provider" value={account.providerName} />
+          <MetadataRow label="Authenticated" value={account.authType} />
+          <MetadataRow label="Connected" value={formatDate(account.createdAt)} />
+          {account.calendarsRefreshedAt && (
+            <MetadataRow label="Calendars Checked" value={formatDate(account.calendarsRefreshedAt)} />
+          )}
+        </NavigationMenu>
+        <NavigationMenu>
+          <RefreshCalendarsItem accountId={accountId} />
+        </NavigationMenu>
+        <DashboardSection
+          title="Account Calendars"
+          description={<>This account has {pluralize(calendars.length, "calendar")} attached to it, choose a calendar below to view more details and configure it. Calendars no longer found at the provider are noted below.</>}
+        />
+        <NavigationMenu>
+          <CalendarList calendars={calendars} accountId={accountId} />
+        </NavigationMenu>
+        <NavigationMenu>
+          <NavigationMenuButtonItem onClick={() => setDeleteOpen(true)}>
+            <NavigationMenuItemIcon>
+              <Trash2 size={15} className="text-destructive" />
+            </NavigationMenuItemIcon>
+            <Text size="sm" tone="danger">Delete Account</Text>
+          </NavigationMenuButtonItem>
+        </NavigationMenu>
+        {deleteError && <Text size="sm" tone="danger">{deleteError}</Text>}
+        <DeleteConfirmation
+          title="Delete calendar account?"
+          description="This will remove the account and all its calendars. Any sync profiles using these calendars will be affected."
+          open={deleteOpen}
+          onOpenChange={setDeleteOpen}
+          deleting={isDeleting}
+          onConfirm={handleConfirmDelete}
+        />
       </div>
-      <DashboardSection
-        title="Account Information"
-        description="View details about the account and its calendars."
-      />
-      <NavigationMenu>
-        <MetadataRow label="Resource Type" value="Account" />
-        <MetadataRow label="Calendar Count" value={String(calendars.length)} />
-        <MetadataRow label="Identifier" value={account.accountIdentifier ?? ""} truncate />
-        <MetadataRow label="Provider" value={account.providerName} />
-        <MetadataRow label="Authenticated" value={account.authType} />
-        <MetadataRow label="Connected" value={formatDate(account.createdAt)} />
-        {account.calendarsRefreshedAt && (
-          <MetadataRow label="Calendars Checked" value={formatDate(account.calendarsRefreshedAt)} />
-        )}
-      </NavigationMenu>
-      <NavigationMenu>
-        <RefreshCalendarsItem accountId={accountId} />
-      </NavigationMenu>
-      <DashboardSection
-        title="Account Calendars"
-        description={<>This account has {pluralize(calendars.length, "calendar")} attached to it, choose a calendar below to view more details and configure it. Calendars no longer found at the provider are noted below.</>}
-      />
-      <NavigationMenu>
-        <CalendarList calendars={calendars} accountId={accountId} />
-      </NavigationMenu>
-      <NavigationMenu>
-        <NavigationMenuButtonItem onClick={() => setDeleteOpen(true)}>
-          <NavigationMenuItemIcon>
-            <Trash2 size={15} className="text-destructive" />
-          </NavigationMenuItemIcon>
-          <Text size="sm" tone="danger">Delete Account</Text>
-        </NavigationMenuButtonItem>
-      </NavigationMenu>
-      {deleteError && <Text size="sm" tone="danger">{deleteError}</Text>}
-      <DeleteConfirmation
-        title="Delete calendar account?"
-        description="This will remove the account and all its calendars. Any sync profiles using these calendars will be affected."
-        open={deleteOpen}
-        onOpenChange={setDeleteOpen}
-        deleting={isDeleting}
-        onConfirm={handleConfirmDelete}
-      />
-    </div>
+    </ScrollFader>
   );
 }
 

--- a/applications/web/src/routes/(dashboard)/dashboard/accounts/$accountId.index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/accounts/$accountId.index.tsx
@@ -4,7 +4,7 @@ import useSWR, { preload, useSWRConfig } from "swr";
 import Calendar from "lucide-react/dist/esm/icons/calendar";
 import Trash2 from "lucide-react/dist/esm/icons/trash-2";
 import { BackButton } from "@/components/ui/primitives/back-button";
-import { ScrollFader } from "@/components/ui/primitives/scroll-fader";
+import { PageBody } from "@/components/ui/primitives/page-body";
 import { StickyPageHeader } from "@/components/ui/primitives/sticky-page-header";
 import { Pagination, PaginationPrevious, PaginationNext } from "@/components/ui/primitives/pagination";
 import { RouteShell } from "@/components/ui/shells/route-shell";
@@ -148,14 +148,14 @@ function AccountDetailPage() {
   );
 
   return (
-    <ScrollFader>
-      <div className="flex flex-col gap-1.5">
-        <StickyPageHeader>
-          <div className="flex items-center justify-between">
-            <BackButton />
-            <AccountPrevNext accountId={accountId} />
-          </div>
-        </StickyPageHeader>
+    <div className="flex flex-col gap-1.5 lg:h-full">
+      <StickyPageHeader>
+        <div className="flex items-center justify-between">
+          <BackButton />
+          <AccountPrevNext accountId={accountId} />
+        </div>
+      </StickyPageHeader>
+      <PageBody className="gap-1.5">
         <DashboardSection
           title="Account Information"
           description="View details about the account and its calendars."
@@ -198,8 +198,8 @@ function AccountDetailPage() {
           deleting={isDeleting}
           onConfirm={handleConfirmDelete}
         />
-      </div>
-    </ScrollFader>
+      </PageBody>
+    </div>
   );
 }
 

--- a/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
@@ -7,6 +7,7 @@ import LoaderCircle from "lucide-react/dist/esm/icons/loader-circle";
 import { BackButton } from "@/components/ui/primitives/back-button";
 import { ErrorState } from "@/components/ui/primitives/error-state";
 import { ScrollFader } from "@/components/ui/primitives/scroll-fader";
+import { StickyPageHeader } from "@/components/ui/primitives/sticky-page-header";
 import { DashboardHeading1, DashboardHeading2 } from "@/components/ui/primitives/dashboard-heading";
 import { Text } from "@/components/ui/primitives/text";
 import { isEventPast, formatDayHeader } from "@/lib/time";
@@ -83,16 +84,15 @@ function EventsPage() {
   );
 }
 
-// Reaches up over the column's top padding at lg so nothing shows above it while stuck.
 function EventsHeader() {
   return (
-    <div className="sticky top-0 z-10 flex flex-col gap-3 bg-background pb-1 after:absolute after:inset-x-0 after:top-full after:h-6 after:bg-linear-to-b after:from-background after:to-transparent lg:-top-6 lg:-mx-1 lg:-mt-6 lg:px-1 lg:pt-6">
+    <StickyPageHeader className="gap-3">
       <BackButton />
       <div className="flex flex-col">
         <DashboardHeading1>Events</DashboardHeading1>
         <Text size="sm">View all of the events across all of your calendars.</Text>
       </div>
-    </div>
+    </StickyPageHeader>
   );
 }
 

--- a/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
@@ -6,6 +6,7 @@ import { loadMotionFeatures } from "@/lib/motion-features";
 import LoaderCircle from "lucide-react/dist/esm/icons/loader-circle";
 import { BackButton } from "@/components/ui/primitives/back-button";
 import { ErrorState } from "@/components/ui/primitives/error-state";
+import { ScrollFader } from "@/components/ui/primitives/scroll-fader";
 import { DashboardHeading1, DashboardHeading2 } from "@/components/ui/primitives/dashboard-heading";
 import { Text } from "@/components/ui/primitives/text";
 import { isEventPast, formatDayHeader } from "@/lib/time";
@@ -73,10 +74,12 @@ const resolveGroupOffsets = (groups: DayGroup[]): number[] => {
 
 function EventsPage() {
   return (
-    <div className="flex flex-col gap-3">
-      <BackButton />
-      <EventsContent />
-    </div>
+    <ScrollFader>
+      <div className="flex flex-col gap-3">
+        <BackButton />
+        <EventsContent />
+      </div>
+    </ScrollFader>
   );
 }
 

--- a/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
@@ -26,9 +26,12 @@ interface DayGroup {
 interface DaySectionProps {
   label: string;
   events: CalendarEvent[];
-  startIndex: number;
-  firstNewIndex: number;
-  reduceMotion: boolean;
+  newOrders: ReadonlyMap<string, number>;
+}
+
+interface SeenIds {
+  previous: ReadonlySet<string>;
+  current: ReadonlySet<string>;
 }
 
 const CARD_HIDDEN = { opacity: 0, y: 8 };
@@ -36,12 +39,20 @@ const CARD_VISIBLE = { opacity: 1, y: 0 };
 const CARD_TRANSITION = { duration: 0.28, ease: [0.2, 0, 0, 1] as const };
 const CARD_STAGGER = 0.035;
 const CARD_STAGGER_CAP = 12;
-const INSTANT = { duration: 0 };
+const NO_NEW_CARDS: ReadonlyMap<string, number> = new Map();
 
-function resolveCardTransition(order: number, reduceMotion: boolean) {
-  if (reduceMotion) return INSTANT;
-  return { ...CARD_TRANSITION, delay: Math.min(order, CARD_STAGGER_CAP) * CARD_STAGGER };
-}
+const resolveCardTransition = (order: number) => ({
+  ...CARD_TRANSITION,
+  delay: Math.min(order, CARD_STAGGER_CAP) * CARD_STAGGER,
+});
+
+const resolveNewOrders = (events: CalendarEvent[], seen: ReadonlySet<string>): ReadonlyMap<string, number> => {
+  const orders = new Map<string, number>();
+  for (const event of events) {
+    if (!seen.has(event.id)) orders.set(event.id, orders.size);
+  }
+  return orders;
+};
 
 interface LoadMoreSentinelProps {
   isValidating: boolean;
@@ -62,15 +73,6 @@ const groupEventsByDay = (events: CalendarEvent[]): DayGroup[] => {
     label: formatDayHeader(new Date(key)),
     events: dayEvents,
   }));
-};
-
-const resolveGroupOffsets = (groups: DayGroup[]): number[] => {
-  let offset = 0;
-  return groups.map((group) => {
-    const start = offset;
-    offset += group.events.length;
-    return start;
-  });
 };
 
 function EventsPage() {
@@ -99,13 +101,17 @@ function EventsHeader() {
 function EventsContent() {
   const { events, error, isLoading, isValidating, hasMore, loadMore } = useEvents();
   const reduceMotion = useReducedMotion() ?? false;
-  // Cards already on screen when the page mounts (cached data) stay put; only newly fetched ones rise in.
-  const [revealed, setRevealed] = useState({ count: isLoading ? 0 : events.length, seen: events.length });
-  if (revealed.seen !== events.length) {
-    setRevealed({ count: revealed.seen, seen: events.length });
+  // Cards already on screen when the page mounts (cached data) stay put; ids seen for the first time rise in.
+  const [seen, setSeen] = useState<SeenIds>(() => {
+    const initial = new Set(isLoading ? [] : events.map((event) => event.id));
+    return { previous: initial, current: initial };
+  });
+  const unseen = events.filter((event) => !seen.current.has(event.id));
+  if (unseen.length > 0) {
+    setSeen({ previous: seen.current, current: new Set([...seen.current, ...unseen.map((event) => event.id)]) });
   }
+  const newOrders = reduceMotion ? NO_NEW_CARDS : resolveNewOrders(events, seen.previous);
   const dayGroups = groupEventsByDay(events);
-  const groupOffsets = resolveGroupOffsets(dayGroups);
 
   if (isLoading) return <LoadingIndicator />;
   if (error) return <ErrorState message="Failed to load events." />;
@@ -114,15 +120,8 @@ function EventsContent() {
     <div className="flex flex-col gap-2">
       <div className="flex flex-col gap-4">
         <LazyMotion features={loadMotionFeatures}>
-          {dayGroups.map((group, groupIndex) => (
-            <DaySection
-              key={group.label}
-              label={group.label}
-              events={group.events}
-              startIndex={groupOffsets[groupIndex]}
-              firstNewIndex={revealed.count}
-              reduceMotion={reduceMotion}
-            />
+          {dayGroups.map((group) => (
+            <DaySection key={group.label} label={group.label} events={group.events} newOrders={newOrders} />
           ))}
         </LazyMotion>
       </div>
@@ -172,25 +171,19 @@ function LoadingIndicator() {
   );
 }
 
-const DaySection = memo(function DaySection({
-  label,
-  events,
-  startIndex,
-  firstNewIndex,
-  reduceMotion,
-}: DaySectionProps) {
+const DaySection = memo(function DaySection({ label, events, newOrders }: DaySectionProps) {
   return (
     <div className="flex flex-col px-0.5">
       <DashboardHeading2>{label}</DashboardHeading2>
       <div className="flex flex-col gap-2 pt-1">
-        {events.map((event, eventIndex) => {
-          const order = startIndex + eventIndex - firstNewIndex;
+        {events.map((event) => {
+          const order = newOrders.get(event.id);
           return (
             <m.div
               key={event.id}
-              initial={order < 0 ? false : CARD_HIDDEN}
+              initial={order === undefined ? false : CARD_HIDDEN}
               animate={CARD_VISIBLE}
-              transition={resolveCardTransition(Math.max(order, 0), reduceMotion)}
+              transition={order === undefined ? undefined : resolveCardTransition(order)}
             >
               <EventCard event={event} past={isEventPast(event.endTime)} />
             </m.div>

--- a/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
@@ -6,7 +6,7 @@ import { loadMotionFeatures } from "@/lib/motion-features";
 import LoaderCircle from "lucide-react/dist/esm/icons/loader-circle";
 import { BackButton } from "@/components/ui/primitives/back-button";
 import { ErrorState } from "@/components/ui/primitives/error-state";
-import { ScrollFader } from "@/components/ui/primitives/scroll-fader";
+import { PageBody } from "@/components/ui/primitives/page-body";
 import { StickyPageHeader } from "@/components/ui/primitives/sticky-page-header";
 import { DashboardHeading1, DashboardHeading2 } from "@/components/ui/primitives/dashboard-heading";
 import { Text } from "@/components/ui/primitives/text";
@@ -75,12 +75,12 @@ const resolveGroupOffsets = (groups: DayGroup[]): number[] => {
 
 function EventsPage() {
   return (
-    <ScrollFader>
-      <div className="flex flex-col gap-3">
-        <EventsHeader />
+    <div className="flex flex-col gap-3 lg:h-full">
+      <EventsHeader />
+      <PageBody>
         <EventsContent />
-      </div>
-    </ScrollFader>
+      </PageBody>
+    </div>
   );
 }
 

--- a/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
@@ -1,5 +1,8 @@
-import { useEffect, useRef, memo } from "react";
+import { useEffect, useRef, useState, memo } from "react";
 import { createFileRoute } from "@tanstack/react-router";
+import { LazyMotion, useReducedMotion } from "motion/react";
+import * as m from "motion/react-m";
+import { loadMotionFeatures } from "@/lib/motion-features";
 import LoaderCircle from "lucide-react/dist/esm/icons/loader-circle";
 import { BackButton } from "@/components/ui/primitives/back-button";
 import { ErrorState } from "@/components/ui/primitives/error-state";
@@ -21,6 +24,21 @@ interface DayGroup {
 interface DaySectionProps {
   label: string;
   events: CalendarEvent[];
+  startIndex: number;
+  firstNewIndex: number;
+  reduceMotion: boolean;
+}
+
+const CARD_HIDDEN = { opacity: 0, y: 8 };
+const CARD_VISIBLE = { opacity: 1, y: 0 };
+const CARD_TRANSITION = { duration: 0.28, ease: [0.2, 0, 0, 1] as const };
+const CARD_STAGGER = 0.035;
+const CARD_STAGGER_CAP = 12;
+const INSTANT = { duration: 0 };
+
+function resolveCardTransition(order: number, reduceMotion: boolean) {
+  if (reduceMotion) return INSTANT;
+  return { ...CARD_TRANSITION, delay: Math.min(order, CARD_STAGGER_CAP) * CARD_STAGGER };
 }
 
 interface LoadMoreSentinelProps {
@@ -44,6 +62,15 @@ const groupEventsByDay = (events: CalendarEvent[]): DayGroup[] => {
   }));
 };
 
+const resolveGroupOffsets = (groups: DayGroup[]): number[] => {
+  let offset = 0;
+  return groups.map((group) => {
+    const start = offset;
+    offset += group.events.length;
+    return start;
+  });
+};
+
 function EventsPage() {
   return (
     <div className="flex flex-col gap-3">
@@ -55,7 +82,14 @@ function EventsPage() {
 
 function EventsContent() {
   const { events, error, isLoading, isValidating, hasMore, loadMore } = useEvents();
+  const reduceMotion = useReducedMotion() ?? false;
+  // Cards already on screen when the page mounts (cached data) stay put; only newly fetched ones rise in.
+  const [revealed, setRevealed] = useState({ count: isLoading ? 0 : events.length, seen: events.length });
+  if (revealed.seen !== events.length) {
+    setRevealed({ count: revealed.seen, seen: events.length });
+  }
   const dayGroups = groupEventsByDay(events);
+  const groupOffsets = resolveGroupOffsets(dayGroups);
 
   if (isLoading) return <LoadingIndicator />;
   if (error) return <ErrorState message="Failed to load events." />;
@@ -67,9 +101,18 @@ function EventsContent() {
           <DashboardHeading1>Events</DashboardHeading1>
           <Text size="sm">View all of the events across all of your calendars.</Text>
         </div>
-        {dayGroups.map((group) => (
-          <DaySection key={group.label} label={group.label} events={group.events} />
-        ))}
+        <LazyMotion features={loadMotionFeatures}>
+          {dayGroups.map((group, groupIndex) => (
+            <DaySection
+              key={group.label}
+              label={group.label}
+              events={group.events}
+              startIndex={groupOffsets[groupIndex]}
+              firstNewIndex={revealed.count}
+              reduceMotion={reduceMotion}
+            />
+          ))}
+        </LazyMotion>
       </div>
       {hasMore && (
         <LoadMoreSentinel
@@ -117,14 +160,30 @@ function LoadingIndicator() {
   );
 }
 
-const DaySection = memo(function DaySection({ label, events }: DaySectionProps) {
+const DaySection = memo(function DaySection({
+  label,
+  events,
+  startIndex,
+  firstNewIndex,
+  reduceMotion,
+}: DaySectionProps) {
   return (
     <div className="flex flex-col px-0.5">
       <DashboardHeading2>{label}</DashboardHeading2>
       <div className="flex flex-col gap-2 pt-1">
-        {events.map((event) => (
-          <EventCard key={event.id} event={event} past={isEventPast(event.endTime)} />
-        ))}
+        {events.map((event, eventIndex) => {
+          const order = startIndex + eventIndex - firstNewIndex;
+          return (
+            <m.div
+              key={event.id}
+              initial={order < 0 ? false : CARD_HIDDEN}
+              animate={CARD_VISIBLE}
+              transition={resolveCardTransition(Math.max(order, 0), reduceMotion)}
+            >
+              <EventCard event={event} past={isEventPast(event.endTime)} />
+            </m.div>
+          );
+        })}
       </div>
     </div>
   );

--- a/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/events/index.tsx
@@ -76,10 +76,23 @@ function EventsPage() {
   return (
     <ScrollFader>
       <div className="flex flex-col gap-3">
-        <BackButton />
+        <EventsHeader />
         <EventsContent />
       </div>
     </ScrollFader>
+  );
+}
+
+// Reaches up over the column's top padding at lg so nothing shows above it while stuck.
+function EventsHeader() {
+  return (
+    <div className="sticky top-0 z-10 flex flex-col gap-3 bg-background pb-1 after:absolute after:inset-x-0 after:top-full after:h-6 after:bg-linear-to-b after:from-background after:to-transparent lg:-top-6 lg:-mx-1 lg:-mt-6 lg:px-1 lg:pt-6">
+      <BackButton />
+      <div className="flex flex-col">
+        <DashboardHeading1>Events</DashboardHeading1>
+        <Text size="sm">View all of the events across all of your calendars.</Text>
+      </div>
+    </div>
   );
 }
 
@@ -100,10 +113,6 @@ function EventsContent() {
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-col gap-4">
-        <div className="flex flex-col">
-          <DashboardHeading1>Events</DashboardHeading1>
-          <Text size="sm">View all of the events across all of your calendars.</Text>
-        </div>
         <LazyMotion features={loadMotionFeatures}>
           {dayGroups.map((group, groupIndex) => (
             <DaySection

--- a/applications/web/src/routes/(dashboard)/dashboard/feedback.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/feedback.tsx
@@ -51,7 +51,7 @@ function FeedbackPage() {
           description="Your feedback has been submitted. We appreciate you taking the time to help us improve."
           level={1}
         />
-        <LinkButton to="/dashboard" variant="elevated" className="w-full justify-center">
+        <LinkButton to="/dashboard" variant="border" className="w-full justify-center">
           <ButtonText>Back to Dashboard</ButtonText>
         </LinkButton>
       </div>

--- a/applications/web/src/routes/(dashboard)/dashboard/ical/$feedId.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/ical/$feedId.tsx
@@ -10,7 +10,7 @@ import { track, ANALYTICS_EVENTS } from "@/lib/analytics";
 import { serializedPatch } from "@/lib/serialized-mutate";
 import { formatDate } from "@/lib/time";
 import { BackButton } from "@/components/ui/primitives/back-button";
-import { ScrollFader } from "@/components/ui/primitives/scroll-fader";
+import { PageBody } from "@/components/ui/primitives/page-body";
 import { StickyPageHeader } from "@/components/ui/primitives/sticky-page-header";
 import { Button, ButtonIcon } from "@/components/ui/primitives/button";
 import { Input } from "@/components/ui/primitives/input";
@@ -197,15 +197,15 @@ function ICalFeedDetailPage() {
   };
 
   return (
-    <ScrollFader>
-      <div className="flex flex-col gap-1.5">
-        <StickyPageHeader className="gap-1.5">
-          <div className="flex items-center justify-between">
-            <BackButton fallback="/dashboard/ical" />
-            <FeedPrevNext feedId={feedId} />
-          </div>
-          <FeedHeader name={feed.name} />
-        </StickyPageHeader>
+    <div className="flex flex-col gap-1.5 lg:h-full">
+      <StickyPageHeader className="gap-1.5">
+        <div className="flex items-center justify-between">
+          <BackButton fallback="/dashboard/ical" />
+          <FeedPrevNext feedId={feedId} />
+        </div>
+        <FeedHeader name={feed.name} />
+      </StickyPageHeader>
+      <PageBody className="gap-1.5">
         {mutationError && <Text size="sm" tone="danger">{mutationError}</Text>}
         <DashboardSection
           title="Feed Link"
@@ -307,8 +307,8 @@ function ICalFeedDetailPage() {
             />
           </>
         )}
-      </div>
-    </ScrollFader>
+      </PageBody>
+    </div>
   );
 }
 

--- a/applications/web/src/routes/(dashboard)/dashboard/ical/$feedId.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/ical/$feedId.tsx
@@ -10,6 +10,8 @@ import { track, ANALYTICS_EVENTS } from "@/lib/analytics";
 import { serializedPatch } from "@/lib/serialized-mutate";
 import { formatDate } from "@/lib/time";
 import { BackButton } from "@/components/ui/primitives/back-button";
+import { ScrollFader } from "@/components/ui/primitives/scroll-fader";
+import { StickyPageHeader } from "@/components/ui/primitives/sticky-page-header";
 import { Button, ButtonIcon } from "@/components/ui/primitives/button";
 import { Input } from "@/components/ui/primitives/input";
 import { DashboardHeading1, DashboardSection } from "@/components/ui/primitives/dashboard-heading";
@@ -195,114 +197,118 @@ function ICalFeedDetailPage() {
   };
 
   return (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex items-center justify-between">
-        <BackButton fallback="/dashboard/ical" />
-        <FeedPrevNext feedId={feedId} />
-      </div>
-      <FeedHeader name={feed.name} />
-      {mutationError && <Text size="sm" tone="danger">{mutationError}</Text>}
-      <DashboardSection
-        title="Feed Link"
-        description="Subscribe to this link in any calendar app."
-      />
-      <FeedLinkField url={feed.icalUrl} onError={setMutationError} />
-      <Text size="sm" tone="muted" className="px-0.5">{resolveFeedDisclosure(feed)}</Text>
-      <DashboardSection
-        title="Feed Name"
-        description="Click below to rename this feed. Only you can see this name."
-      />
-      <NavigationMenu>
-        <NavigationMenuEditableItem value={feed.name} onCommit={handleRename} />
-      </NavigationMenu>
-      <CalendarsSection
-        isDefault={feed.isDefault}
-        selected={selected}
-        onToggle={handleToggleCalendar}
-      />
-      <DashboardSection
-        title="Feed Settings"
-        description={<>Choose which event details this link includes. Use <Text as="span" size="sm" className="text-template inline">{"{{calendar_name}}"}</Text> or <Text as="span" size="sm" className="text-template inline">{"{{event_name}}"}</Text> in text fields for dynamic values.</>}
-      />
-      <PremiumFeatureGate locked={locked} hint="Feed settings are a Pro feature.">
+    <ScrollFader>
+      <div className="flex flex-col gap-1.5">
+        <StickyPageHeader className="gap-1.5">
+          <div className="flex items-center justify-between">
+            <BackButton fallback="/dashboard/ical" />
+            <FeedPrevNext feedId={feedId} />
+          </div>
+          <FeedHeader name={feed.name} />
+        </StickyPageHeader>
+        {mutationError && <Text size="sm" tone="danger">{mutationError}</Text>}
+        <DashboardSection
+          title="Feed Link"
+          description="Subscribe to this link in any calendar app."
+        />
+        <FeedLinkField url={feed.icalUrl} onError={setMutationError} />
+        <Text size="sm" tone="muted" className="px-0.5">{resolveFeedDisclosure(feed)}</Text>
+        <DashboardSection
+          title="Feed Name"
+          description="Click below to rename this feed. Only you can see this name."
+        />
         <NavigationMenu>
-          <EventNameTemplateItem
-            customEventName={feed.customEventName}
-            disabled={locked || feed.includeEventName}
-            onCommit={(customEventName) => patchFeed({ customEventName })}
-          />
-          <NavigationMenuToggleItem
-            checked={feed.includeEventName}
-            disabled={locked}
-            onCheckedChange={handleToggleEventName}
-          >
-            <NavigationMenuItemLabel>Include Event Name</NavigationMenuItemLabel>
-          </NavigationMenuToggleItem>
-          {SETTING_TOGGLES.map(({ field, label }) => (
-            <NavigationMenuToggleItem
-              key={field}
-              checked={feed[field]}
-              disabled={locked}
-              onCheckedChange={() => handleToggleSetting(field)}
-            >
-              <NavigationMenuItemLabel>{label}</NavigationMenuItemLabel>
-            </NavigationMenuToggleItem>
-          ))}
+          <NavigationMenuEditableItem value={feed.name} onCommit={handleRename} />
         </NavigationMenu>
-      </PremiumFeatureGate>
-      <DashboardSection
-        title="Event Filters"
-        description="Leave these event types out of this link."
-      />
-      <PremiumFeatureGate locked={locked} hint="Event filters are a Pro feature.">
-        <NavigationMenu>
-          {FILTER_TOGGLES.map(({ field, label }) => (
-            <NavigationMenuToggleItem
-              key={field}
-              checked={feed[field]}
-              disabled={locked}
-              onCheckedChange={() => handleToggleSetting(field)}
-            >
-              <NavigationMenuItemLabel>{label}</NavigationMenuItemLabel>
-            </NavigationMenuToggleItem>
-          ))}
-        </NavigationMenu>
-      </PremiumFeatureGate>
-      <DashboardSection
-        title="Feed Information"
-        description="View details about this feed."
-      />
-      <NavigationMenu>
-        <MetadataRow label="Resource Type" value={feed.isDefault ? "Default Feed" : "Feed"} />
-        <MetadataRow label="Created" value={formatDate(feed.createdAt)} />
-      </NavigationMenu>
-      {feed.isDefault && (
-        <Text size="sm" tone="muted" className="px-0.5">
-          Your default feed cannot be deleted. Create another feed to share a narrower set of
-          calendars.
-        </Text>
-      )}
-      {!feed.isDefault && (
-        <>
+        <CalendarsSection
+          isDefault={feed.isDefault}
+          selected={selected}
+          onToggle={handleToggleCalendar}
+        />
+        <DashboardSection
+          title="Feed Settings"
+          description={<>Choose which event details this link includes. Use <Text as="span" size="sm" className="text-template inline">{"{{calendar_name}}"}</Text> or <Text as="span" size="sm" className="text-template inline">{"{{event_name}}"}</Text> in text fields for dynamic values.</>}
+        />
+        <PremiumFeatureGate locked={locked} hint="Feed settings are a Pro feature.">
           <NavigationMenu>
-            <NavigationMenuButtonItem onClick={() => setDeleteOpen(true)}>
-              <NavigationMenuItemIcon>
-                <Trash2 size={15} className="text-destructive" />
-              </NavigationMenuItemIcon>
-              <Text size="sm" tone="danger">Delete Feed</Text>
-            </NavigationMenuButtonItem>
+            <EventNameTemplateItem
+              customEventName={feed.customEventName}
+              disabled={locked || feed.includeEventName}
+              onCommit={(customEventName) => patchFeed({ customEventName })}
+            />
+            <NavigationMenuToggleItem
+              checked={feed.includeEventName}
+              disabled={locked}
+              onCheckedChange={handleToggleEventName}
+            >
+              <NavigationMenuItemLabel>Include Event Name</NavigationMenuItemLabel>
+            </NavigationMenuToggleItem>
+            {SETTING_TOGGLES.map(({ field, label }) => (
+              <NavigationMenuToggleItem
+                key={field}
+                checked={feed[field]}
+                disabled={locked}
+                onCheckedChange={() => handleToggleSetting(field)}
+              >
+                <NavigationMenuItemLabel>{label}</NavigationMenuItemLabel>
+              </NavigationMenuToggleItem>
+            ))}
           </NavigationMenu>
-          <DeleteConfirmation
-            title="Delete feed?"
-            description={`This permanently removes "${feed.name}". Calendar apps subscribed to its link will stop receiving events.`}
-            open={deleteOpen}
-            onOpenChange={setDeleteOpen}
-            deleting={deleting}
-            onConfirm={handleDelete}
-          />
-        </>
-      )}
-    </div>
+        </PremiumFeatureGate>
+        <DashboardSection
+          title="Event Filters"
+          description="Leave these event types out of this link."
+        />
+        <PremiumFeatureGate locked={locked} hint="Event filters are a Pro feature.">
+          <NavigationMenu>
+            {FILTER_TOGGLES.map(({ field, label }) => (
+              <NavigationMenuToggleItem
+                key={field}
+                checked={feed[field]}
+                disabled={locked}
+                onCheckedChange={() => handleToggleSetting(field)}
+              >
+                <NavigationMenuItemLabel>{label}</NavigationMenuItemLabel>
+              </NavigationMenuToggleItem>
+            ))}
+          </NavigationMenu>
+        </PremiumFeatureGate>
+        <DashboardSection
+          title="Feed Information"
+          description="View details about this feed."
+        />
+        <NavigationMenu>
+          <MetadataRow label="Resource Type" value={feed.isDefault ? "Default Feed" : "Feed"} />
+          <MetadataRow label="Created" value={formatDate(feed.createdAt)} />
+        </NavigationMenu>
+        {feed.isDefault && (
+          <Text size="sm" tone="muted" className="px-0.5">
+            Your default feed cannot be deleted. Create another feed to share a narrower set of
+            calendars.
+          </Text>
+        )}
+        {!feed.isDefault && (
+          <>
+            <NavigationMenu>
+              <NavigationMenuButtonItem onClick={() => setDeleteOpen(true)}>
+                <NavigationMenuItemIcon>
+                  <Trash2 size={15} className="text-destructive" />
+                </NavigationMenuItemIcon>
+                <Text size="sm" tone="danger">Delete Feed</Text>
+              </NavigationMenuButtonItem>
+            </NavigationMenu>
+            <DeleteConfirmation
+              title="Delete feed?"
+              description={`This permanently removes "${feed.name}". Calendar apps subscribed to its link will stop receiving events.`}
+              open={deleteOpen}
+              onOpenChange={setDeleteOpen}
+              deleting={deleting}
+              onConfirm={handleDelete}
+            />
+          </>
+        )}
+      </div>
+    </ScrollFader>
   );
 }
 

--- a/applications/web/src/routes/(dashboard)/dashboard/ical/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/ical/index.tsx
@@ -170,7 +170,7 @@ function CreateFeedItem({
               <CreateSubmitButton isCreating={isCreating} />
               <Button
                 type="button"
-                variant="elevated"
+                variant="border"
                 className="w-full justify-center"
                 onClick={() => setCreateOpen(false)}
               >

--- a/applications/web/src/routes/(dashboard)/dashboard/ical/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/ical/index.tsx
@@ -170,7 +170,7 @@ function CreateFeedItem({
               <CreateSubmitButton isCreating={isCreating} />
               <Button
                 type="button"
-                variant="border"
+                variant="elevated"
                 className="w-full justify-center"
                 onClick={() => setCreateOpen(false)}
               >

--- a/applications/web/src/routes/(dashboard)/dashboard/report.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/report.tsx
@@ -53,7 +53,7 @@ function ReportPage() {
           description="Your report has been submitted. We'll look into this as soon as possible."
           level={1}
         />
-        <LinkButton to="/dashboard" variant="elevated" className="w-full justify-center">
+        <LinkButton to="/dashboard" variant="border" className="w-full justify-center">
           <ButtonText>Back to Dashboard</ButtonText>
         </LinkButton>
       </div>

--- a/applications/web/src/routes/(dashboard)/route.tsx
+++ b/applications/web/src/routes/(dashboard)/route.tsx
@@ -36,7 +36,7 @@ function DashboardLayout() {
 
   return (
     <div className="relative flex min-h-dvh justify-center lg:justify-start lg:gap-4 lg:p-4">
-      <div className="relative flex w-full max-w-sm shrink-0 flex-col gap-3 px-4 pb-12 pt-4 xs:pt-[min(6rem,25vh)] lg:h-[calc(100dvh-2rem)] lg:overflow-y-auto lg:px-1 lg:pt-6">
+      <div className="relative flex w-full max-w-sm shrink-0 flex-col gap-3 px-4 pb-(--sidebar-pad-b) pt-4 [--sidebar-pad-b:3rem] [--sidebar-pad-t:1.5rem] [--sidebar-pad-x:0.25rem] xs:pt-[min(6rem,25vh)] lg:h-[calc(100dvh-2rem)] lg:overflow-y-auto lg:px-(--sidebar-pad-x) lg:pt-(--sidebar-pad-t)">
         <LazyMotion features={loadMotionFeatures}>
           <AnimatePresence>
             {overlayActive && (

--- a/applications/web/src/routes/(dashboard)/route.tsx
+++ b/applications/web/src/routes/(dashboard)/route.tsx
@@ -7,6 +7,7 @@ import { popoverOverlayAtom } from "@/state/popover-overlay";
 import { SyncProvider } from "@/providers/sync-provider";
 import { resolveDashboardRedirect } from "@/lib/route-access-guards";
 import { CalendarView } from "@/features/dashboard/components/calendar-view";
+import { SidebarPageTransition } from "@/features/dashboard/components/sidebar-page-transition";
 
 export const Route = createFileRoute("/(dashboard)")({
   beforeLoad: ({ context }) => {
@@ -50,7 +51,9 @@ function DashboardLayout() {
           </AnimatePresence>
         </LazyMotion>
         <SyncProvider />
-        <Outlet />
+        <SidebarPageTransition>
+          <Outlet />
+        </SidebarPageTransition>
       </div>
       {/* `isolate` keeps the calendar's sticky z-indices under the popover blur overlay (z-10). */}
       <div className="hidden lg:flex lg:h-[calc(100dvh-2rem)] lg:min-w-0 lg:flex-1 lg:isolate">

--- a/applications/web/src/routes/(dashboard)/route.tsx
+++ b/applications/web/src/routes/(dashboard)/route.tsx
@@ -36,7 +36,7 @@ function DashboardLayout() {
 
   return (
     <div className="relative flex min-h-dvh justify-center lg:justify-start lg:gap-4 lg:p-4">
-      <div className="relative flex w-full max-w-sm shrink-0 flex-col gap-3 px-4 pb-12 pt-4 xs:pt-[min(6rem,25vh)] lg:h-[calc(100dvh-2rem)] lg:overflow-y-auto lg:overscroll-y-none lg:px-1 lg:pt-6">
+      <div className="relative flex w-full max-w-sm shrink-0 flex-col gap-3 px-4 pb-12 pt-4 xs:pt-[min(6rem,25vh)] lg:h-[calc(100dvh-2rem)] lg:overflow-y-auto lg:px-1 lg:pt-6">
         <LazyMotion features={loadMotionFeatures}>
           <AnimatePresence>
             {overlayActive && (

--- a/applications/web/src/routes/(dashboard)/route.tsx
+++ b/applications/web/src/routes/(dashboard)/route.tsx
@@ -36,7 +36,7 @@ function DashboardLayout() {
 
   return (
     <div className="relative flex min-h-dvh justify-center lg:justify-start lg:gap-4 lg:p-4">
-      <div className="relative flex w-full max-w-sm shrink-0 flex-col gap-3 px-4 pb-12 pt-4 xs:pt-[min(6rem,25vh)] lg:h-[calc(100dvh-2rem)] lg:overflow-y-auto lg:px-1 lg:pt-6">
+      <div className="relative flex w-full max-w-sm shrink-0 flex-col gap-3 px-4 pb-12 pt-4 xs:pt-[min(6rem,25vh)] lg:h-[calc(100dvh-2rem)] lg:overflow-y-auto lg:overscroll-y-none lg:px-1 lg:pt-6">
         <LazyMotion features={loadMotionFeatures}>
           <AnimatePresence>
             {overlayActive && (

--- a/applications/web/tests/lib/sidebar-transition.test.ts
+++ b/applications/web/tests/lib/sidebar-transition.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolveSidebarDirection } from "../../src/lib/sidebar-transition";
+
+const at = (pathname: string, index: number) => ({ pathname, index });
+
+describe("resolveSidebarDirection", () => {
+  const cases = [
+    { name: "push deeper", from: at("/dashboard", 0), to: at("/dashboard/settings", 1), expected: "forward" },
+    { name: "push deeper twice", from: at("/dashboard/settings", 1), to: at("/dashboard/settings/passkeys", 2), expected: "forward" },
+    { name: "push sibling", from: at("/dashboard/report", 1), to: at("/dashboard/feedback", 2), expected: "forward" },
+    { name: "history back", from: at("/dashboard/settings", 1), to: at("/dashboard", 0), expected: "back" },
+    { name: "history back to a deeper page", from: at("/dashboard", 2), to: at("/dashboard/settings", 1), expected: "back" },
+    { name: "push to an ancestor", from: at("/dashboard/settings/passkeys", 0), to: at("/dashboard", 1), expected: "back" },
+    { name: "replace deeper", from: at("/dashboard/accounts/a", 1), to: at("/dashboard/accounts/a/setup", 1), expected: "forward" },
+    { name: "replace to an ancestor", from: at("/dashboard/upgrade", 1), to: at("/dashboard", 1), expected: "back" },
+    { name: "ignores trailing slashes", from: at("/dashboard/settings/", 1), to: at("/dashboard/", 2), expected: "back" },
+    { name: "prefix that is not a segment boundary", from: at("/dashboard/settings-x", 1), to: at("/dashboard/settings", 2), expected: "forward" },
+  ] as const;
+
+  for (const testCase of cases) {
+    it(`${testCase.name} -> ${testCase.expected}`, () => {
+      expect(resolveSidebarDirection(testCase.from, testCase.to)).toBe(testCase.expected);
+    });
+  }
+});

--- a/applications/web/tests/lib/sidebar-transition.test.ts
+++ b/applications/web/tests/lib/sidebar-transition.test.ts
@@ -22,4 +22,12 @@ describe("resolveSidebarDirection", () => {
       expect(resolveSidebarDirection(testCase.from, testCase.to)).toBe(testCase.expected);
     });
   }
+
+  it("honours a declared direction on a replace to a sibling", () => {
+    expect(resolveSidebarDirection(at("/dashboard/accounts/a/c2", 1), at("/dashboard/accounts/a/c1", 1), "back")).toBe("back");
+  });
+
+  it("ignores a declared direction once the history index moves", () => {
+    expect(resolveSidebarDirection(at("/dashboard", 0), at("/dashboard/accounts/a/c1", 1), "back")).toBe("forward");
+  });
 });


### PR DESCRIPTION
## Summary

Stacks on the `feature/now-indicator-pill` branch. Restyles the dashboard sidebar to the login page's flat black-and-border look and adds motion to the sidebar's pages.

- **Flat sidebar cards**: menu cards, provider icon discs, the back button, and the buttons that sit directly in the sidebar column take the login page's page-background + hairline-border surface, so the calendar frame is the only raised element.
- **Directional page slides**: navigating between sidebar pages nudges the new page in from the side of travel while the old one slides out (2rem shared-axis, 220ms). The outgoing page is animated as its retained DOM node pinned to the viewport, since the router cannot keep an exited match rendered. Pagination declares its own direction through link state.
- **Event card entry**: newly fetched cards on `/dashboard/events` rise in with a short stagger, keyed by event id so revalidations animate the right cards; cached revisits stay still.
- **Pinned page headers**: the events, calendar, iCal feed, and account pages keep their header fixed while a `PageBody` scroller below it handles scrolling, so the header holds still through elastic overscroll. A gradient fader dissolves the list into the column bottom.
- **Scrollbars**: thin, border-toned scrollbars across the app, set in the base layer so `[scrollbar-width:none]` utilities still win.
- The column's padding is defined once as CSS variables that the header and body primitives read.

## Screenshots

<img width="960" height="540" alt="export-1788495427459" src="https://github.com/user-attachments/assets/28c47051-86f2-4154-8baf-693844370355" />





## Test plan

- [x] `bun run lint`, `bun run types`, `vitest run` (488 passing) in `applications/web`
- [x] Dark and light dashboard at desktop: flat cards, calendar frame raised
- [x] Settings ⇄ dashboard slides in both directions; Previous/Next on a calendar page slide back/forward
- [x] Leaving a scrolled calendar page: outgoing page keeps its scroll position while sliding out
- [x] Events page: fresh load staggers cards, cached revisit does not, load-more batch animates on its own
- [x] Sticky header stays put while the body scrolls; fade strip under it is click-through
- [x] Popover blur covers the fader band
- [x] Narrow viewport (body scrolling) walk-through by hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)

