### PR TITLE
fix(web): derive the settings account label from the session user

### DIFF
--- a/applications/web/src/lib/account-identity.ts
+++ b/applications/web/src/lib/account-identity.ts
@@ -1,0 +1,17 @@
+import type { SessionUser } from "@/hooks/use-session";
+
+interface AccountIdentity {
+  label: "Email" | "Username";
+  value: string;
+}
+
+const resolveAccountIdentity = (user: SessionUser | null): AccountIdentity => {
+  if (user?.username) {
+    return { label: "Username", value: user.username };
+  }
+
+  return { label: "Email", value: user?.email ?? "" };
+};
+
+export { resolveAccountIdentity };
+export type { AccountIdentity };

--- a/applications/web/src/routes/(dashboard)/dashboard/settings/index.tsx
+++ b/applications/web/src/routes/(dashboard)/dashboard/settings/index.tsx
@@ -15,6 +15,7 @@ import { usePasskeys } from "@/hooks/use-passkeys";
 import { useHasPassword } from "@/hooks/use-has-password";
 import { Input } from "@/components/ui/primitives/input";
 import { deleteAccount } from "@/lib/auth";
+import { resolveAccountIdentity } from "@/lib/account-identity";
 import {
   Modal,
   ModalContent,
@@ -52,11 +53,7 @@ function SettingsPage() {
   const navigate = useNavigate();
   const passwordRef = useRef<HTMLInputElement>(null);
   const { data: hasPassword = false } = useHasPassword();
-  const accountLabel = authCapabilities.credentialMode === "username" ? "Username" : "Email";
-  const accountValue =
-    authCapabilities.credentialMode === "username"
-      ? (user?.username ?? user?.name ?? "")
-      : (user?.email ?? "");
+  const { label: accountLabel, value: accountValue } = resolveAccountIdentity(user);
   const { data: apiTokens = [] } = useApiTokens();
   const { data: passkeys = [] } = usePasskeys(authCapabilities.supportsPasskeys);
   const analyticsConsent = useEffectiveConsent();

--- a/applications/web/tests/lib/account-identity.test.ts
+++ b/applications/web/tests/lib/account-identity.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { resolveAccountIdentity } from "../../src/lib/account-identity";
+
+describe("resolveAccountIdentity", () => {
+  it("labels a user with a username by that username", () => {
+    expect(
+      resolveAccountIdentity({ email: "ada@local", id: "user-1", name: "Ada", username: "ada" }),
+    ).toEqual({ label: "Username", value: "ada" });
+  });
+
+  it("labels a user without a username by email", () => {
+    expect(
+      resolveAccountIdentity({ email: "ada@example.com", id: "user-1", name: "Ada" }),
+    ).toEqual({ label: "Email", value: "ada@example.com" });
+  });
+
+  it("returns an empty email label when there is no session", () => {
+    expect(resolveAccountIdentity(null)).toEqual({ label: "Email", value: "" });
+  });
+});


### PR DESCRIPTION
The account row on the settings page previously chose its label from the instance's credential mode and fell back to the display name when a user had no username. It now shows "Username" with the username when the session user has one, and "Email" with the email address otherwise, which covers users who signed up through a social provider on a username-mode instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)