### PR TITLE
fix(google): preserve video meeting links in synced descriptions

### DIFF
--- a/packages/calendar/src/providers/google/source/types.ts
+++ b/packages/calendar/src/providers/google/source/types.ts
@@ -23,6 +23,10 @@ interface GoogleEventDateTime {
 }
 
 interface GoogleCalendarEvent {
+  hangoutLink?: string;
+  conferenceData?: {
+    entryPoints?: { entryPointType?: string; uri?: string }[];
+  };
   id?: string;
   iCalUID?: string;
   status?: "confirmed" | "tentative" | "cancelled";

--- a/packages/calendar/src/providers/google/source/utils/conference-link.ts
+++ b/packages/calendar/src/providers/google/source/utils/conference-link.ts
@@ -1,0 +1,40 @@
+import type { GoogleCalendarEvent } from "../types";
+
+const isWebLink = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+};
+
+// Build from the source description on each read: changed or removed conference
+// Links replace the previous derived content without editing the Google event.
+const resolveGoogleDescription = (event: GoogleCalendarEvent): string | undefined => {
+  const candidates = [
+    event.hangoutLink,
+    ...event.conferenceData?.entryPoints
+      ?.filter((entry) => entry.entryPointType === "video")
+      .map((entry) => entry.uri) ?? [],
+  ];
+  const link = candidates
+    .map((candidate) => candidate?.trim())
+    .find((candidate): candidate is string => Boolean(candidate && isWebLink(candidate)));
+
+  if (!link || event.description?.includes(link)) {
+    return event.description;
+  }
+
+  let label = "Join video meeting";
+  if (new URL(link).hostname === "meet.google.com") {
+    label = "Join Google Meet";
+  }
+  const conferenceLine = `${label}: ${link}`;
+  if (event.description) {
+    return `${event.description}\n\n${conferenceLine}`;
+  }
+  return conferenceLine;
+};
+
+export { resolveGoogleDescription };

--- a/packages/calendar/src/providers/google/source/utils/fetch-events.ts
+++ b/packages/calendar/src/providers/google/source/utils/fetch-events.ts
@@ -1,3 +1,4 @@
+import { resolveGoogleDescription } from "./conference-link";
 import type {
   FetchEventsOptions,
   FetchEventsResult,
@@ -374,7 +375,7 @@ const parseGoogleEventsWithDiagnostics = (
     }
     result.push({
       availability: resolveGoogleAvailability(event),
-      description: event.description,
+      description: resolveGoogleDescription(event),
       endTime,
       isAllDay: isAllDayGoogleEvent(event),
       location: resolveGoogleLocation(event),

--- a/packages/calendar/tests/providers/google/source/utils/conference-link.test.ts
+++ b/packages/calendar/tests/providers/google/source/utils/conference-link.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { parseGoogleEvents } from "../../../../../src/providers/google/source/utils/fetch-events";
+import type { GoogleCalendarEvent } from "../../../../../src/providers/google/source/types";
+import { createSyncEventContentHash } from "../../../../../src/core/events/content-hash";
+
+const missingDescription: Partial<GoogleCalendarEvent> = {};
+const link = "https://meet.google.com/abc-defg-hij";
+const parse = (overrides: Partial<GoogleCalendarEvent> = {}) => {
+  const event: GoogleCalendarEvent = {
+    id: "received-invitation",
+    iCalUID: "external-invitation@google.com",
+    summary: "Invited meeting",
+    start: { dateTime: "2026-09-10T10:00:00Z" },
+    end: { dateTime: "2026-09-10T11:00:00Z" },
+    description: "Original invitation",
+    ...overrides,
+  };
+  const before = structuredClone(event);
+  const [parsed] = parseGoogleEvents([event]);
+  expect(event).toEqual(before);
+  if (!parsed) {
+    throw new Error("Event was not parsed");
+  }
+  return parsed;
+};
+
+describe("Google conference links in copied descriptions", () => {
+  it("preserves a received invitation's Meet link without mutating the source", () => {
+    expect(parse({ hangoutLink: link }).description)
+      .toBe(`Original invitation\n\nJoin Google Meet: ${link}`);
+  });
+  it("uses the video entry point and ignores dial-in entries", () => {
+    expect(parse({ conferenceData: { entryPoints: [
+      { entryPointType: "phone", uri: "tel:+123456" },
+      { entryPointType: "video", uri: link },
+    ] } }).description).toContain(link);
+  });
+  it("prefers hangoutLink when both representations exist", () => {
+    const { description } = parse({ hangoutLink: link, conferenceData: {
+      entryPoints: [{ entryPointType: "video", uri: "https://meet.google.com/other" }],
+    } });
+    expect(description).toContain(link);
+    expect(description).not.toContain("/other");
+  });
+  it.each([missingDescription.description, ""])("handles an empty description: %s", (description) => {
+    expect(parse({ description, hangoutLink: link }).description).toBe(`Join Google Meet: ${link}`);
+  });
+  it.each([`Join ${link}`, `<a href="${link}">Join</a>`])("avoids duplicates: %s", (description) => {
+    expect(parse({ description, hangoutLink: link }).description).toBe(description);
+  });
+  it("preserves descriptions when no conference exists", () => {
+    expect(parse().description).toBe("Original invitation");
+    expect(parse({ description: missingDescription.description }).description).toBeUndefined();
+  });
+  it("falls back from invalid links to a valid video URL", () => {
+    expect(parse({ hangoutLink: "ftp://example.com/meeting", conferenceData: {
+      entryPoints: [{ entryPointType: "video", uri: link }],
+    } }).description).toContain(link);
+    expect(parse({ hangoutLink: "not a URL" }).description).toBe("Original invitation");
+  });
+  it("detects a changed or removed link through the existing content hash", () => {
+    const first = parse({ hangoutLink: link });
+    const changed = parse({ hangoutLink: "https://meet.google.com/new-link" });
+    const removed = parse();
+    expect(changed.description).not.toContain(link);
+    expect(removed.description).toBe("Original invitation");
+    const hashes = [first, changed, removed].map((event) => createSyncEventContentHash({
+      ...event, summary: event.title ?? "",
+    }));
+    expect(new Set(hashes).size).toBe(3);
+  });
+});


### PR DESCRIPTION
Google Calendar events can expose their meeting URL in `hangoutLink` or `conferenceData.entryPoints` without including it in the description. Keeper currently drops that URL when converting the source event, so the synced appointment can lose its join link.

This change appends the source video URL to the copied description, preferring `hangoutLink` and falling back to an HTTP(S) video entry point. It preserves existing descriptions, avoids appending a URL already present, and leaves the Google source event unchanged. Rebuilding the description on each ingest also makes conference-only changes or removal affect the existing content hash.

Related to #453. This addresses Google-source conference links only; it does not implement native conferencing metadata on destination events, a user-facing opt-in setting, or Microsoft-source meeting extraction.

Validation: 96 tests passed across Google source, Google destination, and content hashing, including 10 new regression cases. Calendar TypeScript checking and lint on changed files passed. No live Google-to-Exchange synchronization was performed. Previously ingested events need to be read again from Google to pick up their conference link.
