### PR TITLE
fix(auth): keep the username field out of client-writable user input

### DIFF
--- a/packages/auth/src/plugins/username-only/utils/schema.ts
+++ b/packages/auth/src/plugins/username-only/utils/schema.ts
@@ -4,6 +4,7 @@ export const schema: BetterAuthPlugin["schema"] = {
   user: {
     fields: {
       username: {
+        input: false,
         required: false,
         type: "string",
         unique: true,

--- a/packages/auth/tests/plugins/username-only-update-user.test.ts
+++ b/packages/auth/tests/plugins/username-only-update-user.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { betterAuth } from "better-auth";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import { usernameOnly } from "../../src/plugins/username-only";
+
+const BASE_URL = "http://localhost:3000";
+
+const buildAuth = () =>
+  betterAuth({
+    baseURL: BASE_URL,
+    database: memoryAdapter({ account: [], session: [], user: [], verification: [] }),
+    plugins: [usernameOnly()],
+    secret: "test-secret",
+  });
+
+type Auth = ReturnType<typeof buildAuth>;
+
+const post = (auth: Auth, path: string, body: object, cookie?: string) => {
+  const headers = new Headers({ "content-type": "application/json", origin: BASE_URL });
+  if (cookie) {
+    headers.set("cookie", cookie);
+  }
+  return auth.handler(
+    new Request(`${BASE_URL}/api/auth${path}`, {
+      body: JSON.stringify(body),
+      headers,
+      method: "POST",
+    }),
+  );
+};
+
+const signUp = async (auth: Auth, username: string): Promise<string> => {
+  const response = await post(auth, "/username-only/sign-up", {
+    password: "password123",
+    username,
+  });
+  expect(response.status).toBe(200);
+  return response.headers
+    .getSetCookie()
+    .map((entry) => entry.split(";")[0])
+    .join("; ");
+};
+
+describe("username field through the core update-user endpoint", () => {
+  it("rejects a username change", async () => {
+    const auth = buildAuth();
+    const cookie = await signUp(auth, "alice");
+
+    const response = await post(auth, "/update-user", { username: "bob" }, cookie);
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects taking another user's username", async () => {
+    const auth = buildAuth();
+    await signUp(auth, "bob");
+    const cookie = await signUp(auth, "alice");
+
+    const response = await post(auth, "/update-user", { username: "bob" }, cookie);
+    expect(response.status).toBe(400);
+
+    const signIn = await post(auth, "/username-only/sign-in", {
+      password: "password123",
+      username: "bob",
+    });
+    const body: unknown = await signIn.json();
+    expect(signIn.status).toBe(200);
+    expect(body).toMatchObject({ user: { email: "bob@local", username: "bob" } });
+  });
+
+  it("still allows other profile fields to change", async () => {
+    const auth = buildAuth();
+    const cookie = await signUp(auth, "alice");
+
+    const response = await post(auth, "/update-user", { name: "Alice" }, cookie);
+
+    expect(response.status).toBe(200);
+  });
+});


### PR DESCRIPTION
The username-only plugin declares `username` as an additional user field. Better Auth treats plugin fields as client-writable unless they are marked `input: false`, so the core `update-user` endpoint accepted `username` in its body and bypassed the plugin's format, length, and uniqueness checks.

The field is now declared with `input: false`. The plugin's own sign-up endpoint writes the column directly through the adapter and is unaffected. Tests cover the rejected update and the unchanged sign-up and sign-in paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)