### PR TITLE
chore(test): disable vitest default interop for bun-runtime suites

### DIFF
--- a/applications/web/vitest.config.ts
+++ b/applications/web/vitest.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
     },
   },
   test: {
+    deps: {
+      interopDefault: false,
+    },
     globals: true,
     include: ["./tests/**/*.test.ts", "./tests/**/*.test.tsx"],
     onConsoleLog: (log) => (log.startsWith("[subscription]") ? false : undefined),

--- a/packages/auth/vitest.config.ts
+++ b/packages/auth/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    deps: {
+      interopDefault: false,
+    },
     globals: true,
     include: ["./tests/**/*.test.ts"],
     testTimeout: 30_000,

--- a/packages/calendar/vitest.config.ts
+++ b/packages/calendar/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    deps: {
+      interopDefault: false,
+    },
     globals: true,
     include: ["./tests/**/*.test.ts"],
   },

--- a/packages/data-schemas/vitest.config.ts
+++ b/packages/data-schemas/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    deps: {
+      interopDefault: false,
+    },
     globals: true,
     include: ["./tests/**/*.test.ts"],
   },

--- a/packages/database/vitest.config.ts
+++ b/packages/database/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    deps: {
+      interopDefault: false,
+    },
     globals: true,
     exclude: ["./tests/migrations/**"],
     /*

--- a/packages/premium/vitest.config.ts
+++ b/packages/premium/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    deps: {
+      interopDefault: false,
+    },
     globals: true,
     include: ["./tests/**/*.test.ts"],
   },

--- a/packages/sync/vitest.config.ts
+++ b/packages/sync/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    deps: {
+      interopDefault: false,
+    },
     globals: true,
     include: ["./tests/**/*.test.ts"],
   },

--- a/services/api/vitest.config.ts
+++ b/services/api/vitest.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
     },
   },
   test: {
+    deps: {
+      interopDefault: false,
+    },
     globals: true,
     /*
      * Suites here boot an in-process PGlite and apply their schema in a setup

--- a/services/cron/vitest.config.ts
+++ b/services/cron/vitest.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
     },
   },
   test: {
+    deps: {
+      interopDefault: false,
+    },
     globals: true,
     /*
      * Several suites here shell out to a real `bun` subprocess or build a

--- a/services/worker/vitest.config.ts
+++ b/services/worker/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    deps: {
+      interopDefault: false,
+    },
     globals: true,
     include: ["./tests/**/*.test.ts"],
   },


### PR DESCRIPTION
Every workspace whose test script runs `bun x --bun vitest run` now sets `test.deps.interopDefault: false`.

Under the Bun runtime, vitest's default interop detects `__esModule` on some ESM package namespaces (zod among them) and substitutes the package's inner namespace, which drops named re-exports such as `z`. With interop disabled the module namespace is used as-is, so `import { z } from "zod"` resolves the same way it does under Node.

All affected suites were run with the setting in place and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)