### PR TITLE
feat(web): week header density pips and a two-way sidebar link

### DIFF
--- a/applications/web/src/features/dashboard/components/calendar-view.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-view.tsx
@@ -1,5 +1,7 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { flushSync } from "react-dom";
+import { useStore } from "jotai";
+import { calendarJumpAtom } from "@/state/event-graph-hover";
 import ChevronLeft from "lucide-react/dist/esm/icons/chevron-left";
 import ChevronRight from "lucide-react/dist/esm/icons/chevron-right";
 import { cn } from "@/utils/cn";
@@ -28,6 +30,16 @@ const navButton =
 export function CalendarView() {
   const [view, setView] = useState<CalendarViewMode>("week");
   const [anchor, setAnchor] = useState(() => new Date());
+
+  const store = useStore();
+  useEffect(
+    () =>
+      store.sub(calendarJumpAtom, () => {
+        const jump = store.get(calendarJumpAtom);
+        if (jump) setAnchor(new Date(jump.dayMs));
+      }),
+    [store],
+  );
 
   const monthDays = useMemo(() => getMonthGridDays(anchor), [anchor]);
 

--- a/applications/web/src/features/dashboard/components/calendar-view.tsx
+++ b/applications/web/src/features/dashboard/components/calendar-view.tsx
@@ -36,7 +36,9 @@ export function CalendarView() {
     () =>
       store.sub(calendarJumpAtom, () => {
         const jump = store.get(calendarJumpAtom);
-        if (jump) setAnchor(new Date(jump.dayMs));
+        if (!jump) return;
+        setView("week");
+        setAnchor(new Date(jump.dayMs));
       }),
     [store],
   );

--- a/applications/web/src/features/dashboard/components/day-column.tsx
+++ b/applications/web/src/features/dashboard/components/day-column.tsx
@@ -54,11 +54,7 @@ export const DayColumn = memo(function DayColumn({ day, now, events }: DayColumn
         className="pointer-events-none absolute inset-x-0 bottom-0 bg-[linear-gradient(to_bottom,var(--color-border-hour)_0_1px,transparent_1px)]"
         style={{ top: HOUR_HEIGHT, backgroundSize: `100% ${HOUR_HEIGHT}px` }}
       />
-      {/* Reaches above midnight so rubber-band overscroll can't part the rule from the header. */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute -top-[100dvh] bottom-0 left-0 w-px bg-border-elevated"
-      />
+      <div aria-hidden className="pointer-events-none absolute inset-y-0 left-0 w-px bg-border-elevated" />
       {positioned.map((item) => (
         <EventCard
           key={item.event.id}

--- a/applications/web/src/features/dashboard/components/day-column.tsx
+++ b/applications/web/src/features/dashboard/components/day-column.tsx
@@ -54,7 +54,11 @@ export const DayColumn = memo(function DayColumn({ day, now, events }: DayColumn
         className="pointer-events-none absolute inset-x-0 bottom-0 bg-[linear-gradient(to_bottom,var(--color-border-hour)_0_1px,transparent_1px)]"
         style={{ top: HOUR_HEIGHT, backgroundSize: `100% ${HOUR_HEIGHT}px` }}
       />
-      <div aria-hidden className="pointer-events-none absolute inset-y-0 left-0 w-px bg-border-elevated" />
+      {/* Reaches above midnight so rubber-band overscroll can't part the rule from the header. */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -top-[100dvh] bottom-0 left-0 w-px bg-border-elevated"
+      />
       {positioned.map((item) => (
         <EventCard
           key={item.event.id}

--- a/applications/web/src/features/dashboard/components/day-column.tsx
+++ b/applications/web/src/features/dashboard/components/day-column.tsx
@@ -1,8 +1,11 @@
 import { memo } from "react";
 import type { CSSProperties } from "react";
 import { isEventPast } from "@/lib/time";
+import { resolveDataAttr } from "@/utils/data-attr";
+import { useCalendarHighlightedDay } from "@/hooks/use-calendar-highlighted-day";
 import type { CalendarEvent } from "@/hooks/use-events";
 import { HOUR_HEIGHT } from "./calendar-helpers";
+import { periodWash, resolvePeriod } from "./density-period";
 import { EventCard } from "./event-card";
 import { layoutDayEvents, stackIndentPx, tileBox } from "./event-layout";
 import type { PositionedEvent } from "./event-layout";
@@ -17,6 +20,7 @@ const MAX_CARD_ELEVATION = 8;
 
 interface DayColumnProps {
   day: Date;
+  dayOffset: number;
   /** Null except on today, so only today's column re-renders on the minute tick. */
   now: Date | null;
   events: CalendarEvent[];
@@ -43,11 +47,15 @@ function resolveCardStyle(item: PositionedEvent): CSSProperties {
   };
 }
 
-export const DayColumn = memo(function DayColumn({ day, now, events }: DayColumnProps) {
+export const DayColumn = memo(function DayColumn({ day, dayOffset, now, events }: DayColumnProps) {
   const positioned = layoutDayEvents(events, day);
+  const active = useCalendarHighlightedDay(dayOffset);
 
   return (
-    <div className="relative snap-start">
+    <div
+      className={periodWash({ period: resolvePeriod(dayOffset), className: "relative snap-start" })}
+      data-active={resolveDataAttr(active)}
+    >
       {/* Hour rules, per cell — one strip-wide background layer is too large for some engines to paint. */}
       <div
         aria-hidden

--- a/applications/web/src/features/dashboard/components/density-period.ts
+++ b/applications/web/src/features/dashboard/components/density-period.ts
@@ -18,3 +18,14 @@ export const periodFill = tv({
     },
   },
 });
+
+export const periodWash = tv({
+  base: "transition-[background-color,opacity] duration-150",
+  variants: {
+    period: {
+      past: "data-active:bg-background-hover",
+      today: "data-active:bg-emerald-400/8",
+      future: "data-active:bg-emerald-400/8",
+    },
+  },
+});

--- a/applications/web/src/features/dashboard/components/density-period.ts
+++ b/applications/web/src/features/dashboard/components/density-period.ts
@@ -1,0 +1,20 @@
+import { tv } from "tailwind-variants/lite";
+
+export type Period = "past" | "today" | "future";
+
+export const resolvePeriod = (dayOffset: number): Period => {
+  if (dayOffset < 0) return "past";
+  if (dayOffset === 0) return "today";
+  return "future";
+};
+
+export const periodFill = tv({
+  variants: {
+    period: {
+      past: "bg-background-hover border border-border-elevated",
+      today: "bg-emerald-400 border-transparent",
+      future:
+        "bg-emerald-400 border-emerald-500 bg-[repeating-linear-gradient(-45deg,transparent_0_4px,var(--color-illustration-stripe)_4px_8px)]",
+    },
+  },
+});

--- a/applications/web/src/features/dashboard/components/density-period.ts
+++ b/applications/web/src/features/dashboard/components/density-period.ts
@@ -20,7 +20,7 @@ export const periodFill = tv({
 });
 
 export const periodWash = tv({
-  base: "transition-[background-color,background-image,opacity] duration-150",
+  base: "duration-150",
   variants: {
     period: {
       past: "[--wash:var(--color-background-hover)]",
@@ -28,8 +28,9 @@ export const periodWash = tv({
       future: "[--wash:color-mix(in_oklab,var(--color-emerald-400)_8%,transparent)]",
     },
     edge: {
-      flat: "data-active:bg-(--wash)",
-      fadeTop: "data-active:bg-[linear-gradient(to_bottom,transparent,var(--wash)_1.5rem)]",
+      flat: "transition-[background-color,opacity] data-active:bg-(--wash)",
+      fadeTop:
+        "relative isolate transition-opacity before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:bg-[linear-gradient(to_bottom,transparent,var(--wash)_1.5rem)] before:opacity-0 before:transition-opacity before:duration-150 data-active:before:opacity-100",
     },
   },
   defaultVariants: { edge: "flat" },

--- a/applications/web/src/features/dashboard/components/density-period.ts
+++ b/applications/web/src/features/dashboard/components/density-period.ts
@@ -20,12 +20,17 @@ export const periodFill = tv({
 });
 
 export const periodWash = tv({
-  base: "transition-[background-color,opacity] duration-150",
+  base: "transition-[background-color,background-image,opacity] duration-150",
   variants: {
     period: {
-      past: "data-active:bg-background-hover",
-      today: "data-active:bg-emerald-400/8",
-      future: "data-active:bg-emerald-400/8",
+      past: "[--wash:var(--color-background-hover)]",
+      today: "[--wash:color-mix(in_oklab,var(--color-emerald-400)_8%,transparent)]",
+      future: "[--wash:color-mix(in_oklab,var(--color-emerald-400)_8%,transparent)]",
+    },
+    edge: {
+      flat: "data-active:bg-(--wash)",
+      fadeTop: "data-active:bg-[linear-gradient(to_bottom,transparent,var(--wash)_1.5rem)]",
     },
   },
+  defaultVariants: { edge: "flat" },
 });

--- a/applications/web/src/features/dashboard/components/event-graph.tsx
+++ b/applications/web/src/features/dashboard/components/event-graph.tsx
@@ -18,28 +18,30 @@ import { useAnimatedSWR } from "@/hooks/use-animated-swr";
 import { pluralize } from "@/lib/pluralize";
 import { Text } from "@/components/ui/primitives/text";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import type { ApiEventSummary } from "@/types/api";
+import { addDays, startOfDay } from "./calendar-helpers";
 import { periodFill, resolvePeriod } from "./density-period";
 import type { Period } from "./density-period";
 
 const GRAPH_HEIGHT = 96;
 const MIN_BAR_HEIGHT = 20;
+/** The layout's `lg:` gate on the calendar column; below it a bar has nothing to jump. */
+const CALENDAR_VISIBLE_QUERY = "(min-width: 64rem)";
 
 const MS_PER_DAY = 86_400_000;
 
 const buildGraphUrl = (todayStart: Date): string => {
-  const from = new Date(todayStart.getTime() - EVENT_GRAPH_DAYS_BEFORE * MS_PER_DAY);
-  const to = new Date(
-    todayStart.getTime() + EVENT_GRAPH_DAYS_AFTER * MS_PER_DAY + MS_PER_DAY - 1,
-  );
+  const from = addDays(todayStart, -EVENT_GRAPH_DAYS_BEFORE);
+  const to = new Date(addDays(todayStart, EVENT_GRAPH_DAYS_AFTER + 1).getTime() - 1);
   return `/api/events?from=${from.toISOString()}&to=${to.toISOString()}`;
 };
 
 const countEventsByDay = (events: ApiEventSummary[], todayTimestamp: number): number[] => {
   const counts = new Array<number>(EVENT_GRAPH_TOTAL_DAYS).fill(0);
   for (const event of events) {
-    const eventDate = new Date(event.startTime);
-    const dayOffset = Math.floor((eventDate.getTime() - todayTimestamp) / MS_PER_DAY);
+    const eventDay = startOfDay(new Date(event.startTime));
+    const dayOffset = Math.round((eventDay.getTime() - todayTimestamp) / MS_PER_DAY);
     const slotIndex = dayOffset + EVENT_GRAPH_DAYS_BEFORE;
     if (slotIndex >= 0 && slotIndex < EVENT_GRAPH_TOTAL_DAYS) counts[slotIndex]++;
   }
@@ -54,12 +56,6 @@ interface DayData {
   fullLabel: string;
   period: Period;
 }
-
-const resolveDay = (todayStart: Date, dayOffset: number): Date => {
-  const date = new Date(todayStart);
-  date.setDate(date.getDate() + dayOffset);
-  return date;
-};
 
 const formatDayLabel = (day: Date): string =>
   day.toLocaleDateString("en-US", {
@@ -79,7 +75,7 @@ const normalizeDayData = (counts: number[], todayStart: Date): DayData[] => {
 
   return counts.map((count, slotIndex) => {
     const dayOffset = slotIndex - EVENT_GRAPH_DAYS_BEFORE;
-    const day = resolveDay(todayStart, dayOffset);
+    const day = addDays(todayStart, dayOffset);
     return {
       count,
       dayOffset,
@@ -167,21 +163,39 @@ interface EventGraphBarProps {
   day: DayData;
   dayIndex: number;
   shouldAnimate: boolean;
+  calendarVisible: boolean;
 }
 
-const EventGraphBar = memo(function EventGraphBar({ day, dayIndex, shouldAnimate }: EventGraphBarProps) {
+const EventGraphBar = memo(function EventGraphBar({
+  day,
+  dayIndex,
+  shouldAnimate,
+  calendarVisible,
+}: EventGraphBarProps) {
   const isHighlighted = useIsHighlighted(dayIndex);
   const setHoverIndex = useSetAtom(eventGraphHoverIndexAtom);
+  const setPointerOver = useSetAtom(eventGraphPointerAtom);
   const setJump = useSetAtom(calendarJumpAtom);
 
   return (
     <button
       type="button"
       aria-label={day.fullLabel}
-      className="flex-1 flex flex-col gap-2 cursor-pointer rounded-[0.625rem] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      tabIndex={calendarVisible && day.period === "today" ? 0 : -1}
+      className="flex-1 flex flex-col gap-2 rounded-[0.625rem] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring lg:cursor-pointer"
       data-active={resolveDataAttr(isHighlighted)}
       onPointerEnter={() => setHoverIndex(dayIndex)}
-      onClick={() => setJump({ dayMs: day.dayMs })}
+      onFocus={() => {
+        setPointerOver(true);
+        setHoverIndex(dayIndex);
+      }}
+      onBlur={() => {
+        setPointerOver(false);
+        setHoverIndex(null);
+      }}
+      onClick={() => {
+        if (calendarVisible) setJump({ dayMs: day.dayMs });
+      }}
     >
       <div
         className="flex items-end"
@@ -219,7 +233,26 @@ function EventGraphBars({ days, shouldAnimate }: EventGraphBarsProps) {
   const isHighlighting = useAtomValue(isHighlightingAtom);
   const setHoverIndex = useSetAtom(eventGraphHoverIndexAtom);
   const setPointerOver = useSetAtom(eventGraphPointerAtom);
+  const calendarVisible = useMediaQuery(CALENDAR_VISIBLE_QUERY);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(
+    () => () => {
+      setPointerOver(false);
+      setHoverIndex(null);
+    },
+    [setPointerOver, setHoverIndex],
+  );
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    const step = event.key === "ArrowRight" ? 1 : event.key === "ArrowLeft" ? -1 : 0;
+    if (step === 0) return;
+    const bars = Array.from(containerRef.current?.querySelectorAll("button") ?? []);
+    const next = bars[bars.indexOf(event.target as HTMLButtonElement) + step];
+    if (!next) return;
+    event.preventDefault();
+    next.focus();
+  };
 
   const resolveIndexFromTouch = useCallback((touch: React.Touch) => {
     const container = containerRef.current;
@@ -271,6 +304,8 @@ function EventGraphBars({ days, shouldAnimate }: EventGraphBarsProps) {
       }}
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchEnd}
+      onKeyDown={handleKeyDown}
     >
       {days.map((day, dayIndex) => (
         <EventGraphBar
@@ -278,6 +313,7 @@ function EventGraphBars({ days, shouldAnimate }: EventGraphBarsProps) {
           day={day}
           dayIndex={dayIndex}
           shouldAnimate={shouldAnimate}
+          calendarVisible={calendarVisible}
         />
       ))}
     </div>

--- a/applications/web/src/features/dashboard/components/event-graph.tsx
+++ b/applications/web/src/features/dashboard/components/event-graph.tsx
@@ -4,56 +4,41 @@ import { useAtomValue, useSetAtom } from "jotai";
 import * as m from "motion/react-m";
 import { LazyMotion } from "motion/react";
 import { loadMotionFeatures } from "@/lib/motion-features";
-import { tv } from "tailwind-variants/lite";
-import { eventGraphHoverIndexAtom, eventGraphDraggingAtom } from "@/state/event-graph-hover";
+import {
+  EVENT_GRAPH_DAYS_AFTER,
+  EVENT_GRAPH_DAYS_BEFORE,
+  EVENT_GRAPH_TOTAL_DAYS,
+  eventGraphHoverIndexAtom,
+} from "@/state/event-graph-hover";
 import { fetcher } from "@/lib/fetcher";
 import { useAnimatedSWR } from "@/hooks/use-animated-swr";
 import { pluralize } from "@/lib/pluralize";
 import { Text } from "@/components/ui/primitives/text";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
 import type { ApiEventSummary } from "@/types/api";
+import { periodFill, resolvePeriod } from "./density-period";
+import type { Period } from "./density-period";
 
-const DAYS_BEFORE = 7;
-const DAYS_AFTER = 7;
-const TOTAL_DAYS = DAYS_BEFORE + 1 + DAYS_AFTER;
 const GRAPH_HEIGHT = 96;
 const MIN_BAR_HEIGHT = 20;
-
-const graphBar = tv({
-  base: "flex-1 rounded-[0.625rem]",
-  variants: {
-    period: {
-      past: "bg-background-hover border border-border-elevated",
-      today: "bg-emerald-400 border-transparent",
-      future:
-        "bg-emerald-400 border-emerald-500 bg-[repeating-linear-gradient(-45deg,transparent_0_4px,var(--color-illustration-stripe)_4px_8px)]",
-    },
-  },
-});
-
-type Period = "past" | "today" | "future";
-
-const resolvePeriod = (dayOffset: number): Period => {
-  if (dayOffset < 0) return "past";
-  if (dayOffset === 0) return "today";
-  return "future";
-};
 
 const MS_PER_DAY = 86_400_000;
 
 const buildGraphUrl = (todayStart: Date): string => {
-  const from = new Date(todayStart.getTime() - DAYS_BEFORE * MS_PER_DAY);
-  const to = new Date(todayStart.getTime() + DAYS_AFTER * MS_PER_DAY + MS_PER_DAY - 1);
+  const from = new Date(todayStart.getTime() - EVENT_GRAPH_DAYS_BEFORE * MS_PER_DAY);
+  const to = new Date(
+    todayStart.getTime() + EVENT_GRAPH_DAYS_AFTER * MS_PER_DAY + MS_PER_DAY - 1,
+  );
   return `/api/events?from=${from.toISOString()}&to=${to.toISOString()}`;
 };
 
 const countEventsByDay = (events: ApiEventSummary[], todayTimestamp: number): number[] => {
-  const counts = new Array<number>(TOTAL_DAYS).fill(0);
+  const counts = new Array<number>(EVENT_GRAPH_TOTAL_DAYS).fill(0);
   for (const event of events) {
     const eventDate = new Date(event.startTime);
     const dayOffset = Math.floor((eventDate.getTime() - todayTimestamp) / MS_PER_DAY);
-    const slotIndex = dayOffset + DAYS_BEFORE;
-    if (slotIndex >= 0 && slotIndex < TOTAL_DAYS) counts[slotIndex]++;
+    const slotIndex = dayOffset + EVENT_GRAPH_DAYS_BEFORE;
+    if (slotIndex >= 0 && slotIndex < EVENT_GRAPH_TOTAL_DAYS) counts[slotIndex]++;
   }
   return counts;
 };
@@ -86,7 +71,7 @@ const normalizeDayData = (counts: number[], todayStart: Date): DayData[] => {
   const maxCount = Math.max(...counts, 1);
 
   return counts.map((count, slotIndex) => {
-    const dayOffset = slotIndex - DAYS_BEFORE;
+    const dayOffset = slotIndex - EVENT_GRAPH_DAYS_BEFORE;
     return {
       count,
       dayOffset,
@@ -164,12 +149,14 @@ function resolveBarTransition(shouldAnimate: boolean, dayIndex: number) {
   return { ...ANIMATED_TRANSITION, delay: dayIndex * 0.015 };
 }
 
-function useIsActiveDragTarget(index: number): boolean {
-  const isActiveAtom = useMemo(
-    () => atom((get) => get(eventGraphDraggingAtom) && get(eventGraphHoverIndexAtom) === index),
+const isHighlightingAtom = atom((get) => get(eventGraphHoverIndexAtom) !== null);
+
+function useIsHighlighted(index: number): boolean {
+  const isHighlightedAtom = useMemo(
+    () => atom((get) => get(eventGraphHoverIndexAtom) === index),
     [index],
   );
-  return useAtomValue(isActiveAtom);
+  return useAtomValue(isHighlightedAtom);
 }
 
 interface EventGraphBarProps {
@@ -179,13 +166,13 @@ interface EventGraphBarProps {
 }
 
 const EventGraphBar = memo(function EventGraphBar({ day, dayIndex, shouldAnimate }: EventGraphBarProps) {
-  const isActive = useIsActiveDragTarget(dayIndex);
+  const isHighlighted = useIsHighlighted(dayIndex);
   const setHoverIndex = useSetAtom(eventGraphHoverIndexAtom);
 
   return (
     <div
       className="flex-1 flex flex-col gap-2"
-      data-active={resolveDataAttr(isActive)}
+      data-active={resolveDataAttr(isHighlighted)}
       onPointerEnter={() => setHoverIndex(dayIndex)}
     >
       <div
@@ -193,9 +180,9 @@ const EventGraphBar = memo(function EventGraphBar({ day, dayIndex, shouldAnimate
         style={{ height: GRAPH_HEIGHT }}
       >
         <m.div
-          className={graphBar({
+          className={periodFill({
             period: day.period,
-            className: "w-full",
+            className: "w-full flex-1 rounded-[0.625rem]",
           })}
           initial={{ height: MIN_BAR_HEIGHT }}
           animate={{ height: day.height }}
@@ -220,9 +207,8 @@ interface EventGraphBarsProps {
 }
 
 function EventGraphBars({ days, shouldAnimate }: EventGraphBarsProps) {
-  const isDragging = useAtomValue(eventGraphDraggingAtom);
+  const isHighlighting = useAtomValue(isHighlightingAtom);
   const setHoverIndex = useSetAtom(eventGraphHoverIndexAtom);
-  const setDragging = useSetAtom(eventGraphDraggingAtom);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const resolveIndexFromTouch = useCallback((touch: React.Touch) => {
@@ -230,18 +216,16 @@ function EventGraphBars({ days, shouldAnimate }: EventGraphBarsProps) {
     if (!container) return null;
     const rect = container.getBoundingClientRect();
     const x = touch.clientX - rect.left;
-    const index = Math.floor((x / rect.width) * TOTAL_DAYS);
-    if (index < 0 || index >= TOTAL_DAYS) return null;
+    const index = Math.floor((x / rect.width) * EVENT_GRAPH_TOTAL_DAYS);
+    if (index < 0 || index >= EVENT_GRAPH_TOTAL_DAYS) return null;
     return index;
   }, []);
 
   const handleTouchStart = useCallback(({ touches }: React.TouchEvent) => {
-    setDragging(true);
-
     const touch = touches[0];
     if (!touch) return;
     setHoverIndex(resolveIndexFromTouch(touch));
-  }, [resolveIndexFromTouch, setHoverIndex, setDragging]);
+  }, [resolveIndexFromTouch, setHoverIndex]);
 
   const handleTouchMove = useCallback((event: React.TouchEvent | TouchEvent) => {
     event.preventDefault();
@@ -259,16 +243,13 @@ function EventGraphBars({ days, shouldAnimate }: EventGraphBarsProps) {
     return () => container.removeEventListener("touchmove", listener);
   }, [handleTouchMove]);
 
-  const handleTouchEnd = () => {
-    setDragging(false);
-    setHoverIndex(null);
-  };
+  const handleTouchEnd = () => setHoverIndex(null);
 
   return (
     <div
       ref={containerRef}
-      className="flex gap-0.5 pointer-hover:[&:hover>*]:opacity-50 pointer-hover:[&>*:hover]:opacity-100 data-dragging:*:opacity-50 data-dragging:*:data-active:opacity-100"
-      data-dragging={resolveDataAttr(isDragging)}
+      className="flex gap-0.5 data-highlighting:*:opacity-50 data-highlighting:*:data-active:opacity-100"
+      data-highlighting={resolveDataAttr(isHighlighting)}
       onPointerLeave={() => setHoverIndex(null)}
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}

--- a/applications/web/src/features/dashboard/components/event-graph.tsx
+++ b/applications/web/src/features/dashboard/components/event-graph.tsx
@@ -8,8 +8,11 @@ import {
   EVENT_GRAPH_DAYS_AFTER,
   EVENT_GRAPH_DAYS_BEFORE,
   EVENT_GRAPH_TOTAL_DAYS,
+  calendarJumpAtom,
   eventGraphHoverIndexAtom,
+  eventGraphPointerAtom,
 } from "@/state/event-graph-hover";
+import { resolveDataAttr } from "@/utils/data-attr";
 import { fetcher } from "@/lib/fetcher";
 import { useAnimatedSWR } from "@/hooks/use-animated-swr";
 import { pluralize } from "@/lib/pluralize";
@@ -46,20 +49,24 @@ const countEventsByDay = (events: ApiEventSummary[], todayTimestamp: number): nu
 interface DayData {
   count: number;
   dayOffset: number;
+  dayMs: number;
   height: number;
   fullLabel: string;
   period: Period;
 }
 
-const formatDayLabel = (todayStart: Date, dayOffset: number): string => {
+const resolveDay = (todayStart: Date, dayOffset: number): Date => {
   const date = new Date(todayStart);
   date.setDate(date.getDate() + dayOffset);
-  return date.toLocaleDateString("en-US", {
+  return date;
+};
+
+const formatDayLabel = (day: Date): string =>
+  day.toLocaleDateString("en-US", {
     weekday: "long",
     month: "short",
     day: "numeric",
   });
-};
 
 const GROWTH_SPACE = GRAPH_HEIGHT - MIN_BAR_HEIGHT;
 
@@ -72,11 +79,13 @@ const normalizeDayData = (counts: number[], todayStart: Date): DayData[] => {
 
   return counts.map((count, slotIndex) => {
     const dayOffset = slotIndex - EVENT_GRAPH_DAYS_BEFORE;
+    const day = resolveDay(todayStart, dayOffset);
     return {
       count,
       dayOffset,
+      dayMs: day.getTime(),
       height: resolveBarHeight(count, maxCount),
-      fullLabel: formatDayLabel(todayStart, dayOffset),
+      fullLabel: formatDayLabel(day),
       period: resolvePeriod(dayOffset),
     };
   });
@@ -99,11 +108,6 @@ function resolveEventCount(hoverIndex: number | null, days: DayData[]): number {
 function resolveLabel(hoverIndex: number | null, days: DayData[]): string {
   if (hoverIndex !== null) return days[hoverIndex].fullLabel;
   return "This Week";
-}
-
-function resolveDataAttr(condition: boolean): "" | undefined {
-  if (condition) return "";
-  return undefined;
 }
 
 interface EventGraphSummaryProps {
@@ -168,12 +172,16 @@ interface EventGraphBarProps {
 const EventGraphBar = memo(function EventGraphBar({ day, dayIndex, shouldAnimate }: EventGraphBarProps) {
   const isHighlighted = useIsHighlighted(dayIndex);
   const setHoverIndex = useSetAtom(eventGraphHoverIndexAtom);
+  const setJump = useSetAtom(calendarJumpAtom);
 
   return (
-    <div
-      className="flex-1 flex flex-col gap-2"
+    <button
+      type="button"
+      aria-label={day.fullLabel}
+      className="flex-1 flex flex-col gap-2 cursor-pointer rounded-[0.625rem] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       data-active={resolveDataAttr(isHighlighted)}
       onPointerEnter={() => setHoverIndex(dayIndex)}
+      onClick={() => setJump({ dayMs: day.dayMs })}
     >
       <div
         className="flex items-end"
@@ -190,6 +198,7 @@ const EventGraphBar = memo(function EventGraphBar({ day, dayIndex, shouldAnimate
         />
       </div>
       <Text
+        as="span"
         size="xs"
         tone="default"
         align="center"
@@ -197,7 +206,7 @@ const EventGraphBar = memo(function EventGraphBar({ day, dayIndex, shouldAnimate
       >
         {day.dayOffset}
       </Text>
-    </div>
+    </button>
   );
 });
 
@@ -209,6 +218,7 @@ interface EventGraphBarsProps {
 function EventGraphBars({ days, shouldAnimate }: EventGraphBarsProps) {
   const isHighlighting = useAtomValue(isHighlightingAtom);
   const setHoverIndex = useSetAtom(eventGraphHoverIndexAtom);
+  const setPointerOver = useSetAtom(eventGraphPointerAtom);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const resolveIndexFromTouch = useCallback((touch: React.Touch) => {
@@ -222,10 +232,11 @@ function EventGraphBars({ days, shouldAnimate }: EventGraphBarsProps) {
   }, []);
 
   const handleTouchStart = useCallback(({ touches }: React.TouchEvent) => {
+    setPointerOver(true);
     const touch = touches[0];
     if (!touch) return;
     setHoverIndex(resolveIndexFromTouch(touch));
-  }, [resolveIndexFromTouch, setHoverIndex]);
+  }, [resolveIndexFromTouch, setHoverIndex, setPointerOver]);
 
   const handleTouchMove = useCallback((event: React.TouchEvent | TouchEvent) => {
     event.preventDefault();
@@ -243,14 +254,21 @@ function EventGraphBars({ days, shouldAnimate }: EventGraphBarsProps) {
     return () => container.removeEventListener("touchmove", listener);
   }, [handleTouchMove]);
 
-  const handleTouchEnd = () => setHoverIndex(null);
+  const handleTouchEnd = () => {
+    setPointerOver(false);
+    setHoverIndex(null);
+  };
 
   return (
     <div
       ref={containerRef}
       className="flex gap-0.5 data-highlighting:*:opacity-50 data-highlighting:*:data-active:opacity-100"
       data-highlighting={resolveDataAttr(isHighlighting)}
-      onPointerLeave={() => setHoverIndex(null)}
+      onPointerEnter={() => setPointerOver(true)}
+      onPointerLeave={() => {
+        setPointerOver(false);
+        setHoverIndex(null);
+      }}
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
     >

--- a/applications/web/src/features/dashboard/components/event-layout.ts
+++ b/applications/web/src/features/dashboard/components/event-layout.ts
@@ -244,3 +244,9 @@ export function resolvePillRows(availableHeight: number): number {
   const rowPitch = EVENT_PILL_HEIGHT_PX + EVENT_PILL_GAP_PX;
   return Math.max(Math.floor((availableHeight + EVENT_PILL_GAP_PX) / rowPitch), 0);
 }
+
+const DENSITY_PIP_CAP = 5;
+
+export function resolveDensityPips(count: number): { pips: number; overflow: boolean } {
+  return { pips: Math.min(count, DENSITY_PIP_CAP), overflow: count > DENSITY_PIP_CAP };
+}

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -1,7 +1,7 @@
-import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { useRouter } from "@tanstack/react-router";
-import { useAtomValue, useSetAtom } from "jotai";
+import { atom, useAtomValue, useSetAtom } from "jotai";
 import { scroll } from "motion";
 import { animate } from "motion/mini";
 import { cn } from "@/utils/cn";
@@ -60,6 +60,13 @@ const MS_PER_DAY = 86_400_000;
 // One stable identity, so the memoised columns don't see a fresh [] each render.
 const NO_EVENTS: CalendarEvent[] = [];
 
+const resolveBandHeight = (bandRows: number): number =>
+  bandRows === 0
+    ? 0
+    : bandRows * EVENT_PILL_HEIGHT_PX +
+      (bandRows - 1) * EVENT_PILL_GAP_PX +
+      ALL_DAY_BAND_PADDING_BOTTOM;
+
 interface DayDensityPipsProps {
   count: number;
   period: Period;
@@ -89,7 +96,6 @@ interface DayHeaderCellProps {
   timedCount: number;
   allDay: CalendarEvent[];
   bandRows: number;
-  bandHeight: number;
 }
 
 const DayHeaderCell = memo(function DayHeaderCell({
@@ -98,9 +104,9 @@ const DayHeaderCell = memo(function DayHeaderCell({
   timedCount,
   allDay,
   bandRows,
-  bandHeight,
 }: DayHeaderCellProps) {
   const { visibleCount, hiddenCount } = resolveVisiblePillCount(allDay.length, bandRows);
+  const bandHeight = resolveBandHeight(bandRows);
   const period = resolvePeriod(dayOffset);
   const setGraphHoverIndex = useSetAtom(eventGraphHoverIndexAtom);
   const active = useCalendarHighlightedDay(dayOffset);
@@ -111,7 +117,9 @@ const DayHeaderCell = memo(function DayHeaderCell({
       onPointerEnter={(event) => {
         if (event.pointerType === "mouse") setGraphHoverIndex(resolveGraphSlotIndex(dayOffset));
       }}
-      onPointerLeave={() => setGraphHoverIndex(null)}
+      onPointerLeave={(event) => {
+        if (event.pointerType === "mouse") setGraphHoverIndex(null);
+      }}
     >
       {/* Ramps upward as the header fill evaporates downward, and runs on under the grid so a vertical overscroll bounce can't part it from the column rule. */}
       <div
@@ -192,11 +200,23 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
   const nowLayout = now && resolveNowLayout(stripDays, now);
   const resolveDayOffset = (day: Date) =>
     Math.round((day.getTime() - today.getTime()) / MS_PER_DAY);
-  const highlightSlot = useAtomValue(calendarHighlightSlotAtom);
-  const highlightVisible =
-    highlightSlot !== null &&
-    Math.abs(highlightSlot - EVENT_GRAPH_DAYS_BEFORE - resolveDayOffset(startOfDay(anchor))) <=
-      CENTER_OFFSET;
+  /** Centre day the strip has actually reached; the anchor runs ahead of it during a smooth scroll. */
+  const [visibleCenterMs, setVisibleCenterMs] = useState(() => startOfDay(anchor).getTime());
+  const visibleCenterOffset = resolveDayOffset(new Date(visibleCenterMs));
+  const highlightVisibleAtom = useMemo(
+    () =>
+      atom((get) => {
+        const slot = get(calendarHighlightSlotAtom);
+        return (
+          slot !== null &&
+          Math.abs(slot - EVENT_GRAPH_DAYS_BEFORE - visibleCenterOffset) <= CENTER_OFFSET
+        );
+      }),
+    [visibleCenterOffset],
+  );
+  const highlightVisible = useAtomValue(highlightVisibleAtom);
+  const setGraphHoverIndex = useSetAtom(eventGraphHoverIndexAtom);
+  useEffect(() => () => setGraphHoverIndex(null), [setGraphHoverIndex]);
 
   const columnWidth = useCallback(() => {
     const el = scrollerRef.current;
@@ -356,6 +376,7 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
         Math.min(Math.round(el.scrollLeft / columnWidth()), stripDays.length - VISIBLE_COLUMNS),
       );
       const centerDay = stripDays[index + CENTER_OFFSET];
+      setVisibleCenterMs(centerDay.getTime());
       if (centerDay.getTime() === alignedCenterMsRef.current) return;
       alignedCenterMsRef.current = centerDay.getTime();
       onCenterDayChange(centerDay);
@@ -376,12 +397,6 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
     mostAllDay = Math.max(mostAllDay, allDayCount);
   }
   const bandRows = Math.min(mostAllDay, ALL_DAY_MAX_ROWS);
-  const bandHeight =
-    bandRows === 0
-      ? 0
-      : bandRows * EVENT_PILL_HEIGHT_PX +
-        (bandRows - 1) * EVENT_PILL_GAP_PX +
-        ALL_DAY_BAND_PADDING_BOTTOM;
 
   const dayRow = (
     <div className="flex">
@@ -404,7 +419,6 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
               timedCount={eventsByDay.get(day.getTime())?.timed.length ?? 0}
               allDay={eventsByDay.get(day.getTime())?.allDay ?? NO_EVENTS}
               bandRows={bandRows}
-              bandHeight={bandHeight}
             />
           ))}
         </div>

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -121,6 +121,7 @@ const DayHeaderCell = memo(function DayHeaderCell({
       <div
         className={periodWash({
           period,
+          edge: "fadeTop",
           className:
             "flex flex-col group-data-highlighting:opacity-45 data-active:opacity-100",
         })}

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -395,7 +395,7 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
       <div
         ref={scrollerRef}
         onScroll={handleScroll}
-        className="flex min-h-0 flex-1 items-start snap-x snap-mandatory overflow-auto overscroll-x-none mask-b-from-[calc(100%-24px)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="flex min-h-0 flex-1 items-start snap-x snap-mandatory overflow-auto overscroll-none mask-b-from-[calc(100%-24px)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         style={{ scrollPaddingLeft: GUTTER_WIDTH }}
       >
         <div

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -1,12 +1,19 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { useRouter } from "@tanstack/react-router";
-import { useSetAtom } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { scroll } from "motion";
 import { animate } from "motion/mini";
 import { cn } from "@/utils/cn";
+import { resolveDataAttr } from "@/utils/data-attr";
 import { eventDetailAtom } from "@/state/event-detail";
-import { eventGraphHoverIndexAtom, resolveGraphSlotIndex } from "@/state/event-graph-hover";
+import {
+  EVENT_GRAPH_DAYS_BEFORE,
+  calendarHighlightSlotAtom,
+  eventGraphHoverIndexAtom,
+  resolveGraphSlotIndex,
+} from "@/state/event-graph-hover";
+import { useCalendarHighlightedDay } from "@/hooks/use-calendar-highlighted-day";
 import { useSetPopoverOverlay } from "@/hooks/use-popover-overlay";
 import { useNowMinute } from "@/hooks/use-now-minute";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
@@ -26,7 +33,7 @@ import {
   resolveVisiblePillCount,
 } from "./event-layout";
 import type { DayEvents } from "./event-layout";
-import { periodFill, resolvePeriod } from "./density-period";
+import { periodFill, periodWash, resolvePeriod } from "./density-period";
 import type { Period } from "./density-period";
 import {
   addDays,
@@ -96,6 +103,7 @@ const DayHeaderCell = memo(function DayHeaderCell({
   const { visibleCount, hiddenCount } = resolveVisiblePillCount(allDay.length, bandRows);
   const period = resolvePeriod(dayOffset);
   const setGraphHoverIndex = useSetAtom(eventGraphHoverIndexAtom);
+  const active = useCalendarHighlightedDay(dayOffset);
 
   return (
     <div
@@ -111,30 +119,39 @@ const DayHeaderCell = memo(function DayHeaderCell({
         className="pointer-events-none absolute top-0 -bottom-40 left-0 w-px bg-border-elevated mask-t-from-[calc(100%-2.625rem)]"
       />
       <div
-        className="flex shrink-0 flex-col items-center justify-center gap-1"
-        style={{ height: HEADER_HEIGHT }}
+        className={periodWash({
+          period,
+          className:
+            "flex flex-col group-data-highlighting:opacity-45 data-active:opacity-100",
+        })}
+        data-active={resolveDataAttr(active)}
       >
-        <Text as="span" size="xs" tone="muted" className="font-medium uppercase tracking-wide">
-          {day.toLocaleDateString("en-US", { weekday: "short" })}
-        </Text>
-        <span
-          className={cn(
-            "flex size-6 items-center justify-center text-xs font-medium tabular-nums",
-            period === "today" ? "rounded-full bg-emerald-400 text-neutral-950" : "text-foreground",
-          )}
+        <div
+          className="flex shrink-0 flex-col items-center justify-center gap-1"
+          style={{ height: HEADER_HEIGHT }}
         >
-          {day.getDate()}
-        </span>
-        <DayDensityPips count={timedCount} period={period} />
-      </div>
-      <div
-        className="flex flex-col overflow-clip px-0.5 transition-[height] duration-200 motion-reduce:transition-none"
-        style={{ height: bandHeight, gap: EVENT_PILL_GAP_PX }}
-      >
-        {allDay.slice(0, visibleCount).map((event) => (
-          <EventPill key={event.id} event={event} past={isEventPast(event.endTime)} />
-        ))}
-        {hiddenCount > 0 && <EventPillOverflow count={hiddenCount} />}
+          <Text as="span" size="xs" tone="muted" className="font-medium uppercase tracking-wide">
+            {day.toLocaleDateString("en-US", { weekday: "short" })}
+          </Text>
+          <span
+            className={cn(
+              "flex size-6 items-center justify-center text-xs font-medium tabular-nums",
+              period === "today" ? "rounded-full bg-emerald-400 text-neutral-950" : "text-foreground",
+            )}
+          >
+            {day.getDate()}
+          </span>
+          <DayDensityPips count={timedCount} period={period} />
+        </div>
+        <div
+          className="flex flex-col overflow-clip px-0.5 transition-[height] duration-200 motion-reduce:transition-none"
+          style={{ height: bandHeight, gap: EVENT_PILL_GAP_PX }}
+        >
+          {allDay.slice(0, visibleCount).map((event) => (
+            <EventPill key={event.id} event={event} past={isEventPast(event.endTime)} />
+          ))}
+          {hiddenCount > 0 && <EventPillOverflow count={hiddenCount} />}
+        </div>
       </div>
     </div>
   );
@@ -172,6 +189,13 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
 
   const now = useNowMinute();
   const nowLayout = now && resolveNowLayout(stripDays, now);
+  const resolveDayOffset = (day: Date) =>
+    Math.round((day.getTime() - today.getTime()) / MS_PER_DAY);
+  const highlightSlot = useAtomValue(calendarHighlightSlotAtom);
+  const highlightVisible =
+    highlightSlot !== null &&
+    Math.abs(highlightSlot - EVENT_GRAPH_DAYS_BEFORE - resolveDayOffset(startOfDay(anchor))) <=
+      CENTER_OFFSET;
 
   const columnWidth = useCallback(() => {
     const el = scrollerRef.current;
@@ -364,7 +388,8 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
       <div className="relative min-w-0 flex-1 overflow-x-clip">
         <div
           ref={rowRef}
-          className="relative grid"
+          className="group relative grid"
+          data-highlighting={resolveDataAttr(highlightVisible)}
           style={{
             gridTemplateColumns: columnsTemplate,
             width: `calc(${stripDays.length} * 100% / ${VISIBLE_COLUMNS})`,
@@ -374,7 +399,7 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
             <DayHeaderCell
               key={day.getTime()}
               day={day}
-              dayOffset={Math.round((day.getTime() - today.getTime()) / MS_PER_DAY)}
+              dayOffset={resolveDayOffset(day)}
               timedCount={eventsByDay.get(day.getTime())?.timed.length ?? 0}
               allDay={eventsByDay.get(day.getTime())?.allDay ?? NO_EVENTS}
               bandRows={bandRows}
@@ -430,6 +455,7 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
             <DayColumn
               key={day.getTime()}
               day={day}
+              dayOffset={resolveDayOffset(day)}
               now={isSameDay(day, today) ? now : null}
               events={eventsByDay.get(day.getTime())?.timed ?? NO_EVENTS}
             />

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -6,6 +6,7 @@ import { scroll } from "motion";
 import { animate } from "motion/mini";
 import { cn } from "@/utils/cn";
 import { eventDetailAtom } from "@/state/event-detail";
+import { eventGraphHoverIndexAtom, resolveGraphSlotIndex } from "@/state/event-graph-hover";
 import { useSetPopoverOverlay } from "@/hooks/use-popover-overlay";
 import { useNowMinute } from "@/hooks/use-now-minute";
 import { useStartOfToday } from "@/hooks/use-start-of-today";
@@ -18,8 +19,15 @@ import { EventPill, EventPillOverflow } from "./event-card";
 import { EventDetailPopover } from "./event-detail-popover";
 import { NowIndicator, NowPill } from "./now-indicator";
 import { resolveNowLayout } from "./now-layout";
-import { EVENT_PILL_GAP_PX, EVENT_PILL_HEIGHT_PX, resolveVisiblePillCount } from "./event-layout";
+import {
+  EVENT_PILL_GAP_PX,
+  EVENT_PILL_HEIGHT_PX,
+  resolveDensityPips,
+  resolveVisiblePillCount,
+} from "./event-layout";
 import type { DayEvents } from "./event-layout";
+import { periodFill, resolvePeriod } from "./density-period";
+import type { Period } from "./density-period";
 import {
   addDays,
   formatHourLabel,
@@ -32,7 +40,7 @@ import {
 } from "./calendar-helpers";
 
 const GUTTER_WIDTH = 52;
-const HEADER_HEIGHT = 56;
+const HEADER_HEIGHT = 64;
 const ALL_DAY_MAX_ROWS = 2;
 const ALL_DAY_BAND_PADDING_BOTTOM = 4;
 const VISIBLE_COLUMNS = WEEK_VIEW_DAYS;
@@ -45,23 +53,56 @@ const MS_PER_DAY = 86_400_000;
 // One stable identity, so the memoised columns don't see a fresh [] each render.
 const NO_EVENTS: CalendarEvent[] = [];
 
+interface DayDensityPipsProps {
+  count: number;
+  period: Period;
+}
+
+function DayDensityPips({ count, period }: DayDensityPipsProps) {
+  const { pips, overflow } = resolveDensityPips(count);
+
+  return (
+    <div className="flex h-1 justify-center gap-0.5">
+      {Array.from({ length: pips }, (_, index) => (
+        <span
+          key={index}
+          className={periodFill({
+            period,
+            className: cn("h-1 rounded-full", overflow && index === pips - 1 ? "w-4" : "w-[7px]"),
+          })}
+        />
+      ))}
+    </div>
+  );
+}
+
 interface DayHeaderCellProps {
   day: Date;
-  isToday: boolean;
+  dayOffset: number;
+  timedCount: number;
   allDay: CalendarEvent[];
   bandRows: number;
 }
 
 const DayHeaderCell = memo(function DayHeaderCell({
   day,
-  isToday,
+  dayOffset,
+  timedCount,
   allDay,
   bandRows,
 }: DayHeaderCellProps) {
   const { visibleCount, hiddenCount } = resolveVisiblePillCount(allDay.length, bandRows);
+  const period = resolvePeriod(dayOffset);
+  const setGraphHoverIndex = useSetAtom(eventGraphHoverIndexAtom);
 
   return (
-    <div className="relative flex flex-col overflow-hidden">
+    <div
+      className="relative flex flex-col overflow-hidden"
+      onPointerEnter={(event) => {
+        if (event.pointerType === "mouse") setGraphHoverIndex(resolveGraphSlotIndex(dayOffset));
+      }}
+      onPointerLeave={() => setGraphHoverIndex(null)}
+    >
       {/* Ramps upward as the header fill evaporates downward, so the rules strengthen across the seam. */}
       <div
         aria-hidden
@@ -77,11 +118,12 @@ const DayHeaderCell = memo(function DayHeaderCell({
         <span
           className={cn(
             "flex size-6 items-center justify-center text-xs font-medium tabular-nums",
-            isToday ? "rounded-full bg-emerald-400 text-neutral-950" : "text-foreground",
+            period === "today" ? "rounded-full bg-emerald-400 text-neutral-950" : "text-foreground",
           )}
         >
           {day.getDate()}
         </span>
+        <DayDensityPips count={timedCount} period={period} />
       </div>
       {allDay.length > 0 && (
         <div className="flex flex-col px-0.5" style={{ gap: EVENT_PILL_GAP_PX }}>
@@ -332,7 +374,8 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
             <DayHeaderCell
               key={day.getTime()}
               day={day}
-              isToday={isSameDay(day, today)}
+              dayOffset={Math.round((day.getTime() - today.getTime()) / MS_PER_DAY)}
+              timedCount={eventsByDay.get(day.getTime())?.timed.length ?? 0}
               allDay={eventsByDay.get(day.getTime())?.allDay ?? NO_EVENTS}
               bandRows={bandRows}
             />

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -395,7 +395,7 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
       <div
         ref={scrollerRef}
         onScroll={handleScroll}
-        className="flex min-h-0 flex-1 items-start snap-x snap-mandatory overflow-auto overscroll-none mask-b-from-[calc(100%-24px)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="flex min-h-0 flex-1 items-start snap-x snap-mandatory overflow-auto overscroll-x-none mask-b-from-[calc(100%-24px)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         style={{ scrollPaddingLeft: GUTTER_WIDTH }}
       >
         <div

--- a/applications/web/src/features/dashboard/components/week-grid.tsx
+++ b/applications/web/src/features/dashboard/components/week-grid.tsx
@@ -82,6 +82,7 @@ interface DayHeaderCellProps {
   timedCount: number;
   allDay: CalendarEvent[];
   bandRows: number;
+  bandHeight: number;
 }
 
 const DayHeaderCell = memo(function DayHeaderCell({
@@ -90,6 +91,7 @@ const DayHeaderCell = memo(function DayHeaderCell({
   timedCount,
   allDay,
   bandRows,
+  bandHeight,
 }: DayHeaderCellProps) {
   const { visibleCount, hiddenCount } = resolveVisiblePillCount(allDay.length, bandRows);
   const period = resolvePeriod(dayOffset);
@@ -97,16 +99,16 @@ const DayHeaderCell = memo(function DayHeaderCell({
 
   return (
     <div
-      className="relative flex flex-col overflow-hidden"
+      className="relative flex flex-col overflow-x-clip"
       onPointerEnter={(event) => {
         if (event.pointerType === "mouse") setGraphHoverIndex(resolveGraphSlotIndex(dayOffset));
       }}
       onPointerLeave={() => setGraphHoverIndex(null)}
     >
-      {/* Ramps upward as the header fill evaporates downward, so the rules strengthen across the seam. */}
+      {/* Ramps upward as the header fill evaporates downward, and runs on under the grid so a vertical overscroll bounce can't part it from the column rule. */}
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-y-0 left-0 w-px bg-border-elevated mask-t-from-35%"
+        className="pointer-events-none absolute top-0 -bottom-40 left-0 w-px bg-border-elevated mask-t-from-[calc(100%-2.625rem)]"
       />
       <div
         className="flex shrink-0 flex-col items-center justify-center gap-1"
@@ -125,14 +127,15 @@ const DayHeaderCell = memo(function DayHeaderCell({
         </span>
         <DayDensityPips count={timedCount} period={period} />
       </div>
-      {allDay.length > 0 && (
-        <div className="flex flex-col px-0.5" style={{ gap: EVENT_PILL_GAP_PX }}>
-          {allDay.slice(0, visibleCount).map((event) => (
-            <EventPill key={event.id} event={event} past={isEventPast(event.endTime)} />
-          ))}
-          {hiddenCount > 0 && <EventPillOverflow count={hiddenCount} />}
-        </div>
-      )}
+      <div
+        className="flex flex-col overflow-clip px-0.5 transition-[height] duration-200 motion-reduce:transition-none"
+        style={{ height: bandHeight, gap: EVENT_PILL_GAP_PX }}
+      >
+        {allDay.slice(0, visibleCount).map((event) => (
+          <EventPill key={event.id} event={event} past={isEventPast(event.endTime)} />
+        ))}
+        {hiddenCount > 0 && <EventPillOverflow count={hiddenCount} />}
+      </div>
     </div>
   );
 });
@@ -356,15 +359,12 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
         ALL_DAY_BAND_PADDING_BOTTOM;
 
   const dayRow = (
-    <div
-      className="flex transition-[height] duration-200 motion-reduce:transition-none"
-      style={{ height: HEADER_HEIGHT + bandHeight }}
-    >
+    <div className="flex">
       <div className="shrink-0" style={{ width: GUTTER_WIDTH }} />
-      <div className="relative min-w-0 flex-1 overflow-hidden">
+      <div className="relative min-w-0 flex-1 overflow-x-clip">
         <div
           ref={rowRef}
-          className="relative grid h-full"
+          className="relative grid"
           style={{
             gridTemplateColumns: columnsTemplate,
             width: `calc(${stripDays.length} * 100% / ${VISIBLE_COLUMNS})`,
@@ -378,6 +378,7 @@ export function WeekGrid({ anchor, eventsByDay, onCenterDayChange, toolbar }: We
               timedCount={eventsByDay.get(day.getTime())?.timed.length ?? 0}
               allDay={eventsByDay.get(day.getTime())?.allDay ?? NO_EVENTS}
               bandRows={bandRows}
+              bandHeight={bandHeight}
             />
           ))}
         </div>

--- a/applications/web/src/hooks/use-calendar-highlighted-day.ts
+++ b/applications/web/src/hooks/use-calendar-highlighted-day.ts
@@ -1,0 +1,11 @@
+import { useMemo } from "react";
+import { atom, useAtomValue } from "jotai";
+import { calendarHighlightSlotAtom, resolveGraphSlotIndex } from "@/state/event-graph-hover";
+
+export function useCalendarHighlightedDay(dayOffset: number): boolean {
+  const isHighlightedAtom = useMemo(() => {
+    const slot = resolveGraphSlotIndex(dayOffset);
+    return atom((get) => slot !== null && get(calendarHighlightSlotAtom) === slot);
+  }, [dayOffset]);
+  return useAtomValue(isHighlightedAtom);
+}

--- a/applications/web/src/hooks/use-media-query.ts
+++ b/applications/web/src/hooks/use-media-query.ts
@@ -1,0 +1,17 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      const list = globalThis.matchMedia(query);
+      list.addEventListener("change", onChange);
+      return () => list.removeEventListener("change", onChange);
+    },
+    [query],
+  );
+  return useSyncExternalStore(
+    subscribe,
+    () => globalThis.matchMedia(query).matches,
+    () => false,
+  );
+}

--- a/applications/web/src/state/event-graph-hover.ts
+++ b/applications/web/src/state/event-graph-hover.ts
@@ -10,3 +10,11 @@ export function resolveGraphSlotIndex(dayOffset: number): number | null {
   if (dayOffset < -EVENT_GRAPH_DAYS_BEFORE || dayOffset > EVENT_GRAPH_DAYS_AFTER) return null;
   return dayOffset + EVENT_GRAPH_DAYS_BEFORE;
 }
+
+export const eventGraphPointerAtom = atom(false);
+
+export const calendarHighlightSlotAtom = atom((get) =>
+  get(eventGraphPointerAtom) ? get(eventGraphHoverIndexAtom) : null,
+);
+
+export const calendarJumpAtom = atom<{ dayMs: number } | null>(null);

--- a/applications/web/src/state/event-graph-hover.ts
+++ b/applications/web/src/state/event-graph-hover.ts
@@ -1,4 +1,12 @@
 import { atom } from "jotai";
 
+export const EVENT_GRAPH_DAYS_BEFORE = 7;
+export const EVENT_GRAPH_DAYS_AFTER = 7;
+export const EVENT_GRAPH_TOTAL_DAYS = EVENT_GRAPH_DAYS_BEFORE + 1 + EVENT_GRAPH_DAYS_AFTER;
+
 export const eventGraphHoverIndexAtom = atom<number | null>(null);
-export const eventGraphDraggingAtom = atom(false);
+
+export function resolveGraphSlotIndex(dayOffset: number): number | null {
+  if (dayOffset < -EVENT_GRAPH_DAYS_BEFORE || dayOffset > EVENT_GRAPH_DAYS_AFTER) return null;
+  return dayOffset + EVENT_GRAPH_DAYS_BEFORE;
+}

--- a/applications/web/src/utils/data-attr.ts
+++ b/applications/web/src/utils/data-attr.ts
@@ -1,0 +1,4 @@
+export function resolveDataAttr(condition: boolean): "" | undefined {
+  if (condition) return "";
+  return undefined;
+}

--- a/applications/web/tests/features/dashboard/components/density-period.test.ts
+++ b/applications/web/tests/features/dashboard/components/density-period.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { resolvePeriod } from "../../../../src/features/dashboard/components/density-period";
+
+describe("resolvePeriod", () => {
+  it("splits days around today", () => {
+    expect(resolvePeriod(-1)).toBe("past");
+    expect(resolvePeriod(0)).toBe("today");
+    expect(resolvePeriod(1)).toBe("future");
+  });
+});

--- a/applications/web/tests/features/dashboard/components/event-layout.test.ts
+++ b/applications/web/tests/features/dashboard/components/event-layout.test.ts
@@ -5,6 +5,7 @@ import {
   bucketEventsByDay,
   layoutDayEvents,
   MIN_EVENT_SPAN_MS,
+  resolveDensityPips,
   resolvePillRows,
   resolveVisiblePillCount,
   stackIndentPx,
@@ -392,5 +393,18 @@ describe("timeOfDayFraction", () => {
 
   it("keeps noon halfway down a daylight-saving day", () => {
     expect(timeOfDayFraction(new Date(2026, 2, 8, 12))).toBe(0.5);
+  });
+});
+
+describe("resolveDensityPips", () => {
+  it("shows one pip per event up to the cap", () => {
+    expect(resolveDensityPips(0)).toEqual({ pips: 0, overflow: false });
+    expect(resolveDensityPips(3)).toEqual({ pips: 3, overflow: false });
+    expect(resolveDensityPips(5)).toEqual({ pips: 5, overflow: false });
+  });
+
+  it("caps at five and flags the overflow", () => {
+    expect(resolveDensityPips(6)).toEqual({ pips: 5, overflow: true });
+    expect(resolveDensityPips(12)).toEqual({ pips: 5, overflow: true });
   });
 });

--- a/applications/web/tests/state/event-graph-hover.test.ts
+++ b/applications/web/tests/state/event-graph-hover.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { resolveGraphSlotIndex } from "../../src/state/event-graph-hover";
+
+describe("resolveGraphSlotIndex", () => {
+  it("maps today to the centre slot", () => {
+    expect(resolveGraphSlotIndex(0)).toBe(7);
+  });
+
+  it("maps the window edges to the first and last slots", () => {
+    expect(resolveGraphSlotIndex(-7)).toBe(0);
+    expect(resolveGraphSlotIndex(7)).toBe(14);
+  });
+
+  it("returns null outside the window", () => {
+    expect(resolveGraphSlotIndex(-8)).toBeNull();
+    expect(resolveGraphSlotIndex(8)).toBeNull();
+  });
+});

--- a/applications/web/tests/state/event-graph-hover.test.ts
+++ b/applications/web/tests/state/event-graph-hover.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { resolveGraphSlotIndex } from "../../src/state/event-graph-hover";
+import { createStore } from "jotai";
+import {
+  calendarHighlightSlotAtom,
+  eventGraphHoverIndexAtom,
+  eventGraphPointerAtom,
+  resolveGraphSlotIndex,
+} from "../../src/state/event-graph-hover";
 
 describe("resolveGraphSlotIndex", () => {
   it("maps today to the centre slot", () => {
@@ -14,5 +20,22 @@ describe("resolveGraphSlotIndex", () => {
   it("returns null outside the window", () => {
     expect(resolveGraphSlotIndex(-8)).toBeNull();
     expect(resolveGraphSlotIndex(8)).toBeNull();
+  });
+});
+
+describe("calendarHighlightSlotAtom", () => {
+  it("ignores a hover index the sidebar graph is not pointing at", () => {
+    const store = createStore();
+    store.set(eventGraphHoverIndexAtom, 9);
+    expect(store.get(calendarHighlightSlotAtom)).toBeNull();
+  });
+
+  it("follows the hover index only while the pointer is over the graph", () => {
+    const store = createStore();
+    store.set(eventGraphHoverIndexAtom, 9);
+    store.set(eventGraphPointerAtom, true);
+    expect(store.get(calendarHighlightSlotAtom)).toBe(9);
+    store.set(eventGraphPointerAtom, false);
+    expect(store.get(calendarHighlightSlotAtom)).toBeNull();
   });
 });


### PR DESCRIPTION
Stacked on #985.

**Density pips.** The week header borrows the sidebar graph's density language: one pip per timed event under each date, capped at five with the last pip stretched on overflow, in the same past (neutral), today (emerald), and future (striped emerald) fills. All-day events already show as pills in the band, so they don't count. The period fill and the graph's ±7-day window move into shared modules.

**Two-way link.** Hovering a header cell with a mouse highlights that day's bar in the sidebar and swaps its summary. Hovering a sidebar bar dims the other six header cells and washes the hovered day's header and column; clicking a bar switches to week view and smooth-scrolls to that day. The calendar highlight only follows the graph's own pointer or keyboard focus, and stays off for days outside the visible week. Today's bar is the group's single tab stop, with arrow keys between bars; below `lg`, where the calendar is hidden, the bars aren't focusable and clicks are no-ops.

**Overscroll seam.** A vertical rubber-band pulled the grid away from its header. Nothing inside the scroller can paint into that gap, so each header cell's column rule now runs 160px on under the grid on the same scroll timeline, and the header row and cells clip horizontally only. The all-day band animates its own height so nothing else spills.

## Screenshots

<img width="1073" height="217" alt="image" src="https://github.com/user-attachments/assets/6546c4af-f444-43de-98af-64775bc2f5a5" />

<img width="1476" height="236" alt="image" src="https://github.com/user-attachments/assets/e4f128eb-89be-4482-9f52-0357869c1292" />



**Review fixes.** The graph buckets by calendar days so counts, labels, and jump targets agree across DST; hover atoms reset on touch cancel and on unmount from both sides; the header's leave handler is pointer-type guarded like its enter; the week grid subscribes to a boolean derived from the strip's reached centre rather than the raw slot.


🤖 Generated with [Claude Code](https://claude.com/claude-code)