### PR TITLE
fix(api): resolve feed identifiers by user id before username

### DIFF
--- a/services/api/src/utils/user.ts
+++ b/services/api/src/utils/user.ts
@@ -5,23 +5,23 @@ import { database } from "@/context";
 const FIRST_RESULT_LIMIT = 1;
 
 const resolveUserIdentifier = async (identifier: string): Promise<string | null> => {
-  const [userByUsername] = await database
-    .select({ id: userTable.id })
-    .from(userTable)
-    .where(eq(userTable.username, identifier))
-    .limit(FIRST_RESULT_LIMIT);
-
-  if (userByUsername) {
-    return userByUsername.id;
-  }
-
   const [userById] = await database
     .select({ id: userTable.id })
     .from(userTable)
     .where(eq(userTable.id, identifier))
     .limit(FIRST_RESULT_LIMIT);
 
-  return userById?.id ?? null;
+  if (userById) {
+    return userById.id;
+  }
+
+  const [userByUsername] = await database
+    .select({ id: userTable.id })
+    .from(userTable)
+    .where(eq(userTable.username, identifier))
+    .limit(FIRST_RESULT_LIMIT);
+
+  return userByUsername?.id ?? null;
 };
 
 export { resolveUserIdentifier };

--- a/services/api/tests/utils/user-identifier-resolution.test.ts
+++ b/services/api/tests/utils/user-identifier-resolution.test.ts
@@ -1,0 +1,40 @@
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+const client = new PGlite();
+const database = drizzle(client);
+
+vi.mock("@/context", () => ({ database }));
+
+const { resolveUserIdentifier } = await import("../../src/utils/user");
+
+const DDL = `
+create table "user" (
+  "id" text primary key,
+  "username" text unique
+);
+`;
+
+const OWNER_ID = "AbCdEfGhIjKlMnOpQrStUvWxYz012345";
+const OTHER_ID = "ZyXwVuTsRqPoNmLkJiHgFeDcBa543210";
+
+describe("resolveUserIdentifier", () => {
+  beforeAll(async () => {
+    await client.exec(DDL);
+    await client.query('insert into "user" ("id", "username") values ($1, $2)', [OWNER_ID, "owner"]);
+    await client.query('insert into "user" ("id", "username") values ($1, $2)', [OTHER_ID, OWNER_ID]);
+  });
+
+  it("resolves a user id to that user even when another user's username matches it", async () => {
+    await expect(resolveUserIdentifier(OWNER_ID)).resolves.toBe(OWNER_ID);
+  });
+
+  it("resolves a username that matches no user id", async () => {
+    await expect(resolveUserIdentifier("owner")).resolves.toBe(OWNER_ID);
+  });
+
+  it("returns null for an identifier that is neither an id nor a username", async () => {
+    await expect(resolveUserIdentifier("nobody")).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
Legacy calendar feed URLs accept either a user id or a username. `resolveUserIdentifier` now checks the id column before the username column, so an identifier that matches a user id always resolves to that user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)